### PR TITLE
[7.x] Rename `Metadata#hasConcreteIndex` to `hasIndexAbstraction` (#78493)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -49,7 +49,7 @@ public class TransportTypesExistsAction extends TransportMasterNodeReadAction<Ty
         }
 
         for (String concreteIndex : concreteIndices) {
-            if (state.metadata().hasConcreteIndex(concreteIndex) == false) {
+            if (state.metadata().hasIndexAbstraction(concreteIndex) == false) {
                 listener.onResponse(new TypesExistsResponse(false));
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -700,16 +700,32 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             Arrays.toString(indexNames) + "], can't execute a single index op");
     }
 
+    /**
+     * Checks whether an index exists (as of this {@link Metadata} with the given name. Does not check aliases or data streams.
+     * @param index An index name that may or may not exist in the cluster.
+     * @return {@code true} if a concrete index with that name exists, {@code false} otherwise.
+     */
     public boolean hasIndex(String index) {
         return indices.containsKey(index);
     }
 
+    /**
+     * Checks whether an index exists. Similar to {@link Metadata#hasIndex(String)}, but ensures that the index has the same UUID as
+     * the given {@link Index}.
+     * @param index An {@link Index} object that may or may not exist in the cluster.
+     * @return {@code true} if an index exists with the same name and UUID as the given index object, {@code false} otherwise.
+     */
     public boolean hasIndex(Index index) {
         IndexMetadata metadata = index(index.getName());
         return metadata != null && metadata.getIndexUUID().equals(index.getUUID());
     }
 
-    public boolean hasConcreteIndex(String index) {
+    /**
+     * Checks whether an index abstraction (that is, index, alias, or data stream) exists (as of this {@link Metadata} with the given name.
+     * @param index An index name that may or may not exist in the cluster.
+     * @return {@code true} if an index abstraction with that name exists, {@code false} otherwise.
+     */
+    public boolean hasIndexAbstraction(String index) {
         return getIndicesLookup().containsKey(index);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -115,7 +115,7 @@ public class SystemIndexManager implements ClusterStateListener {
         return this.systemIndices.getSystemIndexDescriptors()
             .stream()
             .filter(SystemIndexDescriptor::isAutomaticallyManaged)
-            .filter(d -> metadata.hasConcreteIndex(d.getPrimaryIndex()))
+            .filter(d -> metadata.hasIndexAbstraction(d.getPrimaryIndex()))
             .collect(Collectors.toList());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -58,7 +58,7 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
             Collection<Index> indices = (Collection<Index>) i.getArguments()[1];
             Metadata.Builder meta = Metadata.builder(state.metadata());
             for (Index index : indices) {
-                assertTrue("index now found", state.metadata().hasConcreteIndex(index.getName()));
+                assertTrue("index now found", state.metadata().hasIndexAbstraction(index.getName()));
                 meta.remove(index.getName()); // We only think about metadata for this test. Not routing or any other fun stuff.
             }
             return ClusterState.builder(state).metadata(meta).build();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Rename `Metadata#hasConcreteIndex` to `hasIndexAbstraction` (#78493)