### PR TITLE
Avoid misconfiguring older nodes as a result of lazy cluster evaluation

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -31,8 +31,8 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  def bwcVersionString = bwcVersion.toString();
-  String baseName = "v"+ bwcVersionString;
+  def bwcVersionString = bwcVersion.toString()
+  String baseName = "v"+ bwcVersionString
 
   def baseCluster = testClusters.register(baseName) {
       testDistribution = "DEFAULT"
@@ -58,7 +58,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 
-      if (bwcVersion.onOrAfter('6.7.0')) {
+      if (Version.fromString(bwcVersionString).onOrAfter('6.7.0')) {
         setting 'xpack.security.authc.api_key.enabled', 'true'
       }
   }


### PR DESCRIPTION
This fixes some fallout from #78312 where we aren't correctly configuring older BWC nodes. This happens anytime you have a lazily evaluated configuration block inside of a loop.

Closes https://github.com/elastic/elasticsearch/issues/78459