### PR TITLE
Remove server jar accessDeclaredMembers permission

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -22,8 +22,6 @@ grant codeBase "${codebase.elasticsearch-secure-sm}" {
 grant codeBase "${codebase.elasticsearch}" {
   // needed for loading plugins which may expect the context class loader to be set
   permission java.lang.RuntimePermission "setContextClassLoader";
-  // needed for SPI class loading
-  permission java.lang.RuntimePermission "accessDeclaredMembers";
   // needed by HotThreads to enable wait/block time accounting on demand
   permission java.lang.management.ManagementPermission "control";
 };


### PR DESCRIPTION
We added this permission to get CI passing with the initial lucene 9 upgrade,
but it turns out this was only necessary for SPI reloading of analysis components,
which we do separately.  This commit removes the permission.