### PR TITLE
[DOCS] Removes partintro from Java LLRC main page

### DIFF
--- a/docs/java-rest/low-level/index.asciidoc
+++ b/docs/java-rest/low-level/index.asciidoc
@@ -1,9 +1,6 @@
 [[java-rest-low]]
 = Java Low Level REST Client
 
-[partintro]
---
-
 The low-level client's features include:
 
 * minimal dependencies
@@ -22,7 +19,6 @@ The low-level client's features include:
 
 * optional automatic <<sniffer,discovery of cluster nodes>>
 
---
 
 :doc-tests: {elasticsearch-root}/client/rest/src/test/java/org/elasticsearch/client/documentation
 include::usage.asciidoc[]


### PR DESCRIPTION
## Overview

This PR removes `partintro` from Java LLRC index file to make the docs-ci pass on https://github.com/elastic/docs/pull/2230


### Preview

[LLRC index]() --available soon