### PR TITLE
[7.x] Adds some REST tests for boxplot metric aggregations. (#78354)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/boxplot.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/boxplot.yml
@@ -35,6 +35,11 @@ setup:
           - index:
               _index: "latency"
           - load_time: 15
+
+          - index:
+              _index: "latency"
+          - { }
+
 ---
 "Basic Search":
 
@@ -54,3 +59,55 @@ setup:
   - match: { aggregations.plot.q2: 5.0 }
   - match: { aggregations.plot.q3: 11.25 }
 
+---
+"Search With Runtime Field":
+
+  - do:
+      search:
+        index: "latency"
+        body:
+          query:
+            exists:
+              field: load_time
+          runtime_mappings:
+            load_time_adjusted:
+              type: long
+              script:
+                source: "emit((long)((doc['load_time'].value == 10 ? 1000 : doc['load_time'].value) * params.multiplier))"
+                params:
+                  multiplier: 10
+          size: 0
+          aggs:
+            plot:
+              boxplot:
+                field: "load_time_adjusted"
+
+  - match: { aggregations.plot.min: 20.0 }
+  - match: { aggregations.plot.max: 10000.0 }
+  - match: { aggregations.plot.q1: 27.5 }
+  - match: { aggregations.plot.q2: 50.0 }
+  - match: { aggregations.plot.q3: 2612.5 }
+  - match: { aggregations.plot.lower: 20.0 }
+  - match: { aggregations.plot.upper: 150.0 }
+
+---
+"Search With Missing":
+
+  - do:
+      search:
+        index: "latency"
+        body:
+          size: 0
+          aggs:
+            plot:
+              boxplot:
+                field: "load_time"
+                missing: 10000
+
+  - match: { aggregations.plot.min: 2.0 }
+  - match: { aggregations.plot.max: 10000.0 }
+  - match: { aggregations.plot.q1: 3 }
+  - match: { aggregations.plot.q2: 7.5 }
+  - match: { aggregations.plot.q3: 15.0 }
+  - match: { aggregations.plot.lower: 2.0 }
+  - match: { aggregations.plot.upper: 15.0 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adds some REST tests for boxplot metric aggregations. (#78354)