### PR TITLE
[7.x] Ensure remote-cluster cluster is available when configuring tasks using it (#78397)

### DIFF
--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -12,9 +12,12 @@ apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
+
 dependencies {
   testImplementation project(":client:rest-high-level")
 }
+
+testClusters.register('remote-cluster')
 
 tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure remote-cluster cluster is available when configuring tasks using it (#78397)