### PR TITLE
[DOCS] Troubleshoot the flood-stage watermark error

### DIFF
--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -31,6 +31,8 @@ GET _cluster/allocation/explain
   "current_node": "my-node"
 }
 ----
+// TEST[s/^/PUT my-index\n/]
+// TEST[s/"primary": false,/"primary": false/]
 // TEST[s/"current_node": "my-node"//]
 
 To immediately restore write operations, you can temporarily increase the disk

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -13,9 +13,9 @@ node to prevent a full disk. If the block affects related system indices, {kib}
 and other {stack} features may become unavailable.
 
 {es} will automatically remove the write block when the affected node goes below
-the <<cluster-routing-watermark-high,high disk watermark>>. To free up disk
-space, {es} will move the affected node's shards to other nodes in the data
-tier. However, {es} will only allocate shards to nodes below the high disk usage
+the <<cluster-routing-watermark-high,high disk watermark>>. To achieve this,
+{es} automatically moves the affected node's shards to other nodes in the data
+tier. However, {es} can only allocate shards to nodes below the high disk usage
 watermark.
 
 To verify that some nodes in the tier are below the high disk watermark, use the

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -1,7 +1,68 @@
 [[fix-common-cluster-issues]]
 == Fix common cluster issues
 
-This guide describes how to fix common problems with {es} clusters.
+This guide describes how to fix common errors and problems with {es} clusters.
+
+[discrete]
+=== disk usage exceeded flood-stage watermark, index has read-only-allow-delete block
+
+This error indicates a data node is critically low on disk space and has reached
+the <<cluster-routing-flood-stage,flood-stage disk usage watermark>>. When a
+node reaches this watermark, {es} blocks writes to any index with a shard on the
+node to prevent a full disk. If the block affects related system indices, {kib}
+and other {stack} features may become unavailable.
+
+You can use the <<cat-allocation,cat allocation API>> to get the current
+available disk space (`disk.avail`) and disk usage percentage (`disk.percent`)
+for each node.
+
+[source,console]
+----
+GET _cat/allocation?v=true
+----
+
+{es} will automatically remove the write block when the node goes below the
+<<cluster-routing-watermark-high,high disk disk watermark>>. To immediately
+restore write operations, you can temporarily increase the disk watermarks and
+remove the write block.
+
+[source,console]
+----
+PUT _cluster/settings
+{ 
+  "transient": {
+    "cluster.routing.allocation.disk.watermark.low": "90%",
+    "cluster.routing.allocation.disk.watermark.high": "95%",
+    "cluster.routing.allocation.disk.watermark.flood_stage": "97%"
+  }
+}
+
+PUT */_settings?expand_wildcards=all
+{ 
+  "index.blocks.read_only_allow_delete": null
+}
+----
+// TEST[s/^/PUT my-index\n/]
+
+As a long-term solution, we recommend you add nodes to the affected data tiers
+or upgrade existing nodes to increase disk space. To free up additional disk
+space, you can:
+
+include::fix-common-cluster-issues.asciidoc[tag=free-up-disk-space]
+
+When a long-term solution is in place, reset or reconfigure the disk watermarks.
+
+[source,console]
+----
+PUT _cluster/settings
+{ 
+  "transient": {
+    "cluster.routing.allocation.disk.watermark.low": null,
+    "cluster.routing.allocation.disk.watermark.high": null,
+    "cluster.routing.allocation.disk.watermark.flood_stage": null
+  }
+}
+----
 
 [discrete]
 [[circuit-breaker-errors]]
@@ -460,7 +521,8 @@ If your nodes are running low on disk space, you have a few options:
 
 * Upgrade your nodes to increase disk space.
 
-* Delete unneeded indices to free up space. If you use {ilm-init}, you can
+// tag::free-up-disk-space[]
+* Delete unneeded indices. If you use {ilm-init}, you can
 update your lifecycle policy to use <<ilm-searchable-snapshot,searchable
 snapshots>> or add a delete phase. If you no longer need to search the data, you
 can use a <<snapshot-restore,snapshot>> to store it off-cluster.
@@ -483,6 +545,7 @@ POST my-index/_forcemerge
 POST my-index/_shrink/my-shrunken-index
 ----
 // TEST[s/^/PUT my-index\n{"settings":{"index.number_of_shards":2,"blocks.write":true}}\n/]
+// end::free-up-disk-space[]
 
 * If your node has a large disk capacity, you can increase the low disk
 watermark or set it to an explicit byte value.

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -12,19 +12,50 @@ node reaches this watermark, {es} blocks writes to any index with a shard on the
 node to prevent a full disk. If the block affects related system indices, {kib}
 and other {stack} features may become unavailable.
 
-You can use the <<cat-allocation,cat allocation API>> to get the current
-available disk space (`disk.avail`) and disk usage percentage (`disk.percent`)
-for each node.
+{es} will automatically remove the write block when the affected node goes below
+the <<cluster-routing-watermark-high,high disk watermark>>. To free up disk
+space, {es} will move the affected node's shards to other nodes in the data
+tier. However, {es} will only allocate shards to nodes below the high disk usage
+watermark.
+
+To verify that some nodes in the tier are below the high disk watermark, use the
+<<cat-allocation,cat allocation API>> to get each node's disk usage percentage
+(`disk.percent`) and current available disk space (`disk.avail`).
 
 [source,console]
 ----
 GET _cat/allocation?v=true
 ----
 
-{es} will automatically remove the write block when the node goes below the
-<<cluster-routing-watermark-high,high disk disk watermark>>. To immediately
-restore write operations, you can temporarily increase the disk watermarks and
-remove the write block.
+To check that shards are moving from the affected node to other nodes, use the
+<<cat-shards,cat shards API>>. If {es} can't allocate a shard to another node,
+the shard has a `state` of `UNASSIGNED`. The `unassigned.reason` describes why
+the shard remains unassigned.
+
+[source,console]
+----
+GET _cat/shards?v=true&h=index,shard,prirep,state,node,unassigned.reason&s=state
+----
+
+To get a more in-depth explanation of an unassigned shard's allocation status,
+use the <<cluster-allocation-explain,cluster allocation explanation API>>.
+
+[source,console]
+----
+GET _cluster/allocation/explain?filter_path=index,node_allocation_decisions.node_name,node_allocation_decisions.deciders.*
+{
+  "index": "my-index",
+  "shard": 0,
+  "primary": false,
+  "current_node": "my-node"
+}
+----
+// TEST[s/^/PUT my-index\n/]
+// TEST[s/"primary": false,/"primary": false/]
+// TEST[s/"current_node": "my-node"//]
+
+To immediately restore write operations, you can temporarily increase the disk
+watermarks and remove the write block.
 
 [source,console]
 ----
@@ -46,9 +77,14 @@ PUT */_settings?expand_wildcards=all
 
 As a long-term solution, we recommend you add nodes to the affected data tiers
 or upgrade existing nodes to increase disk space. To free up additional disk
-space, you can:
+space, you can delete unneeded indices using the <<indices-delete-index,delete
+index API>>.
 
-include::fix-common-cluster-issues.asciidoc[tag=free-up-disk-space]
+[source,console]
+----
+DELETE my-index
+----
+// TEST[s/^/PUT my-index\n/]
 
 When a long-term solution is in place, reset or reconfigure the disk watermarks.
 
@@ -521,8 +557,7 @@ If your nodes are running low on disk space, you have a few options:
 
 * Upgrade your nodes to increase disk space.
 
-// tag::free-up-disk-space[]
-* Delete unneeded indices. If you use {ilm-init}, you can
+* Delete unneeded indices to free up space. If you use {ilm-init}, you can
 update your lifecycle policy to use <<ilm-searchable-snapshot,searchable
 snapshots>> or add a delete phase. If you no longer need to search the data, you
 can use a <<snapshot-restore,snapshot>> to store it off-cluster.
@@ -545,7 +580,6 @@ POST my-index/_forcemerge
 POST my-index/_shrink/my-shrunken-index
 ----
 // TEST[s/^/PUT my-index\n{"settings":{"index.number_of_shards":2,"blocks.write":true}}\n/]
-// end::free-up-disk-space[]
 
 * If your node has a large disk capacity, you can increase the low disk
 watermark or set it to an explicit byte value.

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -14,9 +14,9 @@ and other {stack} features may become unavailable.
 
 {es} will automatically remove the write block when the affected node goes below
 the <<cluster-routing-watermark-high,high disk watermark>>. To achieve this,
-{es} automatically moves the affected node's shards to other nodes in the data
-tier. However, {es} can only allocate shards to nodes below the high disk usage
-watermark.
+{es} automatically moves some of the affected node's shards to other nodes in
+the data tier. However, {es} will only allocate shards to nodes below the high
+disk usage watermark.
 
 To verify that some nodes in the tier are below the high disk watermark, use the
 <<cat-allocation,cat allocation API>> to get each node's disk usage percentage

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -4,7 +4,7 @@
 This guide describes how to fix common errors and problems with {es} clusters.
 
 [discrete]
-=== disk usage exceeded flood-stage watermark, index has read-only-allow-delete block
+=== Error: disk usage exceeded flood-stage watermark, index has read-only-allow-delete block
 
 This error indicates a data node is critically low on disk space and has reached
 the <<cluster-routing-flood-stage,flood-stage disk usage watermark>>. When a

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -7,42 +7,23 @@ This guide describes how to fix common errors and problems with {es} clusters.
 === Error: disk usage exceeded flood-stage watermark, index has read-only-allow-delete block
 
 This error indicates a data node is critically low on disk space and has reached
-the <<cluster-routing-flood-stage,flood-stage disk usage watermark>>. When a
-node reaches this watermark, {es} blocks writes to any index with a shard on the
-node to prevent a full disk. If the block affects related system indices, {kib}
-and other {stack} features may become unavailable.
+the <<cluster-routing-flood-stage,flood-stage disk usage watermark>>. To prevent
+a full disk, when a node reaches this watermark, {es} blocks writes to any index
+with a shard on the node. If the block affects related system indices, {kib} and
+other {stack} features may become unavailable.
 
-{es} will automatically remove the write block when the affected node goes below
-the <<cluster-routing-watermark-high,high disk watermark>>. To achieve this,
-{es} automatically moves some of the affected node's shards to other nodes in
-the data tier. However, {es} will only allocate shards to nodes below the high
-disk usage watermark.
+{es} will automatically remove the write block when the affected node's disk
+usage goes below the <<cluster-routing-watermark-high,high disk watermark>>. To
+achieve this, {es} automatically moves some of the affected node's shards to
+other nodes in the data tier.
 
-To verify that some nodes in the tier are below the high disk watermark, use the
-<<cat-allocation,cat allocation API>> to get each node's disk usage percentage
-(`disk.percent`) and current available disk space (`disk.avail`).
-
-[source,console]
-----
-GET _cat/allocation?v=true
-----
-
-To check that shards are moving from the affected node to other nodes, use the
-<<cat-shards,cat shards API>>. If {es} can't allocate a shard to another node,
-the shard has a `state` of `UNASSIGNED`. The `unassigned.reason` describes why
-the shard remains unassigned.
+To verify that shards are moving off the affected node, use the
+<<cluster-allocation-explain,cluster allocation explanation API>>. If shards
+remain on the node, the API provides a detailed explanation for their status.
 
 [source,console]
 ----
-GET _cat/shards?v=true&h=index,shard,prirep,state,node,unassigned.reason&s=state
-----
-
-To get a more in-depth explanation of an unassigned shard's allocation status,
-use the <<cluster-allocation-explain,cluster allocation explanation API>>.
-
-[source,console]
-----
-GET _cluster/allocation/explain?filter_path=index,node_allocation_decisions.node_name,node_allocation_decisions.deciders.*
+GET _cluster/allocation/explain
 {
   "index": "my-index",
   "shard": 0,
@@ -50,8 +31,6 @@ GET _cluster/allocation/explain?filter_path=index,node_allocation_decisions.node
   "current_node": "my-node"
 }
 ----
-// TEST[s/^/PUT my-index\n/]
-// TEST[s/"primary": false,/"primary": false/]
 // TEST[s/"current_node": "my-node"//]
 
 To immediately restore write operations, you can temporarily increase the disk

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -63,7 +63,7 @@ PUT */_settings?expand_wildcards=all
 ----
 // TEST[s/^/PUT my-index\n/]
 
-As a long-term solution, we recommend you add nodes to the affected data tier
+As a long-term solution, we recommend you add nodes to the affected data tiers
 or upgrade existing nodes to increase disk space. To free up additional disk
 space, you can delete unneeded indices using the <<indices-delete-index,delete
 index API>>.
@@ -74,8 +74,7 @@ DELETE my-index
 ----
 // TEST[s/^/PUT my-index\n/]
 
-When a long-term solution is in place, you can reset or reconfigure the disk
-watermarks.
+When a long-term solution is in place, reset or reconfigure the disk watermarks.
 
 [source,console]
 ----

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -15,7 +15,7 @@ other {stack} features may become unavailable.
 {es} will automatically remove the write block when the affected node's disk
 usage goes below the <<cluster-routing-watermark-high,high disk watermark>>. To
 achieve this, {es} automatically moves some of the affected node's shards to
-other nodes in the data tier.
+other nodes in the same data tier.
 
 To verify that shards are moving off the affected node, use the
 <<cluster-allocation-explain,cluster allocation explanation API>>. If shards

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -17,9 +17,16 @@ usage goes below the <<cluster-routing-watermark-high,high disk watermark>>. To
 achieve this, {es} automatically moves some of the affected node's shards to
 other nodes in the same data tier.
 
-To verify that shards are moving off the affected node, use the
-<<cluster-allocation-explain,cluster allocation explanation API>>. If shards
-remain on the node, the API provides an explanation for their status.
+To verify that shards are moving off the affected node, use the <<cat-shards,cat
+shards API>>.
+
+[source,console]
+----
+GET _cat/shards?v=true
+----
+
+If shards remain on the node, use the <<cluster-allocation-explain,cluster
+allocation explanation API>> to get an explanation for their allocation status.
 
 [source,console]
 ----
@@ -56,7 +63,7 @@ PUT */_settings?expand_wildcards=all
 ----
 // TEST[s/^/PUT my-index\n/]
 
-As a long-term solution, we recommend you add nodes to the affected data tiers
+As a long-term solution, we recommend you add nodes to the affected data tier
 or upgrade existing nodes to increase disk space. To free up additional disk
 space, you can delete unneeded indices using the <<indices-delete-index,delete
 index API>>.
@@ -67,7 +74,8 @@ DELETE my-index
 ----
 // TEST[s/^/PUT my-index\n/]
 
-When a long-term solution is in place, reset or reconfigure the disk watermarks.
+When a long-term solution is in place, you can reset or reconfigure the disk
+watermarks.
 
 [source,console]
 ----

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -19,7 +19,7 @@ other nodes in the data tier.
 
 To verify that shards are moving off the affected node, use the
 <<cluster-allocation-explain,cluster allocation explanation API>>. If shards
-remain on the node, the API provides a detailed explanation for their status.
+remain on the node, the API provides an explanation for their status.
 
 [source,console]
 ----


### PR DESCRIPTION
Adds troubleshooting steps for the flood-stage watermark error.

Closes #77906.

### Preview
https://elasticsearch_78519.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/fix-common-cluster-issues.html#_disk_usage_exceeded_flood_stage_watermark_index_has_read_only_allow_delete_block