### PR TITLE
[7.x] Ensure docker test fixture preProcess task is always executed (#78421)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -77,7 +77,6 @@ public class TestFixturesPlugin implements Plugin<Project> {
             project.getPluginManager().apply(DockerComposePlugin.class);
 
             TaskProvider<Task> preProcessFixture = project.getTasks().register("preProcessFixture", t -> {
-                t.getOutputs().dir(testfixturesDir);
                 t.doFirst(new Action<Task>() {
                     @Override
                     public void execute(Task task) {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -189,12 +189,12 @@ tasks.named("preProcessFixture").configure {
   doLast {
     // tests expect to have an empty repo
     project.delete(
-      "${buildDir}/repo",
+      "${testFixturesDir}/repo",
     )
     createAndSetWritable(
-      "${buildDir}/repo",
-      "${buildDir}/logs/default-1",
-      "${buildDir}/logs/default-2",
+      "${testFixturesDir}/repo",
+      "${testFixturesDir}/logs/default-1",
+      "${testFixturesDir}/logs/default-2",
     )
   }
 }

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -33,10 +33,10 @@ services:
        - xpack.license.self_generated.type=trial
        - action.destructive_requires_name=false
     volumes:
-       - ./build/repo:/tmp/es-repo
+       - ./testfixtures_shared/repo:/tmp/es-repo
        - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
        - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
-       - ./build/logs/default-1:/usr/share/elasticsearch/logs
+       - ./testfixtures_shared/logs/default-1:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
       - "9200"
@@ -77,10 +77,10 @@ services:
        - xpack.license.self_generated.type=trial
        - action.destructive_requires_name=false
     volumes:
-       - ./build/repo:/tmp/es-repo
+       - ./testfixtures_shared/repo:/tmp/es-repo
        - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
        - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
-       - ./build/logs/default-2:/usr/share/elasticsearch/logs
+       - ./testfixtures_shared/logs/default-2:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
       - "9200"

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -49,16 +49,16 @@ tasks.named("preProcessFixture").configure {
   doLast {
     // tests expect to have an empty repo
     project.delete(
-      "${buildDir}/repo",
-      "${buildDir}/oss-repo"
+      "${testFixturesDir}/repo",
+      "${testFixturesDir}/oss-repo"
     )
     createAndSetWritable(
-      "${buildDir}/repo",
-      "${buildDir}/oss-repo",
-      "${buildDir}/logs/default-1",
-      "${buildDir}/logs/default-2",
-      "${buildDir}/logs/oss-1",
-      "${buildDir}/logs/oss-2"
+      "${testFixturesDir}/repo",
+      "${testFixturesDir}/oss-repo",
+      "${testFixturesDir}/logs/default-1",
+      "${testFixturesDir}/logs/default-2",
+      "${testFixturesDir}/logs/oss-1",
+      "${testFixturesDir}/logs/oss-2"
     )
   }
 }

--- a/qa/remote-clusters/docker-compose.yml
+++ b/qa/remote-clusters/docker-compose.yml
@@ -33,10 +33,10 @@ services:
        - xpack.license.self_generated.type=trial
        - action.destructive_requires_name=false
     volumes:
-       - ./build/repo:/tmp/es-repo
+       - ./testfixtures_shared/repo:/tmp/es-repo
        - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
        - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
-       - ./build/logs/default-1:/usr/share/elasticsearch/logs
+       - ./testfixtures_shared/logs/default-1:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
       - "9200"
@@ -87,10 +87,10 @@ services:
        - xpack.license.self_generated.type=trial
        - action.destructive_requires_name=false
     volumes:
-       - ./build/repo:/tmp/es-repo
+       - ./testfixtures_shared/repo:/tmp/es-repo
        - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
        - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
-       - ./build/logs/default-2:/usr/share/elasticsearch/logs
+       - ./testfixtures_shared/logs/default-2:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
       - "9200"

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -27,7 +27,7 @@ elasticsearch_distributions {
 tasks.named("preProcessFixture").configure {
   dependsOn "copyKeystore", elasticsearch_distributions.docker
   doLast {
-    File file = file("${buildDir}/logs/node1")
+    File file = file("${testFixturesDir}/logs/node1")
     file.mkdirs()
     file.setWritable(true, false)
   }

--- a/x-pack/test/idp-fixture/docker-compose.yml
+++ b/x-pack/test/idp-fixture/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - xpack.security.authc.realms.oidc.c2id-jwt.claims.mail=email
       - xpack.security.authc.realms.oidc.c2id-jwt.claims.groups=groups
     volumes:
-      - ./build/logs/node1:/usr/share/elasticsearch/logs
+      - ./testfixtures_shared/logs/node1:/usr/share/elasticsearch/logs
       - ./build/certs/testnode.jks:/usr/share/elasticsearch/config/testnode.jks
       - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
       - ./oidc/op-jwks.json:/usr/share/elasticsearch/config/op-jwks.json


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure docker test fixture preProcess task is always executed (#78421)