### PR TITLE
Deprecate create_legacy_templates setting on HTTP Exporters

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -79,7 +79,8 @@ will be removed in 8.0.0. This parameter controls the creation of pipelines for 
 indices. These pipelines currently have no function.
 
 *Impact* +
-Discontinue the use of the `xpack.monitoring.exporters.*.use_ingest` setting.
+Discontinue the use of the `xpack.monitoring.exporters.*.use_ingest` setting
+as it will no longer be recognized in the next major release.
 ====
 
 [[monitoring-pipeline-master-timeout-setting-deprecation]]
@@ -93,7 +94,24 @@ Monitoring cluster to create pipelines. These pipelines for monitoring indices c
 have no function and will be removed in 8.0.0.
 
 *Impact* +
-Discontinue the use of the `xpack.monitoring.exporters.*.index.pipeline.master_timeout` setting.
+Discontinue the use of the `xpack.monitoring.exporters.*.index.pipeline.master_timeout` setting
+as it will no longer be recognized in the next major release.
+====
+
+[[monitoring-template-create-legacy-setting-deprecation]]
+.The `index.template.create_legacy_templates` setting on Monitoring HTTP exporter configurations is deprecated.
+[%collapsible]
+====
+*Details* +
+The `xpack.monitoring.exporters.*.index.template.create_legacy_templates` property has been
+deprecated in 7.16.0. This parameter instructs the exporter to install the previous version
+of monitoring templates on the monitoring cluster. These older templates were meant to assist
+in transitioning to the current monitoring data format. They are currently empty and are no
+longer of any use.
+
+*Impact* +
+Discontinue the use of the `xpack.monitoring.exporters.*.index.template.create_legacy_templates` setting
+as it will no longer be recognized in the next major release.
 ====
 
 // end::notable-breaking-changes[]

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -504,12 +504,6 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
         final List<Tuple<String, String>> templates = monitoringTemplates(includeOldTemplates);
 
         assertMonitorVersionResource(webServer, alreadyExists, "/_template/", templates, customHeaders, basePath);
-
-        if (includeOldTemplates) {
-            assertWarnings("[xpack.monitoring.exporters._http.index.template.create_legacy_templates] setting was deprecated in " +
-                "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
-                "major version.");
-        }
     }
 
     private void assertMonitorPipelines(final MockWebServer webServer,

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -504,6 +504,12 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
         final List<Tuple<String, String>> templates = monitoringTemplates(includeOldTemplates);
 
         assertMonitorVersionResource(webServer, alreadyExists, "/_template/", templates, customHeaders, basePath);
+
+        if (includeOldTemplates) {
+            assertWarnings("[xpack.monitoring.exporters._http.index.template.create_legacy_templates] setting was deprecated in " +
+                "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
+                "major version.");
+        }
     }
 
     private void assertMonitorPipelines(final MockWebServer webServer,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -383,7 +383,8 @@ public class HttpExporter extends Exporter {
      */
     public static final Setting.AffixSetting<Boolean> TEMPLATE_CREATE_LEGACY_VERSIONS_SETTING =
             Setting.affixKeySetting("xpack.monitoring.exporters.","index.template.create_legacy_templates",
-                    (key) -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope), HTTP_TYPE_DEPENDENCY);
+                    (key) -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.Deprecated),
+                HTTP_TYPE_DEPENDENCY);
     /**
      * ES level timeout used when checking and writing pipelines (used to speed up tests)
      */

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -543,6 +543,10 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
         verifyPutWatches(0);
         verifyDeleteWatches(EXPECTED_WATCHES);
         verifyNoMoreInteractions(client);
+
+        assertWarnings("[xpack.monitoring.exporters._http.index.template.create_legacy_templates] setting was deprecated in " +
+            "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
+            "major version.");
     }
 
     public void testSuccessfulChecksOnElectedMasterNode() {
@@ -629,6 +633,10 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
         verifyGetPipelines(EXPECTED_PIPELINES);
         verifyPutPipelines(unsuccessfulGetPipelines);
         verifyNoMoreInteractions(client);
+
+        assertWarnings("[xpack.monitoring.exporters._http.index.template.create_legacy_templates] setting was deprecated in " +
+            "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
+            "major version.");
     }
 
     private Exception failureGetException() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -425,8 +425,8 @@ public class HttpExporterTests extends ESTestCase {
 
         if (useIngest == false) {
             builder.put("xpack.monitoring.exporters._http.use_ingest", false);
-            expectedWarnings.add("[xpack.monitoring.exporters._http.use_ingest] setting was deprecated in Elasticsearch and will be removed " +
-                "in a future release! See the breaking changes documentation for the next major version.");
+            expectedWarnings.add("[xpack.monitoring.exporters._http.use_ingest] setting was deprecated in Elasticsearch and will be " +
+                "removed in a future release! See the breaking changes documentation for the next major version.");
         }
 
         if (clusterAlertManagement == false) {
@@ -447,7 +447,7 @@ public class HttpExporterTests extends ESTestCase {
         // note: this shouldn't get used with useIngest == false, but it doesn't hurt to try to cause issues
         if (pipelineTimeout != null) {
             builder.put("xpack.monitoring.exporters._http.index.pipeline.master_timeout", pipelineTimeout.getStringRep());
-            if (useIngest == true) {
+            if (useIngest) {
                 expectedWarnings.add("[xpack.monitoring.exporters._http.index.pipeline.master_timeout] setting was deprecated in " +
                     "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
                     "major version.");

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -421,9 +421,12 @@ public class HttpExporterTests extends ESTestCase {
 
         final Settings.Builder builder = Settings.builder()
                 .put("xpack.monitoring.exporters._http.type", "http");
+        List<String> expectedWarnings = new ArrayList<>();
 
         if (useIngest == false) {
             builder.put("xpack.monitoring.exporters._http.use_ingest", false);
+            expectedWarnings.add("[xpack.monitoring.exporters._http.use_ingest] setting was deprecated in Elasticsearch and will be removed " +
+                "in a future release! See the breaking changes documentation for the next major version.");
         }
 
         if (clusterAlertManagement == false) {
@@ -432,6 +435,9 @@ public class HttpExporterTests extends ESTestCase {
 
         if (createOldTemplates == false) {
             builder.put("xpack.monitoring.exporters._http.index.template.create_legacy_templates", false);
+            expectedWarnings.add("[xpack.monitoring.exporters._http.index.template.create_legacy_templates] setting was deprecated in " +
+                "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
+                "major version.");
         }
 
         if (templateTimeout != null) {
@@ -441,6 +447,11 @@ public class HttpExporterTests extends ESTestCase {
         // note: this shouldn't get used with useIngest == false, but it doesn't hurt to try to cause issues
         if (pipelineTimeout != null) {
             builder.put("xpack.monitoring.exporters._http.index.pipeline.master_timeout", pipelineTimeout.getStringRep());
+            if (useIngest == true) {
+                expectedWarnings.add("[xpack.monitoring.exporters._http.index.pipeline.master_timeout] setting was deprecated in " +
+                    "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next " +
+                    "major version.");
+            }
         }
 
         final Config config = createConfig(builder.build());
@@ -491,9 +502,8 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(uniqueOwners, hasSize(1));
         assertThat(uniqueOwners.get(0), equalTo("xpack.monitoring.exporters._http"));
 
-        if (useIngest == false) {
-            assertWarnings("[xpack.monitoring.exporters._http.use_ingest] setting was deprecated in Elasticsearch and will be removed " +
-                "in a future release! See the breaking changes documentation for the next major version.");
+        if (expectedWarnings.size() > 0) {
+            assertWarnings(expectedWarnings.toArray(new String[0]));
         }
     }
 


### PR DESCRIPTION
This PR marks the `xpack.monitoring.exporters.*.index.template.create_legacy_templates` setting as deprecated.

This also addresses a couple of deprecation related failures that were introduced as part of the test updates.