### PR TITLE
Mute SqlSearchIT testAllTypesWithRequestToUpgradedNodes and

### DIFF
--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.sql.qa.mixed_node;
 
 import org.apache.http.HttpHost;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -64,6 +65,7 @@ public class SqlCompatIT extends BaseRestSqlTestCase {
         });
     }
 
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78424")
     public void testNullsOrderBeforeMissingOrderSupportQueryingNewNode() throws IOException {
         testNullsOrderBeforeMissingOrderSupport(newNodesClient);
     }

--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -150,6 +150,7 @@ public class SqlSearchIT extends ESRestTestCase {
         assertAllTypesWithNodes(expectedResponse, bwcNodes);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78424")
     public void testAllTypesWithRequestToUpgradedNodes() throws Exception {
         Map<String, Object> expectedResponse = prepareTestData(
             columns -> {


### PR DESCRIPTION
SqlCompatIT.testNullsOrderBeforeMissingOrderSupportQueryingNewNode tests

See #78424