### PR TITLE
Rest api to reset deprecation indexing cache backport(#78392)

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -509,7 +509,6 @@ public class DeprecationHttpIT extends ESRestTestCase {
         }
     }
 
-
     private void configureWriteDeprecationLogsToIndex(Boolean value) throws IOException {
         final Request request = new Request("PUT", "_cluster/settings");
         request.setJsonEntity("{ \"transient\": { \"cluster.deprecation_indexing.enabled\": " + value + " } }");

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -36,18 +36,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -277,7 +276,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
 
                 assertThat(
                     documents,
-                    hasItems(
+                    containsInAnyOrder(
                         allOf(
                             hasEntry("event.code", "deprecated_route_POST_/_test_cluster/deprecated_settings"),
                             hasEntry("message", "[/_test_cluster/deprecated_settings] exists for deprecated tests")
@@ -354,7 +353,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                 for (int i = 0; i < hits; i++) {
                     final JsonNode hit = jsonNode.at("/hits/hits/" + i + "/_source");
 
-                    final Map<String, Object> document = new TreeMap<>();
+                    final Map<String, Object> document = new HashMap<>();
                     hit.fields().forEachRemaining(entry -> document.put(entry.getKey(), entry.getValue().textValue()));
 
                     documents.add(document);
@@ -365,7 +364,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
 
                 assertThat(
                     documents,
-                    hasItems(
+                    containsInAnyOrder(
                         allOf(
                             hasKey("@timestamp"),
                             hasKey("elasticsearch.cluster.name"),
@@ -464,7 +463,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
 
                 assertThat(
                     documents,
-                    hasItems(
+                    containsInAnyOrder(
                         allOf(
                             hasKey("@timestamp"),
                             hasKey("elasticsearch.cluster.name"),
@@ -509,6 +508,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
             client().performRequest(new Request("DELETE", "_data_stream/" + DATA_STREAM_NAME));
         }
     }
+
 
     private void configureWriteDeprecationLogsToIndex(Boolean value) throws IOException {
         final Request request = new Request("PUT", "_cluster/settings");

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.logging.RateLimitingFilter;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -29,8 +30,11 @@ import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.deprecation.logging.DeprecationCacheResetAction;
 import org.elasticsearch.xpack.deprecation.logging.DeprecationIndexingComponent;
 import org.elasticsearch.xpack.deprecation.logging.DeprecationIndexingTemplateRegistry;
+import org.elasticsearch.xpack.deprecation.logging.RestDeprecationCacheResetAction;
+import org.elasticsearch.xpack.deprecation.logging.TransportDeprecationCacheResetAction;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,12 +48,13 @@ import static org.elasticsearch.xpack.deprecation.logging.DeprecationIndexingCom
  * The plugin class for the Deprecation API
  */
 public class Deprecation extends Plugin implements ActionPlugin {
+
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Collections.unmodifiableList(Arrays.asList(
-            new ActionHandler<>(DeprecationInfoAction.INSTANCE, TransportDeprecationInfoAction.class),
-            new ActionHandler<>(NodesDeprecationCheckAction.INSTANCE, TransportNodeDeprecationCheckAction.class)
-        ));
+                new ActionHandler<>(DeprecationInfoAction.INSTANCE, TransportDeprecationInfoAction.class),
+                new ActionHandler<>(NodesDeprecationCheckAction.INSTANCE, TransportNodeDeprecationCheckAction.class),
+                new ActionHandler<>(DeprecationCacheResetAction.INSTANCE, TransportDeprecationCacheResetAction.class));
     }
 
     @Override
@@ -59,7 +64,7 @@ public class Deprecation extends Plugin implements ActionPlugin {
                                              Supplier<DiscoveryNodes> nodesInCluster) {
 
 
-        return Collections.singletonList(new RestDeprecationInfoAction());
+        return org.elasticsearch.core.List.of(new RestDeprecationInfoAction(), new RestDeprecationCacheResetAction());
     }
 
     @Override
@@ -80,14 +85,17 @@ public class Deprecation extends Plugin implements ActionPlugin {
             new DeprecationIndexingTemplateRegistry(environment.settings(), clusterService, threadPool, client, xContentRegistry);
         templateRegistry.initialize();
 
-        final DeprecationIndexingComponent component = new DeprecationIndexingComponent(client, environment.settings());
+        final RateLimitingFilter rateLimitingFilterForIndexing = new RateLimitingFilter();
+
+        final DeprecationIndexingComponent component = new DeprecationIndexingComponent(client, environment.settings(),
+            rateLimitingFilterForIndexing);
         clusterService.addListener(component);
 
-        return Collections.singletonList(component);
+        return org.elasticsearch.core.List.of(component, rateLimitingFilterForIndexing);
     }
 
     @Override
     public List<Setting<?>> getSettings() {
-        return Collections.singletonList(WRITE_DEPRECATION_LOGS_TO_INDEX);
+        return org.elasticsearch.core.List.of(WRITE_DEPRECATION_LOGS_TO_INDEX);
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
@@ -36,9 +36,7 @@ import org.elasticsearch.xpack.deprecation.logging.DeprecationIndexingTemplateRe
 import org.elasticsearch.xpack.deprecation.logging.RestDeprecationCacheResetAction;
 import org.elasticsearch.xpack.deprecation.logging.TransportDeprecationCacheResetAction;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -51,7 +49,7 @@ public class Deprecation extends Plugin implements ActionPlugin {
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return Collections.unmodifiableList(Arrays.asList(
+        return org.elasticsearch.core.List.of(
                 new ActionHandler<>(DeprecationInfoAction.INSTANCE, TransportDeprecationInfoAction.class),
                 new ActionHandler<>(NodesDeprecationCheckAction.INSTANCE, TransportNodeDeprecationCheckAction.class),
                 new ActionHandler<>(DeprecationCacheResetAction.INSTANCE, TransportDeprecationCacheResetAction.class));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.deprecation.logging;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.transport.TransportRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+    Resets deprecation indexing rate limiting cache on each node.
+ */
+public class DeprecationCacheResetAction extends ActionType<DeprecationCacheResetAction.Response> {
+    public static final DeprecationCacheResetAction INSTANCE = new DeprecationCacheResetAction();
+    public static final String NAME = "cluster:admin/deprecation/cache/reset";
+
+    private DeprecationCacheResetAction() {
+        super(NAME, Response::new);
+    }
+
+    public static class Request extends BaseNodesRequest<Request> implements ToXContentObject {
+        public Request() {
+            super((String[]) null);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            // Nothing to hash atm, so just use the action name
+            return Objects.hashCode(NAME);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    public static class Response extends BaseNodesResponse<NodeResponse> implements Writeable, ToXContentObject {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public Response(ClusterName clusterName, List<NodeResponse> nodes, List<FailedNodeException> failures) {
+            super(clusterName, nodes, failures);
+        }
+
+        @Override
+        protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readList(NodeResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
+            out.writeList(nodes);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response that = (Response) o;
+            return Objects.equals(getNodes(), that.getNodes()) && Objects.equals(failures(), that.failures());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getNodes(), failures());
+        }
+    }
+
+    public static class NodeRequest extends TransportRequest {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeRequest(Request request) {
+        }
+    }
+
+    public static class NodeResponse extends BaseNodeResponse {
+
+
+        protected NodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        protected NodeResponse(DiscoveryNode node ) {
+            super(node);
+
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.deprecation.logging;
 
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
@@ -19,7 +20,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -108,7 +108,7 @@ public class DeprecationCacheResetAction extends ActionType<DeprecationCacheRese
         }
     }
 
-    public static class NodeRequest extends TransportRequest {
+    public static class NodeRequest extends BaseNodeRequest {
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
@@ -54,9 +54,11 @@ public class DeprecationIndexingComponent extends AbstractLifecycleComponent imp
 
     private final DeprecationIndexingAppender appender;
     private final BulkProcessor processor;
-    private final RateLimitingFilter filter;
+    private final RateLimitingFilter rateLimitingFilterForIndexing;
 
-    public DeprecationIndexingComponent(Client client, Settings settings) {
+    public DeprecationIndexingComponent(Client client, Settings settings, RateLimitingFilter rateLimitingFilterForIndexing) {
+        this.rateLimitingFilterForIndexing = rateLimitingFilterForIndexing;
+
         this.processor = getBulkProcessor(new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN), settings);
         final Consumer<IndexRequest> consumer = this.processor::add;
 
@@ -69,8 +71,8 @@ public class DeprecationIndexingComponent extends AbstractLifecycleComponent imp
             .setConfiguration(configuration)
             .build();
 
-        this.filter = new RateLimitingFilter();
-        this.appender = new DeprecationIndexingAppender("deprecation_indexing_appender", filter, ecsLayout, consumer);
+        this.appender = new DeprecationIndexingAppender("deprecation_indexing_appender",
+            rateLimitingFilterForIndexing, ecsLayout, consumer);
     }
 
     @Override
@@ -105,7 +107,7 @@ public class DeprecationIndexingComponent extends AbstractLifecycleComponent imp
             // We've flipped from disabled to enabled. Make sure we start with a clean cache of
             // previously-seen keys, otherwise we won't index anything.
             if (newEnabled) {
-                this.filter.reset();
+                this.rateLimitingFilterForIndexing.reset();
             }
             appender.setEnabled(newEnabled);
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/RestDeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/RestDeprecationCacheResetAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.deprecation.logging;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+public class RestDeprecationCacheResetAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/_logging/deprecation_cache"));
+    }
+
+    @Override
+    public String getName() {
+        return "reset_deprecation_cache";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        DeprecationCacheResetAction.Request resetRequest = new DeprecationCacheResetAction.Request();
+        return channel -> client.execute(DeprecationCacheResetAction.INSTANCE, resetRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/RestDeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/RestDeprecationCacheResetAction.java
@@ -21,7 +21,7 @@ public class RestDeprecationCacheResetAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(DELETE, "/_logging/deprecation_cache"));
+        return org.elasticsearch.core.List.of(new Route(DELETE, "/_logging/deprecation_cache"));
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.deprecation.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.RateLimitingFilter;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportDeprecationCacheResetAction
+    extends TransportNodesAction<DeprecationCacheResetAction.Request,
+    DeprecationCacheResetAction.Response,
+    DeprecationCacheResetAction.NodeRequest,
+    DeprecationCacheResetAction.NodeResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportDeprecationCacheResetAction.class);
+
+    private final RateLimitingFilter rateLimitingFilterForIndexing;
+
+    @Inject
+    public TransportDeprecationCacheResetAction(ThreadPool threadPool,
+                                                ClusterService clusterService,
+                                                TransportService transportService,
+                                                ActionFilters actionFilters,
+                                                RateLimitingFilter rateLimitingFilterForIndexing) {
+        super(DeprecationCacheResetAction.NAME, threadPool, clusterService, transportService, actionFilters,
+            DeprecationCacheResetAction.Request::new,
+            DeprecationCacheResetAction.NodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            DeprecationCacheResetAction.NodeResponse.class);
+        this.rateLimitingFilterForIndexing = rateLimitingFilterForIndexing;
+    }
+
+    @Override
+    protected DeprecationCacheResetAction.Response newResponse(DeprecationCacheResetAction.Request request,
+                                                               List<DeprecationCacheResetAction.NodeResponse> nodeResponses,
+                                                               List<FailedNodeException> failures) {
+        return new DeprecationCacheResetAction.Response(clusterService.getClusterName(), nodeResponses, failures);
+    }
+
+    @Override
+    protected DeprecationCacheResetAction.NodeRequest newNodeRequest(DeprecationCacheResetAction.Request request) {
+        return new DeprecationCacheResetAction.NodeRequest(request);
+    }
+
+    @Override
+    protected DeprecationCacheResetAction.NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new DeprecationCacheResetAction.NodeResponse(in);
+    }
+
+    @Override
+    protected DeprecationCacheResetAction.NodeResponse nodeOperation(DeprecationCacheResetAction.NodeRequest request, Task task) {
+        rateLimitingFilterForIndexing.reset();
+        logger.debug( "Deprecation cache was reset");
+        return new DeprecationCacheResetAction.NodeResponse(transportService.getLocalNode());
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
@@ -66,6 +66,11 @@ public class TransportDeprecationCacheResetAction
     }
 
     @Override
+    protected DeprecationCacheResetAction.NodeResponse nodeOperation(DeprecationCacheResetAction.NodeRequest request) {
+        return nodeOperation(request);
+    }
+
+    @Override
     protected DeprecationCacheResetAction.NodeResponse nodeOperation(DeprecationCacheResetAction.NodeRequest request, Task task) {
         rateLimitingFilterForIndexing.reset();
         logger.debug( "Deprecation cache was reset");

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
         "cluster:admin/data_frame/start",
         "cluster:admin/data_frame/stop",
         "cluster:admin/data_frame/update",
+        "cluster:admin/deprecation/cache/reset",
         "cluster:admin/ilm/_move/post",
         "cluster:admin/ilm/delete",
         "cluster:admin/ilm/get",


### PR DESCRIPTION
Deprecation indexing is using RateLimitingFilter to throttle duplicated
deprecations.
This commit adds REST API and transport actions to reset the LRU cache in this filter.

This will not affect the log4j filter used for thottling file appenders.

closes #78134

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
