### PR TITLE
Avoid overriding existing forced modules in build script

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rewrite/RewritePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rewrite/RewritePlugin.java
@@ -8,12 +8,9 @@
 
 package org.elasticsearch.gradle.internal.rewrite;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.plugins.JavaBasePlugin;

--- a/x-pack/qa/security-tools-tests/build.gradle
+++ b/x-pack/qa/security-tools-tests/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
 configurations.all {
   resolutionStrategy {
-    forcedModules = ["com.google.guava:guava:${versions.jimfs_guava}"]
+    force "com.google.guava:guava:${versions.jimfs_guava}"
   }
 }
 // add test resources from security, so certificate tool tests can use example certs


### PR DESCRIPTION
When adding a forced module in the `security-tools-tests` project we mistakenly override the existing force declarations that exist in `elasticsearch.auto-backporting.gradle`. These are necessarily to avoid conflict resolution errors during dependency resolution. When running a task like `resolveAllDependencies` you'd get an [error like this](https://gradle-enterprise.elastic.co/s/m3mgm6e6ydmmm/failure#1).