### PR TITLE
TSDB: Mark tests as 8.0.0 only

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -9,6 +9,7 @@ add time series mappings:
           body:
             settings:
               index:
+                index_mode: time_series
                 number_of_replicas: 0
                 number_of_shards: 2
             mappings:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -9,7 +9,6 @@ add time series mappings:
           body:
             settings:
               index:
-                index_mode: time_series
                 number_of_replicas: 0
                 number_of_shards: 2
             mappings:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
@@ -1,7 +1,7 @@
 enable:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       indices.create:
@@ -41,7 +41,7 @@ enable:
 no sort field:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       catch: /\[index.mode=time_series\] is incompatible with \[index.sort.field\]/
@@ -57,7 +57,7 @@ no sort field:
 no sort order:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       catch: /\[index.mode=time_series\] is incompatible with \[index.sort.order\]/
@@ -73,7 +73,7 @@ no sort order:
 no sort mode:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       catch: /\[index.mode=time_series\] is incompatible with \[index.sort.mode\]/
@@ -89,7 +89,7 @@ no sort mode:
 no sort missing:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       catch: /\[index.mode=time_series\] is incompatible with \[index.sort.missing\]/
@@ -105,7 +105,7 @@ no sort missing:
 no partitioning:
   - skip:
       version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      reason: introduced in 8.0.0
 
   - do:
       catch: /\[index.mode=time_series\] is incompatible with \[index.routing_partition_size\]/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -9,6 +9,7 @@ add time series mappings:
           body:
             settings:
               index:
+                mode: time_series
                 number_of_replicas: 0
                 number_of_shards: 2
             mappings:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -1,0 +1,49 @@
+add time series mappings:
+  - skip:
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0
+
+  - do:
+      indices.create:
+          index: tsdb_index
+          body:
+            settings:
+              index:
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                metricset:
+                  type: keyword
+                  time_series_dimension: true
+                k8s:
+                  properties:
+                    pod:
+                      properties:
+                        availability_zone:
+                          type: short
+                          time_series_dimension: true
+                        uid:
+                          type: keyword
+                          time_series_dimension: true
+                        name:
+                          type: keyword
+                        ip:
+                          type: ip
+                          time_series_dimension: true
+                        network:
+                          properties:
+                            tx:
+                              type: long
+                              time_series_metric: counter
+                            rx:
+                              type: integer
+                              time_series_metric: gauge
+                            packets_dropped:
+                              type: long
+                              time_series_metric: gauge
+                            latency:
+                              type: double
+                              time_series_metric: gauge


### PR DESCRIPTION
We're not going to have a useful release of tsdb in 7.16 so we've backed
out the tiny amount of work that we've landed into that branch.
`time_series` mode will be a 8.0+ thing. Thsis updates the tests to
reflect that.
