### PR TITLE
Wildcard field regex query fix.

### DIFF
--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -589,7 +589,9 @@ public class WildcardFieldMapper extends FieldMapper {
                 if (q instanceof MatchAllDocsQuery) {
                     matchAllCount++;
                 } else if (q instanceof MatchAllButRequireVerificationQuery) {
-                    verifyCount++;
+                    if (booleanClause.getOccur() != Occur.SHOULD) {
+                        verifyCount++;
+                    }
                 } else {
                     // Concrete query
                     if (booleanClause.getOccur() != Occur.SHOULD) {
@@ -598,7 +600,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 }
             }
 
-            if ((allConcretesAreOptional && matchAllCount > 0)) {
+            if ((allConcretesAreOptional && matchAllCount > 0 && verifyCount == 0)) {
                 // Any match all expression takes precedence over all optional concrete queries.
                 return new MatchAllDocsQuery();
             }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -484,7 +484,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
 
     public void testRegexAcceleration() throws IOException, ParseException {
         // All these expressions should rewrite to a match all with no verification step required at all
-        String superfastRegexes[]= { ".*", "a*", "(foo|bar|.*)", "@"};
+        String superfastRegexes[]= { ".*", "a*", "(foo|bar|.*)", "@", "((foo|bar|b*)|(fob|baz|.*))"};
         for (String regex : superfastRegexes) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, RegExp.ALL, 0, 20000, null, MOCK_CONTEXT);
             assertTrue(
@@ -495,7 +495,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         
         // Regexes that were previously rewritten to a match all with no verification 
         // but shouldn't have been (See https://github.com/elastic/elasticsearch/issues/78391 )
-        String shouldntMatchAllPatterns[] = { "[a*]a+"};
+        String shouldntMatchAllPatterns[] = { "[a*]a+", "(([a*]a+)|[b*]b+)"};
         for (String pattern : shouldntMatchAllPatterns) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(pattern, RegExp.ALL, 0, 20000, null, MOCK_CONTEXT);
             wildcardFieldQuery = unwrapAnyConstantScore(wildcardFieldQuery);


### PR DESCRIPTION
Don’t revert to match_all when query only exists of required clauses that can’t be expressed as queries on ngram index.

Reverting to a match_all is an important optimisation e.g. if users type `a*` - we don't want to decompress all docs and run a regex on the contents when we can know this is literally a match all expression.

Closes #78391
