### PR TITLE
Rename INDEX_ROUTING_PREFER to TIER_PREFERENCE

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -118,7 +118,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 6)
                     .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
-                    .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, allocatable ? "data_hot" : "data_content")
+                    .put(DataTierAllocationDecider.TIER_PREFERENCE, allocatable ? "data_hot" : "data_content")
                     .build()
             ).setWaitForActiveShards(allocatable ? ActiveShardCount.DEFAULT : ActiveShardCount.NONE)
         );
@@ -132,7 +132,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
                 .indices()
                 .updateSettings(
                     new UpdateSettingsRequest(indexName).settings(
-                        Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                        Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, "data_warm,data_hot")
                     )
                 )
                 .actionGet()

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -288,9 +288,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             ) != Decision.NO;
             if (result
                 && nodes.isEmpty()
-                && Strings.hasText(
-                    DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(indexMetadata(shard, allocation).getSettings())
-                )) {
+                && Strings.hasText(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(indexMetadata(shard, allocation).getSettings()))) {
                 // The data tier decider allows a shard to remain on a lower preference tier when no nodes exists on higher preference
                 // tiers.
                 // Here we ensure that if our policy governs the highest preference tier, we assume the shard needs to move to that tier

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/util/FrozenUtils.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/util/FrozenUtils.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.core.DataTier;
 
 public class FrozenUtils {
     public static boolean isFrozenIndex(Settings indexSettings) {
-        String tierPreference = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
+        String tierPreference = DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(indexSettings);
         String[] preferredTiers = DataTierAllocationDecider.parseTierList(tierPreference);
         if (preferredTiers.length >= 1 && preferredTiers[0].equals(DataTier.DATA_FROZEN)) {
             assert preferredTiers.length == 1 : "frozen tier preference must be frozen only";

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -292,7 +292,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
         overrideSetting(
             imd,
             builder,
-            DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING,
+            DataTierAllocationDecider.TIER_PREFERENCE_SETTING,
             randomFrom(DataTier.DATA_COLD, DataTier.DATA_COLD + "," + DataTier.DATA_HOT)
         );
         return IndexMetadata.builder(imd).settings(builder).build();
@@ -593,7 +593,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
     }
 
     private static ClusterState addRandomIndices(int minShards, int maxShardCopies, ClusterState state) {
-        String[] tierSettingNames = new String[] { DataTierAllocationDecider.INDEX_ROUTING_PREFER };
+        String[] tierSettingNames = new String[] { DataTierAllocationDecider.TIER_PREFERENCE };
         int shards = randomIntBetween(minShards, 20);
         Metadata.Builder builder = Metadata.builder();
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -513,7 +513,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
 
     public ClusterState addPreference(IndexMetadata indexMetadata, ClusterState clusterState, String preference) {
         IndexMetadata indexMetadataWithPreference = IndexMetadata.builder(indexMetadata)
-            .settings(Settings.builder().put(indexMetadata.getSettings()).put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, preference))
+            .settings(Settings.builder().put(indexMetadata.getSettings()).put(DataTierAllocationDecider.TIER_PREFERENCE, preference))
             .build();
 
         return ClusterState.builder(clusterState)
@@ -552,7 +552,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         Metadata.Builder metaBuilder = Metadata.builder();
         Settings.Builder settings = settings(Version.CURRENT);
         if (randomBoolean()) {
-            settings.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, randomBoolean() ? DataTier.DATA_HOT : "data_hot,data_warm");
+            settings.put(DataTierAllocationDecider.TIER_PREFERENCE, randomBoolean() ? DataTier.DATA_HOT : "data_hot,data_warm");
         }
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
             .settings(settings)

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/util/FrozenUtilsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/util/FrozenUtilsTests.java
@@ -42,7 +42,7 @@ public class FrozenUtilsTests extends AutoscalingTestCase {
     public static Settings indexSettings(String tierPreference) {
         Settings.Builder settings = Settings.builder()
             .put(randomAlphaOfLength(10), randomLong())
-            .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, tierPreference)
+            .put(DataTierAllocationDecider.TIER_PREFERENCE, tierPreference)
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT);
         // pass setting validator.
         if (Objects.equals(tierPreference, DataTier.DATA_FROZEN)) {

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierIT.java
@@ -47,7 +47,7 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index).setWaitForActiveShards(0).get();
 
         Settings idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_CONTENT));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_CONTENT));
 
         // index should be red
         assertThat(client().admin().cluster().prepareHealth(index).get().getIndices().get(index).getStatus(),
@@ -73,11 +73,11 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index)
             .setWaitForActiveShards(0)
             .setSettings(Settings.builder()
-                .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_WARM))
+                .put(DataTierAllocationDecider.TIER_PREFERENCE, DataTier.DATA_WARM))
             .get();
 
         Settings idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(idxSettings.get(DataTierAllocationDecider.INDEX_ROUTING_PREFER), equalTo(DataTier.DATA_WARM));
+        assertThat(idxSettings.get(DataTierAllocationDecider.TIER_PREFERENCE), equalTo(DataTier.DATA_WARM));
 
         // index should be yellow
         logger.info("--> waiting for {} to be yellow", index);
@@ -92,13 +92,13 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index)
             .setWaitForActiveShards(0)
             .setSettings(Settings.builder()
-                .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER))
+                .putNull(DataTierAllocationDecider.TIER_PREFERENCE))
             .get();
 
         Settings idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(""));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(""));
         // Even the key shouldn't exist if it has been nulled out
-        assertFalse(idxSettings.keySet().toString(), idxSettings.keySet().contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER));
+        assertFalse(idxSettings.keySet().toString(), idxSettings.keySet().contains(DataTierAllocationDecider.TIER_PREFERENCE));
 
         // index should be yellow
         logger.info("--> waiting for {} to be yellow", index);
@@ -114,9 +114,9 @@ public class DataTierIT extends ESIntegTestCase {
             .get();
 
         idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(""));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(""));
         // The key should not be put in place since it was overridden
-        assertFalse(idxSettings.keySet().contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER));
+        assertFalse(idxSettings.keySet().contains(DataTierAllocationDecider.TIER_PREFERENCE));
         assertThat(idxSettings.get(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".box"), equalTo("cold"));
 
         // index should be yellow
@@ -137,7 +137,7 @@ public class DataTierIT extends ESIntegTestCase {
             .setSettings(Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_warm"))
+                .put(DataTierAllocationDecider.TIER_PREFERENCE, "data_warm"))
             .get();
 
         client().admin().indices().prepareAddBlock(IndexMetadata.APIBlock.READ_ONLY, index).get();
@@ -153,7 +153,7 @@ public class DataTierIT extends ESIntegTestCase {
         Settings idxSettings = client().admin().indices().prepareGetIndex().addIndices(index + "-shrunk")
             .get().getSettings().get(index + "-shrunk");
         // It should inherit the setting of its originator
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_WARM));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_WARM));
 
         // Required or else the test cleanup fails because it can't delete the indices
         client().admin().indices().prepareUpdateSettings(index, index + "-shrunk")
@@ -177,7 +177,7 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index).setWaitForActiveShards(0).get();
 
         Settings idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(idxSettings.keySet().contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER), equalTo(false));
+        assertThat(idxSettings.keySet().contains(DataTierAllocationDecider.TIER_PREFERENCE), equalTo(false));
 
         // index should be yellow
         ensureYellow(index);
@@ -185,7 +185,7 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareDelete(index).get();
 
         t = new Template(Settings.builder()
-            .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER)
+            .putNull(DataTierAllocationDecider.TIER_PREFERENCE)
             .build(), null, null);
         ct = new ComposableIndexTemplate.Builder().indexPatterns(Collections.singletonList(index))
                  .template(t).build();
@@ -195,7 +195,7 @@ public class DataTierIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate(index).setWaitForActiveShards(0).get();
 
         idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(index);
-        assertThat(idxSettings.keySet().contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER), equalTo(false));
+        assertThat(idxSettings.keySet().contains(DataTierAllocationDecider.TIER_PREFERENCE), equalTo(false));
 
         ensureYellow(index);
     }
@@ -207,7 +207,7 @@ public class DataTierIT extends ESIntegTestCase {
 
         client().admin().indices().prepareCreate(index)
             .setSettings(Settings.builder()
-                .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_hot")
+                .put(DataTierAllocationDecider.TIER_PREFERENCE, "data_hot")
                 .put("index.number_of_shards", 2)
                 .put("index.number_of_replicas", 0))
             .setWaitForActiveShards(0)
@@ -253,7 +253,7 @@ public class DataTierIT extends ESIntegTestCase {
             () -> createIndex(index, Settings.builder()
                 .put("index.number_of_shards", 1)
                 .put("index.number_of_replicas", 0)
-                .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_FROZEN)
+                .put(DataTierAllocationDecider.TIER_PREFERENCE, DataTier.DATA_FROZEN)
                 .build()));
         assertThat(e.getMessage(), equalTo("[data_frozen] tier can only be used for partial searchable snapshots"));
 
@@ -261,7 +261,7 @@ public class DataTierIT extends ESIntegTestCase {
         createIndex(index, Settings.builder()
             .put("index.number_of_shards", 1)
             .put("index.number_of_replicas", 0)
-            .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, initialTier)
+            .put(DataTierAllocationDecider.TIER_PREFERENCE, initialTier)
             .build());
 
         IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> updatePreference(DataTier.DATA_FROZEN));
@@ -272,7 +272,7 @@ public class DataTierIT extends ESIntegTestCase {
 
     private void updatePreference(String tier) {
         client().admin().indices().updateSettings(new UpdateSettingsRequest(index)
-            .settings(Map.of(DataTierAllocationDecider.INDEX_ROUTING_PREFER, tier))).actionGet();
+            .settings(Map.of(DataTierAllocationDecider.TIER_PREFERENCE, tier))).actionGet();
     }
 
     private DataTiersFeatureSetUsage getUsage() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -46,10 +46,10 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     public static final String NAME = "data_tier";
 
-    public static final String INDEX_ROUTING_PREFER = "index.routing.allocation.include._tier_preference";
+    public static final String TIER_PREFERENCE = "index.routing.allocation.include._tier_preference";
 
     private static final DataTierValidator VALIDATOR = new DataTierValidator();
-    public static final Setting<String> INDEX_ROUTING_PREFER_SETTING = new Setting<>(new Setting.SimpleKey(INDEX_ROUTING_PREFER),
+    public static final Setting<String> TIER_PREFERENCE_SETTING = new Setting<>(new Setting.SimpleKey(TIER_PREFERENCE),
         DataTierValidator::getDefaultTierPreference, Function.identity(), VALIDATOR, Property.Dynamic, Property.IndexScope);
 
     private static void validateTierSetting(String setting) {
@@ -153,7 +153,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
     private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, Set<DiscoveryNodeRole> roles,
                                            PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
         Settings indexSettings = indexMetadata.getSettings();
-        String tierPreference = INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
+        String tierPreference = TIER_PREFERENCE_SETTING.get(indexSettings);
 
         if (Strings.hasText(tierPreference)) {
             Optional<String> tier = preferredTierFunction.apply(tierPreference, allocation.nodes());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -56,15 +56,18 @@ public class DataTierAllocationDecider extends AllocationDecider {
             for (String s : setting.split(",")) {
                 if (DataTier.validTierName(s) == false) {
                     throw new IllegalArgumentException(
-                            "invalid tier names found in [" + setting + "] allowed values are " + DataTier.ALL_DATA_TIERS);
+                        "invalid tier names found in [" + setting + "] allowed values are " + DataTier.ALL_DATA_TIERS);
                 }
             }
         }
     }
 
     private static class DataTierValidator implements Setting.Validator<String> {
-        private static final Collection<Setting<?>> dependencies = List.of(IndexModule.INDEX_STORE_TYPE_SETTING,
-            SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING);
+
+        private static final Collection<Setting<?>> dependencies = List.of(
+            IndexModule.INDEX_STORE_TYPE_SETTING,
+            SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING
+        );
 
         public static String getDefaultTierPreference(Settings settings) {
             if (SearchableSnapshotsSettings.isPartialSearchableSnapshotIndex(settings)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
@@ -49,7 +50,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     private static final DataTierValidator VALIDATOR = new DataTierValidator();
     public static final Setting<String> INDEX_ROUTING_PREFER_SETTING = new Setting<>(new Setting.SimpleKey(INDEX_ROUTING_PREFER),
-        DataTierValidator::getDefaultTierPreference, Function.identity(), VALIDATOR, Setting.Property.Dynamic, Setting.Property.IndexScope);
+        DataTierValidator::getDefaultTierPreference, Function.identity(), VALIDATOR, Property.Dynamic, Property.IndexScope);
 
     private static void validateTierSetting(String setting) {
         if (Strings.hasText(setting)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
@@ -89,7 +89,7 @@ public class DataTierFieldMapper extends MetadataFieldMapper {
          */
         private String getTierPreference(SearchExecutionContext context) {
             Settings settings = context.getIndexSettings().getSettings();
-            String value = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings);
+            String value = DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings);
 
             if (Strings.hasText(value) == false) {
                 return null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -129,8 +129,8 @@ public class DataTier {
         public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings indexSettings) {
             Set<String> settings = indexSettings.keySet();
             if (settings.contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER)) {
-                // It's okay to put it, it will be removed or overridden by the template/request settings
-                return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_HOT).build();
+                // just a marker -- this null value will be removed or overridden by the template/request settings
+                return Settings.builder().putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER).build();
             } else if (settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX + "."))) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -48,8 +48,7 @@ public class DataTier {
     }
 
     // Represents an ordered list of data tiers from frozen to hot (or slow to fast)
-    private static final List<String> ORDERED_FROZEN_TO_HOT_TIERS =
-        List.of(DataTier.DATA_FROZEN, DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
+    private static final List<String> ORDERED_FROZEN_TO_HOT_TIERS = List.of(DATA_FROZEN, DATA_COLD, DATA_WARM, DATA_HOT);
 
     /**
      * Returns true if the given tier name is a valid tier

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -60,7 +60,7 @@ public class DataTier {
     /**
      * Based on the provided target tier it will return a comma separated list of preferred tiers.
      * ie. if `data_cold` is the target tier, it will return `data_cold,data_warm,data_hot`
-     * This is usually used in conjunction with {@link DataTierAllocationDecider#INDEX_ROUTING_PREFER_SETTING}
+     * This is usually used in conjunction with {@link DataTierAllocationDecider#TIER_PREFERENCE_SETTING}
      */
     public static String getPreferredTiersConfiguration(String targetTier) {
         int indexOfTargetTier = ORDERED_FROZEN_TO_HOT_TIERS.indexOf(targetTier);
@@ -128,9 +128,9 @@ public class DataTier {
         @Override
         public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings indexSettings) {
             Set<String> settings = indexSettings.keySet();
-            if (settings.contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER)) {
+            if (settings.contains(DataTierAllocationDecider.TIER_PREFERENCE)) {
                 // just a marker -- this null value will be removed or overridden by the template/request settings
-                return Settings.builder().putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER).build();
+                return Settings.builder().putNull(DataTierAllocationDecider.TIER_PREFERENCE).build();
             } else if (settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX + "."))) {
@@ -141,9 +141,9 @@ public class DataTier {
                 // Otherwise, put the setting in place by default, the "hot" tier if the index is part of a data stream,
                 // the "content" tier if it is not.
                 if (isDataStreamIndex) {
-                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_HOT).build();
+                    return Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, DATA_HOT).build();
                 } else {
-                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_CONTENT).build();
+                    return Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, DATA_CONTENT).build();
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -43,7 +43,7 @@ public class DataTier {
         for (String tier : ALL_DATA_TIERS) {
             assert tier.equals(DATA_FROZEN) || tier.contains(DATA_FROZEN) == false
                 : "can't have two tier names containing [" + DATA_FROZEN + "] because it would break setting validation optimizations" +
-                    " in the data tier allocation decider";
+                " in the data tier allocation decider";
         }
     }
 
@@ -139,9 +139,8 @@ public class DataTier {
                 logger.debug("index [{}] specifies custom index level routing filtering, skipping tier allocation", indexName);
                 return Settings.EMPTY;
             } else {
-                // Otherwise, put the setting in place by default, the "hot"
-                // tier if the index is part of a data stream, the "content"
-                // tier if it is not.
+                // Otherwise, put the setting in place by default, the "hot" tier if the index is part of a data stream,
+                // the "content" tier if it is not.
                 if (isDataStreamIndex) {
                     return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_HOT).build();
                 } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -138,8 +138,9 @@ public class DataTier {
                 logger.debug("index [{}] specifies custom index level routing filtering, skipping tier allocation", indexName);
                 return Settings.EMPTY;
             } else {
-                // Otherwise, put the setting in place by default, the "hot" tier if the index is part of a data stream,
-                // the "content" tier if it is not.
+                // Otherwise, put the setting in place by default, the "hot"
+                // tier if the index is part of a data stream, the "content"
+                // tier if it is not.
                 if (isDataStreamIndex) {
                     return Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, DATA_HOT).build();
                 } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -130,7 +130,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
     private static void aggregateDataTierNodeCounts(NodeStats nodeStats, Map<String, TierStatsAccumulator> tiersStats) {
         nodeStats.getNode().getRoles().stream()
             .map(DiscoveryNodeRole::roleName)
-            .filter(DataTier.ALL_DATA_TIERS::contains)
+            .filter(DataTier::validTierName)
             .forEach(tier -> tiersStats.computeIfAbsent(tier, k -> new TierStatsAccumulator()).nodeCount++);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -83,7 +83,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
     static Map<String, String> tierIndices(ImmutableOpenMap<String, IndexMetadata> indices) {
         Map<String, String> indexByTier = new HashMap<>();
         indices.forEach(entry -> {
-            String tierPref = entry.value.getSettings().get(DataTierAllocationDecider.INDEX_ROUTING_PREFER);
+            String tierPref = entry.value.getSettings().get(DataTierAllocationDecider.TIER_PREFERENCE);
             if (Strings.hasText(tierPref)) {
                 String[] tiers = tierPref.split(",");
                 if (tiers.length > 0) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -110,8 +110,8 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
 
     // Visible for testing
     static Map<String, DataTiersFeatureSetUsage.TierSpecificStats> calculateStats(List<NodeStats> nodesStats,
-                                                                                   Map<String, String> indexByTier,
-                                                                                   RoutingNodes routingNodes) {
+                                                                                  Map<String, String> indexByTier,
+                                                                                  RoutingNodes routingNodes) {
         Map<String, TierStatsAccumulator> statsAccumulators = new HashMap<>();
         for (NodeStats nodeStats : nodesStats) {
             aggregateDataTierNodeCounts(nodeStats, statsAccumulators);
@@ -138,7 +138,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
      * Locate which indices are hosted on the node specified by the NodeStats, then group and aggregate the available index stats by tier.
      */
     private static void aggregateDataTierIndexStats(NodeStats nodeStats, RoutingNodes routingNodes, Map<String, String> indexByTier,
-                                             Map<String, TierStatsAccumulator> accumulators) {
+                                                    Map<String, TierStatsAccumulator> accumulators) {
         final RoutingNode node = routingNodes.node(nodeStats.getNode().getId());
         if (node != null) {
             StreamSupport.stream(node.spliterator(), false)
@@ -152,7 +152,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
      * Determine which tier an index belongs in, then accumulate its stats into that tier's stats.
      */
     private static void classifyIndexAndCollectStats(Index index, NodeStats nodeStats, Map<String, String> indexByTier,
-                                              RoutingNode node, Map<String, TierStatsAccumulator> accumulators) {
+                                                     RoutingNode node, Map<String, TierStatsAccumulator> accumulators) {
         // Look up which tier this index belongs to (its most preferred)
         String indexTier = indexByTier.get(index.getName());
         if (indexTier != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -384,7 +384,7 @@ public class XPackPlugin extends XPackClientPlugin
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = super.getSettings();
         settings.add(SourceOnlySnapshotRepository.SOURCE_ONLY);
-        settings.add(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING);
+        settings.add(DataTierAllocationDecider.TIER_PREFERENCE_SETTING);
         return settings;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.TIER_PREFERENCE_SETTING;
 import static org.elasticsearch.xpack.core.ilm.AllocationRoutedStep.getPendingAllocations;
 import static org.elasticsearch.xpack.core.ilm.step.info.AllocationInfo.waitingForActiveShardsAllocationInfo;
 
@@ -56,7 +56,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
             return new Result(false, null);
         }
-        String preferredTierConfiguration = INDEX_ROUTING_PREFER_SETTING.get(idxMeta.getSettings());
+        String preferredTierConfiguration = TIER_PREFERENCE_SETTING.get(idxMeta.getSettings());
         Optional<String> availableDestinationTier = DataTierAllocationDecider.preferredAvailableTier(preferredTierConfiguration,
             clusterState.getNodes());
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -117,7 +117,7 @@ public class MigrateAction implements LifecycleAction {
                 });
             UpdateSettingsStep updateMigrationSettingStep = new UpdateSettingsStep(migrationKey, migrationRoutedKey, client,
                 Settings.builder()
-                    .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, getPreferredTiersConfiguration(targetTier))
+                    .put(DataTierAllocationDecider.TIER_PREFERENCE, getPreferredTiersConfiguration(targetTier))
                     .build());
             DataTierMigrationRoutedStep migrationRoutedStep = new DataTierMigrationRoutedStep(migrationRoutedKey, nextStepKey);
             return List.of(conditionalSkipActionStep, updateMigrationSettingStep, migrationRoutedStep);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -107,7 +107,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         final Settings.Builder settingsBuilder = Settings.builder();
 
         overrideTierPreference(this.getKey().getPhase())
-            .ifPresent(override -> settingsBuilder.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, override));
+            .ifPresent(override -> settingsBuilder.put(DataTierAllocationDecider.TIER_PREFERENCE, override));
 
         final MountSearchableSnapshotRequest mountSearchableSnapshotRequest = new MountSearchableSnapshotRequest(mountedIndexName,
             snapshotRepository, snapshotName, indexName, settingsBuilder.build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -86,7 +86,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                         .put(IndexMetadata.SETTING_INDEX_UUID, "myindex")
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                        .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_warm,data_cold")
+                        .put(DataTierAllocationDecider.TIER_PREFERENCE, "data_warm,data_cold")
                         .build()))
                 .build())
             .build();
@@ -121,7 +121,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                         .put(IndexMetadata.SETTING_INDEX_UUID, "myindex")
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                        .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_warm,data_cold")
+                        .put(DataTierAllocationDecider.TIER_PREFERENCE, "data_warm,data_cold")
                         .build()))
                 .build())
             .build();
@@ -217,7 +217,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
         Randomness.shuffle(tierList);
 
         String value = Strings.join(tierList, ",");
-        Setting<String> setting = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING;
+        Setting<String> setting = DataTierAllocationDecider.TIER_PREFERENCE_SETTING;
         Settings.Builder builder = Settings.builder().put(setting.getKey(), value);
         if (randomBoolean()) {
             builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
@@ -229,7 +229,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testFrozenLegalForPartialSnapshot() {
-        Setting<String> setting = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING;
+        Setting<String> setting = DataTierAllocationDecider.TIER_PREFERENCE_SETTING;
         Settings.Builder builder = Settings.builder().put(setting.getKey(), DATA_FROZEN);
         builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
         builder.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true);
@@ -250,53 +250,53 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
 
         {
             String value = Strings.join(tierList, ",");
-            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, value);
+            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, value);
             builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
             builder.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true);
 
             Settings settings = builder.build();
 
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings));
+                () -> DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings));
             assertThat(e.getMessage(),
                 containsString("only the [data_frozen] tier preference may be used for partial searchable snapshots"));
         }
 
         {
-            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "");
+            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, "");
             builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
             builder.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true);
 
             Settings settings = builder.build();
 
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings));
+                () -> DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings));
             assertThat(e.getMessage(),
                 containsString("only the [data_frozen] tier preference may be used for partial searchable snapshots"));
         }
 
         {
-            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "  ");
+            Settings.Builder builder = Settings.builder().put(DataTierAllocationDecider.TIER_PREFERENCE, "  ");
             builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
             builder.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true);
 
             Settings settings = builder.build();
 
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings));
+                () -> DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings));
             assertThat(e.getMessage(),
                 containsString("only the [data_frozen] tier preference may be used for partial searchable snapshots"));
         }
     }
 
     public void testDefaultValueForPreference() {
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(Settings.EMPTY), equalTo(""));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(Settings.EMPTY), equalTo(""));
 
         Settings.Builder builder = Settings.builder();
         builder.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
         builder.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true);
 
         Settings settings = builder.build();
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings), equalTo(DATA_FROZEN));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings), equalTo(DATA_FROZEN));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -101,7 +101,7 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     // Tier can be an ordered list of preferences - starting with primary and followed by fallbacks.
-                    .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                    .put(DataTierAllocationDecider.TIER_PREFERENCE, "data_warm,data_hot")
             )
             .numberOfShards(1)
             .numberOfReplicas(0)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -697,9 +697,9 @@ public class DataTiersUsageTransportActionTests extends ESTestCase {
             for (int idx = 1; idx < dataTierPrefs.length; idx++) {
                 tierBuilder.append(',').append(dataTierPrefs[idx]);
             }
-            settingsBuilder.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, tierBuilder.toString());
+            settingsBuilder.put(DataTierAllocationDecider.TIER_PREFERENCE, tierBuilder.toString());
         } else if (dataTierPrefs.length == 1) {
-            settingsBuilder.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, dataTierPrefs[0]);
+            settingsBuilder.put(DataTierAllocationDecider.TIER_PREFERENCE, dataTierPrefs[0]);
         }
 
         return IndexMetadata.builder(indexName)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import static java.util.Collections.emptyMap;
-import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.TIER_PREFERENCE;
 import static org.elasticsearch.xpack.core.ilm.CheckShrinkReadyStepTests.randomUnassignedInfo;
 import static org.elasticsearch.xpack.core.ilm.step.info.AllocationInfo.waitingForActiveShardsAllocationInfo;
 import static org.hamcrest.Matchers.is;
@@ -94,7 +94,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
 
     public void testExecuteWithPendingShards() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(5, 10))
-            .settings(settings(Version.CURRENT).put(INDEX_ROUTING_PREFER, DataTier.DATA_WARM))
+            .settings(settings(Version.CURRENT).put(TIER_PREFERENCE, DataTier.DATA_WARM))
             .numberOfShards(1).numberOfReplicas(0).build();
         Index index = indexMetadata.getIndex();
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)
@@ -121,7 +121,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
 
     public void testExecuteWithPendingShardsAndTargetRoleNotPresentInCluster() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(5, 10))
-            .settings(settings(Version.CURRENT).put(INDEX_ROUTING_PREFER, DataTier.DATA_WARM))
+            .settings(settings(Version.CURRENT).put(TIER_PREFERENCE, DataTier.DATA_WARM))
             .numberOfShards(1).numberOfReplicas(0).build();
         Index index = indexMetadata.getIndex();
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)
@@ -157,7 +157,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
 
     public void testExecuteIsComplete() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(5, 10))
-            .settings(settings(Version.CURRENT).put(INDEX_ROUTING_PREFER, DataTier.DATA_WARM))
+            .settings(settings(Version.CURRENT).put(TIER_PREFERENCE, DataTier.DATA_WARM))
             .numberOfShards(1).numberOfReplicas(0).build();
         Index index = indexMetadata.getIndex();
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)
@@ -179,7 +179,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
 
     public void testExecuteWithGenericDataNodes() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(5, 10))
-            .settings(settings(Version.CURRENT).put(INDEX_ROUTING_PREFER, DataTier.DATA_WARM))
+            .settings(settings(Version.CURRENT).put(TIER_PREFERENCE, DataTier.DATA_WARM))
             .numberOfShards(1).numberOfReplicas(0).build();
         Index index = indexMetadata.getIndex();
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
@@ -89,19 +89,19 @@ public class MigrateActionTests extends AbstractActionTestCase<MigrateAction> {
         {
             List<Step> steps = action.toSteps(null, HOT_PHASE, nextStepKey);
             UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(1);
-            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+            assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(firstStep.getSettings()),
                 is(DATA_HOT));
         }
         {
             List<Step> steps = action.toSteps(null, WARM_PHASE, nextStepKey);
             UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(1);
-            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+            assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(firstStep.getSettings()),
                 is(DATA_WARM + "," + DATA_HOT));
         }
         {
             List<Step> steps = action.toSteps(null, COLD_PHASE, nextStepKey);
             UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(1);
-            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+            assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(firstStep.getSettings()),
                 is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
         }
     }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
@@ -60,7 +60,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .get()
             .getSettings()
             .get(DataStream.getDefaultBackingIndexName(index, 1));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         logger.info("--> waiting for {} to be yellow", index);
         ensureYellow(index);
@@ -74,7 +74,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .get()
             .getSettings()
             .get(DataStream.getDefaultBackingIndexName(index, 2));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         client().execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { index }));
     }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
@@ -10,8 +10,6 @@ package org.elasticsearch.xpack;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -116,7 +114,7 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-            .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER)
+            .putNull(DataTierAllocationDecider.TIER_PREFERENCE)
             .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias)
         );
 
@@ -138,7 +136,7 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
             createIndexWithSettings(client(), rolloverIndexPrefix + "-00000" + i, alias + i, Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER)
+                .putNull(DataTierAllocationDecider.TIER_PREFERENCE)
                 .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias + i)
             );
         }
@@ -179,7 +177,7 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
         // let's assert the require.data:warm configuration the "indexWithDataWarmRouting" had was migrated to
         // _tier_preference:data_warm,data_hot
         Map<String, Object> indexSettings = getOnlyIndexSettings(client(), indexWithDataWarmRouting);
-        assertThat(indexSettings.get(DataTierAllocationDecider.INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        assertThat(indexSettings.get(DataTierAllocationDecider.TIER_PREFERENCE), is("data_warm,data_hot"));
 
         // let's retrieve the migrated policy and check it was migrated correctly - namely the warm phase should not contain any allocate
         // action anymore and the cold phase should contain an allocate action that only configures the number of replicas
@@ -237,7 +235,7 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-            .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER)
+            .putNull(DataTierAllocationDecider.TIER_PREFERENCE)
             .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias)
         );
 
@@ -286,7 +284,7 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
 
         // the index settings should not contain the _tier_preference
         Map<String, Object> indexSettings = getOnlyIndexSettings(client(), indexWithDataWarmRouting);
-        assertThat(indexSettings.get(DataTierAllocationDecider.INDEX_ROUTING_PREFER), nullValue());
+        assertThat(indexSettings.get(DataTierAllocationDecider.TIER_PREFERENCE), nullValue());
 
         // let's check the ILM policy was not migrated - ie. the warm phase still contains the allocate action
         Request getPolicy = new Request("GET", "/_ilm/policy/" + policy);

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -497,7 +497,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         indexDocument(client(), dataStream, true);
         String firstGenIndex = DataStream.getDefaultBackingIndexName(dataStream, 1L);
         Map<String, Object> indexSettings = getIndexSettingsAsMap(firstGenIndex);
-        assertThat(indexSettings.get(DataTierAllocationDecider.INDEX_ROUTING_PREFER), is("data_hot"));
+        assertThat(indexSettings.get(DataTierAllocationDecider.TIER_PREFERENCE), is("data_hot"));
 
         // rollover the data stream so searchable_snapshot can complete
         rolloverMaxOneDocCondition(client(), dataStream);
@@ -512,7 +512,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         Map<String, Object> hotIndexSettings = getIndexSettingsAsMap(restoredIndex);
         // searchable snapshots mounted in the hot phase should be pinned to hot nodes
-        assertThat(hotIndexSettings.get(DataTierAllocationDecider.INDEX_ROUTING_PREFER),
+        assertThat(hotIndexSettings.get(DataTierAllocationDecider.TIER_PREFERENCE),
             is("data_hot"));
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -25,14 +24,12 @@ import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDeci
 import org.elasticsearch.xpack.core.ilm.CheckTargetShardsCountStep;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
-import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.MigrateAction;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.SetSingleNodeAllocateStep;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
-import org.elasticsearch.xpack.core.ilm.ShrinkStep;
 import org.elasticsearch.xpack.core.ilm.Step;
 import org.junit.Before;
 
@@ -42,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonMap;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createIndexWithSettings;
@@ -212,7 +208,7 @@ public class ShrinkActionIT extends ESRestTestCase {
         createIndexWithSettings(client(), index, alias, Settings.builder()
             .put(SETTING_NUMBER_OF_SHARDS, numShards)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER));
+            .putNull(DataTierAllocationDecider.TIER_PREFERENCE));
 
         ensureGreen(index);
 

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
@@ -190,7 +190,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             assertReplicaIsUnassigned();
         }, 30, TimeUnit.SECONDS);
 
-        Settings removeTierRoutingSetting = Settings.builder().putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER).build();
+        Settings removeTierRoutingSetting = Settings.builder().putNull(DataTierAllocationDecider.TIER_PREFERENCE).build();
         UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(managedIndex).settings(removeTierRoutingSetting);
         assertAcked(client().admin().indices().updateSettings(updateSettingsRequest).actionGet());
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -50,7 +50,7 @@ import java.util.stream.StreamSupport;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING;
-import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.TIER_PREFERENCE;
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.xpack.core.ilm.OperationMode.STOPPED;
 import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
@@ -418,7 +418,7 @@ public final class MetadataMigrateToDataTiersRoutingService {
         // look at the value, get the correct tiers config and update the settings and index metadata
         Settings.Builder newSettingsBuilder = Settings.builder().put(currentIndexSettings);
         String indexName = indexMetadata.getIndex().getName();
-        if (currentIndexSettings.keySet().contains(INDEX_ROUTING_PREFER)) {
+        if (currentIndexSettings.keySet().contains(TIER_PREFERENCE)) {
             newSettingsBuilder.remove(attributeBasedRoutingSettingName);
             logger.debug("index [{}]: removed setting [{}]", indexName, attributeBasedRoutingSettingName);
         } else {
@@ -426,11 +426,11 @@ public final class MetadataMigrateToDataTiersRoutingService {
             String attributeValue = currentIndexSettings.get(attributeBasedRoutingSettingName);
             String convertedTierPreference = convertAttributeValueToTierPreference(attributeValue);
             if (convertedTierPreference != null) {
-                newSettingsBuilder.put(INDEX_ROUTING_PREFER, convertedTierPreference);
+                newSettingsBuilder.put(TIER_PREFERENCE, convertedTierPreference);
                 newSettingsBuilder.remove(attributeBasedRoutingSettingName);
                 logger.debug("index [{}]: removed setting [{}]", indexName, attributeBasedRoutingSettingName);
                 logger.debug("index [{}]: configured setting [{}] to [{}]", indexName,
-                    INDEX_ROUTING_PREFER, convertedTierPreference);
+                        TIER_PREFERENCE, convertedTierPreference);
             } else {
                 // log warning and do *not* remove setting, return the settings unchanged
                 logger.warn("index [{}]: could not convert attribute based setting [{}] value of [{}] to a tier preference " +

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTier
 import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateIlmPolicies;
 import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateIndices;
 import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateToDataTiersRouting;
-import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.TIER_PREFERENCE;
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -374,7 +374,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWitWarmDataAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
 
         {
@@ -394,7 +394,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWitWarmDataAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
 
         {
@@ -404,7 +404,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 IndexMetadata.builder("indexWithTierPreferenceAndDataAttribute").settings(getBaseIndexSettings()
                     .put(DATA_ROUTING_REQUIRE_SETTING, "cold")
                     .put(DATA_ROUTING_INCLUDE_SETTING, "hot")
-                    .put(INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                    .put(TIER_PREFERENCE, "data_warm,data_hot")
                 );
             ClusterState state =
                 ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithTierPreferenceAndDataAttribute)).build();
@@ -419,7 +419,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWithTierPreferenceAndDataAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
 
         {
@@ -428,7 +428,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             IndexMetadata.Builder indexWithTierPreferenceAndDataAttribute =
                 IndexMetadata.builder("indexWithTierPreferenceAndDataAttribute").settings(getBaseIndexSettings()
                     .put(DATA_ROUTING_INCLUDE_SETTING, "cold")
-                    .put(INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                    .put(TIER_PREFERENCE, "data_warm,data_hot")
                 );
             ClusterState state =
                 ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithTierPreferenceAndDataAttribute)).build();
@@ -442,7 +442,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWithTierPreferenceAndDataAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
 
         {
@@ -481,7 +481,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWithDataAndBoxAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
             assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), is("box1"));
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
 
         {
@@ -500,7 +500,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             IndexMetadata migratedIndex = migratedState.metadata().index("indexWithBoxAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
             assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), is("warm"));
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), nullValue());
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), nullValue());
         }
 
         {
@@ -518,7 +518,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             IndexMetadata migratedIndex = migratedState.metadata().index("indexNoRoutingAttribute");
             assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
             assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), nullValue());
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), nullValue());
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), nullValue());
         }
     }
 
@@ -544,7 +544,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
         assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
         assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
         assertThat(migratedIndex.getSettings().get(DATA_ROUTING_EXCLUDE_SETTING), nullValue());
-        assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
     }
 
     public void testMigrateToDataTiersRouting() {
@@ -633,7 +633,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             assertThat(migratedEntities.migratedIndices.get(0), is("indexWitWarmDataAttribute"));
 
             IndexMetadata migratedIndex = migratedEntitiesTuple.v1().metadata().index("indexWitWarmDataAttribute");
-            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+            assertThat(migratedIndex.getSettings().get(TIER_PREFERENCE), is("data_warm,data_hot"));
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -300,7 +300,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         assertTrue(SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING.exists(settings));
         assertThat(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(settings).toString(), equalTo("false"));
         assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings), equalTo(expectedReplicas));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings), equalTo(expectedDataTiersPreference));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings), equalTo(expectedDataTiersPreference));
         assertTrue(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.get(settings));
         assertTrue(DiskThresholdDecider.SETTING_IGNORE_DISK_WATERMARKS.get(settings));
         assertThat(IndexSettings.INDEX_CHECK_ON_STARTUP.get(settings), equalTo(indexCheckOnStartup));
@@ -436,7 +436,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                     Settings.builder()
                         .putNull(IndexModule.INDEX_STORE_TYPE_SETTING.getKey())
                         .putNull(IndexModule.INDEX_RECOVERY_TYPE_SETTING.getKey())
-                        .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_HOT)
+                        .put(DataTierAllocationDecider.TIER_PREFERENCE, DataTier.DATA_HOT)
                         .build()
                 )
         );

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -203,7 +203,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                     DataTier.ALL_DATA_TIERS.stream().filter(tier -> tier.equals(DataTier.DATA_FROZEN) == false).collect(Collectors.toSet())
                 )
             );
-            indexSettingsBuilder.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, expectedDataTiersPreference);
+            indexSettingsBuilder.put(DataTierAllocationDecider.TIER_PREFERENCE, expectedDataTiersPreference);
         } else {
             expectedDataTiersPreference = MountSearchableSnapshotRequest.Storage.FULL_COPY.defaultDataTiersPreference();
         }
@@ -247,7 +247,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertTrue(SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING.exists(settings));
         assertThat(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(settings).toString(), equalTo("false"));
         assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings), equalTo(expectedReplicas));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(settings), equalTo(expectedDataTiersPreference));
+        assertThat(DataTierAllocationDecider.TIER_PREFERENCE_SETTING.get(settings), equalTo(expectedDataTiersPreference));
         assertThat(IndexSettings.INDEX_CHECK_ON_STARTUP.get(settings), equalTo("false"));
 
         checkSoftDeletesNotEagerlyLoaded(restoredIndexName);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
@@ -120,7 +120,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
                     Settings.builder()
                         .putNull(IndexModule.INDEX_STORE_TYPE_SETTING.getKey())
                         .putNull(IndexModule.INDEX_RECOVERY_TYPE_SETTING.getKey())
-                        .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_HOT)
+                        .put(DataTierAllocationDecider.TIER_PREFERENCE, DataTier.DATA_HOT)
                         .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
                         .build()
                 )

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDataTierIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDataTierIntegTests.java
@@ -25,7 +25,7 @@ public class SearchableSnapshotDataTierIntegTests extends BaseFrozenSearchableSn
     private static final String snapshotName = "test-snapshot";
     private static final String mountedIndexName = "test-index-mounted";
     private static final Settings frozenSettings = Settings.builder()
-        .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_FROZEN)
+        .put(DataTierAllocationDecider.TIER_PREFERENCE, DataTier.DATA_FROZEN)
         .build();
 
     public void testPartialLegalOnFrozen() throws Exception {
@@ -64,7 +64,7 @@ public class SearchableSnapshotDataTierIntegTests extends BaseFrozenSearchableSn
             Settings.EMPTY,
             Settings.builder()
                 .put(
-                    DataTierAllocationDecider.INDEX_ROUTING_PREFER,
+                    DataTierAllocationDecider.TIER_PREFERENCE,
                     randomValueOtherThan(DataTier.DATA_FROZEN, () -> randomFrom(DataTier.ALL_DATA_TIERS))
                 )
                 .build()
@@ -77,9 +77,7 @@ public class SearchableSnapshotDataTierIntegTests extends BaseFrozenSearchableSn
     private void updatePreference(String tier) {
         client().admin()
             .indices()
-            .updateSettings(
-                new UpdateSettingsRequest(mountedIndexName).settings(Map.of(DataTierAllocationDecider.INDEX_ROUTING_PREFER, tier))
-            )
+            .updateSettings(new UpdateSettingsRequest(mountedIndexName).settings(Map.of(DataTierAllocationDecider.TIER_PREFERENCE, tier)))
             .actionGet();
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -205,7 +205,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
                 .indices()
                 .prepareGetSettings(SNAPSHOT_BLOB_CACHE_INDEX)
                 .get()
-                .getSetting(SNAPSHOT_BLOB_CACHE_INDEX, DataTierAllocationDecider.INDEX_ROUTING_PREFER),
+                .getSetting(SNAPSHOT_BLOB_CACHE_INDEX, DataTierAllocationDecider.TIER_PREFERENCE),
             equalTo("data_content,data_hot")
         );
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.cluster.routing.allocation.decider.EnableAllocat
 import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.TIER_PREFERENCE;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -163,7 +163,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
                 .build()
         );
 
-        createIndex("other-index", Settings.builder().putNull(INDEX_ROUTING_PREFER).build());
+        createIndex("other-index", Settings.builder().putNull(TIER_PREFERENCE).build());
         ensureGreen("other-index");
         final RoutingNodes routingNodes = client().admin()
             .cluster()

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -592,7 +592,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .put(IndexMetadata.SETTING_PRIORITY, "900")
             .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC)
-            .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_TIERS_CACHE_INDEX_PREFERENCE)
+            .put(DataTierAllocationDecider.TIER_PREFERENCE, DATA_TIERS_CACHE_INDEX_PREFERENCE)
             .build();
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -72,7 +72,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
     RestoreSnapshotResponse> {
 
     private static final Collection<Setting<String>> DATA_TIER_ALLOCATION_SETTINGS = List.of(
-        DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING
+        DataTierAllocationDecider.TIER_PREFERENCE_SETTING
     );
 
     private final Client client;
@@ -233,7 +233,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0) // can be overridden
                 .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false) // can be overridden
                 .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), false) // can be overridden
-                .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, request.storage().defaultDataTiersPreference())
+                .put(DataTierAllocationDecider.TIER_PREFERENCE, request.storage().defaultDataTiersPreference())
                 .put(request.indexSettings())
                 .put(
                     buildIndexSettings(


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/76147, this is a cleanup and refactoring PR that just gets some groundwork out of the way -- here as a separate PR to keep overall noise down.

Reviewing commit by commit is probably easiest.