### PR TITLE
Disk usage API does not support timeout parameters

### DIFF
--- a/docs/reference/indices/diskusage.asciidoc
+++ b/docs/reference/indices/diskusage.asciidoc
@@ -55,8 +55,6 @@ Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
-
 `run_expensive_tasks`::
 (Required, Boolean) Analyzing field disk usage is resource-intensive. To use the
 API, this parameter must be set to `true`. Defaults to `false`.


### PR DESCRIPTION
Fixes the documentation.

Closes #78356