### PR TITLE
Prevent Duplicate ILM Cluster State Updates from Being Created (#78390)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/BranchingStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/BranchingStep.java
@@ -27,10 +27,10 @@ public class BranchingStep extends ClusterStateActionStep {
 
     private static final Logger logger = LogManager.getLogger(BranchingStep.class);
 
-    private StepKey nextStepKeyOnFalse;
-    private StepKey nextStepKeyOnTrue;
-    private BiPredicate<Index, ClusterState> predicate;
-    private SetOnce<Boolean> predicateValue;
+    private final StepKey nextStepKeyOnFalse;
+    private final StepKey nextStepKeyOnTrue;
+    private final BiPredicate<Index, ClusterState> predicate;
+    private final SetOnce<Boolean> predicateValue;
 
     /**
      * {@link BranchingStep} is a step whose next step is based on

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ilm;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
+
+/**
+ * Base class for index lifecycle cluster state update tasks that requires implementing {@code equals} and {@code hashCode} to allow
+ * for these tasks to be deduplicated by {@link IndexLifecycleRunner}.
+ */
+public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateUpdateTask {
+
+    private final ListenableFuture<Void> listener = new ListenableFuture<>();
+
+    @Override
+    public final void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+        listener.onResponse(null);
+        onClusterStateProcessed(source, oldState, newState);
+    }
+
+    @Override
+    public final void onFailure(String source, Exception e) {
+        listener.onFailure(e);
+        handleFailure(source, e);
+    }
+
+    /**
+     * Add a listener that is resolved once this update has been processed or failed and before either the
+     * {@link #onClusterStateProcessed(String, ClusterState, ClusterState)} or the {@link #handleFailure(String, Exception)} hooks are
+     * executed.
+     */
+    public final void addListener(ActionListener<Void> listener) {
+        this.listener.addListener(listener);
+    }
+
+    /**
+     * This method is functionally the same as {@link ClusterStateUpdateTask#clusterStateProcessed(String, ClusterState, ClusterState)}
+     * and implementations can override it as they would override {@code ClusterStateUpdateTask#clusterStateProcessed}.
+     */
+    protected void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+    }
+
+    @Override
+    public abstract boolean equals(Object other);
+
+    @Override
+    public abstract int hashCode();
+
+    /**
+     * This method is functionally the same as {@link ClusterStateUpdateTask#onFailure(String, Exception)} and implementations can override
+     * it as they would override {@code ClusterStateUpdateTask#onFailure}.
+     */
+    protected abstract void handleFailure(String source, Exception e);
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -78,8 +78,8 @@ public class IndexLifecycleService
     private final PolicyStepsRegistry policyRegistry;
     private final IndexLifecycleRunner lifecycleRunner;
     private final Settings settings;
-    private ClusterService clusterService;
-    private LongSupplier nowSupplier;
+    private final ClusterService clusterService;
+    private final LongSupplier nowSupplier;
     private SchedulerEngine.Job scheduledJob;
 
     public IndexLifecycleService(Settings settings, Client client, ClusterService clusterService, ThreadPool threadPool, Clock clock,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -8,9 +8,8 @@ package org.elasticsearch.xpack.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchException;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -18,10 +17,11 @@ import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Step;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 
-public class MoveToNextStepUpdateTask extends ClusterStateUpdateTask {
+public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTask {
     private static final Logger logger = LogManager.getLogger(MoveToNextStepUpdateTask.class);
 
     private final Index index;
@@ -42,22 +42,6 @@ public class MoveToNextStepUpdateTask extends ClusterStateUpdateTask {
         this.nowSupplier = nowSupplier;
         this.stepRegistry = stepRegistry;
         this.stateChangeConsumer = stateChangeConsumer;
-    }
-
-    Index getIndex() {
-        return index;
-    }
-
-    String getPolicy() {
-        return policy;
-    }
-
-    Step.StepKey getCurrentStepKey() {
-        return currentStepKey;
-    }
-
-    Step.StepKey getNextStepKey() {
-        return nextStepKey;
     }
 
     @Override
@@ -82,15 +66,36 @@ public class MoveToNextStepUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
         if (oldState.equals(newState) == false) {
             stateChangeConsumer.accept(newState);
         }
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
-        throw new ElasticsearchException("policy [" + policy + "] for index [" + index.getName() + "] failed trying to move from step ["
-                + currentStepKey + "] to step [" + nextStepKey + "].", e);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MoveToNextStepUpdateTask that = (MoveToNextStepUpdateTask) o;
+        return index.equals(that.index)
+            && policy.equals(that.policy)
+            && currentStepKey.equals(that.currentStepKey)
+            && nextStepKey.equals(that.nextStepKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, policy, currentStepKey, nextStepKey);
+    }
+
+    @Override
+    public void handleFailure(String source, Exception e) {
+        logger.warn(
+            new ParameterizedMessage(
+                "policy [{}] for index [{}] failed trying to move from step [{}] to step [{}].",
+                policy, index, currentStepKey, nextStepKey
+            ),
+            e
+        );
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -25,7 +24,7 @@ import org.elasticsearch.xpack.core.ilm.Step;
 import java.io.IOException;
 import java.util.Objects;
 
-public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
+public class SetStepInfoUpdateTask extends IndexLifecycleClusterStateUpdateTask {
 
     private static final Logger logger = LogManager.getLogger(SetStepInfoUpdateTask.class);
 
@@ -78,9 +77,28 @@ public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
-        logger.warn(new ParameterizedMessage("policy [{}] for index [{}] failed trying to set step info for step [{}].",
-                policy, index.getName(), currentStepKey), e);
+    public void handleFailure(String source, Exception e) {
+        logger.warn(
+            new ParameterizedMessage(
+                "policy [{}] for index [{}] failed trying to set step info for step [{}].",
+                policy, index, currentStepKey
+            ),
+            e
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SetStepInfoUpdateTask that = (SetStepInfoUpdateTask) o;
+        return index.equals(that.index) && policy.equals(that.policy)
+            && currentStepKey.equals(that.currentStepKey) && Objects.equals(stepInfo, that.stepInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, policy, currentStepKey, stepInfo);
     }
 
     public static class ExceptionWrapper implements ToXContentObject {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK
 
 public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
 
-    private static Logger logger = LogManager.getLogger(SnapshotLifecycleTask.class);
+    private static final Logger logger = LogManager.getLogger(SnapshotLifecycleTask.class);
 
     private final Client client;
     private final ClusterService clusterService;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ilm;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -250,11 +249,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         long now = randomNonNegativeLong();
         ExecuteStepsUpdateTask task = new ExecuteStepsUpdateTask(mixedPolicyName, index, startStep, policyStepsRegistry, null, () -> now);
         Exception expectedException = new RuntimeException();
-        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-                () -> task.onFailure(randomAlphaOfLength(10), expectedException));
-        assertEquals("policy [" + mixedPolicyName + "] for index [" + index.getName() + "] failed on step [" + startStep.getKey() + "].",
-                exception.getMessage());
-        assertSame(expectedException, exception.getCause());
+        task.onFailure(randomAlphaOfLength(10), expectedException);
     }
 
     public void testClusterActionStepThrowsException() throws IOException {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -164,8 +164,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
 
-        Mockito.verify(clusterService, times(2)).submitStateUpdateTask(any(), any());
-
+        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(any(), any());
     }
 
     public void testRunPolicyErrorStep() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ilm;
 
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -139,11 +138,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         MoveToNextStepUpdateTask task = new MoveToNextStepUpdateTask(index, policy, currentStepKey, nextStepKey, () -> now,
             new AlwaysExistingStepRegistry(), state -> {});
         Exception expectedException = new RuntimeException();
-        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-                () -> task.onFailure(randomAlphaOfLength(10), expectedException));
-        assertEquals("policy [" + policy + "] for index [" + index.getName() + "] failed trying to move from step [" + currentStepKey
-                + "] to step [" + nextStepKey + "].", exception.getMessage());
-        assertSame(expectedException, exception.getCause());
+        task.onFailure(randomAlphaOfLength(10), expectedException);
     }
 
     /**

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -126,7 +126,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
                         "warning",
                         SetStepInfoUpdateTask.class.getCanonicalName(),
                         Level.WARN,
-                        "*policy [" + policy + "] for index [" + index.getName() + "] failed trying to set step info for step ["
+                        "*policy [" + policy + "] for index [" + index + "] failed trying to set step info for step ["
                                 + currentStepKey + "]."));
 
         final Logger taskLogger = LogManager.getLogger(SetStepInfoUpdateTask.class);


### PR DESCRIPTION
Prevent duplicate ILM tasks from being enqueued to fix the most immediate issues around #78246. The ILM logic should be further improved though. I did not include `MoveToErrorStepUpdateTask` in this change yet as I wasn't entirely sure how valid/safe hashing/comparing arbitrary `Exception`s would be. That could be looked into in a follow-up as well.

Relates #77466 

Closes #78246

backport of #78390 