### PR TITLE
Properly handle wildcards in data stream deletion requests

### DIFF
--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
@@ -86,7 +86,6 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
         for (String name : names) {
             systemIndices.validateDataStreamAccess(name, threadPool.getThreadContext());
         }
-        request.indices(names.toArray(Strings.EMPTY_ARRAY));
 
         clusterService.submitStateUpdateTask(
             "remove-data-stream [" + Strings.arrayToCommaDelimitedString(request.getNames()) + "]",

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -406,8 +406,8 @@ setup:
 ---
 "Delete data stream by wildcard":
   - skip:
-      version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      version: " - 7.99.99"
+      reason: "change to [-7.8.99] and [data streams only supported in 7.9+] after backport"
 
   - do:
       indices.create_data_stream:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -404,6 +404,43 @@ setup:
         name: simple-data-stream2
 
 ---
+"Delete data stream by wildcard":
+  - skip:
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream2
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_data_stream:
+        name: no-matching-data-streams*
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - match: { data_streams.1.name: simple-data-stream2 }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream*
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - length: { data_streams: 0 }
+
+---
 "append-only writes to backing indices prohibited":
   - skip:
       version: " - 7.8.99"


### PR DESCRIPTION
The root cause of this bug was the replacement of the wildcard expression in the request's `indices` member with the actual data streams that expression matched. In the case that the authz code had already replaced it with the `*,-*` token that means "no authorized data streams", the expression would be evaluated again, would match no data streams, and would set the `indices` member to an empty array. An empty array is equivalent to `*`, so all data streams would then be deleted.

Fixes #78422