### PR TITLE
[DOCS] EQL: Document `runs` keyword

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -695,6 +695,45 @@ until [ process where event.type == "stop" ]
 ====
 
 [discrete]
+[[eql-runs-keyword]]
+=== `runs` keyword
+
+Use a `runs` statement to repeat an event within a sequence query. For example:
+
+[source,eql]
+----
+sequence
+  [ process where event.type == "creation" ]
+  [ library where process.name == "regsvr32.exe" ] [runs=3]
+  [ registry where true ]
+----
+
+is equivalent to:
+
+[source,eql]
+----
+sequence
+  [ process where event.type == "creation" ]
+  [ library where process.name == "regsvr32.exe" ]
+  [ library where process.name == "regsvr32.exe" ]
+  [ library where process.name == "regsvr32.exe" ]
+  [ registry where true ]
+----
+
+A `runs` statement must be enclosed in square brackets (`[ ]`). The `runs` value
+must be between `1` and `100` (inclusive).
+ 
+You can use a `runs` statement with the <<eql-by-keyword,`by` keyword>>. For
+example:
+
+[source,eql]
+----
+sequence
+  [ process where event.type == "creation" ] by process.executable
+  [ library where process.name == "regsvr32.exe" ] by dll.path [runs=3]
+----
+
+[discrete]
 [[eql-functions]]
 === Functions
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -698,7 +698,8 @@ until [ process where event.type == "stop" ]
 [[eql-runs-keyword]]
 === `runs` keyword
 
-Use a `runs` statement to repeat an event within a sequence query. For example:
+Use a `runs` statement to run the same event criteria successively within a
+sequence query. For example:
 
 [source,eql]
 ----

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,8 +32,9 @@ Other versions:
 [discrete]
 === EQL: `runs` keyword for repeated events
 
-In 7.16, we added the `runs` keyword to EQL. Rather than type the same event
-criteria multiple times, you can use a `runs` statement to declare the criteria
-once and run it successively. For more details, check out the
-{ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
+In 7.16, we added the `runs` keyword to EQL. Sometimes a sequence includes a
+repeated event. Rather than type the same event criteria multiple times, you can
+use a `runs` statement to declare the criteria once and run it successively. For
+more details, check out the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax
+documentation].
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -33,8 +33,8 @@ Other versions:
 === EQL: `runs` keyword for repeated events
 
 In 7.16, we added the `runs` keyword to EQL sequence queries. Sometimes you want
-to find a sequence that contains a repeated, successive event. Rather than type
-the same event criteria multiple times, you can use a `runs` statement to
-declare the criteria once and run it successively. For more details, check out
-the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
+to find a sequence that contains an event multiple times in sucession. Rather
+than type the same event criteria multiple times, you can use a `runs` statement
+to declare the criteria once and run it successively. For more details, check
+out the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -8,7 +8,8 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // Add previous release to the list
 Other versions:
-{ref-bare}/7.14/release-highlights.html[7.14]
+{ref-bare}/7.15/release-highlights.html[7.15]
+| {ref-bare}/7.14/release-highlights.html[7.14]
 | {ref-bare}/7.13/release-highlights.html[7.13]
 | {ref-bare}/7.11/release-highlights.html[7.12]
 | {ref-bare}/7.11/release-highlights.html[7.11]
@@ -26,15 +27,14 @@ Other versions:
 
 // Use the notable-highlights tag to mark entries that
 // should be featured in the Stack Installation and Upgrade Guide:
-// tag::notable-highlights[]
-// [discrete]
-// === Heading
-//
-// Description.
-// end::notable-highlights[]
 
-// Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [discrete]
-// === Heading
-//
-// Description.
+// tag::notable-highlights[]
+[discrete]
+=== EQL: `runs` keyword for repeated events
+
+In 7.16, we added the `runs` keyword to EQL. Sometimes a sequence includes
+a repeated event. Rather than typing the same event criteria multiple times, you
+can use a `runs` statement to easily repeat an event within a sequence query.
+For more details, check out the {ref}/eql-syntax.html#eql-runs-keyword[EQL
+syntax documentation].
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,9 +32,9 @@ Other versions:
 [discrete]
 === EQL: `runs` keyword for repeated events
 
-In 7.16, we added the `runs` keyword to EQL. Sometimes you want to find a
-sequence that contains a repeated, successive event. Rather than type the same
-event criteria multiple times, you can use a `runs` statement to declare the
-criteria once and run it successively. For more details, check out the
-{ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
+In 7.16, we added the `runs` keyword to EQL sequence queries. Sometimes you want
+to find a sequence that contains a repeated, successive event. Rather than type
+the same event criteria multiple times, you can use a `runs` statement to
+declare the criteria once and run it successively. For more details, check out
+the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -33,7 +33,7 @@ Other versions:
 === EQL: `runs` keyword for repeated events
 
 In 7.16, we added the `runs` keyword to EQL sequence queries. Sometimes you want
-to find a sequence that contains an event multiple times in sucession. Rather
+to find a sequence that contains an event multiple times in succession. Rather
 than type the same event criteria multiple times, you can use a `runs` statement
 to declare the criteria once and run it successively. For more details, check
 out the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,9 +32,8 @@ Other versions:
 [discrete]
 === EQL: `runs` keyword for repeated events
 
-In 7.16, we added the `runs` keyword to EQL. Sometimes a sequence includes
-a repeated event. Rather than typing the same event criteria multiple times, you
-can use a `runs` statement to easily repeat an event within a sequence query.
-For more details, check out the {ref}/eql-syntax.html#eql-runs-keyword[EQL
-syntax documentation].
+In 7.16, we added the `runs` keyword to EQL. Rather than type the same event
+criteria multiple times, you can use a `runs` statement to declare the criteria
+once and run it successively. For more details, check out the
+{ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,9 +32,9 @@ Other versions:
 [discrete]
 === EQL: `runs` keyword for repeated events
 
-In 7.16, we added the `runs` keyword to EQL. Sometimes a sequence includes a
-repeated event. Rather than type the same event criteria multiple times, you can
-use a `runs` statement to declare the criteria once and run it successively. For
-more details, check out the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax
-documentation].
+In 7.16, we added the `runs` keyword to EQL. Sometimes you want to find a
+sequence that contains a repeated, successive event. Rather than type the same
+event criteria multiple times, you can use a `runs` statement to declare the
+criteria once and run it successively. For more details, check out the
+{ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
 // end::notable-highlights[]


### PR DESCRIPTION
Documents the `runs` keyword for running the same event criteria successively in a sequence query.

Relates to #75082.

Targeting 7.x to include the release highlight. I'll remove the highlight from the 8.0/master port.

### Preview
* Release highlight: https://elasticsearch_78478.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/release-highlights.html#_eql_runs_keyword_for_repeated_events
* `runs` keyword docs: https://elasticsearch_78478.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/eql-syntax.html#eql-runs-keyword