### PR TITLE
[7.x] Wait for the cluster state before unlocking nodes

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -171,16 +171,6 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
             inProgressSnapshots.add(startFullSnapshot(repoName, snapshotName));
         }
         awaitNumberOfSnapshotsInProgress(inProgressCount);
-
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);
-
-        unblockAllDataNodes(repoName);
-        for (ActionFuture<CreateSnapshotResponse> inProgressSnapshot : inProgressSnapshots) {
-            assertSuccessful(inProgressSnapshot);
-        }
-
         awaitClusterState(
             state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
                 .entries()
@@ -191,6 +181,16 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
                         || e.getValue().state() == SnapshotsInProgress.ShardState.SUCCESS
                 )
         );
+
+        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
+        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
+        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);
+
+        unblockAllDataNodes(repoName);
+        for (ActionFuture<CreateSnapshotResponse> inProgressSnapshot : inProgressSnapshots) {
+            assertSuccessful(inProgressSnapshot);
+        }
+
 
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -191,7 +191,6 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
             assertSuccessful(inProgressSnapshot);
         }
 
-
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);


### PR DESCRIPTION
Fixes an incorrect merge from #78341

