### PR TITLE
[DOCS] Add reference to PHP client on Bulk API page

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -143,7 +143,7 @@ JavaScript::
     See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
 
 PHP::
-    See https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/indexing_documents.html#_bulk_indexing[`Bulk indexing`]
+    See https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/indexing_documents.html#_bulk_indexing[Bulk indexing]
 
 [discrete]
 [[bulk-curl]]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -142,6 +142,9 @@ JavaScript::
 .NET::
     See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
 
+PHP::
+    See https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/indexing_documents.html#_bulk_indexing[`Bulk indexing`]
+
 [discrete]
 [[bulk-curl]]
 ===== Submitting bulk requests with cURL


### PR DESCRIPTION
Hey folks, 

The PHP client docs already have instructions for using the Bulk API, I thought I'd submit an update to the Bulk API page that references that (in the [client support for Bulk API requests](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-clients) section, specifically).

The contributing guidelines suggest to open an issue in the repo, but I decided against it purely because of the size and nature of the change - I'm adding a single link to help with cross-referencing, in a document which already has a number of similar links.
If you'd still prefer I open an issue let me know and I'll go ahead.

Cheers!