### PR TITLE
Fields API - add ignored field values to results

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -376,6 +376,93 @@ won't be included in the response because `include_unmapped` isn't set to
 // TESTRESPONSE[s/"max_score" : 1.0/"max_score" : $body.hits.max_score/]
 // TESTRESPONSE[s/"_score" : 1.0/"_score" : $body.hits.hits.0._score/]
 
+
+[discrete]
+[[Ignored-field values]]
+==== Ignored field values
+The `fields` option only returns values that were valid when indexed.
+If your search request asks for values from a field that ignored certain
+because they were malformed or too large these values are returned
+separately in an `ignored_field_values` section.
+
+In this example we index a document that has a value which is ignored and
+not added to the index so is shown separately in search results:
+
+[source,console]
+----
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "my-small" : { "type" : "keyword", "ignore_above": 1 }, <1>
+      "my-large" : { "type" : "keyword" }
+    }
+  }
+}
+
+PUT my-index-000001/_doc/1?refresh=true
+{
+  "my-small": "bad content", <2>
+  "my-large": "ok content"
+}
+
+POST my-index-000001/_search
+{
+  "fields": ["my-*"],
+  "_source": false
+}
+----
+
+<1> This field has a size restriction
+<2> This document field exceeds the size restriction so is ignored and not indexed
+
+The response will contain ignored field results under the  `ignored_field_values` path.
+These values are retrieved from the document's original JSON source and are raw so will
+not be formatted or treated in any way, unlike the successfully indexed fields which are
+returned in the `fields` section.
+
+[source,console-result]
+----
+{
+  "took" : 2,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 1,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "my-index-000001",
+        "_id" : "1",
+        "_score" : 1.0,
+        "fields" : {
+          "my-large": [
+            "ok content"
+          ]
+        },
+        "ignored_field_values" : {
+          "my-small": [
+            "bad content"
+          ]
+        }
+      }
+    ]
+  }
+}
+----
+// TESTRESPONSE[s/"took" : 2/"took": $body.took/]
+// TESTRESPONSE[s/"max_score" : 1.0/"max_score" : $body.hits.max_score/]
+// TESTRESPONSE[s/"_score" : 1.0/"_score" : $body.hits.hits.0._score/]
+
+
 [discrete]
 [[source-filtering]]
 === The `_source` option

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -443,6 +443,7 @@ returned in the `fields` section.
         "_index" : "my-index-000001",
         "_id" : "1",
         "_score" : 1.0,
+        "_ignored" : [ "my-small"],
         "fields" : {
           "my-large": [
             "ok content"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
@@ -97,7 +97,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
-        body: { query: { ids: { "values": [ "3" ] } } }
+        body: { query: { ids: { "values": [ "3" ] } },"_source":false, "fields":["my*"]}
 
   - length:   { hits.hits: 1  }
   - length:   { hits.hits.0._ignored: 2}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
@@ -76,7 +76,8 @@ setup:
 
   - length:   { hits.hits: 1  }
   - length:   { hits.hits.0._ignored: 2}
-
+  - length:   { hits.hits.0.ignored_field_values.my_date: 1}
+  - length:   { hits.hits.0.ignored_field_values.my_ip: 1}
 ---
 "_ignored is still returned with explicit list of stored fields":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/200_ignore_malformed.yml
@@ -76,8 +76,6 @@ setup:
 
   - length:   { hits.hits: 1  }
   - length:   { hits.hits.0._ignored: 2}
-  - length:   { hits.hits.0.ignored_field_values.my_date: 1}
-  - length:   { hits.hits.0.ignored_field_values.my_ip: 1}
 ---
 "_ignored is still returned with explicit list of stored fields":
 
@@ -89,3 +87,20 @@ setup:
 
   - length:   { hits.hits: 1  }
   - is_true:  hits.hits.0._ignored
+
+---
+"ignored_field_values is returned by default":
+  - skip:
+      version: " - 7.99.99"
+      reason: ignored_field_values was added in 8.0
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { query: { ids: { "values": [ "3" ] } } }
+
+  - length:   { hits.hits: 1  }
+  - length:   { hits.hits.0._ignored: 2}
+  - length:   { hits.hits.0.ignored_field_values.my_date: 1}
+  - length:   { hits.hits.0.ignored_field_values.my_ip: 1}
+

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -84,8 +84,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
 
     private BytesReference source;
 
-    // TODO - just use List<Object> instead of DocumentField here?
-    private Map<String, DocumentField> ignoredFieldValues;
+    private Map<String, DocumentField> ignoredFieldValues  = emptyMap();
     private Map<String, DocumentField> documentFields;
     private final Map<String, DocumentField> metaFields;
 
@@ -129,7 +128,6 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         }
         this.nestedIdentity = nestedIdentity;
         this.documentFields = documentFields == null ? emptyMap() : documentFields;
-        this.ignoredFieldValues = emptyMap();
         this.metaFields = metaFields == null ? emptyMap() : metaFields;
     }
 
@@ -729,7 +727,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             }
             builder.endObject();
         }
-        if (ignoredFieldValues != null && ignoredFieldValues.isEmpty() == false) {
+        if (ignoredFieldValues.isEmpty() == false) {
             builder.startObject(Fields.IGNORED_FIELD_VALUES);
             for (DocumentField field : ignoredFieldValues.values()) {
                 if (field.getValues().size() > 0) {
@@ -846,7 +844,6 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (matchedQueries != null) {
             searchHit.matchedQueries(matchedQueries.toArray(new String[0]));
         }
-        searchHit.ignoredFieldValues = emptyMap();
 
         return searchHit;
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -846,6 +846,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (matchedQueries != null) {
             searchHit.matchedQueries(matchedQueries.toArray(new String[0]));
         }
+        searchHit.ignoredFieldValues = emptyMap();
+
         return searchHit;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -729,7 +729,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             }
             builder.endObject();
         }
-        if (ignoredFieldValues.isEmpty() == false) {
+        if (ignoredFieldValues != null && ignoredFieldValues.isEmpty() == false) {
             builder.startObject(Fields.IGNORED_FIELD_VALUES);
             for (DocumentField field : ignoredFieldValues.values()) {
                 if (field.getValues().size() > 0) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -10,6 +10,11 @@ package org.elasticsearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.mapper.IgnoredFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -17,6 +22,8 @@ import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -37,6 +44,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
         }
 
         FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(), fetchFieldsContext.fields());
+//        final FetchDocValuesContext fdv = fetchContext.docValuesContext();
 
         return new FetchSubPhaseProcessor() {
             @Override
@@ -48,6 +56,41 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             public void process(HitContext hitContext) throws IOException {
                 SearchHit hit = hitContext.hit();
                 SourceLookup sourceLookup = hitContext.sourceLookup();
+                
+                DocumentField ignored = hit.field(IgnoredFieldMapper.NAME);
+                if (ignored != null) {
+                    for (Object ignoredField : ignored.getValues()) {                        
+                        String ignoredFieldName = ignoredField.toString();
+                        boolean wasRequested = fetchFieldsContext.fields().stream().anyMatch(f -> Regex.simpleMatch(f.field, ignoredFieldName));
+                        if (wasRequested == false) {
+                            // We don't care that this field was ignored at index time - the user didn't request to see it.
+                            continue;
+                        }
+                        SearchExecutionContext sec = fetchContext.getSearchExecutionContext();
+                        MappedFieldType fieldType = sec.getFieldType(ignoredFieldName);
+                        ValueFetcher valueFetcher = fieldType.valueFetcher(sec, null);
+                        List<Object> docValues = valueFetcher.fetchValues(sourceLookup);
+                        List<Object> sourceValues = sourceLookup.extractRawValues(ignoredFieldName);
+
+                        int lastDot = ignoredFieldName.lastIndexOf(".");
+                        if (sourceValues.isEmpty() && lastDot > 0) {
+                            // Looks like a multifield e.g. foo.keyword
+                            // Will need to strip "keyword" part from fieldname to retrieve foo from source.
+                            // Ideally MappedFieldType would have a "isMultiField()" method but need to do this "suck it and see" approach
+                            // to retrieving from source
+                            String parentFieldName = ignoredFieldName.substring(0, lastDot);
+                            sourceValues = sourceLookup.extractRawValues(parentFieldName);
+                        }
+                        // De-duplicate source values and remove any non-ignored values that were seen in doc values
+                        // Not perfect because a valid normalized keyword field can differ from source value meaning we
+                        // will return the source value as example of ignored field when it wasn't ignored.
+                        HashSet<Object> ignoredSourceValues = new HashSet<Object>(sourceValues);
+                        ignoredSourceValues.removeAll(docValues);
+                        if (ignoredSourceValues.isEmpty() == false) {
+                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.of(ignoredSourceValues)));                            
+                        }
+                    }
+                }
 
                 Map<String, DocumentField> documentFields = fieldFetcher.fetch(sourceLookup);
                 for (Map.Entry<String, DocumentField> entry : documentFields.entrySet()) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -59,9 +59,11 @@ public final class FetchFieldsPhase implements FetchSubPhase {
                 
                 DocumentField ignored = hit.field(IgnoredFieldMapper.NAME);
                 if (ignored != null) {
-                    for (Object ignoredField : ignored.getValues()) {                        
+                    for (Object ignoredField : ignored.getValues()) {
                         String ignoredFieldName = ignoredField.toString();
-                        boolean wasRequested = fetchFieldsContext.fields().stream().anyMatch(f -> Regex.simpleMatch(f.field, ignoredFieldName));
+                        boolean wasRequested = fetchFieldsContext.fields()
+                            .stream()
+                            .anyMatch(f -> Regex.simpleMatch(f.field, ignoredFieldName));
                         if (wasRequested == false) {
                             // We don't care that this field was ignored at index time - the user didn't request to see it.
                             continue;
@@ -87,7 +89,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
                         HashSet<Object> ignoredSourceValues = new HashSet<Object>(sourceValues);
                         ignoredSourceValues.removeAll(docValues);
                         if (ignoredSourceValues.isEmpty() == false) {
-                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.of(ignoredSourceValues)));                            
+                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.of(ignoredSourceValues)));
                         }
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -89,7 +89,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
                         HashSet<Object> ignoredSourceValues = new HashSet<Object>(sourceValues);
                         ignoredSourceValues.removeAll(docValues);
                         if (ignoredSourceValues.isEmpty() == false) {
-                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.of(ignoredSourceValues)));
+                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.copyOf(ignoredSourceValues)));
                         }
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -89,7 +89,10 @@ public final class FetchFieldsPhase implements FetchSubPhase {
                         HashSet<Object> ignoredSourceValues = new HashSet<Object>(sourceValues);
                         ignoredSourceValues.removeAll(docValues);
                         if (ignoredSourceValues.isEmpty() == false) {
-                            hit.setIgnoredFieldValues(ignoredFieldName, new DocumentField(ignoredFieldName, List.copyOf(ignoredSourceValues)));
+                            hit.setIgnoredFieldValues(
+                                ignoredFieldName,
+                                new DocumentField(ignoredFieldName, List.copyOf(ignoredSourceValues))
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Since Kibana's Discover switched to retrieving values via the fields API rather than source there have been gaps in the display caused by "ignored" fields (those that fall foul of `ignore_above` and `ignore_malformed` size and formatting rules).

This PR retrieves and returns ignored values from source when a user-requested field is mentioned in the `_ignored` field for a document. In these cases the corresponding hit adds a new `ignored_field_values` section in the response.

Closes #74121
