### PR TITLE
Skip Inspecting Busy Indices on ILM CS Application

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -30,7 +30,6 @@ import java.util.function.LongSupplier;
 public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask {
     private static final Logger logger = LogManager.getLogger(ExecuteStepsUpdateTask.class);
     private final String policy;
-    private final Index index;
     private final Step startStep;
     private final PolicyStepsRegistry policyStepsRegistry;
     private final IndexLifecycleRunner lifecycleRunner;
@@ -40,8 +39,8 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
 
     public ExecuteStepsUpdateTask(String policy, Index index, Step startStep, PolicyStepsRegistry policyStepsRegistry,
                                   IndexLifecycleRunner lifecycleRunner, LongSupplier nowSupplier) {
+        super(index, startStep.getKey());
         this.policy = policy;
-        this.index = index;
         this.startStep = startStep;
         this.policyStepsRegistry = policyStepsRegistry;
         this.nowSupplier = nowSupplier;
@@ -50,10 +49,6 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
 
     String getPolicy() {
         return policy;
-    }
-
-    Index getIndex() {
-        return index;
     }
 
     Step getStartStep() {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -11,6 +11,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.xpack.core.ilm.Step;
 
 /**
  * Base class for index lifecycle cluster state update tasks that requires implementing {@code equals} and {@code hashCode} to allow
@@ -19,6 +21,23 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateUpdateTask {
 
     private final ListenableFuture<Void> listener = new ListenableFuture<>();
+
+    protected final Index index;
+
+    protected final Step.StepKey currentStepKey;
+
+    protected IndexLifecycleClusterStateUpdateTask(Index index, Step.StepKey currentStepKey) {
+        this.index = index;
+        this.currentStepKey = currentStepKey;
+    }
+
+    final Index getIndex() {
+        return index;
+    }
+
+    final Step.StepKey getCurrentStepKey() {
+        return currentStepKey;
+    }
 
     @Override
     public final void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -24,9 +24,7 @@ import java.util.function.LongSupplier;
 public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTask {
     private static final Logger logger = LogManager.getLogger(MoveToNextStepUpdateTask.class);
 
-    private final Index index;
     private final String policy;
-    private final Step.StepKey currentStepKey;
     private final Step.StepKey nextStepKey;
     private final LongSupplier nowSupplier;
     private final PolicyStepsRegistry stepRegistry;
@@ -35,9 +33,8 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
     public MoveToNextStepUpdateTask(Index index, String policy, Step.StepKey currentStepKey, Step.StepKey nextStepKey,
                                     LongSupplier nowSupplier, PolicyStepsRegistry stepRegistry,
                                     Consumer<ClusterState> stateChangeConsumer) {
-        this.index = index;
+        super(index, currentStepKey);
         this.policy = policy;
-        this.currentStepKey = currentStepKey;
         this.nextStepKey = nextStepKey;
         this.nowSupplier = nowSupplier;
         this.stepRegistry = stepRegistry;

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -28,28 +28,17 @@ public class SetStepInfoUpdateTask extends IndexLifecycleClusterStateUpdateTask 
 
     private static final Logger logger = LogManager.getLogger(SetStepInfoUpdateTask.class);
 
-    private final Index index;
     private final String policy;
-    private final Step.StepKey currentStepKey;
     private final ToXContentObject stepInfo;
 
     public SetStepInfoUpdateTask(Index index, String policy, Step.StepKey currentStepKey, ToXContentObject stepInfo) {
-        this.index = index;
+        super(index, currentStepKey);
         this.policy = policy;
-        this.currentStepKey = currentStepKey;
         this.stepInfo = stepInfo;
-    }
-
-    Index getIndex() {
-        return index;
     }
 
     String getPolicy() {
         return policy;
-    }
-
-    Step.StepKey getCurrentStepKey() {
-        return currentStepKey;
     }
 
     ToXContentObject getStepInfo() {


### PR DESCRIPTION
If the current combination of current-step and index has a running CS update task
enqueued there is no point in adding yet another task for this combination on the applier
and we can skip the expensive inspection for the index on the applier thread.

I didn't go further in terms of making this check during periodic application as well, just to keep the change simple and safe for now.

follow up to #78390
