### PR TITLE
[7.x] Backport HotThreads memory report type (#72850)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -55,7 +55,10 @@ public class HotThreadsIT extends ESIntegTestCase {
             }
             nodesHotThreadsRequestBuilder.setIgnoreIdleThreads(randomBoolean());
             if (randomBoolean()) {
-                switch (randomIntBetween(0, 2)) {
+                switch (randomIntBetween(0, 3)) {
+                    case 3:
+                        type = "mem";
+                        break;
                     case 2:
                         type = "cpu";
                         break;

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/SunThreadInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/SunThreadInfo.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.monitor.jvm;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.management.ThreadMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+
+public class SunThreadInfo {
+
+    private static final ThreadMXBean threadMXBean;
+    private static final Method getThreadAllocatedBytes;
+    private static final Method isThreadAllocatedMemorySupported;
+    private static final Method isThreadAllocatedMemoryEnabled;
+
+    private static final Logger logger = LogManager.getLogger(SunThreadInfo.class);
+    public static final SunThreadInfo INSTANCE = new SunThreadInfo();
+
+    static {
+        threadMXBean = ManagementFactory.getThreadMXBean();
+        getThreadAllocatedBytes = getMethod("getThreadAllocatedBytes", long.class);
+        isThreadAllocatedMemorySupported = getMethod("isThreadAllocatedMemorySupported");
+        isThreadAllocatedMemoryEnabled = getMethod("isThreadAllocatedMemoryEnabled");
+    }
+
+    public boolean isThreadAllocatedMemorySupported() {
+        if (isThreadAllocatedMemorySupported == null) {
+            return false;
+        }
+
+        try {
+            return (boolean) isThreadAllocatedMemorySupported.invoke(threadMXBean);
+        } catch (Exception e) {
+            logger.warn("exception while invoke isThreadAllocatedMemorySupported", e);
+            return false;
+        }
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() {
+        if (isThreadAllocatedMemoryEnabled == null) {
+            return false;
+        }
+
+        try {
+            return (boolean) isThreadAllocatedMemoryEnabled.invoke(threadMXBean);
+        } catch (Exception e) {
+            logger.warn("exception while invoke isThreadAllocatedMemoryEnabled", e);
+            return false;
+        }
+    }
+
+    public long getThreadAllocatedBytes(long id) {
+        if (getThreadAllocatedBytes == null) {
+            return 0;
+        }
+
+        if (isThreadAllocatedMemorySupported() == false || isThreadAllocatedMemoryEnabled() == false) {
+            return 0;
+        }
+
+        if (id <= 0) {
+            return 0;
+        }
+
+        try {
+            long bytes = (long) getThreadAllocatedBytes.invoke(threadMXBean, id);
+            assert bytes >= 0 : "OS reported a negative thread allocated size [" + bytes + "], thread id [" + id + "].";
+            return Math.max(0, bytes);
+        } catch (Exception e) {
+            logger.warn("exception retrieving thread allocated memory", e);
+            return 0;
+        }
+    }
+
+    private static Method getMethod(String methodName, Class<?>... parameterTypes) {
+        try {
+            Method method = Class.forName("com.sun.management.ThreadMXBean").getMethod(methodName, parameterTypes);
+            return method;
+        } catch (Exception e) {
+            // not available
+            return null;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.monitor.jvm;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.InOrder;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -31,11 +33,11 @@ import static org.mockito.Mockito.when;
 public class HotThreadsTests extends ESTestCase {
 
     public void testSupportedThreadsReportType() {
-        for (String type : new String[]{"unsupported", "", null, "CPU", "WAIT", "BLOCK"}) {
+        for (String type : new String[]{"unsupported", "", null, "CPU", "WAIT", "BLOCK", "MEM"}) {
             expectThrows(IllegalArgumentException.class, () -> new HotThreads().type(HotThreads.ReportType.of(type)));
         }
 
-        for (String type : new String[]{"cpu", "wait", "block"}) {
+        for (String type : new String[]{"cpu", "wait", "block", "mem"}) {
             try {
                 new HotThreads().type(HotThreads.ReportType.of(type));
             } catch (IllegalArgumentException e) {
@@ -238,6 +240,10 @@ public class HotThreadsTests extends ESTestCase {
         ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
+        SunThreadInfo mockedSunThreadInfo = mock(SunThreadInfo.class);
+        when(mockedSunThreadInfo.isThreadAllocatedMemorySupported()).thenReturn(true);
+        when(mockedSunThreadInfo.isThreadAllocatedMemoryEnabled()).thenReturn(true);
+
         long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
         long mockCurrentThreadId = 0L;
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
@@ -254,7 +260,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10nanos, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -268,7 +274,7 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
 
         // Let's ask again without progressing the CPU thread counters, e.g. resetting the mocks
-        innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("0.0% (0s out of 10nanos) cpu usage by thread 'Thread 4'"));
         assertThat(innerResult, containsString("0.0% (0s out of 10nanos) cpu usage by thread 'Thread 3'"));
@@ -287,7 +293,7 @@ public class HotThreadsTests extends ESTestCase {
             allInfos.get(3), allInfos.get(1), allInfos.get(0), allInfos.get(2));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(waitOrderedInfos.toArray(new ThreadInfo[0]));
 
-        String waitInnerResult = hotWaitingThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String waitInnerResult = hotWaitingThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(waitInnerResult, containsString("40.0% (4nanos out of 10nanos) wait usage by thread 'Thread 4'"));
         assertThat(waitInnerResult, containsString("20.0% (2nanos out of 10nanos) wait usage by thread 'Thread 2'"));
@@ -306,7 +312,7 @@ public class HotThreadsTests extends ESTestCase {
             allInfos.get(2), allInfos.get(0), allInfos.get(1), allInfos.get(3));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(blockOrderedInfos.toArray(new ThreadInfo[0]));
 
-        String blockInnerResult = hotBlockedThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String blockInnerResult = hotBlockedThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(blockInnerResult, containsString("30.0% (3nanos out of 10nanos) block usage by thread 'Thread 3'"));
         assertThat(blockInnerResult, containsString("10.0% (1nanos out of 10nanos) block usage by thread 'Thread 1'"));
@@ -326,7 +332,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(1)
             .ignoreIdleThreads(false);
 
-        String singleResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String singleResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(singleResult, containsString("  unique snapshot"));
         assertEquals(5, singleResult.split(" unique snapshot").length);
@@ -337,6 +343,28 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_0(Some_File:1)"));
         assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_1(Some_File:1)"));
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
+
+        allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+        cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
+
+        for (long threadId : threadIds) {
+            when(mockedSunThreadInfo.getThreadAllocatedBytes(threadId)).thenReturn(0L).thenReturn(threadId*100);
+        }
+
+        hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.MEM)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(1)
+            .ignoreIdleThreads(false);
+
+        String memInnerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
+        assertThat(memInnerResult, containsString("  unique snapshot"));
+        assertThat(memInnerResult, containsString("400b memory allocated by thread 'Thread 4'"));
+        assertThat(memInnerResult, containsString("300b memory allocated by thread 'Thread 3'"));
+        assertThat(memInnerResult, containsString("200b memory allocated by thread 'Thread 2'"));
+        assertThat(memInnerResult, containsString("100b memory allocated by thread 'Thread 1'"));
     }
 
     public void testEnsureInnerDetectSkipsCurrentThread() throws Exception {
@@ -358,7 +386,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String innerResult = hotThreads.innerDetect(mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId);
 
         assertEquals(1, innerResult.split("\r\n|\r|\n").length);
     }
@@ -369,11 +397,12 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedThreadInfo.getBlockedTime()).thenReturn(2L).thenReturn(0L);
         when(mockedThreadInfo.getWaitedTime()).thenReturn(3L).thenReturn(0L);
 
-        HotThreads.ThreadTimeAccumulator info = new HotThreads.ThreadTimeAccumulator(mockedThreadInfo, 1L);
+        HotThreads.ThreadTimeAccumulator info = new HotThreads.ThreadTimeAccumulator(mockedThreadInfo, 1L, 4L);
 
         assertEquals(1L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.CPU).applyAsLong(info));
         assertEquals(3L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.WAIT).applyAsLong(info));
         assertEquals(2L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.BLOCK).applyAsLong(info));
+        assertEquals(4L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.MEM).applyAsLong(info));
 
         //Ensure all enum types have a report type getter
         for (HotThreads.ReportType type : HotThreads.ReportType.values()) {
@@ -384,6 +413,7 @@ public class HotThreadsTests extends ESTestCase {
     public void testGetAllValidThreadInfos() {
         ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+        SunThreadInfo mockedSunThreadInfo = mock(SunThreadInfo.class);
 
         long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
         long mockCurrentThreadId = 0L;
@@ -399,7 +429,8 @@ public class HotThreadsTests extends ESTestCase {
         // Test the case when all threads exist before and after sleep
         List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
 
-        Map<Long, HotThreads.ThreadTimeAccumulator> validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        Map<Long, HotThreads.ThreadTimeAccumulator> validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo,
+            mockCurrentThreadId);
         assertEquals(allInfos.size(), validInfos.size());
 
         for (long threadId : threadIds) {
@@ -412,7 +443,8 @@ public class HotThreadsTests extends ESTestCase {
 
         // Fake sleep, e.g don't sleep call the mock again
 
-        Map<Long, HotThreads.ThreadTimeAccumulator> afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        Map<Long, HotThreads.ThreadTimeAccumulator> afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo,
+            mockCurrentThreadId);
         assertEquals(allInfos.size(), afterValidInfos.size());
         for (long threadId : threadIds) {
             HotThreads.ThreadTimeAccumulator accumulator = afterValidInfos.get(threadId);
@@ -427,7 +459,7 @@ public class HotThreadsTests extends ESTestCase {
         // Test when a thread has terminated during sleep, we don't report that thread
         allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
 
-        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertEquals(allInfos.size(), validInfos.size());
 
         ThreadInfo removedInfo = allInfos.remove(0);
@@ -438,7 +470,7 @@ public class HotThreadsTests extends ESTestCase {
 
         // Fake sleep
 
-        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertEquals(reducedThreadIds.length, afterValidInfos.size());
 
         for (long threadId : reducedThreadIds) {
@@ -459,7 +491,7 @@ public class HotThreadsTests extends ESTestCase {
 
         // Fake sleep
 
-        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertEquals(threadIds.length, afterValidInfos.size());
 
         HotThreads.ThreadTimeAccumulator firstAccumulator = afterValidInfos.get(removedInfo.getThreadId());
@@ -468,19 +500,19 @@ public class HotThreadsTests extends ESTestCase {
         assertEquals(1, firstAccumulator.getBlockedTime());
 
         // Test skipping of current thread
-        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, threadIds[threadIds.length - 1]);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, threadIds[threadIds.length - 1]);
         assertEquals(threadIds.length - 1, validInfos.size());
         assertFalse(validInfos.containsKey(threadIds[threadIds.length - 1]));
 
         // Test skipping threads with CPU time of -1
         when(mockedMXBean.getThreadCpuTime(threadIds[0])).thenReturn(-1L);
-        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertEquals(threadIds.length - 1, validInfos.size());
         assertFalse(validInfos.containsKey(threadIds[0]));
 
         // Test skipping null thread infos
         when(mockedMXBean.getThreadInfo(eq(threadIds[0]), anyInt())).thenReturn(null);
-        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertEquals(threadIds.length - 1, validInfos.size());
         assertFalse(validInfos.containsKey(threadIds[0]));
     }
@@ -526,25 +558,27 @@ public class HotThreadsTests extends ESTestCase {
         ThreadInfo threadOne = makeThreadInfoMocksHelper(mockedMXBean, 1L);
         ThreadInfo threadTwo = makeThreadInfoMocksHelper(mockedMXBean, 2L);
 
-        HotThreads.ThreadTimeAccumulator acc = new HotThreads.ThreadTimeAccumulator(threadOne, 100L);
-        HotThreads.ThreadTimeAccumulator accNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+        HotThreads.ThreadTimeAccumulator acc = new HotThreads.ThreadTimeAccumulator(threadOne, 100L, 1000L);
+        HotThreads.ThreadTimeAccumulator accNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L, 2500L);
         accNext.subtractPrevious(acc);
 
+        assertEquals(1500, accNext.getAllocatedBytes());
         assertEquals(150, accNext.getCpuTime());
         assertEquals(0, accNext.getWaitedTime());
         assertEquals(1, accNext.getBlockedTime());
 
-        HotThreads.ThreadTimeAccumulator accNotMoving = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
-        HotThreads.ThreadTimeAccumulator accNotMovingNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+        HotThreads.ThreadTimeAccumulator accNotMoving = new HotThreads.ThreadTimeAccumulator(threadOne, 250L, 2500L);
+        HotThreads.ThreadTimeAccumulator accNotMovingNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L, 2500L);
 
         accNotMovingNext.subtractPrevious(accNotMoving);
 
+        assertEquals(0, accNotMovingNext.getAllocatedBytes());
         assertEquals(0, accNotMovingNext.getCpuTime());
         assertEquals(0, accNotMovingNext.getWaitedTime());
         assertEquals(0, accNotMovingNext.getBlockedTime());
 
-        HotThreads.ThreadTimeAccumulator accOne = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
-        HotThreads.ThreadTimeAccumulator accTwo = new HotThreads.ThreadTimeAccumulator(threadTwo, 350L);
+        HotThreads.ThreadTimeAccumulator accOne = new HotThreads.ThreadTimeAccumulator(threadOne, 250L, 2500L);
+        HotThreads.ThreadTimeAccumulator accTwo = new HotThreads.ThreadTimeAccumulator(threadTwo, 350L, 3500L);
 
         expectThrows(IllegalStateException.class, () -> accTwo.subtractPrevious(accOne));
     }
@@ -570,7 +604,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+        String innerResult = hotThreads.innerDetect(mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10nanos, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -603,11 +637,58 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        expectThrows(RuntimeException.class, () -> hotThreads.innerDetect(mockedMXBean, 0L));
+        expectThrows(RuntimeException.class, () -> hotThreads.innerDetect(mockedMXBean, mock(SunThreadInfo.class), 0L));
 
         // Ensure we called the monitoring enabled with true and then with false even with exception thrown
         InOrder orderVerifier = inOrder(mockedMXBean);
         orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(true);
         orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(false);
+    }
+
+    public void testGetThreadAllocatedBytesFailures() throws Exception {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+        when(mockedMXBean.isThreadContentionMonitoringSupported()).thenReturn(true);
+
+        SunThreadInfo mockedSunThreadInfo = mock(SunThreadInfo.class);
+        when(mockedSunThreadInfo.isThreadAllocatedMemorySupported()).thenReturn(false);
+
+        long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
+        long mockCurrentThreadId = 0L;
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+        List<ThreadInfo> cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
+
+        HotThreads hotThreads0 = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.MEM)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(1)
+            .ignoreIdleThreads(false);
+
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+            () -> hotThreads0.innerDetect(mockedMXBean, mockedSunThreadInfo, 0L));
+        assertThat(exception.getMessage(), equalTo("thread allocated memory is not supported on this JDK"));
+
+        // making sure CPU type was not affected when isThreadAllocatedMemorySupported() == false
+
+        HotThreads hotThreads1 = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(1)
+            .ignoreIdleThreads(false);
+
+        String innerResult = hotThreads1.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
+        assertThat(innerResult, containsString("Hot threads at "));
+        assertThat(innerResult, containsString("40.0% (4nanos out of 10nanos) cpu usage by thread 'Thread 4'"));
+        assertThat(innerResult, containsString("30.0% (3nanos out of 10nanos) cpu usage by thread 'Thread 3'"));
+        assertThat(innerResult, containsString("20.0% (2nanos out of 10nanos) cpu usage by thread 'Thread 2'"));
+        assertThat(innerResult, containsString("10.0% (1nanos out of 10nanos) cpu usage by thread 'Thread 1'"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_0(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_1(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -345,7 +345,7 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
 
         allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
-        cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        cpuOrderedInfos = org.elasticsearch.core.List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
 
         for (long threadId : threadIds) {
@@ -658,7 +658,8 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
         List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
-        List<ThreadInfo> cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        List<ThreadInfo> cpuOrderedInfos = org.elasticsearch.core.List.of(
+            allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
 
         HotThreads hotThreads0 = new HotThreads()


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/72850.

Introduce new HotThreads report type for displaying allocated memory per thread.

Closes https://github.com/elastic/elasticsearch/issues/70345