### PR TITLE
Simple ILM Task Batching Implementation (#78547)

### DIFF
--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -154,9 +156,19 @@ public class ClusterStateWaitThresholdBreachTests extends ESIntegTestCase {
         // shrink cycle is started
         LongSupplier nowWayBackInThePastSupplier = () -> 1234L;
         clusterService.submitStateUpdateTask("testing-move-to-step-to-manipulate-step-time",
-            new MoveToNextStepUpdateTask(managedIndexMetadata.getIndex(), policy, currentStepKey, currentStepKey,
-                nowWayBackInThePastSupplier, indexLifecycleService.getPolicyRegistry(), state -> {
-            }));
+                new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) throws Exception {
+                        return new MoveToNextStepUpdateTask(managedIndexMetadata.getIndex(), policy, currentStepKey, currentStepKey,
+                                nowWayBackInThePastSupplier, indexLifecycleService.getPolicyRegistry(), state -> {
+                        }).execute(currentState);
+                    }
+
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        throw new AssertionError(e);
+                    }
+                });
 
         String[] secondCycleShrinkIndexName = new String[1];
         assertBusy(() -> {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.ilm.Step;
@@ -18,7 +18,7 @@ import org.elasticsearch.xpack.core.ilm.Step;
  * Base class for index lifecycle cluster state update tasks that requires implementing {@code equals} and {@code hashCode} to allow
  * for these tasks to be deduplicated by {@link IndexLifecycleRunner}.
  */
-public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateUpdateTask {
+public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterStateTaskListener {
 
     private final ListenableFuture<Void> listener = new ListenableFuture<>();
 
@@ -39,10 +39,25 @@ public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateU
         return currentStepKey;
     }
 
+    private boolean executed;
+
+    public final ClusterState execute(ClusterState currentState) throws Exception {
+        assert executed == false;
+        final ClusterState updatedState = doExecute(currentState);
+        if (currentState != updatedState) {
+            executed = true;
+        }
+        return updatedState;
+    }
+
+    protected abstract ClusterState doExecute(ClusterState currentState) throws Exception;
+
     @Override
     public final void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
         listener.onResponse(null);
-        onClusterStateProcessed(source, oldState, newState);
+        if (executed) {
+            onClusterStateProcessed(source, oldState, newState);
+        }
     }
 
     @Override
@@ -61,8 +76,11 @@ public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateU
     }
 
     /**
-     * This method is functionally the same as {@link ClusterStateUpdateTask#clusterStateProcessed(String, ClusterState, ClusterState)}
+     * This method is functionally the same as {@link ClusterStateTaskListener#clusterStateProcessed(String, ClusterState, ClusterState)}
      * and implementations can override it as they would override {@code ClusterStateUpdateTask#clusterStateProcessed}.
+     * The only difference to  {@code ClusterStateUpdateTask#clusterStateProcessed} is that if the {@link #execute(ClusterState)}
+     * implementation was a noop and returned the input cluster state, then this method will not be invoked. It is therefore guaranteed
+     * that {@code oldState} is always different from {@code newState}.
      */
     protected void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
     }
@@ -74,8 +92,8 @@ public abstract class IndexLifecycleClusterStateUpdateTask extends ClusterStateU
     public abstract int hashCode();
 
     /**
-     * This method is functionally the same as {@link ClusterStateUpdateTask#onFailure(String, Exception)} and implementations can override
-     * it as they would override {@code ClusterStateUpdateTask#onFailure}.
+     * This method is functionally the same as {@link ClusterStateTaskListener#onFailure(String, Exception)} and implementations can
+     * override it as they would override {@code ClusterStateUpdateTask#onFailure}.
      */
     protected abstract void handleFailure(String source, Exception e);
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -42,7 +42,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
     }
 
     @Override
-    public ClusterState execute(ClusterState currentState) {
+    public ClusterState doExecute(ClusterState currentState) {
         IndexMetadata indexMetadata = currentState.getMetadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
@@ -64,9 +64,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
 
     @Override
     public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        if (oldState.equals(newState) == false) {
-            stateChangeConsumer.accept(newState);
-        }
+        stateChangeConsumer.accept(newState);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -46,7 +46,7 @@ public class SetStepInfoUpdateTask extends IndexLifecycleClusterStateUpdateTask 
     }
 
     @Override
-    public ClusterState execute(ClusterState currentState) throws IOException {
+    protected ClusterState doExecute(ClusterState currentState) throws IOException {
         IndexMetadata idxMeta = currentState.getMetadata().index(index);
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -143,7 +143,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         return indexMetadata;
     }
 
-    public void testNeverExecuteNonClusterStateStep() throws IOException {
+    public void testNeverExecuteNonClusterStateStep() throws Exception {
         setStateToKey(thirdStepKey);
         Step startStep = policyStepsRegistry.getStep(indexMetadata, thirdStepKey);
         long now = randomNonNegativeLong();
@@ -151,7 +151,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         assertThat(task.execute(clusterState), sameInstance(clusterState));
     }
 
-    public void testSuccessThenFailureUnsetNextKey() throws IOException {
+    public void testSuccessThenFailureUnsetNextKey() throws Exception {
         secondStep.setWillComplete(false);
         setStateToKey(firstStepKey);
         Step startStep = policyStepsRegistry.getStep(indexMetadata, firstStepKey);
@@ -169,7 +169,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         assertThat(lifecycleState.getStepInfo(), nullValue());
     }
 
-    public void testExecuteUntilFirstNonClusterStateStep() throws IOException {
+    public void testExecuteUntilFirstNonClusterStateStep() throws Exception {
         setStateToKey(secondStepKey);
         Step startStep = policyStepsRegistry.getStep(indexMetadata, secondStepKey);
         long now = randomNonNegativeLong();
@@ -185,7 +185,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         assertThat(lifecycleState.getStepInfo(), nullValue());
     }
 
-    public void testExecuteInvalidStartStep() throws IOException {
+    public void testExecuteInvalidStartStep() throws Exception {
         // Unset the index's phase/action/step to simulate starting from scratch
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder(
             LifecycleExecutionState.fromIndexMetadata(clusterState.getMetadata().index(index)));
@@ -207,7 +207,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         assertSame(newState, clusterState);
     }
 
-    public void testExecuteIncompleteWaitStepNoInfo() throws IOException {
+    public void testExecuteIncompleteWaitStepNoInfo() throws Exception {
         secondStep.setWillComplete(false);
         setStateToKey(secondStepKey);
         Step startStep = policyStepsRegistry.getStep(indexMetadata, secondStepKey);
@@ -224,7 +224,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         assertThat(lifecycleState.getStepInfo(), nullValue());
     }
 
-    public void testExecuteIncompleteWaitStepWithInfo() throws IOException {
+    public void testExecuteIncompleteWaitStepWithInfo() throws Exception {
         secondStep.setWillComplete(false);
         RandomStepInfo stepInfo = new RandomStepInfo(() -> randomAlphaOfLength(10));
         secondStep.expectedInfo(stepInfo);
@@ -252,7 +252,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         task.onFailure(randomAlphaOfLength(10), expectedException);
     }
 
-    public void testClusterActionStepThrowsException() throws IOException {
+    public void testClusterActionStepThrowsException() throws Exception {
         RuntimeException thrownException = new RuntimeException("error");
         firstStep.setException(thrownException);
         setStateToKey(firstStepKey);
@@ -272,7 +272,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
             containsString("{\"type\":\"runtime_exception\",\"reason\":\"error\",\"stack_trace\":\""));
     }
 
-    public void testClusterWaitStepThrowsException() throws IOException {
+    public void testClusterWaitStepThrowsException() throws Exception {
         RuntimeException thrownException = new RuntimeException("error");
         secondStep.setException(thrownException);
         setStateToKey(firstStepKey);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -91,6 +91,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -164,7 +166,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
 
-        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(any(), any());
+        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(anyString(), any(), any(), any(), any());
     }
 
     public void testRunPolicyErrorStep() {
@@ -626,10 +628,15 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
+        final ExecuteStepsUpdateTaskMatcher taskMatcher =
+                new ExecuteStepsUpdateTaskMatcher(indexMetadata.getIndex(), policyName, step);
         Mockito.verify(clusterService, Mockito.times(1)).submitStateUpdateTask(
             Mockito.eq("ilm-execute-cluster-state-steps [{\"phase\":\"phase\",\"action\":\"action\"," +
                 "\"name\":\"cluster_state_action_step\"} => null]"),
-                Mockito.argThat(new ExecuteStepsUpdateTaskMatcher(indexMetadata.getIndex(), policyName, step))
+                Mockito.argThat(taskMatcher),
+                eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
+                any(),
+                Mockito.argThat(taskMatcher)
         );
         Mockito.verifyNoMoreInteractions(clusterService);
     }
@@ -646,10 +653,15 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
+        final ExecuteStepsUpdateTaskMatcher taskMatcher =
+                new ExecuteStepsUpdateTaskMatcher(indexMetadata.getIndex(), policyName, step);
         Mockito.verify(clusterService, Mockito.times(1)).submitStateUpdateTask(
             Mockito.eq("ilm-execute-cluster-state-steps [{\"phase\":\"phase\",\"action\":\"action\"," +
                 "\"name\":\"cluster_state_action_step\"} => null]"),
-                Mockito.argThat(new ExecuteStepsUpdateTaskMatcher(indexMetadata.getIndex(), policyName, step))
+                Mockito.argThat(taskMatcher),
+                eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
+                any(),
+                Mockito.argThat(taskMatcher)
         );
         Mockito.verifyNoMoreInteractions(clusterService);
     }
@@ -699,16 +711,20 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         // verify that no exception is thrown
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
+        final SetStepInfoUpdateTaskMatcher taskMatcher = new SetStepInfoUpdateTaskMatcher(indexMetadata.getIndex(), policyName, null,
+            (builder, params) -> {
+                builder.startObject();
+                builder.field("reason", "policy [does_not_exist] does not exist");
+                builder.field("type", "illegal_argument_exception");
+                builder.endObject();
+                return builder;
+        });
         Mockito.verify(clusterService, Mockito.times(1)).submitStateUpdateTask(
             Mockito.eq("ilm-set-step-info {policy [cluster_state_action_policy], index [my_index], currentStep [null]}"),
-            Mockito.argThat(new SetStepInfoUpdateTaskMatcher(indexMetadata.getIndex(), policyName, null,
-                (builder, params) -> {
-                    builder.startObject();
-                    builder.field("reason", "policy [does_not_exist] does not exist");
-                    builder.field("type", "illegal_argument_exception");
-                    builder.endObject();
-                    return builder;
-                }))
+            Mockito.argThat(taskMatcher),
+            eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
+            any(),
+            Mockito.argThat(taskMatcher)
         );
         Mockito.verifyNoMoreInteractions(clusterService);
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -304,7 +304,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             ranPolicy.set(true);
             throw new AssertionError("invalid invocation");
-        }).when(clusterService).submitStateUpdateTask(anyString(), any(ExecuteStepsUpdateTask.class));
+        }).when(clusterService).submitStateUpdateTask(anyString(), any(), eq(IndexLifecycleRunner.ILM_TASK_CONFIG), any(), any());
 
         doAnswer(invocationOnMock -> {
             OperationModeUpdateTask task = (OperationModeUpdateTask) invocationOnMock.getArguments()[1];

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -62,7 +62,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
     }
 
-    public void testExecuteSuccessfullyMoved() {
+    public void testExecuteSuccessfullyMoved() throws Exception {
         long now = randomNonNegativeLong();
         List<Step> steps = lifecyclePolicy.toSteps(null, null);
         StepKey currentStepKey = steps.get(0).getKey();
@@ -84,7 +84,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         assertTrue(changed.get());
     }
 
-    public void testExecuteDifferentCurrentStep() {
+    public void testExecuteDifferentCurrentStep() throws Exception {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         StepKey notCurrentStepKey = new StepKey("not-current", "not-current", "not-current");
         long now = randomNonNegativeLong();
@@ -95,7 +95,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         assertSame(newState, clusterState);
     }
 
-    public void testExecuteDifferentPolicy() {
+    public void testExecuteDifferentPolicy() throws Exception {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         long now = randomNonNegativeLong();
         setStateToKey(currentStepKey, now);
@@ -106,7 +106,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         assertSame(newState, clusterState);
     }
 
-    public void testExecuteSuccessfulMoveWithInvalidNextStep() {
+    public void testExecuteSuccessfulMoveWithInvalidNextStep() throws Exception {
         long now = randomNonNegativeLong();
         List<Step> steps = lifecyclePolicy.toSteps(null, null);
         StepKey currentStepKey = steps.get(0).getKey();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -31,8 +31,6 @@ import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.junit.Before;
 
-import java.io.IOException;
-
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -59,7 +57,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
     }
 
-    public void testExecuteSuccessfullySet() throws IOException {
+    public void testExecuteSuccessfullySet() throws Exception {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         ToXContentObject stepInfo = getRandomStepInfo();
         setStateToKey(currentStepKey);
@@ -90,7 +88,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         };
     }
 
-    public void testExecuteNoopDifferentStep() throws IOException {
+    public void testExecuteNoopDifferentStep() throws Exception {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         StepKey notCurrentStepKey = new StepKey("not-current", "not-current", "not-current");
         ToXContentObject stepInfo = getRandomStepInfo();
@@ -100,7 +98,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         assertThat(newState, sameInstance(clusterState));
     }
 
-    public void testExecuteNoopDifferentPolicy() throws IOException {
+    public void testExecuteNoopDifferentPolicy() throws Exception {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         ToXContentObject stepInfo = getRandomStepInfo();
         setStateToKey(currentStepKey);


### PR DESCRIPTION
A simple implementation for ILM task batching that resolves the issue of ILM
creating endless queues of tasks at `NORMAL` priority in most cases.
A follow-up to this should make this more efficient by not using outright
cluster state updates as batching tasks to avoid creating a series of concrete
cluster states for each task which can become somewhat expensive if a larger
number of tasks is batched together.

backport of #78547 