### PR TITLE
Remove indices_segments 'verbose' parameter

### DIFF
--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -50,14 +50,6 @@ Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-`verbose`::
-experimental:[]
-(Optional, Boolean)
-If `true`, the response includes detailed information
-about Lucene's memory usage.
-Defaults to `false`.
-
-
 [[index-segments-api-response-body]]
 ==== {api-response-body-title}
 
@@ -80,10 +72,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
 `size_in_bytes`::
 (Integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-size]
-
-`memory_in_bytes`::
-(Integer)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=memory]
 
 `committed`::
 (Boolean)
@@ -182,47 +170,3 @@ The API returns the following response:
 // TESTRESPONSE[s/"attributes": \{[^}]*\}/"attributes": $body.$_path/]
 // TESTRESPONSE[s/: (\-)?[0-9]+/: $body.$_path/]
 // TESTRESPONSE[s/7\.0\.0/$body.$_path/]
-
-
-===== Verbose mode
-
-To add additional information that can be used for debugging,
-use the `verbose` flag.
-
-experimental::[]
-
-[source,console]
---------------------------------------------------
-GET /test/_segments?verbose=true
---------------------------------------------------
-// TEST[continued]
-
-The API returns the following response:
-
-[source,console-response]
---------------------------------------------------
-{
-  ...
-    "_0": {
-      ...
-      "ram_tree": [
-        {
-          "description": "postings [PerFieldPostings(format=1)]",
-          "size_in_bytes": 2696,
-          "children": [
-            {
-              "description": "format 'Lucene50_0' ...",
-              "size_in_bytes": 2608,
-              "children" :[ ... ]
-            },
-            ...
-          ]
-        },
-        ...
-      ]
-
-    }
-  ...
-}
---------------------------------------------------
-// TESTRESPONSE[skip:Response is too verbose to be fully shown in documentation, so we just show the relevant bit and don't test the response.]

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -149,7 +149,6 @@ The API returns the following response:
                 "num_docs": 1,
                 "deleted_docs": 0,
                 "size_in_bytes": 3800,
-                "memory_in_bytes": 0,
                 "committed": false,
                 "search": true,
                 "version": "7.0.0",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -55,7 +55,11 @@
       "verbose":{
         "type":"boolean",
         "description":"Includes detailed memory usage by Lucene.",
-        "default":false
+        "default":false,
+        "deprecated" : {
+          "version" : "8.0.0",
+          "description" : "lucene no longer keeps track of segment memory overhead as it is largely off-heap"
+        }
       }
     }
   }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.engine.Segment;
 import org.elasticsearch.transport.Transports;
 
@@ -113,7 +114,9 @@ public class IndicesSegmentResponse extends BroadcastResponse {
                         builder.field(Fields.NUM_DOCS, segment.getNumDocs());
                         builder.field(Fields.DELETED_DOCS, segment.getDeletedDocs());
                         builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, segment.getSize());
-                        builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, new ByteSizeValue(0));
+                        if (builder.getRestApiVersion() == RestApiVersion.V_7) {
+                            builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, new ByteSizeValue(0));
+                        }
                         builder.field(Fields.COMMITTED, segment.isCommitted());
                         builder.field(Fields.SEARCH, segment.isSearch());
                         if (segment.getVersion() != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.indices.segments;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -21,41 +22,27 @@ import java.util.Map;
 
 public class IndicesSegmentsRequest extends BroadcastRequest<IndicesSegmentsRequest> {
 
-    protected boolean verbose = false;
-
     public IndicesSegmentsRequest() {
         this(Strings.EMPTY_ARRAY);
     }
 
     public IndicesSegmentsRequest(StreamInput in) throws IOException {
         super(in);
-        verbose = in.readBoolean();
+        if (in.getVersion().before(Version.V_8_0_0)) {
+            in.readBoolean();   // old 'verbose' option, since removed
+        }
     }
 
     public IndicesSegmentsRequest(String... indices) {
         super(indices);
     }
 
-    /**
-     * <code>true</code> if detailed information about each segment should be returned,
-     * <code>false</code> otherwise.
-     */
-    public boolean verbose() {
-        return verbose;
-    }
-
-    /**
-     * Sets the <code>verbose</code> option.
-     * @see #verbose()
-     */
-    public void verbose(boolean v) {
-        verbose = v;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBoolean(verbose);
+        if (out.getVersion().before(Version.V_8_0_0)) {
+            out.writeBoolean(false);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
@@ -17,9 +17,4 @@ public class IndicesSegmentsRequestBuilder
     public IndicesSegmentsRequestBuilder(ElasticsearchClient client, IndicesSegmentsAction action) {
         super(client, action, new IndicesSegmentsRequest());
     }
-
-    public IndicesSegmentsRequestBuilder setVerbose(boolean verbose) {
-        request.verbose = verbose;
-        return this;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -89,7 +89,7 @@ public class TransportIndicesSegmentsAction
             assert task instanceof CancellableTask;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.index());
             IndexShard indexShard = indexService.getShard(shardRouting.id());
-            return new ShardSegments(indexShard.routingEntry(), indexShard.segments(request.verbose()));
+            return new ShardSegments(indexShard.routingEntry(), indexShard.segments());
         });
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -829,13 +829,13 @@ public abstract class Engine implements Closeable {
     /** How much heap is used that would be freed by a refresh.  Note that this may throw {@link AlreadyClosedException}. */
     public abstract long getIndexBufferRAMBytesUsed();
 
-    final Segment[] getSegmentInfo(SegmentInfos lastCommittedSegmentInfos, boolean verbose) {
+    final Segment[] getSegmentInfo(SegmentInfos lastCommittedSegmentInfos) {
         ensureOpen();
         Map<String, Segment> segments = new HashMap<>();
         // first, go over and compute the search ones...
         try (Searcher searcher = acquireSearcher("segments", SearcherScope.EXTERNAL)){
             for (LeafReaderContext ctx : searcher.getIndexReader().getContext().leaves()) {
-                fillSegmentInfo(Lucene.segmentReader(ctx.reader()), verbose, true, segments);
+                fillSegmentInfo(Lucene.segmentReader(ctx.reader()), true, segments);
             }
         }
 
@@ -843,7 +843,7 @@ public abstract class Engine implements Closeable {
             for (LeafReaderContext ctx : searcher.getIndexReader().getContext().leaves()) {
                 SegmentReader segmentReader = Lucene.segmentReader(ctx.reader());
                 if (segments.containsKey(segmentReader.getSegmentName()) == false) {
-                    fillSegmentInfo(segmentReader, verbose, false, segments);
+                    fillSegmentInfo(segmentReader, false, segments);
                 }
             }
         }
@@ -879,7 +879,7 @@ public abstract class Engine implements Closeable {
         return segmentsArr;
     }
 
-    private void fillSegmentInfo(SegmentReader segmentReader, boolean verbose, boolean search, Map<String, Segment> segments) {
+    private void fillSegmentInfo(SegmentReader segmentReader, boolean search, Map<String, Segment> segments) {
         SegmentCommitInfo info = segmentReader.getSegmentInfo();
         assert segments.containsKey(info.info.name) == false;
         Segment segment = new Segment(info.info.name);
@@ -902,7 +902,7 @@ public abstract class Engine implements Closeable {
     /**
      * The list of segments in the engine.
      */
-    public abstract List<Segment> segments(boolean verbose);
+    public abstract List<Segment> segments();
 
     public boolean refreshNeeded() {
         if (store.tryIncRef()) {

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2059,9 +2059,9 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public List<Segment> segments(boolean verbose) {
+    public List<Segment> segments() {
         try (ReleasableLock lock = readLock.acquire()) {
-            Segment[] segmentsArr = getSegmentInfo(lastCommittedSegmentInfos, verbose);
+            Segment[] segmentsArr = getSegmentInfo(lastCommittedSegmentInfos);
 
             // fill in the merges flag
             Set<OnGoingMerge> onGoingMerges = mergeScheduler.onGoingMerges();

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -378,8 +378,8 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    public List<Segment> segments(boolean verbose) {
-        return Arrays.asList(getSegmentInfo(lastCommittedSegmentInfos, verbose));
+    public List<Segment> segments() {
+        return Arrays.asList(getSegmentInfo(lastCommittedSegmentInfos));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -14,17 +14,15 @@ import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
-import org.apache.lucene.util.Accountable;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
@@ -271,17 +269,6 @@ public class Segment implements Writeable {
         int numChildren = in.readVInt();
         for (int i = 0; i < numChildren; i++) {
             readRamTree(in);
-        }
-    }
-
-    // the ram tree is written recursively since the depth is fairly low (5 or 6)
-    private void writeRamTree(StreamOutput out, Accountable tree) throws IOException {
-        out.writeString(tree.toString());
-        out.writeVLong(tree.ramBytesUsed());
-        Collection<Accountable> children = tree.getChildResources();
-        out.writeVInt(children.size());
-        for (Accountable child : children) {
-            writeRamTree(out, child);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2085,8 +2085,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return getEngine().newChangesSnapshot(source, fromSeqNo, toSeqNo, requiredFullRange, singleConsumer, accessStats);
     }
 
-    public List<Segment> segments(boolean verbose) {
-        return getEngine().segments(verbose);
+    public List<Segment> segments() {
+        return getEngine().segments();
     }
 
     public String getHistoryUUID() {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesSegmentsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesSegmentsAction.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.DispatchingRestToXContentListener;
@@ -24,6 +26,8 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestIndicesSegmentsAction extends BaseRestHandler {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RestIndicesSegmentsAction.class);
 
     private final ThreadPool threadPool;
 
@@ -47,7 +51,13 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(
                 Strings.splitStringByCommaToArray(request.param("index")));
-        indicesSegmentsRequest.verbose(request.paramAsBoolean("verbose", false));
+        if (request.hasParam("verbose")) {
+            DEPRECATION_LOGGER.warn(
+                DeprecationCategory.INDICES,
+                "indices_segments_action_verbose",
+                "The [verbose] query parameter for [indices_segments_action] has no effect and is deprecated"
+            );
+        }
         indicesSegmentsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesSegmentsRequest.indicesOptions()));
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin().indices().segments(
                 indicesSegmentsRequest,

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -275,14 +275,14 @@ public class InternalEngineTests extends EngineTestCase {
     public void testVerboseSegments() throws Exception {
         try (Store store = createStore();
              Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
-            List<Segment> segments = engine.segments(true);
+            List<Segment> segments = engine.segments();
             assertThat(segments.isEmpty(), equalTo(true));
 
             ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
             engine.index(indexForDoc(doc));
             engine.refresh("test");
 
-            segments = engine.segments(true);
+            segments = engine.segments();
             assertThat(segments.size(), equalTo(1));
 
             ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
@@ -292,7 +292,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(indexForDoc(doc3));
             engine.refresh("test");
 
-            segments = engine.segments(true);
+            segments = engine.segments();
             assertThat(segments.size(), equalTo(3));
         }
     }
@@ -304,11 +304,11 @@ public class InternalEngineTests extends EngineTestCase {
             Engine.Index index = indexForDoc(doc);
             engine.index(index);
             engine.flush();
-            assertThat(engine.segments(false).size(), equalTo(1));
+            assertThat(engine.segments().size(), equalTo(1));
             index = indexForDoc(testParsedDocument("2", null, testDocument(), B_1, null));
             engine.index(index);
             engine.flush();
-            List<Segment> segments = engine.segments(false);
+            List<Segment> segments = engine.segments();
             assertThat(segments.size(), equalTo(2));
             for (Segment segment : segments) {
                 assertThat(segment.getMergeId(), nullValue());
@@ -316,7 +316,7 @@ public class InternalEngineTests extends EngineTestCase {
             index = indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null));
             engine.index(index);
             engine.flush();
-            segments = engine.segments(false);
+            segments = engine.segments();
             assertThat(segments.size(), equalTo(3));
             for (Segment segment : segments) {
                 assertThat(segment.getMergeId(), nullValue());
@@ -332,7 +332,7 @@ public class InternalEngineTests extends EngineTestCase {
             // ensure that we have released the older segments with a refresh so they can be removed
             assertFalse(engine.refreshNeeded());
 
-            for (Segment segment : engine.segments(false)) {
+            for (Segment segment : engine.segments()) {
                 assertThat(segment.getMergeId(), nullValue());
             }
             // we could have multiple underlying merges, so the generation may increase more than once
@@ -341,7 +341,7 @@ public class InternalEngineTests extends EngineTestCase {
             final boolean flush = randomBoolean();
             final long gen2 = store.readLastCommittedSegmentsInfo().getGeneration();
             engine.forceMerge(flush, 1, false, UUIDs.randomBase64UUID());
-            for (Segment segment : engine.segments(false)) {
+            for (Segment segment : engine.segments()) {
                 assertThat(segment.getMergeId(), nullValue());
             }
 
@@ -359,14 +359,14 @@ public class InternalEngineTests extends EngineTestCase {
                      createEngine(defaultSettings, store, createTempDir(),
                          NoMergePolicy.INSTANCE, null, null, null,
                          indexSort, null)) {
-            List<Segment> segments = engine.segments(true);
+            List<Segment> segments = engine.segments();
             assertThat(segments.isEmpty(), equalTo(true));
 
             ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
             engine.index(indexForDoc(doc));
             engine.refresh("test");
 
-            segments = engine.segments(false);
+            segments = engine.segments();
             assertThat(segments.size(), equalTo(1));
             assertThat(segments.get(0).getSegmentSort(), equalTo(indexSort));
 
@@ -377,7 +377,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(indexForDoc(doc3));
             engine.refresh("test");
 
-            segments = engine.segments(true);
+            segments = engine.segments();
             assertThat(segments.size(), equalTo(3));
             assertThat(segments.get(0).getSegmentSort(), equalTo(indexSort));
             assertThat(segments.get(1).getSegmentSort(), equalTo(indexSort));
@@ -423,7 +423,7 @@ public class InternalEngineTests extends EngineTestCase {
         try (Store store = createStore();
              InternalEngine engine = createEngine(config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null,
                  null, globalCheckpoint::get))) {
-            assertThat(engine.segments(false), empty());
+            assertThat(engine.segments(), empty());
             int numDocsFirstSegment = randomIntBetween(5, 50);
             Set<String> liveDocsFirstSegment = new HashSet<>();
             for (int i = 0; i < numDocsFirstSegment; i++) {
@@ -433,7 +433,7 @@ public class InternalEngineTests extends EngineTestCase {
                 liveDocsFirstSegment.add(id);
             }
             engine.refresh("test");
-            List<Segment> segments = engine.segments(randomBoolean());
+            List<Segment> segments = engine.segments();
             assertThat(segments, hasSize(1));
             assertThat(segments.get(0).getNumDocs(), equalTo(liveDocsFirstSegment.size()));
             assertThat(segments.get(0).getDeletedDocs(), equalTo(0));
@@ -463,7 +463,7 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.flush();
             }
             engine.refresh("test");
-            segments = engine.segments(randomBoolean());
+            segments = engine.segments();
             assertThat(segments, hasSize(2));
             assertThat(segments.get(0).getNumDocs(), equalTo(liveDocsFirstSegment.size()));
             assertThat(segments.get(0).getDeletedDocs(), equalTo(updates + deletes));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3469,7 +3469,7 @@ public class IndexShardTests extends IndexShardTestCase {
             indexDoc(shard, "_doc", Integer.toString(i));
             shard.refresh("test"); // produce segments
         }
-        List<Segment> segments = shard.segments(false);
+        List<Segment> segments = shard.segments();
         Set<String> names = new HashSet<>();
         for (Segment segment : segments) {
             assertFalse(segment.committed);
@@ -3480,7 +3480,7 @@ public class IndexShardTests extends IndexShardTestCase {
         shard.flush(new FlushRequest());
         shard.forceMerge(new ForceMergeRequest().maxNumSegments(1).flush(false));
         shard.refresh("test");
-        segments = shard.segments(false);
+        segments = shard.segments();
         for (Segment segment : segments) {
             if (names.contains(segment.getName())) {
                 assertTrue(segment.committed);
@@ -3496,7 +3496,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertFalse(shard.isActive());
 
         assertBusy(() -> { // flush happens in the background using the flush threadpool
-            List<Segment> segmentsAfterFlush = shard.segments(false);
+            List<Segment> segmentsAfterFlush = shard.segments();
             assertEquals(1, segmentsAfterFlush.size());
             for (Segment segment : segmentsAfterFlush) {
                 assertTrue(segment.committed);

--- a/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenEngineTests.java
+++ b/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenEngineTests.java
@@ -166,19 +166,19 @@ public class FrozenEngineTests extends EngineTestCase {
                         SegmentsStats segmentsStats = frozenEngine.segmentsStats(randomBoolean(), false);
                         try (Engine.Searcher searcher = reader.acquireSearcher("test")) {
                             segmentsStats = frozenEngine.segmentsStats(randomBoolean(), false);
-                            assertEquals(frozenEngine.segments(randomBoolean()).size(), segmentsStats.getCount());
+                            assertEquals(frozenEngine.segments().size(), segmentsStats.getCount());
                             assertEquals(1, listener.afterRefresh.get());
                         }
                         segmentsStats = frozenEngine.segmentsStats(randomBoolean(), false);
                         assertEquals(0, segmentsStats.getCount());
                         try (Engine.Searcher searcher = reader.acquireSearcher("test")) {
                             segmentsStats = frozenEngine.segmentsStats(randomBoolean(), true);
-                            assertEquals(frozenEngine.segments(randomBoolean()).size(), segmentsStats.getCount());
+                            assertEquals(frozenEngine.segments().size(), segmentsStats.getCount());
                             assertEquals(2, listener.afterRefresh.get());
                         }
                         assertFalse(frozenEngine.isReaderOpen());
                         segmentsStats = frozenEngine.segmentsStats(randomBoolean(), true);
-                        assertEquals(frozenEngine.segments(randomBoolean()).size(), segmentsStats.getCount());
+                        assertEquals(frozenEngine.segments().size(), segmentsStats.getCount());
                     }
                 }
             }


### PR DESCRIPTION
The 'verbose' option to `/_segments` returns memory information
for each segment.  However, lucene 9 has stopped tracking this memory
information as it is largely held off-heap and so is no longer significant.

This commit deprecates the 'verbose' parameter and makes it a no-op.

Fixes #75955