### PR TITLE
[ML] fixing flaky test for text classification config update

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
@@ -67,7 +67,7 @@ public class TextClassificationConfigUpdateTests extends AbstractBWCSerializatio
             VocabularyConfigTests.createRandom(),
             BertTokenizationTests.createRandom(),
             List.of("one", "two"),
-            randomIntBetween(-1, 10),
+            randomFrom(-1, randomIntBetween(1, 10)),
             "foo-results"
         );
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
@@ -89,10 +89,10 @@ public class TextClassificationConfigUpdateTests extends AbstractBWCSerializatio
                 .apply(originalConfig)
             ));
         assertThat(new TextClassificationConfig.Builder(originalConfig)
-                .setNumTopClasses(originalConfig.getNumTopClasses() +1)
+                .setNumTopClasses(originalConfig.getNumTopClasses() + 2)
                 .build(),
             equalTo(new TextClassificationConfigUpdate.Builder()
-                .setNumTopClasses(originalConfig.getNumTopClasses() +1)
+                .setNumTopClasses(originalConfig.getNumTopClasses() + 2)
                 .build()
                 .apply(originalConfig)
             ));
@@ -101,7 +101,7 @@ public class TextClassificationConfigUpdateTests extends AbstractBWCSerializatio
     public void testApplyWithInvalidLabels() {
         TextClassificationConfig originalConfig = TextClassificationConfigTests.createRandom();
 
-        int numberNewLabels = originalConfig.getClassificationLabels().size() +1;
+        int numberNewLabels = originalConfig.getClassificationLabels().size() + 2;
         List<String> newLabels = randomList(numberNewLabels, numberNewLabels, () -> randomAlphaOfLength(6));
 
         var update = new TextClassificationConfigUpdate.Builder()


### PR DESCRIPTION
Fixes flaky test. Test case would randomly set top classes to `0` which is currently not allowed. 