### PR TITLE
[7.x] Add centroid grid type in mvt request (#78305)

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -227,6 +227,11 @@ Each feature is a `Polygon` of the cell's bounding box.
 
 `point`:::
 Each feature is a `Point` that's the centroid of the cell.
+
+`centroid`:::
+Each feature is a `Point` that's the centroid of the data within the cell. For
+complex geometries, the actual centroid may be outside the cell. In these cases,
+the feature is set to the closest point to the centroid inside the cell.
 // end::grid-type[]
 
 // tag::size[]
@@ -259,6 +264,9 @@ aggregation types:
 * <<search-aggregations-metrics-max-aggregation,`max`>>
 * <<search-aggregations-metrics-min-aggregation,`min`>>
 * <<search-aggregations-metrics-sum-aggregation,`sum`>>
++
+The aggregation names can't start with `_mvt_`. The `_mvt_` prefix is reserved
+for internal aggregations.
 
 include::search-vector-tile-api.asciidoc[tag=exact-bounds]
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -67,7 +67,8 @@
         "type":"enum",
         "options":[
           "grid",
-          "point"
+          "point",
+          "centroid"
         ],
         "description":"Determines the geometry type for features in the aggs layer.",
         "default":"grid"

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -373,10 +373,48 @@ public class VectorTileRestIT extends ESRestTestCase {
         }
         {
             final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_type\": \"centroid\" }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+            assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
+        }
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
             mvtRequest.setJsonEntity("{\"grid_type\": \"invalid_type\" }");
             final ResponseException ex = expectThrows(ResponseException.class, () -> execute(mvtRequest));
             assertThat(ex.getResponse().getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_BAD_REQUEST));
         }
+    }
+
+    public void testInvalidAggName() {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity(
+            "{\"size\" : 0,"
+                + "  \"aggs\": {\n"
+                + "    \"_mvt_name\": {\n"
+                + "      \"min\": {\n"
+                + "         \"field\": \"value1\"\n"
+                + "        }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        ResponseException ex = expectThrows(ResponseException.class, () -> execute(mvtRequest));
+        // the prefix '_mvt_' is reserved for internal aggregations
+        assertThat(ex.getMessage(), Matchers.containsString("Invalid aggregation name [_mvt_name]"));
+    }
+
+    public void testCentroidGridTypeOnPolygon() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + (z + 2) + "/" + 4 * x + "/" + 4 * y);
+        mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_type\": \"centroid\",  \"grid_precision\": 2}");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(2));
+        assertLayer(tile, AGGS_LAYER, 4096, 4 * 4, 1);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
+        assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
     }
 
     public void testTrackTotalHitsAsBoolean() throws Exception {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -42,7 +42,9 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGridBucket;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoTileGrid;
 import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.GeoCentroidAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.InternalGeoBounds;
+import org.elasticsearch.search.aggregations.metrics.InternalGeoCentroid;
 import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.profile.SearchProfileResults;
@@ -74,6 +76,10 @@ public class RestVectorTileAction extends BaseRestHandler {
 
     // mime type as defined by the mapbox vector tile specification
     private static final String MIME_TYPE = "application/vnd.mapbox-vector-tile";
+    // prefox for internal aggregations. User aggregations cannot start with this prefix
+    private static final String INTERNAL_AGG_PREFIX = "_mvt_";
+    // internal centroid aggregation name
+    private static final String CENTROID_AGG_NAME = INTERNAL_AGG_PREFIX + "centroid";
 
     public RestVectorTileAction() {}
 
@@ -205,11 +211,25 @@ public class RestVectorTileAction extends BaseRestHandler {
                 .size(extent * extent);
             searchRequestBuilder.addAggregation(tileAggBuilder);
             searchRequestBuilder.addAggregation(new StatsBucketPipelineAggregationBuilder(COUNT_TAG, GRID_FIELD + "." + COUNT_TAG));
+            if (request.getGridType() == VectorTileRequest.GRID_TYPE.CENTROID) {
+                GeoCentroidAggregationBuilder centroidAggregationBuilder = new GeoCentroidAggregationBuilder(CENTROID_AGG_NAME);
+                centroidAggregationBuilder.field(request.getField());
+                tileAggBuilder.subAggregation(centroidAggregationBuilder);
+            }
             final AggregatorFactories.Builder otherAggBuilder = request.getAggBuilder();
             if (otherAggBuilder != null) {
-                tileAggBuilder.subAggregations(request.getAggBuilder());
                 final Collection<AggregationBuilder> aggregations = otherAggBuilder.getAggregatorFactories();
                 for (AggregationBuilder aggregation : aggregations) {
+                    if (aggregation.getName().startsWith(INTERNAL_AGG_PREFIX)) {
+                        throw new IllegalArgumentException(
+                            "Invalid aggregation name ["
+                                + aggregation.getName()
+                                + "]. Aggregation names cannot start with prefix '"
+                                + INTERNAL_AGG_PREFIX
+                                + "'"
+                        );
+                    }
+                    tileAggBuilder.subAggregation(aggregation);
                     // we add the metric (.value) to the path in order to support aggregation names with '.'
                     final String bucketPath = GRID_FIELD + ">" + aggregation.getName() + ".value";
                     searchRequestBuilder.addAggregation(new StatsBucketPipelineAggregationBuilder(aggregation.getName(), bucketPath));
@@ -269,18 +289,34 @@ public class RestVectorTileAction extends BaseRestHandler {
         for (InternalGeoGridBucket bucket : grid.getBuckets()) {
             featureBuilder.clear();
             // Add geometry
-            if (request.getGridType() == VectorTileRequest.GRID_TYPE.GRID) {
-                final Rectangle r = GeoTileUtils.toBoundingBox(bucket.getKeyAsString());
-                featureBuilder.mergeFrom(geomBuilder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat()));
-            } else {
-                // TODO: it should be the centroid of the data?
-                final GeoPoint point = (GeoPoint) bucket.getKey();
-                featureBuilder.mergeFrom(geomBuilder.point(point.lon(), point.lat()));
+            switch (request.getGridType()) {
+                case GRID: {
+                    final Rectangle r = GeoTileUtils.toBoundingBox(bucket.getKeyAsString());
+                    featureBuilder.mergeFrom(geomBuilder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat()));
+                    break;
+                }
+                case POINT: {
+                    final GeoPoint point = (GeoPoint) bucket.getKey();
+                    featureBuilder.mergeFrom(geomBuilder.point(point.lon(), point.lat()));
+                    break;
+                }
+                case CENTROID: {
+                    final Rectangle r = GeoTileUtils.toBoundingBox(bucket.getKeyAsString());
+                    final InternalGeoCentroid centroid = bucket.getAggregations().get(CENTROID_AGG_NAME);
+                    final double featureLon = Math.min(Math.max(centroid.centroid().lon(), r.getMinLon()), r.getMaxLon());
+                    final double featureLat = Math.min(Math.max(centroid.centroid().lat(), r.getMinLat()), r.getMaxLat());
+                    featureBuilder.mergeFrom(geomBuilder.point(featureLon, featureLat));
+                    break;
+                }
+                default:
+                    throw new IllegalArgumentException("unsupported grid type + [" + request.getGridType() + "]");
             }
             // Add count as key value pair
             VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, COUNT_TAG, bucket.getDocCount());
             for (Aggregation aggregation : bucket.getAggregations()) {
-                VectorTileUtils.addToXContentToFeature(featureBuilder, layerProps, aggregation);
+                if (aggregation.getName().startsWith(INTERNAL_AGG_PREFIX) == false) {
+                    VectorTileUtils.addToXContentToFeature(featureBuilder, layerProps, aggregation);
+                }
             }
             aggLayerBuilder.addFeatures(featureBuilder);
         }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -63,7 +63,8 @@ class VectorTileRequest {
 
     protected enum GRID_TYPE {
         GRID,
-        POINT;
+        POINT,
+        CENTROID;
 
         private static GRID_TYPE fromString(String type) {
             switch (type.toLowerCase(Locale.ROOT)) {
@@ -71,6 +72,8 @@ class VectorTileRequest {
                     return GRID;
                 case "point":
                     return POINT;
+                case "centroid":
+                    return CENTROID;
                 default:
                     throw new IllegalArgumentException("Invalid grid type [" + type + "]");
             }

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -99,6 +99,19 @@ setup:
         zoom: 0
         body:
           grid_type: grid
+
+---
+"grid type centroid":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_type: centroid
+
 ---
 "field field":
   - do:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add centroid grid type in mvt request (#78305)