### PR TITLE
Avoiding setting xpack.security.authc.api_key.enabled on versions that cannot handle it

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -32,6 +32,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
   def bwcVersionString = bwcVersion.toString();
+  def bwcVersionLocal = bwcVersion;
   String baseName = "v"+ bwcVersionString;
 
   def baseCluster = testClusters.register(baseName) {
@@ -57,8 +58,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       setting 'xpack.security.transport.ssl.key', 'testnode.pem'
       setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-
-      if (bwcVersion.onOrAfter('6.7.0')) {
+      if (bwcVersionLocal.onOrAfter('6.7.0')) {
         setting 'xpack.security.authc.api_key.enabled', 'true'
       }
   }


### PR DESCRIPTION
The xpack.security.authc.api_key.enabled setting was inadvertently being set on all versions, rather than just ones
higher than 6.7 because the bwcVersion variable was not captured in the closure -- it was using the last value that
bwcVersion had been set to, which was always greater than 6.7. This commit makes a local copy of bwcVersion.
Closes #78459