### PR TITLE
Fix 'part' type for put_trained_model_definition_part API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_definition_part.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_definition_part.json
@@ -23,7 +23,7 @@
               "description":"The ID of the trained model for this definition part"
             },
             "part":{
-              "type":"integer",
+              "type":"int",
               "description":"The part number"
             }
           }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/76987 introduced this spec file but it seems the type for `Part` has slipped review.

`Part` type should be `int` instead of `integer` according to [spec](https://github.com/elastic/elasticsearch/tree/main/rest-api-spec)!