### PR TITLE
Adjust assertion in BlobStoreCacheMaintenanceService

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
@@ -143,7 +143,8 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
 
             for (Index deletedIndex : event.indicesDeleted()) {
                 final IndexMetadata indexMetadata = event.previousState().metadata().index(deletedIndex);
-                assert indexMetadata != null : "no previous metadata found for " + deletedIndex;
+                assert indexMetadata != null || state.metadata().indexGraveyard().containsIndex(deletedIndex)
+                    : "no previous metadata found for " + deletedIndex;
                 if (indexMetadata != null) {
                     final Settings indexSetting = indexMetadata.getSettings();
                     if (SearchableSnapshotsSettings.isSearchableSnapshotStore(indexSetting)) {


### PR DESCRIPTION
If the deleted index comes from the index graveyard there is
no index metadata in the previous cluster state.

Closes #78316