### PR TITLE
[DOCS] Fix erroneous page break.

### DIFF
--- a/docs/reference/migration/migrate_8_0/monitoring.asciidoc
+++ b/docs/reference/migration/migrate_8_0/monitoring.asciidoc
@@ -1,4 +1,4 @@
-[discreet]
+[discrete]
 [[breaking_80_monitoring_changes]]
 === Monitoring changes
 


### PR DESCRIPTION
Typo in the discrete tag was creating a new page.