### PR TITLE
EQL: Introduce repeatable queries (#75082)

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -228,19 +228,35 @@ sequence by unique_pid
   [any where true]
   [any where serial_event_id < 72]
 '''
-expected_event_ids  = [
-                       54, 55, 59,
-                       55, 59, 61,
-                       59, 61, 65,
-                       16, 60, 66,
-                       61, 65, 67,
-                       65, 67, 70,
-                       60, 66, 71]
+expected_event_ids = [
+                      54, 55, 59,
+                      55, 59, 61,
+                      59, 61, 65,
+                      16, 60, 66,
+                      61, 65, 67,
+                      65, 67, 70,
+                      60, 66, 71]
+
+[[queries]]
+name = "sequenceWithMoreThan10Results-Runs"
+query = '''
+sequence by unique_pid
+  [any where true] [runs=2]
+  [any where serial_event_id < 72]
+'''
+expected_event_ids = [
+                      54, 55, 59,
+                      55, 59, 61,
+                      59, 61, 65,
+                      16, 60, 66,
+                      61, 65, 67,
+                      65, 67, 70,
+                      60, 66, 71]
 
 [[queries]]
 name = "seqSingleArg"
 query = 'process where string(serial_event_id) : ("1")'
-expected_event_ids  = [1]
+expected_event_ids = [1]
 
 [[queries]]
 name = "seqSingleArgPattern"

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -554,7 +554,16 @@ sequence
   [process where true]
   [process where true]
 '''
-expected_event_ids  = [1, 2, 3]
+expected_event_ids = [1, 2, 3]
+
+[[queries]]
+name = "sequenceOneManyMany-Runs"
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where true] [runs=2]
+'''
+expected_event_ids = [1, 2, 3]
 
 [[queries]]
 name = "sequenceConditionManyMany"
@@ -567,6 +576,18 @@ sequence
 expected_event_ids = [1, 2, 3,
                       2, 3, 4,
                       3, 4, 5]
+
+[[queries]]
+name = "sequenceConditionManyMany-Runs"
+query = '''
+sequence
+  [process where serial_event_id <= 3]
+  [process where true] [runs=2]
+'''
+expected_event_ids = [1, 2, 3,
+                      2, 3, 4,
+                      3, 4, 5]
+
 [[queries]]
 name = "sequenceManyConditionMany"
 query = '''
@@ -577,6 +598,7 @@ sequence
 '''
 expected_event_ids = [1, 2, 3,
                       2, 3, 4]
+
 [[queries]]
 name = "sequenceManyManyCondition"
 query = '''
@@ -585,7 +607,16 @@ sequence
   [process where true]
   [process where serial_event_id <= 3]
 '''
-expected_event_ids  = [1, 2, 3]
+expected_event_ids = [1, 2, 3]
+
+[[queries]]
+name = "sequenceManyManyCondition-Runs"
+query = '''
+sequence
+  [process where true] [runs=2]
+  [process where serial_event_id <= 3]
+'''
+expected_event_ids = [1, 2, 3]
 
 [[queries]]
 name = "sequenceThreeManyCondition1"
@@ -596,10 +627,22 @@ sequence
   [process where true]
   [process where true]
 '''
-expected_event_ids  = [1, 2, 3, 4,
-                       2, 3, 4, 5,
-                       3, 4, 5, 6,
-                       4, 5, 6, 7]
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5,
+                      3, 4, 5, 6,
+                      4, 5, 6, 7]
+
+[[queries]]
+name = "sequenceThreeManyCondition1-Runs"
+query = '''
+sequence
+  [process where serial_event_id <= 4]
+  [process where true] [runs=3]
+'''
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5,
+                      3, 4, 5, 6,
+                      4, 5, 6, 7]
 
 [[queries]]
 name = "sequenceThreeManyCondition2"
@@ -610,9 +653,21 @@ sequence
   [process where true]
   [process where true]
 '''
-expected_event_ids  = [1, 2, 3, 4,
-                       2, 3, 4, 5,
-                       3, 4, 5, 6]
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5,
+                      3, 4, 5, 6]
+
+[[queries]]
+name = "sequenceThreeManyCondition2-Runs"
+query = '''
+sequence
+  [process where true]
+  [process where serial_event_id <= 4]
+  [process where true] [runs=2]
+'''
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5,
+                      3, 4, 5, 6]
 
 [[queries]]
 name = "sequenceThreeManyCondition3"
@@ -623,8 +678,19 @@ sequence
   [process where serial_event_id <= 4]
   [process where true]
 '''
-expected_event_ids  = [1, 2, 3, 4,
-                       2, 3, 4, 5]
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5]
+
+[[queries]]
+name = "sequenceThreeManyCondition3-Runs"
+query = '''
+sequence
+  [process where true] [runs=2]
+  [process where serial_event_id <= 4]
+  [process where true]
+'''
+expected_event_ids = [1, 2, 3, 4,
+                      2, 3, 4, 5]
 
 [[queries]]
 name = "sequenceThreeManyCondition4"
@@ -635,7 +701,16 @@ sequence
   [process where true]
   [process where serial_event_id <= 4]
 '''
-expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = [1, 2, 3, 4]
+
+[[queries]]
+name = "sequenceThreeManyCondition4-Runs"
+query = '''
+sequence
+  [process where true] [runs=3]
+  [process where serial_event_id <= 4]
+'''
+expected_event_ids = [1, 2, 3, 4]
 
 [[queries]]
 name = "twoSequencesWithKeys"
@@ -644,10 +719,10 @@ sequence
   [process where true]        by unique_pid
   [process where opcode == 1] by unique_ppid
 '''
-expected_event_ids  = [48, 53,
-                       53, 54,
-                       54, 56,
-                       97, 98]
+expected_event_ids = [48, 53,
+                      53, 54,
+                      54, 56,
+                      97, 98]
 
 [[queries]]
 name = "twoSequencesWithTwoKeys"
@@ -672,7 +747,19 @@ sequence
 until
   [file where opcode == 2]    by unique_pid
 '''
-expected_event_ids  = []
+expected_event_ids = []
+
+[[queries]]
+name = "fourSequencesByPidWithUntil1-Runs"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid  [runs=3]
+until
+  [file where opcode == 2]    by unique_pid
+'''
+expected_event_ids = []
+
 
 [[queries]]
 name = "fourSequencesByPidWithUntil2"
@@ -685,7 +772,19 @@ sequence
 until
   [file where opcode == 200]  by unique_pid
 '''
-expected_event_ids  = [54, 55, 61, 67]
+expected_event_ids = [54, 55, 61, 67]
+
+[[queries]]
+name = "fourSequencesByPidWithUntil2-Runs"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid  [runs=3]
+until
+  [file where opcode == 200]  by unique_pid
+'''
+expected_event_ids = [54, 55, 61, 67]
+
 
 #[[queries]]
 #name = "fourSequencesByPidWithUntil3"
@@ -707,7 +806,16 @@ sequence
   [file where opcode == 0]    by unique_pid
   [file where opcode == 0]    by unique_pid
 '''
-expected_event_ids  = [54, 55, 61, 67]
+expected_event_ids = [54, 55, 61, 67]
+
+[[queries]]
+name = "fourSequencesByPid-Runs"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid  [runs=3]
+'''
+expected_event_ids = [54, 55, 61, 67]
 
 
 [[queries]]
@@ -719,8 +827,16 @@ sequence
   [file where opcode == 0]    by unique_pid,  process_path
   [file where opcode == 0]    by unique_pid,  process_path
 '''
-expected_event_ids  = [54, 55, 61, 67]
+expected_event_ids = [54, 55, 61, 67]
 
+[[queries]]
+name = "fourSequencesByPidAndProcessPath1-Runs"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path [runs=3]
+'''
+expected_event_ids = [54, 55, 61, 67]
 
 [[queries]]
 name = "fourSequencesByPidAndProcessPathWithUntil"
@@ -733,7 +849,30 @@ sequence
 until
   [file where opcode == 200]  by unique_pid,  process_path
 '''
-expected_event_ids  = [54, 55, 61, 67]
+expected_event_ids = [54, 55, 61, 67]
+
+[[queries]]
+name = "fourSequencesByPidAndProcessPathWithUntil-Runs"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path [runs=3]
+until
+  [file where opcode == 200]  by unique_pid,  process_path
+'''
+expected_event_ids = [54, 55, 61, 67]
+
+[[queries]]
+name = "fourSequencesByPidAndProcessPathWithUntil-RunsExtra"
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path [runs=2]
+  [file where opcode == 0]    by unique_pid,  process_path [runs=1]
+until
+  [file where opcode == 200]  by unique_pid,  process_path
+'''
+expected_event_ids = [54, 55, 61, 67]
 
 [[queries]]
 name = "sequenceOneManyWithJoin"
@@ -742,7 +881,7 @@ sequence
   [process where serial_event_id==1] by unique_pid
   [process where true] by unique_ppid
 '''
-expected_event_ids  = [1, 2]
+expected_event_ids = [1, 2]
 
 
 [[queries]]
@@ -879,9 +1018,20 @@ sequence
   [process where serial_event_id < 5]
   [process where serial_event_id < 5]
 '''
-expected_event_ids  = [1, 2,
-                       2, 3,
-                       3, 4]
+expected_event_ids = [1, 2,
+                      2, 3,
+                      3, 4]
+
+[[queries]]
+name = "doubleSameSequence-Runs"
+query = '''
+sequence
+  [process where serial_event_id < 5] [runs=2]
+'''
+expected_event_ids = [1, 2,
+                      2, 3,
+                      3, 4]
+
 
 [[queries]]
 name = "sequencesOnDifferentEventTypesWithBy"
@@ -890,7 +1040,7 @@ sequence
   [file where opcode==0 and file_name:"svchost.exe"] by unique_pid
   [process where opcode == 1] by unique_ppid
 '''
-expected_event_ids  = [55, 56]
+expected_event_ids = [55, 56]
 
 [[queries]]
 name = "doubleSameSequenceWithBy"
@@ -900,7 +1050,17 @@ sequence
   [file where opcode==0] by unique_pid
 | head 1
 '''
-expected_event_ids  = [55, 61]
+expected_event_ids = [55, 61]
+
+[[queries]]
+name = "doubleSameSequenceWithBy-Runs"
+query = '''
+sequence
+  [file where opcode==0] by unique_pid  [runs=2]
+| head 1
+'''
+expected_event_ids = [55, 61]
+
 
 #[[queries]]
 #name = "doubleSameSequenceWithByAndFilter"
@@ -921,7 +1081,17 @@ sequence
 until [process where opcode==5000] by unique_ppid
 | head 1
 '''
-expected_event_ids  = [55, 61]
+expected_event_ids = [55, 61]
+
+[[queries]]
+name = "doubleSameSequenceWithByUntilAndHead1-Runs"
+query = '''
+sequence
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid [runs=2]
+until [process where opcode==5000] by unique_ppid
+| head 1
+'''
+expected_event_ids = [55, 61]
 
 [[queries]]
 name = "doubleSameSequenceWithByUntilAndHead2"
@@ -929,6 +1099,16 @@ query = '''
 sequence
   [file where opcode==0 and file_name:"*.exe"] by unique_pid
   [file where opcode==0 and file_name:"*.exe"] by unique_pid
+until [process where opcode==1] by unique_ppid
+| head 1
+'''
+expected_event_ids = []
+
+[[queries]]
+name = "doubleSameSequenceWithByUntilAndHead2-Runs"
+query = '''
+sequence
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid [runs=2]
 until [process where opcode==1] by unique_ppid
 | head 1
 '''

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
@@ -384,6 +384,25 @@ time = 2.8286166191101074
 type = "sequence"
 
 [[queries]]
+queryNo = 231
+count = 0
+expected_event_ids = []
+filter_counts = [6, 6, 6, 6]
+filters = [
+  'security where hostname != "newyork" and event_id == 4625',
+  'security where hostname != "newyork" and event_id == 4625',
+  'security where hostname != "newyork" and event_id == 4625',
+  'security where hostname != "newyork" and event_id == 4625'
+]
+query = '''
+sequence by source_address, hostname with maxspan=5s
+  [security where hostname != "newyork" and event_id == 4625] [runs=4]
+'''
+time = 2.8286166191101074
+type = "sequence"
+
+
+[[queries]]
 queryNo = 24
 count = 1
 expected_event_ids = [2860083, 2860090, 2860098]
@@ -398,6 +417,23 @@ sequence by source_address, hostname with maxspan=10s
   [security where hostname != "newyork" and event_id == 4625]
   [security where hostname != "newyork" and event_id == 4625]
   [security where hostname != "newyork" and event_id == 4625]
+'''
+time = 2.765869617462158
+type = "sequence"
+
+[[queries]]
+queryNo = 241
+count = 1
+expected_event_ids = [2860083, 2860090, 2860098]
+filter_counts = [6, 6, 6]
+filters = [
+  'security where hostname != "newyork" and event_id == 4625',
+  'security where hostname != "newyork" and event_id == 4625',
+  'security where hostname != "newyork" and event_id == 4625'
+]
+query = '''
+sequence by source_address, hostname with maxspan=10s
+  [security where hostname != "newyork" and event_id == 4625] [runs=3]
 '''
 time = 2.765869617462158
 type = "sequence"

--- a/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
+++ b/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
@@ -32,7 +32,7 @@ sequenceParams
 
 sequence
     : SEQUENCE (by=joinKeys sequenceParams? | sequenceParams disallowed=joinKeys?)?
-      sequenceTerm sequenceTerm+
+      sequenceTerm+
       (UNTIL until=sequenceTerm)?
     ;
 
@@ -56,7 +56,7 @@ joinTerm
    ;
 
 sequenceTerm
-   : subquery (by=joinKeys)?
+   : subquery (by=joinKeys)? (LB key=IDENTIFIER ASGN value=number RB)?
    ;
 
 subquery

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
@@ -412,14 +412,14 @@ class EqlBaseParser extends Parser {
     public JoinKeysContext disallowed;
     public SequenceTermContext until;
     public TerminalNode SEQUENCE() { return getToken(EqlBaseParser.SEQUENCE, 0); }
+    public SequenceParamsContext sequenceParams() {
+      return getRuleContext(SequenceParamsContext.class,0);
+    }
     public List<SequenceTermContext> sequenceTerm() {
       return getRuleContexts(SequenceTermContext.class);
     }
     public SequenceTermContext sequenceTerm(int i) {
       return getRuleContext(SequenceTermContext.class,i);
-    }
-    public SequenceParamsContext sequenceParams() {
-      return getRuleContext(SequenceParamsContext.class,0);
     }
     public TerminalNode UNTIL() { return getToken(EqlBaseParser.UNTIL, 0); }
     public JoinKeysContext joinKeys() {
@@ -493,30 +493,28 @@ class EqlBaseParser extends Parser {
       default:
         break;
       }
-      setState(96);
-      sequenceTerm();
-      setState(98); 
+      setState(97); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
         {
         {
-        setState(97);
+        setState(96);
         sequenceTerm();
         }
         }
-        setState(100); 
+        setState(99); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
-      setState(104);
+      setState(103);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==UNTIL) {
         {
-        setState(102);
+        setState(101);
         match(UNTIL);
-        setState(103);
+        setState(102);
         ((SequenceContext)_localctx).until = sequenceTerm();
         }
       }
@@ -574,42 +572,42 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(106);
+      setState(105);
       match(JOIN);
-      setState(108);
+      setState(107);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(107);
+        setState(106);
         ((JoinContext)_localctx).by = joinKeys();
         }
       }
 
-      setState(110);
+      setState(109);
       joinTerm();
-      setState(112); 
+      setState(111); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
         {
         {
-        setState(111);
+        setState(110);
         joinTerm();
         }
         }
-        setState(114); 
+        setState(113); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
-      setState(118);
+      setState(117);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==UNTIL) {
         {
-        setState(116);
+        setState(115);
         match(UNTIL);
-        setState(117);
+        setState(116);
         ((JoinContext)_localctx).until = joinTerm();
         }
       }
@@ -667,30 +665,30 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(120);
+      setState(119);
       match(PIPE);
-      setState(121);
+      setState(120);
       ((PipeContext)_localctx).kind = match(IDENTIFIER);
-      setState(130);
+      setState(129);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER) | (1L << QUOTED_IDENTIFIER) | (1L << TILDE_IDENTIFIER))) != 0)) {
         {
-        setState(122);
+        setState(121);
         booleanExpression(0);
-        setState(127);
+        setState(126);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(123);
+          setState(122);
           match(COMMA);
-          setState(124);
+          setState(123);
           booleanExpression(0);
           }
           }
-          setState(129);
+          setState(128);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
@@ -748,23 +746,23 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(132);
+      setState(131);
       match(BY);
-      setState(133);
+      setState(132);
       expression();
-      setState(138);
+      setState(137);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==COMMA) {
         {
         {
-        setState(134);
+        setState(133);
         match(COMMA);
-        setState(135);
+        setState(134);
         expression();
         }
         }
-        setState(140);
+        setState(139);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -815,14 +813,14 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(141);
+      setState(140);
       subquery();
-      setState(143);
+      setState(142);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(142);
+        setState(141);
         ((JoinTermContext)_localctx).by = joinKeys();
         }
       }
@@ -842,11 +840,20 @@ class EqlBaseParser extends Parser {
 
   public static class SequenceTermContext extends ParserRuleContext {
     public JoinKeysContext by;
+    public Token key;
+    public NumberContext value;
     public SubqueryContext subquery() {
       return getRuleContext(SubqueryContext.class,0);
     }
+    public TerminalNode LB() { return getToken(EqlBaseParser.LB, 0); }
+    public TerminalNode ASGN() { return getToken(EqlBaseParser.ASGN, 0); }
+    public TerminalNode RB() { return getToken(EqlBaseParser.RB, 0); }
     public JoinKeysContext joinKeys() {
       return getRuleContext(JoinKeysContext.class,0);
+    }
+    public TerminalNode IDENTIFIER() { return getToken(EqlBaseParser.IDENTIFIER, 0); }
+    public NumberContext number() {
+      return getRuleContext(NumberContext.class,0);
     }
     public SequenceTermContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
@@ -874,18 +881,36 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(145);
+      setState(144);
       subquery();
-      setState(147);
+      setState(146);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(146);
+        setState(145);
         ((SequenceTermContext)_localctx).by = joinKeys();
         }
       }
 
+      setState(154);
+      _errHandler.sync(this);
+      switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
+      case 1:
+        {
+        setState(148);
+        match(LB);
+        setState(149);
+        ((SequenceTermContext)_localctx).key = match(IDENTIFIER);
+        setState(150);
+        match(ASGN);
+        setState(151);
+        ((SequenceTermContext)_localctx).value = number();
+        setState(152);
+        match(RB);
+        }
+        break;
+      }
       }
     }
     catch (RecognitionException re) {
@@ -930,11 +955,11 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(149);
+      setState(156);
       match(LB);
-      setState(150);
+      setState(157);
       eventFilter();
-      setState(151);
+      setState(158);
       match(RB);
       }
     }
@@ -978,7 +1003,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(153);
+      setState(160);
       eventFilter();
       }
     }
@@ -1028,28 +1053,28 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(157);
+      setState(164);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case ANY:
         {
-        setState(155);
+        setState(162);
         match(ANY);
         }
         break;
       case STRING:
       case IDENTIFIER:
         {
-        setState(156);
+        setState(163);
         ((EventFilterContext)_localctx).event = eventValue();
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(159);
+      setState(166);
       match(WHERE);
-      setState(160);
+      setState(167);
       expression();
       }
     }
@@ -1093,7 +1118,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(162);
+      setState(169);
       booleanExpression(0);
       }
     }
@@ -1223,18 +1248,18 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(171);
+      setState(178);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
       case 1:
         {
         _localctx = new LogicalNotContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(165);
+        setState(172);
         match(NOT);
-        setState(166);
+        setState(173);
         booleanExpression(5);
         }
         break;
@@ -1243,11 +1268,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ProcessCheckContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(167);
+        setState(174);
         ((ProcessCheckContext)_localctx).relationship = match(IDENTIFIER);
-        setState(168);
+        setState(175);
         match(OF);
-        setState(169);
+        setState(176);
         subquery();
         }
         break;
@@ -1256,33 +1281,33 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanDefaultContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(170);
+        setState(177);
         valueExpression();
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(181);
+      setState(188);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(179);
+          setState(186);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
           case 1:
             {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(173);
+            setState(180);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(174);
+            setState(181);
             ((LogicalBinaryContext)_localctx).operator = match(AND);
-            setState(175);
+            setState(182);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(3);
             }
             break;
@@ -1291,20 +1316,20 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(176);
+            setState(183);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(177);
+            setState(184);
             ((LogicalBinaryContext)_localctx).operator = match(OR);
-            setState(178);
+            setState(185);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(2);
             }
             break;
           }
           } 
         }
-        setState(183);
+        setState(190);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
       }
       }
     }
@@ -1381,14 +1406,14 @@ class EqlBaseParser extends Parser {
     ValueExpressionContext _localctx = new ValueExpressionContext(_ctx, getState());
     enterRule(_localctx, 32, RULE_valueExpression);
     try {
-      setState(189);
+      setState(196);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
       case 1:
         _localctx = new ValueExpressionDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(184);
+        setState(191);
         operatorExpression(0);
         }
         break;
@@ -1396,11 +1421,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ComparisonContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(185);
+        setState(192);
         ((ComparisonContext)_localctx).left = operatorExpression(0);
-        setState(186);
+        setState(193);
         comparisonOperator();
-        setState(187);
+        setState(194);
         ((ComparisonContext)_localctx).right = operatorExpression(0);
         }
         break;
@@ -1519,7 +1544,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(198);
+      setState(205);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case FALSE:
@@ -1537,14 +1562,14 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(192);
+        setState(199);
         primaryExpression();
-        setState(194);
+        setState(201);
         _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
+        switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
         case 1:
           {
-          setState(193);
+          setState(200);
           predicate();
           }
           break;
@@ -1557,7 +1582,7 @@ class EqlBaseParser extends Parser {
         _localctx = new ArithmeticUnaryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(196);
+        setState(203);
         ((ArithmeticUnaryContext)_localctx).operator = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1568,7 +1593,7 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(197);
+        setState(204);
         operatorExpression(3);
         }
         break;
@@ -1576,25 +1601,25 @@ class EqlBaseParser extends Parser {
         throw new NoViableAltException(this);
       }
       _ctx.stop = _input.LT(-1);
-      setState(208);
+      setState(215);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(206);
+          setState(213);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,23,_ctx) ) {
           case 1:
             {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(200);
+            setState(207);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(201);
+            setState(208);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ASTERISK) | (1L << SLASH) | (1L << PERCENT))) != 0)) ) {
@@ -1605,7 +1630,7 @@ class EqlBaseParser extends Parser {
               _errHandler.reportMatch(this);
               consume();
             }
-            setState(202);
+            setState(209);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(3);
             }
             break;
@@ -1614,9 +1639,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(203);
+            setState(210);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(204);
+            setState(211);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1627,16 +1652,16 @@ class EqlBaseParser extends Parser {
               _errHandler.reportMatch(this);
               consume();
             }
-            setState(205);
+            setState(212);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(2);
             }
             break;
           }
           } 
         }
-        setState(210);
+        setState(217);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       }
       }
     }
@@ -1703,23 +1728,23 @@ class EqlBaseParser extends Parser {
     enterRule(_localctx, 36, RULE_predicate);
     int _la;
     try {
-      setState(240);
+      setState(247);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(212);
+        setState(219);
         _errHandler.sync(this);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(211);
+          setState(218);
           match(NOT);
           }
         }
 
-        setState(214);
+        setState(221);
         ((PredicateContext)_localctx).kind = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==IN || _la==IN_INSENSITIVE) ) {
@@ -1730,34 +1755,34 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(215);
+        setState(222);
         match(LP);
-        setState(216);
+        setState(223);
         expression();
-        setState(221);
+        setState(228);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(217);
+          setState(224);
           match(COMMA);
-          setState(218);
+          setState(225);
           expression();
           }
           }
-          setState(223);
+          setState(230);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(224);
+        setState(231);
         match(RP);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(226);
+        setState(233);
         ((PredicateContext)_localctx).kind = _input.LT(1);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LIKE) | (1L << LIKE_INSENSITIVE) | (1L << REGEX) | (1L << REGEX_INSENSITIVE) | (1L << SEQ))) != 0)) ) {
@@ -1768,14 +1793,14 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(227);
+        setState(234);
         constant();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(228);
+        setState(235);
         ((PredicateContext)_localctx).kind = _input.LT(1);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LIKE) | (1L << LIKE_INSENSITIVE) | (1L << REGEX) | (1L << REGEX_INSENSITIVE) | (1L << SEQ))) != 0)) ) {
@@ -1786,27 +1811,27 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(229);
+        setState(236);
         match(LP);
-        setState(230);
+        setState(237);
         constant();
-        setState(235);
+        setState(242);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(231);
+          setState(238);
           match(COMMA);
-          setState(232);
+          setState(239);
           constant();
           }
           }
-          setState(237);
+          setState(244);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(238);
+        setState(245);
         match(RP);
         }
         break;
@@ -1917,14 +1942,14 @@ class EqlBaseParser extends Parser {
     PrimaryExpressionContext _localctx = new PrimaryExpressionContext(_ctx, getState());
     enterRule(_localctx, 38, RULE_primaryExpression);
     try {
-      setState(249);
+      setState(256);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         _localctx = new ConstantDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(242);
+        setState(249);
         constant();
         }
         break;
@@ -1932,7 +1957,7 @@ class EqlBaseParser extends Parser {
         _localctx = new FunctionContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(243);
+        setState(250);
         functionExpression();
         }
         break;
@@ -1940,7 +1965,7 @@ class EqlBaseParser extends Parser {
         _localctx = new DereferenceContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(244);
+        setState(251);
         qualifiedName();
         }
         break;
@@ -1948,11 +1973,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ParenthesizedExpressionContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(245);
+        setState(252);
         match(LP);
-        setState(246);
+        setState(253);
         expression();
-        setState(247);
+        setState(254);
         match(RP);
         }
         break;
@@ -2012,37 +2037,37 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(251);
+      setState(258);
       ((FunctionExpressionContext)_localctx).name = functionName();
-      setState(252);
+      setState(259);
       match(LP);
-      setState(261);
+      setState(268);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER) | (1L << QUOTED_IDENTIFIER) | (1L << TILDE_IDENTIFIER))) != 0)) {
         {
-        setState(253);
+        setState(260);
         expression();
-        setState(258);
+        setState(265);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(254);
+          setState(261);
           match(COMMA);
-          setState(255);
+          setState(262);
           expression();
           }
           }
-          setState(260);
+          setState(267);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(263);
+      setState(270);
       match(RP);
       }
     }
@@ -2086,7 +2111,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(265);
+      setState(272);
       _la = _input.LA(1);
       if ( !(_la==IDENTIFIER || _la==TILDE_IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2199,14 +2224,14 @@ class EqlBaseParser extends Parser {
     ConstantContext _localctx = new ConstantContext(_ctx, getState());
     enterRule(_localctx, 44, RULE_constant);
     try {
-      setState(271);
+      setState(278);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(267);
+        setState(274);
         match(NULL);
         }
         break;
@@ -2215,7 +2240,7 @@ class EqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(268);
+        setState(275);
         number();
         }
         break;
@@ -2224,7 +2249,7 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(269);
+        setState(276);
         booleanValue();
         }
         break;
@@ -2232,7 +2257,7 @@ class EqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(270);
+        setState(277);
         string();
         }
         break;
@@ -2284,7 +2309,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(273);
+      setState(280);
       _la = _input.LA(1);
       if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << NEQ) | (1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -2336,7 +2361,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(275);
+      setState(282);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -2409,44 +2434,44 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(277);
+      setState(284);
       identifier();
-      setState(289);
+      setState(296);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,34,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,35,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
-          setState(287);
+          setState(294);
           _errHandler.sync(this);
           switch (_input.LA(1)) {
           case DOT:
             {
-            setState(278);
+            setState(285);
             match(DOT);
-            setState(279);
+            setState(286);
             identifier();
             }
             break;
           case LB:
             {
-            setState(280);
+            setState(287);
             match(LB);
-            setState(282); 
+            setState(289); 
             _errHandler.sync(this);
             _la = _input.LA(1);
             do {
               {
               {
-              setState(281);
+              setState(288);
               match(INTEGER_VALUE);
               }
               }
-              setState(284); 
+              setState(291); 
               _errHandler.sync(this);
               _la = _input.LA(1);
             } while ( _la==INTEGER_VALUE );
-            setState(286);
+            setState(293);
             match(RB);
             }
             break;
@@ -2455,9 +2480,9 @@ class EqlBaseParser extends Parser {
           }
           } 
         }
-        setState(291);
+        setState(298);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,34,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,35,_ctx);
       }
       }
     }
@@ -2501,7 +2526,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(292);
+      setState(299);
       _la = _input.LA(1);
       if ( !(_la==IDENTIFIER || _la==QUOTED_IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2556,14 +2581,14 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(294);
+      setState(301);
       number();
-      setState(296);
+      setState(303);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==IDENTIFIER) {
         {
-        setState(295);
+        setState(302);
         ((TimeUnitContext)_localctx).unit = match(IDENTIFIER);
         }
       }
@@ -2631,14 +2656,14 @@ class EqlBaseParser extends Parser {
     NumberContext _localctx = new NumberContext(_ctx, getState());
     enterRule(_localctx, 56, RULE_number);
     try {
-      setState(300);
+      setState(307);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(298);
+        setState(305);
         match(DECIMAL_VALUE);
         }
         break;
@@ -2646,7 +2671,7 @@ class EqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(299);
+        setState(306);
         match(INTEGER_VALUE);
         }
         break;
@@ -2692,7 +2717,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(302);
+      setState(309);
       match(STRING);
       }
     }
@@ -2736,7 +2761,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(304);
+      setState(311);
       _la = _input.LA(1);
       if ( !(_la==STRING || _la==IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2788,113 +2813,116 @@ class EqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\64\u0135\4\2\t\2"+
+    "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\64\u013c\4\2\t\2"+
     "\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
     "\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
     "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \3\2"+
     "\3\2\3\2\3\3\3\3\3\3\3\4\3\4\7\4I\n\4\f\4\16\4L\13\4\3\5\3\5\3\5\5\5Q"+
     "\n\5\3\6\3\6\3\6\3\6\3\6\3\7\3\7\3\7\5\7[\n\7\3\7\3\7\5\7_\n\7\5\7a\n"+
-    "\7\3\7\3\7\6\7e\n\7\r\7\16\7f\3\7\3\7\5\7k\n\7\3\b\3\b\5\bo\n\b\3\b\3"+
-    "\b\6\bs\n\b\r\b\16\bt\3\b\3\b\5\by\n\b\3\t\3\t\3\t\3\t\3\t\7\t\u0080\n"+
-    "\t\f\t\16\t\u0083\13\t\5\t\u0085\n\t\3\n\3\n\3\n\3\n\7\n\u008b\n\n\f\n"+
-    "\16\n\u008e\13\n\3\13\3\13\5\13\u0092\n\13\3\f\3\f\5\f\u0096\n\f\3\r\3"+
-    "\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17\u00a0\n\17\3\17\3\17\3\17\3\20\3\20"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u00ae\n\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\7\21\u00b6\n\21\f\21\16\21\u00b9\13\21\3\22\3\22\3\22\3\22"+
-    "\3\22\5\22\u00c0\n\22\3\23\3\23\3\23\5\23\u00c5\n\23\3\23\3\23\5\23\u00c9"+
-    "\n\23\3\23\3\23\3\23\3\23\3\23\3\23\7\23\u00d1\n\23\f\23\16\23\u00d4\13"+
-    "\23\3\24\5\24\u00d7\n\24\3\24\3\24\3\24\3\24\3\24\7\24\u00de\n\24\f\24"+
-    "\16\24\u00e1\13\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\7\24\u00ec"+
-    "\n\24\f\24\16\24\u00ef\13\24\3\24\3\24\5\24\u00f3\n\24\3\25\3\25\3\25"+
-    "\3\25\3\25\3\25\3\25\5\25\u00fc\n\25\3\26\3\26\3\26\3\26\3\26\7\26\u0103"+
-    "\n\26\f\26\16\26\u0106\13\26\5\26\u0108\n\26\3\26\3\26\3\27\3\27\3\30"+
-    "\3\30\3\30\3\30\5\30\u0112\n\30\3\31\3\31\3\32\3\32\3\33\3\33\3\33\3\33"+
-    "\3\33\6\33\u011d\n\33\r\33\16\33\u011e\3\33\7\33\u0122\n\33\f\33\16\33"+
-    "\u0125\13\33\3\34\3\34\3\35\3\35\5\35\u012b\n\35\3\36\3\36\5\36\u012f"+
-    "\n\36\3\37\3\37\3 \3 \3 \2\4 $!\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36"+
-    " \"$&(*,.\60\62\64\668:<>\2\13\3\2 !\3\2\"$\3\2\7\b\5\2\n\13\21\22\30"+
-    "\30\4\2//\61\61\3\2\32\37\4\2\6\6\24\24\3\2/\60\4\2,,//\2\u0142\2@\3\2"+
-    "\2\2\4C\3\2\2\2\6F\3\2\2\2\bP\3\2\2\2\nR\3\2\2\2\fW\3\2\2\2\16l\3\2\2"+
-    "\2\20z\3\2\2\2\22\u0086\3\2\2\2\24\u008f\3\2\2\2\26\u0093\3\2\2\2\30\u0097"+
-    "\3\2\2\2\32\u009b\3\2\2\2\34\u009f\3\2\2\2\36\u00a4\3\2\2\2 \u00ad\3\2"+
-    "\2\2\"\u00bf\3\2\2\2$\u00c8\3\2\2\2&\u00f2\3\2\2\2(\u00fb\3\2\2\2*\u00fd"+
-    "\3\2\2\2,\u010b\3\2\2\2.\u0111\3\2\2\2\60\u0113\3\2\2\2\62\u0115\3\2\2"+
-    "\2\64\u0117\3\2\2\2\66\u0126\3\2\2\28\u0128\3\2\2\2:\u012e\3\2\2\2<\u0130"+
-    "\3\2\2\2>\u0132\3\2\2\2@A\5\6\4\2AB\7\2\2\3B\3\3\2\2\2CD\5\36\20\2DE\7"+
-    "\2\2\3E\5\3\2\2\2FJ\5\b\5\2GI\5\20\t\2HG\3\2\2\2IL\3\2\2\2JH\3\2\2\2J"+
-    "K\3\2\2\2K\7\3\2\2\2LJ\3\2\2\2MQ\5\f\7\2NQ\5\16\b\2OQ\5\32\16\2PM\3\2"+
-    "\2\2PN\3\2\2\2PO\3\2\2\2Q\t\3\2\2\2RS\7\27\2\2ST\7\f\2\2TU\7\31\2\2UV"+
-    "\58\35\2V\13\3\2\2\2W`\7\23\2\2XZ\5\22\n\2Y[\5\n\6\2ZY\3\2\2\2Z[\3\2\2"+
-    "\2[a\3\2\2\2\\^\5\n\6\2]_\5\22\n\2^]\3\2\2\2^_\3\2\2\2_a\3\2\2\2`X\3\2"+
-    "\2\2`\\\3\2\2\2`a\3\2\2\2ab\3\2\2\2bd\5\26\f\2ce\5\26\f\2dc\3\2\2\2ef"+
-    "\3\2\2\2fd\3\2\2\2fg\3\2\2\2gj\3\2\2\2hi\7\25\2\2ik\5\26\f\2jh\3\2\2\2"+
-    "jk\3\2\2\2k\r\3\2\2\2ln\7\t\2\2mo\5\22\n\2nm\3\2\2\2no\3\2\2\2op\3\2\2"+
-    "\2pr\5\24\13\2qs\5\24\13\2rq\3\2\2\2st\3\2\2\2tr\3\2\2\2tu\3\2\2\2ux\3"+
-    "\2\2\2vw\7\25\2\2wy\5\24\13\2xv\3\2\2\2xy\3\2\2\2y\17\3\2\2\2z{\7+\2\2"+
-    "{\u0084\7/\2\2|\u0081\5 \21\2}~\7&\2\2~\u0080\5 \21\2\177}\3\2\2\2\u0080"+
-    "\u0083\3\2\2\2\u0081\177\3\2\2\2\u0081\u0082\3\2\2\2\u0082\u0085\3\2\2"+
-    "\2\u0083\u0081\3\2\2\2\u0084|\3\2\2\2\u0084\u0085\3\2\2\2\u0085\21\3\2"+
-    "\2\2\u0086\u0087\7\5\2\2\u0087\u008c\5\36\20\2\u0088\u0089\7&\2\2\u0089"+
-    "\u008b\5\36\20\2\u008a\u0088\3\2\2\2\u008b\u008e\3\2\2\2\u008c\u008a\3"+
-    "\2\2\2\u008c\u008d\3\2\2\2\u008d\23\3\2\2\2\u008e\u008c\3\2\2\2\u008f"+
-    "\u0091\5\30\r\2\u0090\u0092\5\22\n\2\u0091\u0090\3\2\2\2\u0091\u0092\3"+
-    "\2\2\2\u0092\25\3\2\2\2\u0093\u0095\5\30\r\2\u0094\u0096\5\22\n\2\u0095"+
-    "\u0094\3\2\2\2\u0095\u0096\3\2\2\2\u0096\27\3\2\2\2\u0097\u0098\7\'\2"+
-    "\2\u0098\u0099\5\34\17\2\u0099\u009a\7(\2\2\u009a\31\3\2\2\2\u009b\u009c"+
-    "\5\34\17\2\u009c\33\3\2\2\2\u009d\u00a0\7\4\2\2\u009e\u00a0\5> \2\u009f"+
-    "\u009d\3\2\2\2\u009f\u009e\3\2\2\2\u00a0\u00a1\3\2\2\2\u00a1\u00a2\7\26"+
-    "\2\2\u00a2\u00a3\5\36\20\2\u00a3\35\3\2\2\2\u00a4\u00a5\5 \21\2\u00a5"+
-    "\37\3\2\2\2\u00a6\u00a7\b\21\1\2\u00a7\u00a8\7\r\2\2\u00a8\u00ae\5 \21"+
-    "\7\u00a9\u00aa\7/\2\2\u00aa\u00ab\7\17\2\2\u00ab\u00ae\5\30\r\2\u00ac"+
-    "\u00ae\5\"\22\2\u00ad\u00a6\3\2\2\2\u00ad\u00a9\3\2\2\2\u00ad\u00ac\3"+
-    "\2\2\2\u00ae\u00b7\3\2\2\2\u00af\u00b0\f\4\2\2\u00b0\u00b1\7\3\2\2\u00b1"+
-    "\u00b6\5 \21\5\u00b2\u00b3\f\3\2\2\u00b3\u00b4\7\20\2\2\u00b4\u00b6\5"+
-    " \21\4\u00b5\u00af\3\2\2\2\u00b5\u00b2\3\2\2\2\u00b6\u00b9\3\2\2\2\u00b7"+
-    "\u00b5\3\2\2\2\u00b7\u00b8\3\2\2\2\u00b8!\3\2\2\2\u00b9\u00b7\3\2\2\2"+
-    "\u00ba\u00c0\5$\23\2\u00bb\u00bc\5$\23\2\u00bc\u00bd\5\60\31\2\u00bd\u00be"+
-    "\5$\23\2\u00be\u00c0\3\2\2\2\u00bf\u00ba\3\2\2\2\u00bf\u00bb\3\2\2\2\u00c0"+
-    "#\3\2\2\2\u00c1\u00c2\b\23\1\2\u00c2\u00c4\5(\25\2\u00c3\u00c5\5&\24\2"+
-    "\u00c4\u00c3\3\2\2\2\u00c4\u00c5\3\2\2\2\u00c5\u00c9\3\2\2\2\u00c6\u00c7"+
-    "\t\2\2\2\u00c7\u00c9\5$\23\5\u00c8\u00c1\3\2\2\2\u00c8\u00c6\3\2\2\2\u00c9"+
-    "\u00d2\3\2\2\2\u00ca\u00cb\f\4\2\2\u00cb\u00cc\t\3\2\2\u00cc\u00d1\5$"+
-    "\23\5\u00cd\u00ce\f\3\2\2\u00ce\u00cf\t\2\2\2\u00cf\u00d1\5$\23\4\u00d0"+
-    "\u00ca\3\2\2\2\u00d0\u00cd\3\2\2\2\u00d1\u00d4\3\2\2\2\u00d2\u00d0\3\2"+
-    "\2\2\u00d2\u00d3\3\2\2\2\u00d3%\3\2\2\2\u00d4\u00d2\3\2\2\2\u00d5\u00d7"+
-    "\7\r\2\2\u00d6\u00d5\3\2\2\2\u00d6\u00d7\3\2\2\2\u00d7\u00d8\3\2\2\2\u00d8"+
-    "\u00d9\t\4\2\2\u00d9\u00da\7)\2\2\u00da\u00df\5\36\20\2\u00db\u00dc\7"+
-    "&\2\2\u00dc\u00de\5\36\20\2\u00dd\u00db\3\2\2\2\u00de\u00e1\3\2\2\2\u00df"+
-    "\u00dd\3\2\2\2\u00df\u00e0\3\2\2\2\u00e0\u00e2\3\2\2\2\u00e1\u00df\3\2"+
-    "\2\2\u00e2\u00e3\7*\2\2\u00e3\u00f3\3\2\2\2\u00e4\u00e5\t\5\2\2\u00e5"+
-    "\u00f3\5.\30\2\u00e6\u00e7\t\5\2\2\u00e7\u00e8\7)\2\2\u00e8\u00ed\5.\30"+
-    "\2\u00e9\u00ea\7&\2\2\u00ea\u00ec\5.\30\2\u00eb\u00e9\3\2\2\2\u00ec\u00ef"+
-    "\3\2\2\2\u00ed\u00eb\3\2\2\2\u00ed\u00ee\3\2\2\2\u00ee\u00f0\3\2\2\2\u00ef"+
-    "\u00ed\3\2\2\2\u00f0\u00f1\7*\2\2\u00f1\u00f3\3\2\2\2\u00f2\u00d6\3\2"+
-    "\2\2\u00f2\u00e4\3\2\2\2\u00f2\u00e6\3\2\2\2\u00f3\'\3\2\2\2\u00f4\u00fc"+
-    "\5.\30\2\u00f5\u00fc\5*\26\2\u00f6\u00fc\5\64\33\2\u00f7\u00f8\7)\2\2"+
-    "\u00f8\u00f9\5\36\20\2\u00f9\u00fa\7*\2\2\u00fa\u00fc\3\2\2\2\u00fb\u00f4"+
-    "\3\2\2\2\u00fb\u00f5\3\2\2\2\u00fb\u00f6\3\2\2\2\u00fb\u00f7\3\2\2\2\u00fc"+
-    ")\3\2\2\2\u00fd\u00fe\5,\27\2\u00fe\u0107\7)\2\2\u00ff\u0104\5\36\20\2"+
-    "\u0100\u0101\7&\2\2\u0101\u0103\5\36\20\2\u0102\u0100\3\2\2\2\u0103\u0106"+
-    "\3\2\2\2\u0104\u0102\3\2\2\2\u0104\u0105\3\2\2\2\u0105\u0108\3\2\2\2\u0106"+
-    "\u0104\3\2\2\2\u0107\u00ff\3\2\2\2\u0107\u0108\3\2\2\2\u0108\u0109\3\2"+
-    "\2\2\u0109\u010a\7*\2\2\u010a+\3\2\2\2\u010b\u010c\t\6\2\2\u010c-\3\2"+
-    "\2\2\u010d\u0112\7\16\2\2\u010e\u0112\5:\36\2\u010f\u0112\5\62\32\2\u0110"+
-    "\u0112\5<\37\2\u0111\u010d\3\2\2\2\u0111\u010e\3\2\2\2\u0111\u010f\3\2"+
-    "\2\2\u0111\u0110\3\2\2\2\u0112/\3\2\2\2\u0113\u0114\t\7\2\2\u0114\61\3"+
-    "\2\2\2\u0115\u0116\t\b\2\2\u0116\63\3\2\2\2\u0117\u0123\5\66\34\2\u0118"+
-    "\u0119\7%\2\2\u0119\u0122\5\66\34\2\u011a\u011c\7\'\2\2\u011b\u011d\7"+
-    "-\2\2\u011c\u011b\3\2\2\2\u011d\u011e\3\2\2\2\u011e\u011c\3\2\2\2\u011e"+
-    "\u011f\3\2\2\2\u011f\u0120\3\2\2\2\u0120\u0122\7(\2\2\u0121\u0118\3\2"+
-    "\2\2\u0121\u011a\3\2\2\2\u0122\u0125\3\2\2\2\u0123\u0121\3\2\2\2\u0123"+
-    "\u0124\3\2\2\2\u0124\65\3\2\2\2\u0125\u0123\3\2\2\2\u0126\u0127\t\t\2"+
-    "\2\u0127\67\3\2\2\2\u0128\u012a\5:\36\2\u0129\u012b\7/\2\2\u012a\u0129"+
-    "\3\2\2\2\u012a\u012b\3\2\2\2\u012b9\3\2\2\2\u012c\u012f\7.\2\2\u012d\u012f"+
-    "\7-\2\2\u012e\u012c\3\2\2\2\u012e\u012d\3\2\2\2\u012f;\3\2\2\2\u0130\u0131"+
-    "\7,\2\2\u0131=\3\2\2\2\u0132\u0133\t\n\2\2\u0133?\3\2\2\2\'JPZ^`fjntx"+
-    "\u0081\u0084\u008c\u0091\u0095\u009f\u00ad\u00b5\u00b7\u00bf\u00c4\u00c8"+
-    "\u00d0\u00d2\u00d6\u00df\u00ed\u00f2\u00fb\u0104\u0107\u0111\u011e\u0121"+
-    "\u0123\u012a\u012e";
+    "\7\3\7\6\7d\n\7\r\7\16\7e\3\7\3\7\5\7j\n\7\3\b\3\b\5\bn\n\b\3\b\3\b\6"+
+    "\br\n\b\r\b\16\bs\3\b\3\b\5\bx\n\b\3\t\3\t\3\t\3\t\3\t\7\t\177\n\t\f\t"+
+    "\16\t\u0082\13\t\5\t\u0084\n\t\3\n\3\n\3\n\3\n\7\n\u008a\n\n\f\n\16\n"+
+    "\u008d\13\n\3\13\3\13\5\13\u0091\n\13\3\f\3\f\5\f\u0095\n\f\3\f\3\f\3"+
+    "\f\3\f\3\f\3\f\5\f\u009d\n\f\3\r\3\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17"+
+    "\u00a7\n\17\3\17\3\17\3\17\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
+    "\5\21\u00b5\n\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u00bd\n\21\f\21\16"+
+    "\21\u00c0\13\21\3\22\3\22\3\22\3\22\3\22\5\22\u00c7\n\22\3\23\3\23\3\23"+
+    "\5\23\u00cc\n\23\3\23\3\23\5\23\u00d0\n\23\3\23\3\23\3\23\3\23\3\23\3"+
+    "\23\7\23\u00d8\n\23\f\23\16\23\u00db\13\23\3\24\5\24\u00de\n\24\3\24\3"+
+    "\24\3\24\3\24\3\24\7\24\u00e5\n\24\f\24\16\24\u00e8\13\24\3\24\3\24\3"+
+    "\24\3\24\3\24\3\24\3\24\3\24\3\24\7\24\u00f3\n\24\f\24\16\24\u00f6\13"+
+    "\24\3\24\3\24\5\24\u00fa\n\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\5\25"+
+    "\u0103\n\25\3\26\3\26\3\26\3\26\3\26\7\26\u010a\n\26\f\26\16\26\u010d"+
+    "\13\26\5\26\u010f\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\5\30\u0119"+
+    "\n\30\3\31\3\31\3\32\3\32\3\33\3\33\3\33\3\33\3\33\6\33\u0124\n\33\r\33"+
+    "\16\33\u0125\3\33\7\33\u0129\n\33\f\33\16\33\u012c\13\33\3\34\3\34\3\35"+
+    "\3\35\5\35\u0132\n\35\3\36\3\36\5\36\u0136\n\36\3\37\3\37\3 \3 \3 \2\4"+
+    " $!\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>\2"+
+    "\13\3\2 !\3\2\"$\3\2\7\b\5\2\n\13\21\22\30\30\4\2//\61\61\3\2\32\37\4"+
+    "\2\6\6\24\24\3\2/\60\4\2,,//\2\u014a\2@\3\2\2\2\4C\3\2\2\2\6F\3\2\2\2"+
+    "\bP\3\2\2\2\nR\3\2\2\2\fW\3\2\2\2\16k\3\2\2\2\20y\3\2\2\2\22\u0085\3\2"+
+    "\2\2\24\u008e\3\2\2\2\26\u0092\3\2\2\2\30\u009e\3\2\2\2\32\u00a2\3\2\2"+
+    "\2\34\u00a6\3\2\2\2\36\u00ab\3\2\2\2 \u00b4\3\2\2\2\"\u00c6\3\2\2\2$\u00cf"+
+    "\3\2\2\2&\u00f9\3\2\2\2(\u0102\3\2\2\2*\u0104\3\2\2\2,\u0112\3\2\2\2."+
+    "\u0118\3\2\2\2\60\u011a\3\2\2\2\62\u011c\3\2\2\2\64\u011e\3\2\2\2\66\u012d"+
+    "\3\2\2\28\u012f\3\2\2\2:\u0135\3\2\2\2<\u0137\3\2\2\2>\u0139\3\2\2\2@"+
+    "A\5\6\4\2AB\7\2\2\3B\3\3\2\2\2CD\5\36\20\2DE\7\2\2\3E\5\3\2\2\2FJ\5\b"+
+    "\5\2GI\5\20\t\2HG\3\2\2\2IL\3\2\2\2JH\3\2\2\2JK\3\2\2\2K\7\3\2\2\2LJ\3"+
+    "\2\2\2MQ\5\f\7\2NQ\5\16\b\2OQ\5\32\16\2PM\3\2\2\2PN\3\2\2\2PO\3\2\2\2"+
+    "Q\t\3\2\2\2RS\7\27\2\2ST\7\f\2\2TU\7\31\2\2UV\58\35\2V\13\3\2\2\2W`\7"+
+    "\23\2\2XZ\5\22\n\2Y[\5\n\6\2ZY\3\2\2\2Z[\3\2\2\2[a\3\2\2\2\\^\5\n\6\2"+
+    "]_\5\22\n\2^]\3\2\2\2^_\3\2\2\2_a\3\2\2\2`X\3\2\2\2`\\\3\2\2\2`a\3\2\2"+
+    "\2ac\3\2\2\2bd\5\26\f\2cb\3\2\2\2de\3\2\2\2ec\3\2\2\2ef\3\2\2\2fi\3\2"+
+    "\2\2gh\7\25\2\2hj\5\26\f\2ig\3\2\2\2ij\3\2\2\2j\r\3\2\2\2km\7\t\2\2ln"+
+    "\5\22\n\2ml\3\2\2\2mn\3\2\2\2no\3\2\2\2oq\5\24\13\2pr\5\24\13\2qp\3\2"+
+    "\2\2rs\3\2\2\2sq\3\2\2\2st\3\2\2\2tw\3\2\2\2uv\7\25\2\2vx\5\24\13\2wu"+
+    "\3\2\2\2wx\3\2\2\2x\17\3\2\2\2yz\7+\2\2z\u0083\7/\2\2{\u0080\5 \21\2|"+
+    "}\7&\2\2}\177\5 \21\2~|\3\2\2\2\177\u0082\3\2\2\2\u0080~\3\2\2\2\u0080"+
+    "\u0081\3\2\2\2\u0081\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0083{\3\2\2\2"+
+    "\u0083\u0084\3\2\2\2\u0084\21\3\2\2\2\u0085\u0086\7\5\2\2\u0086\u008b"+
+    "\5\36\20\2\u0087\u0088\7&\2\2\u0088\u008a\5\36\20\2\u0089\u0087\3\2\2"+
+    "\2\u008a\u008d\3\2\2\2\u008b\u0089\3\2\2\2\u008b\u008c\3\2\2\2\u008c\23"+
+    "\3\2\2\2\u008d\u008b\3\2\2\2\u008e\u0090\5\30\r\2\u008f\u0091\5\22\n\2"+
+    "\u0090\u008f\3\2\2\2\u0090\u0091\3\2\2\2\u0091\25\3\2\2\2\u0092\u0094"+
+    "\5\30\r\2\u0093\u0095\5\22\n\2\u0094\u0093\3\2\2\2\u0094\u0095\3\2\2\2"+
+    "\u0095\u009c\3\2\2\2\u0096\u0097\7\'\2\2\u0097\u0098\7/\2\2\u0098\u0099"+
+    "\7\31\2\2\u0099\u009a\5:\36\2\u009a\u009b\7(\2\2\u009b\u009d\3\2\2\2\u009c"+
+    "\u0096\3\2\2\2\u009c\u009d\3\2\2\2\u009d\27\3\2\2\2\u009e\u009f\7\'\2"+
+    "\2\u009f\u00a0\5\34\17\2\u00a0\u00a1\7(\2\2\u00a1\31\3\2\2\2\u00a2\u00a3"+
+    "\5\34\17\2\u00a3\33\3\2\2\2\u00a4\u00a7\7\4\2\2\u00a5\u00a7\5> \2\u00a6"+
+    "\u00a4\3\2\2\2\u00a6\u00a5\3\2\2\2\u00a7\u00a8\3\2\2\2\u00a8\u00a9\7\26"+
+    "\2\2\u00a9\u00aa\5\36\20\2\u00aa\35\3\2\2\2\u00ab\u00ac\5 \21\2\u00ac"+
+    "\37\3\2\2\2\u00ad\u00ae\b\21\1\2\u00ae\u00af\7\r\2\2\u00af\u00b5\5 \21"+
+    "\7\u00b0\u00b1\7/\2\2\u00b1\u00b2\7\17\2\2\u00b2\u00b5\5\30\r\2\u00b3"+
+    "\u00b5\5\"\22\2\u00b4\u00ad\3\2\2\2\u00b4\u00b0\3\2\2\2\u00b4\u00b3\3"+
+    "\2\2\2\u00b5\u00be\3\2\2\2\u00b6\u00b7\f\4\2\2\u00b7\u00b8\7\3\2\2\u00b8"+
+    "\u00bd\5 \21\5\u00b9\u00ba\f\3\2\2\u00ba\u00bb\7\20\2\2\u00bb\u00bd\5"+
+    " \21\4\u00bc\u00b6\3\2\2\2\u00bc\u00b9\3\2\2\2\u00bd\u00c0\3\2\2\2\u00be"+
+    "\u00bc\3\2\2\2\u00be\u00bf\3\2\2\2\u00bf!\3\2\2\2\u00c0\u00be\3\2\2\2"+
+    "\u00c1\u00c7\5$\23\2\u00c2\u00c3\5$\23\2\u00c3\u00c4\5\60\31\2\u00c4\u00c5"+
+    "\5$\23\2\u00c5\u00c7\3\2\2\2\u00c6\u00c1\3\2\2\2\u00c6\u00c2\3\2\2\2\u00c7"+
+    "#\3\2\2\2\u00c8\u00c9\b\23\1\2\u00c9\u00cb\5(\25\2\u00ca\u00cc\5&\24\2"+
+    "\u00cb\u00ca\3\2\2\2\u00cb\u00cc\3\2\2\2\u00cc\u00d0\3\2\2\2\u00cd\u00ce"+
+    "\t\2\2\2\u00ce\u00d0\5$\23\5\u00cf\u00c8\3\2\2\2\u00cf\u00cd\3\2\2\2\u00d0"+
+    "\u00d9\3\2\2\2\u00d1\u00d2\f\4\2\2\u00d2\u00d3\t\3\2\2\u00d3\u00d8\5$"+
+    "\23\5\u00d4\u00d5\f\3\2\2\u00d5\u00d6\t\2\2\2\u00d6\u00d8\5$\23\4\u00d7"+
+    "\u00d1\3\2\2\2\u00d7\u00d4\3\2\2\2\u00d8\u00db\3\2\2\2\u00d9\u00d7\3\2"+
+    "\2\2\u00d9\u00da\3\2\2\2\u00da%\3\2\2\2\u00db\u00d9\3\2\2\2\u00dc\u00de"+
+    "\7\r\2\2\u00dd\u00dc\3\2\2\2\u00dd\u00de\3\2\2\2\u00de\u00df\3\2\2\2\u00df"+
+    "\u00e0\t\4\2\2\u00e0\u00e1\7)\2\2\u00e1\u00e6\5\36\20\2\u00e2\u00e3\7"+
+    "&\2\2\u00e3\u00e5\5\36\20\2\u00e4\u00e2\3\2\2\2\u00e5\u00e8\3\2\2\2\u00e6"+
+    "\u00e4\3\2\2\2\u00e6\u00e7\3\2\2\2\u00e7\u00e9\3\2\2\2\u00e8\u00e6\3\2"+
+    "\2\2\u00e9\u00ea\7*\2\2\u00ea\u00fa\3\2\2\2\u00eb\u00ec\t\5\2\2\u00ec"+
+    "\u00fa\5.\30\2\u00ed\u00ee\t\5\2\2\u00ee\u00ef\7)\2\2\u00ef\u00f4\5.\30"+
+    "\2\u00f0\u00f1\7&\2\2\u00f1\u00f3\5.\30\2\u00f2\u00f0\3\2\2\2\u00f3\u00f6"+
+    "\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5\u00f7\3\2\2\2\u00f6"+
+    "\u00f4\3\2\2\2\u00f7\u00f8\7*\2\2\u00f8\u00fa\3\2\2\2\u00f9\u00dd\3\2"+
+    "\2\2\u00f9\u00eb\3\2\2\2\u00f9\u00ed\3\2\2\2\u00fa\'\3\2\2\2\u00fb\u0103"+
+    "\5.\30\2\u00fc\u0103\5*\26\2\u00fd\u0103\5\64\33\2\u00fe\u00ff\7)\2\2"+
+    "\u00ff\u0100\5\36\20\2\u0100\u0101\7*\2\2\u0101\u0103\3\2\2\2\u0102\u00fb"+
+    "\3\2\2\2\u0102\u00fc\3\2\2\2\u0102\u00fd\3\2\2\2\u0102\u00fe\3\2\2\2\u0103"+
+    ")\3\2\2\2\u0104\u0105\5,\27\2\u0105\u010e\7)\2\2\u0106\u010b\5\36\20\2"+
+    "\u0107\u0108\7&\2\2\u0108\u010a\5\36\20\2\u0109\u0107\3\2\2\2\u010a\u010d"+
+    "\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2\2\2\u010c\u010f\3\2\2\2\u010d"+
+    "\u010b\3\2\2\2\u010e\u0106\3\2\2\2\u010e\u010f\3\2\2\2\u010f\u0110\3\2"+
+    "\2\2\u0110\u0111\7*\2\2\u0111+\3\2\2\2\u0112\u0113\t\6\2\2\u0113-\3\2"+
+    "\2\2\u0114\u0119\7\16\2\2\u0115\u0119\5:\36\2\u0116\u0119\5\62\32\2\u0117"+
+    "\u0119\5<\37\2\u0118\u0114\3\2\2\2\u0118\u0115\3\2\2\2\u0118\u0116\3\2"+
+    "\2\2\u0118\u0117\3\2\2\2\u0119/\3\2\2\2\u011a\u011b\t\7\2\2\u011b\61\3"+
+    "\2\2\2\u011c\u011d\t\b\2\2\u011d\63\3\2\2\2\u011e\u012a\5\66\34\2\u011f"+
+    "\u0120\7%\2\2\u0120\u0129\5\66\34\2\u0121\u0123\7\'\2\2\u0122\u0124\7"+
+    "-\2\2\u0123\u0122\3\2\2\2\u0124\u0125\3\2\2\2\u0125\u0123\3\2\2\2\u0125"+
+    "\u0126\3\2\2\2\u0126\u0127\3\2\2\2\u0127\u0129\7(\2\2\u0128\u011f\3\2"+
+    "\2\2\u0128\u0121\3\2\2\2\u0129\u012c\3\2\2\2\u012a\u0128\3\2\2\2\u012a"+
+    "\u012b\3\2\2\2\u012b\65\3\2\2\2\u012c\u012a\3\2\2\2\u012d\u012e\t\t\2"+
+    "\2\u012e\67\3\2\2\2\u012f\u0131\5:\36\2\u0130\u0132\7/\2\2\u0131\u0130"+
+    "\3\2\2\2\u0131\u0132\3\2\2\2\u01329\3\2\2\2\u0133\u0136\7.\2\2\u0134\u0136"+
+    "\7-\2\2\u0135\u0133\3\2\2\2\u0135\u0134\3\2\2\2\u0136;\3\2\2\2\u0137\u0138"+
+    "\7,\2\2\u0138=\3\2\2\2\u0139\u013a\t\n\2\2\u013a?\3\2\2\2(JPZ^`eimsw\u0080"+
+    "\u0083\u008b\u0090\u0094\u009c\u00a6\u00b4\u00bc\u00be\u00c6\u00cb\u00cf"+
+    "\u00d7\u00d9\u00dd\u00e6\u00f4\u00f9\u0102\u010b\u010e\u0118\u0125\u0128"+
+    "\u012a\u0131\u0135";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
@@ -179,6 +179,16 @@ public class LogicalPlanTests extends ESTestCase {
         assertEquals(new TimeValue(2, TimeUnit.SECONDS), maxSpan);
     }
 
+    public void testRepeatedQuery() throws Exception {
+        LogicalPlan plan = parser.createStatement("sequence " + " [any where true] [runs=2]" + " [any where true]");
+        plan = defaultPipes(plan);
+        assertEquals(Sequence.class, plan.getClass());
+        Sequence seq = (Sequence) plan;
+
+        List<? extends LogicalPlan> queries = seq.queries();
+        assertEquals(3, queries.size());
+    }
+
     private LogicalPlan wrapFilter(Expression exp) {
         LogicalPlan filter = new Filter(Source.EMPTY, relation(), exp);
         Order order = new Order(Source.EMPTY, timestamp(), OrderDirection.ASC, NullsPosition.FIRST);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.planner;
 
+import org.elasticsearch.xpack.eql.EqlClientException;
 import org.elasticsearch.xpack.eql.analysis.VerificationException;
 import org.elasticsearch.xpack.ql.ParsingException;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
@@ -236,4 +237,16 @@ public class QueryTranslatorFailTests extends AbstractQueryTranslatorTestCase {
         assertEquals("Found 1 problem\n" +
                 "line 1:15: first argument of [wildcard(pid, \"*.exe\")] must be [string], found value [pid] type [long]", msg);
     }
+
+    public void testSequenceWithTooLittleQueries() throws Exception {
+        String s = errorParsing("sequence [any where true]");
+        assertEquals("1:2: A sequence requires a minimum of 2 queries, found [1]", s);
+    }
+
+    public void testSequenceWithIncorrectOption() throws Exception {
+        EqlClientException e = expectThrows(EqlClientException.class, () -> plan("sequence [any where true] [repeat=123]"));
+        String msg = e.getMessage();
+        assertEquals("line 1:29: Unrecognized option [repeat], expecting [runs]", msg);
+    }
+
 }


### PR DESCRIPTION
Allow individual queries within a sequence to be ran multiple times
through using the [runs=number] construct as a suffix without
having to redeclare the query.

sequence
  queryA [runs=2]
  queryB
  queryC [runs=3]
  queryD

is the same as:

sequence
  queryA
  queryA
  queryB
  queryC
  queryC
  queryC
  queryD

but more concise.

(cherry picked from commit c7ef3a6c3a67ca59deba88c2598903a3787b8fec)