### PR TITLE
Use batching for ILM cluster state updates

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -177,7 +177,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
 
     @Override
     public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        if (oldState.equals(newState) == false) {
+        if (changeMade && oldState.equals(newState) == false) {
             IndexMetadata indexMetadata = newState.metadata().index(index);
             if (indexMetadata != null) {
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateUpdateTask {
 
     private final ListenableFuture<Void> listener = new ListenableFuture<>();
+    protected volatile boolean changeMade;
 
     @Override
     public final void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -67,7 +67,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
 
     @Override
     public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        if (oldState.equals(newState) == false) {
+        if (changeMade && oldState.equals(newState) == false) {
             stateChangeConsumer.accept(newState);
         }
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -80,6 +80,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         assertThat(lifecycleState.getPhaseTime(), equalTo(now));
         assertThat(lifecycleState.getActionTime(), equalTo(now));
         assertThat(lifecycleState.getStepTime(), equalTo(now));
+        task.changeMade = true;
         task.clusterStateProcessed("source", clusterState, newState);
         assertTrue(changed.get());
     }
@@ -124,6 +125,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         assertThat(lifecycleState.getPhaseTime(), equalTo(now));
         assertThat(lifecycleState.getActionTime(), equalTo(now));
         assertThat(lifecycleState.getStepTime(), equalTo(now));
+        task.changeMade = true;
         task.clusterStateProcessed("source", clusterState, newState);
         assertTrue(changed.get());
     }


### PR DESCRIPTION
This change introduce executor that batches ILM cluster state updates to avoid tasks explosion and speed up ILM processing.
With tasks deduplication introduced in https://github.com/elastic/elasticsearch/pull/78390 there should never be more tasks than indices so application should be quick.

Relates #77466