### PR TITLE
[7.x] Mute 'histogram with time series mappings' test yaml test (#78502)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -175,8 +175,8 @@ setup:
 ---
 histogram with time series mappings:
   - skip:
-      version: " - 7.15.99"
-      reason: introduced in 7.16.0
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/78443"
 
   - do:
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mute 'histogram with time series mappings' test yaml test (#78502)