### PR TITLE
Add dynamic (duck) type resolution to Painless static types

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotation.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless.spi.annotation;
+
+public class DynamicTypeAnnotation {
+
+    public static final String NAME = "dynamic_type";
+
+    public static final DynamicTypeAnnotation INSTANCE = new DynamicTypeAnnotation();
+
+    private DynamicTypeAnnotation() {
+
+    }
+}

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotationParser.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotationParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless.spi.annotation;
+
+import java.util.Map;
+
+public class DynamicTypeAnnotationParser implements WhitelistAnnotationParser {
+
+    public static final DynamicTypeAnnotationParser INSTANCE = new DynamicTypeAnnotationParser();
+
+    private DynamicTypeAnnotationParser() {}
+
+    @Override
+    public Object parse(Map<String, String> arguments) {
+        if (arguments.isEmpty() == false) {
+            throw new IllegalArgumentException(
+                    "unexpected parameters for [@" + DynamicTypeAnnotation.NAME + "] annotation, found " + arguments
+            );
+        }
+
+        return DynamicTypeAnnotationParser.INSTANCE;
+    }
+}

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotationParser.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/DynamicTypeAnnotationParser.java
@@ -24,6 +24,6 @@ public class DynamicTypeAnnotationParser implements WhitelistAnnotationParser {
             );
         }
 
-        return DynamicTypeAnnotationParser.INSTANCE;
+        return DynamicTypeAnnotation.INSTANCE;
     }
 }

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/WhitelistAnnotationParser.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/WhitelistAnnotationParser.java
@@ -27,7 +27,8 @@ public interface WhitelistAnnotationParser {
                     new AbstractMap.SimpleEntry<>(NonDeterministicAnnotation.NAME, NonDeterministicAnnotationParser.INSTANCE),
                     new AbstractMap.SimpleEntry<>(InjectConstantAnnotation.NAME, InjectConstantAnnotationParser.INSTANCE),
                     new AbstractMap.SimpleEntry<>(CompileTimeOnlyAnnotation.NAME, CompileTimeOnlyAnnotationParser.INSTANCE),
-                    new AbstractMap.SimpleEntry<>(AugmentedAnnotation.NAME, AugmentedAnnotationParser.INSTANCE)
+                    new AbstractMap.SimpleEntry<>(AugmentedAnnotation.NAME, AugmentedAnnotationParser.INSTANCE),
+                    new AbstractMap.SimpleEntry<>(DynamicTypeAnnotation.NAME, DynamicTypeAnnotationParser.INSTANCE)
             ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
     );
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClass.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClass.java
@@ -20,6 +20,7 @@ public final class PainlessClass {
     public final Map<String, PainlessField> staticFields;
     public final Map<String, PainlessField> fields;
     public final PainlessMethod functionalInterfaceMethod;
+    public final Map<Class<?>, Object> annotations;
 
     public final Map<String, PainlessMethod> runtimeMethods;
     public final Map<String, MethodHandle> getterMethodHandles;
@@ -29,6 +30,7 @@ public final class PainlessClass {
             Map<String, PainlessMethod> staticMethods, Map<String, PainlessMethod> methods,
             Map<String, PainlessField> staticFields, Map<String, PainlessField> fields,
             PainlessMethod functionalInterfaceMethod,
+            Map<Class<?>, Object> annotations,
             Map<String, PainlessMethod> runtimeMethods,
             Map<String, MethodHandle> getterMethodHandles, Map<String, MethodHandle> setterMethodHandles) {
 
@@ -38,6 +40,7 @@ public final class PainlessClass {
         this.staticFields = Map.copyOf(staticFields);
         this.fields = Map.copyOf(fields);
         this.functionalInterfaceMethod = functionalInterfaceMethod;
+        this.annotations = annotations;
 
         this.getterMethodHandles = Map.copyOf(getterMethodHandles);
         this.setterMethodHandles = Map.copyOf(setterMethodHandles);
@@ -61,11 +64,12 @@ public final class PainlessClass {
                 Objects.equals(methods, that.methods) &&
                 Objects.equals(staticFields, that.staticFields) &&
                 Objects.equals(fields, that.fields) &&
-                Objects.equals(functionalInterfaceMethod, that.functionalInterfaceMethod);
+                Objects.equals(functionalInterfaceMethod, that.functionalInterfaceMethod) &&
+                Objects.equals(annotations, that.annotations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod);
+        return Objects.hash(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod, annotations);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClassBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClassBuilder.java
@@ -21,6 +21,7 @@ final class PainlessClassBuilder {
     final Map<String, PainlessField> staticFields;
     final Map<String, PainlessField> fields;
     PainlessMethod functionalInterfaceMethod;
+    final Map<Class<?>, Object> annotations;
 
     final Map<String, PainlessMethod> runtimeMethods;
     final Map<String, MethodHandle> getterMethodHandles;
@@ -33,6 +34,7 @@ final class PainlessClassBuilder {
         staticFields = new HashMap<>();
         fields = new HashMap<>();
         functionalInterfaceMethod = null;
+        annotations = new HashMap<>();
 
         runtimeMethods = new HashMap<>();
         getterMethodHandles = new HashMap<>();
@@ -40,7 +42,7 @@ final class PainlessClassBuilder {
     }
 
     PainlessClass build() {
-        return new PainlessClass(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod,
+        return new PainlessClass(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod, annotations,
                 runtimeMethods, getterMethodHandles, setterMethodHandles);
     }
 
@@ -61,11 +63,12 @@ final class PainlessClassBuilder {
                 Objects.equals(methods, that.methods) &&
                 Objects.equals(staticFields, that.staticFields) &&
                 Objects.equals(fields, that.fields) &&
-                Objects.equals(functionalInterfaceMethod, that.functionalInterfaceMethod);
+                Objects.equals(functionalInterfaceMethod, that.functionalInterfaceMethod) &&
+                Objects.equals(annotations, that.annotations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod);
+        return Objects.hash(constructors, staticMethods, methods, staticFields, fields, functionalInterfaceMethod, annotations);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -140,6 +140,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -2525,9 +2526,8 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
                     }
                 } else if (prefixValueType != null && prefixValueType.getValueType() == def.class) {
                     TargetType targetType = userDotNode.isNullSafe() ? null : semanticScope.getDecoration(userDotNode, TargetType.class);
-                    // TODO: remove ZonedDateTime exception when JodaCompatibleDateTime is removed
-                    valueType = targetType == null || targetType.getTargetType() == ZonedDateTime.class ||
-                            semanticScope.getCondition(userDotNode, Explicit.class) ? def.class : targetType.getTargetType();
+                    valueType = targetType == null || semanticScope.getCondition(userDotNode, Explicit.class) ?
+                            def.class : targetType.getTargetType();
 
                     if (write) {
                         semanticScope.setCondition(userDotNode, DefOptimized.class);
@@ -2888,9 +2888,38 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
                     "[" + semanticScope.getDecoration(userPrefixNode, PartialCanonicalTypeName.class).getPartialCanonicalTypeName() + "]"));
         }
 
+        boolean indy = false;
+        PainlessMethod method = null;
+
+        if (prefixValueType != null) {
+            if (prefixValueType.getValueType() == def.class) {
+                indy = true;
+            } else {
+                method = semanticScope.getScriptScope().getPainlessLookup().lookupPainlessMethod(
+                        prefixValueType.getValueType(), false, methodName, userArgumentsSize);
+
+                if (method == null) {
+                    throw userCallNode.createError(new IllegalArgumentException("member method " +
+                            "[" + prefixValueType.getValueCanonicalTypeName() + ", " + methodName + "/" + userArgumentsSize + "] " +
+                            "not found"));
+                }
+            }
+        } else if (prefixStaticType != null) {
+            method = semanticScope.getScriptScope().getPainlessLookup().lookupPainlessMethod(
+                    prefixStaticType.getStaticType(), true, methodName, userArgumentsSize);
+
+            if (method == null) {
+                throw userCallNode.createError(new IllegalArgumentException("static method " +
+                        "[" + prefixStaticType.getStaticCanonicalTypeName() + ", " + methodName + "/" + userArgumentsSize + "] " +
+                        "not found"));
+            }
+        } else {
+            throw userCallNode.createError(new IllegalStateException("value required: instead found no value"));
+        }
+
         Class<?> valueType;
 
-        if (prefixValueType != null && prefixValueType.getValueType() == def.class) {
+        if (indy) {
             for (AExpression userArgumentNode : userArgumentNodes) {
                 semanticScope.setCondition(userArgumentNode, Read.class);
                 semanticScope.setCondition(userArgumentNode, Internal.class);
@@ -2904,34 +2933,10 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
             }
 
             TargetType targetType = userCallNode.isNullSafe() ? null : semanticScope.getDecoration(userCallNode, TargetType.class);
-            // TODO: remove ZonedDateTime exception when JodaCompatibleDateTime is removed
-            valueType = targetType == null || targetType.getTargetType() == ZonedDateTime.class ||
-                    semanticScope.getCondition(userCallNode, Explicit.class) ? def.class : targetType.getTargetType();
+            valueType = targetType == null || semanticScope.getCondition(userCallNode, Explicit.class) ?
+                    def.class : targetType.getTargetType();
         } else {
-            PainlessMethod method;
-
-            if (prefixValueType != null) {
-                method = semanticScope.getScriptScope().getPainlessLookup().lookupPainlessMethod(
-                        prefixValueType.getValueType(), false, methodName, userArgumentsSize);
-
-                if (method == null) {
-                    throw userCallNode.createError(new IllegalArgumentException("member method " +
-                            "[" + prefixValueType.getValueCanonicalTypeName() + ", " + methodName + "/" + userArgumentsSize + "] " +
-                            "not found"));
-                }
-            } else if (prefixStaticType != null) {
-                method = semanticScope.getScriptScope().getPainlessLookup().lookupPainlessMethod(
-                        prefixStaticType.getStaticType(), true, methodName, userArgumentsSize);
-
-                if (method == null) {
-                    throw userCallNode.createError(new IllegalArgumentException("static method " +
-                            "[" + prefixStaticType.getStaticCanonicalTypeName() + ", " + methodName + "/" + userArgumentsSize + "] " +
-                            "not found"));
-                }
-            } else {
-                throw userCallNode.createError(new IllegalStateException("value required: instead found no value"));
-            }
-
+            Objects.requireNonNull(method);
             semanticScope.getScriptScope().markNonDeterministic(method.annotations.containsKey(NonDeterministicAnnotation.class));
 
             for (int argument = 0; argument < userArgumentsSize; ++argument) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.Operation;
 import org.elasticsearch.painless.lookup.PainlessCast;
+import org.elasticsearch.painless.lookup.PainlessClass;
 import org.elasticsearch.painless.lookup.PainlessClassBinding;
 import org.elasticsearch.painless.lookup.PainlessConstructor;
 import org.elasticsearch.painless.lookup.PainlessField;
@@ -85,6 +86,7 @@ import org.elasticsearch.painless.symbol.Decorations.CompoundType;
 import org.elasticsearch.painless.symbol.Decorations.ContinuousLoop;
 import org.elasticsearch.painless.symbol.Decorations.DefOptimized;
 import org.elasticsearch.painless.symbol.Decorations.DowncastPainlessCast;
+import org.elasticsearch.painless.symbol.Decorations.DynamicInvocation;
 import org.elasticsearch.painless.symbol.Decorations.EncodingDecoration;
 import org.elasticsearch.painless.symbol.Decorations.Explicit;
 import org.elasticsearch.painless.symbol.Decorations.ExpressionPainlessCast;
@@ -2944,6 +2946,8 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
             TargetType targetType = userCallNode.isNullSafe() ? null : semanticScope.getDecoration(userCallNode, TargetType.class);
             valueType = targetType == null || semanticScope.getCondition(userCallNode, Explicit.class) ?
                     def.class : targetType.getTargetType();
+
+            semanticScope.setCondition(userCallNode, DynamicInvocation.class);
         } else {
             Objects.requireNonNull(method);
             semanticScope.getScriptScope().markNonDeterministic(method.annotations.containsKey(NonDeterministicAnnotation.class));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -14,7 +14,6 @@ import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.Operation;
 import org.elasticsearch.painless.lookup.PainlessCast;
-import org.elasticsearch.painless.lookup.PainlessClass;
 import org.elasticsearch.painless.lookup.PainlessClassBinding;
 import org.elasticsearch.painless.lookup.PainlessConstructor;
 import org.elasticsearch.painless.lookup.PainlessField;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -154,6 +154,7 @@ import org.elasticsearch.painless.symbol.Decorations.Compound;
 import org.elasticsearch.painless.symbol.Decorations.CompoundType;
 import org.elasticsearch.painless.symbol.Decorations.ContinuousLoop;
 import org.elasticsearch.painless.symbol.Decorations.DowncastPainlessCast;
+import org.elasticsearch.painless.symbol.Decorations.DynamicInvocation;
 import org.elasticsearch.painless.symbol.Decorations.EncodingDecoration;
 import org.elasticsearch.painless.symbol.Decorations.Explicit;
 import org.elasticsearch.painless.symbol.Decorations.ExpressionPainlessCast;
@@ -1802,7 +1803,7 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
         ValueType prefixValueType = scriptScope.getDecoration(userCallNode.getPrefixNode(), ValueType.class);
         Class<?> valueType = scriptScope.getDecoration(userCallNode, ValueType.class).getValueType();
 
-        if (prefixValueType != null && prefixValueType.getValueType() == def.class) {
+        if (scriptScope.getCondition(userCallNode, DynamicInvocation.class)) {
             InvokeCallDefNode irCallSubDefNode = new InvokeCallDefNode(userCallNode.getLocation());
 
             for (AExpression userArgumentNode : userCallNode.getArgumentNodes()) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
@@ -365,6 +365,10 @@ public class Decorations {
         }
     }
 
+    public interface DynamicInvocation extends Condition {
+
+    }
+
     public static class GetterPainlessMethod implements Decoration {
 
         private final PainlessMethod getterPainlessMethod;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DynamicTypeTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DynamicTypeTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.action.PainlessExecuteAction.PainlessTestScript;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DynamicTypeTests extends ScriptTestCase {
+
+    @Override
+    protected Map<ScriptContext<?>, List<Whitelist>> scriptContexts() {
+        Map<ScriptContext<?>, List<Whitelist>> contexts = new HashMap<>();
+        List<Whitelist> whitelists = new ArrayList<>(PainlessPlugin.BASE_WHITELISTS);
+        whitelists.add(WhitelistLoader.loadFromResourceFiles(PainlessPlugin.class, "org.elasticsearch.painless.test"));
+        whitelists.add(WhitelistLoader.loadFromResourceFiles(PainlessPlugin.class, "org.elasticsearch.painless.dynamic"));
+        contexts.put(PainlessTestScript.CONTEXT, whitelists);
+        return contexts;
+    }
+
+    public interface DynI {
+
+    }
+
+    public static class DynA {
+    }
+
+    public static class DynB extends DynA implements DynI {
+    }
+
+    public static class DynC extends DynB {
+    }
+
+    public static class DynD extends DynB {
+        public char letter() {
+            return 'D';
+        }
+    }
+
+    public static class DynE extends DynC {
+        public char letter() {
+            return 'E';
+        }
+    }
+
+    public static class DynF extends DynE {
+    }
+
+    public static class DynG extends DynF {
+        public char letter() {
+            return 'G';
+        }
+
+        public int value() {
+            return 1;
+        }
+    }
+
+    public void testDynamicTypeResolution() {
+        assertEquals('D', exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynD(); return i.letter()"));
+        assertEquals('E', exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynE(); return i.letter()"));
+        assertEquals('E', exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynF(); return i.letter()"));
+        assertEquals('G', exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynG(); return i.letter()"));
+        IllegalArgumentException iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynD(); return i.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynE(); return i.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynF(); return i.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        assertEquals(1, exec("DynamicTypeTests.DynI i = new DynamicTypeTests.DynG(); return i.value()"));
+
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynD(); return a.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynE(); return a.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynF(); return a.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynG(); return a.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynD(); return a.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynE(); return a.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynF(); return a.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynA a = new DynamicTypeTests.DynG(); return a.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+
+        assertEquals('D', exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynD(); return b.letter()"));
+        assertEquals('E', exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynE(); return b.letter()"));
+        assertEquals('E', exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynF(); return b.letter()"));
+        assertEquals('G', exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynG(); return b.letter()"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynD(); return b.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynE(); return b.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynF(); return b.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        assertEquals(1, exec("DynamicTypeTests.DynB b = new DynamicTypeTests.DynG(); return b.value()"));
+
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynE(); return c.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynF(); return c.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynG(); return c.letter()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynE(); return c.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynF(); return c.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynC c = new DynamicTypeTests.DynG(); return c.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+
+        assertEquals('D', exec("DynamicTypeTests.DynD d = new DynamicTypeTests.DynD(); return d.letter()"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynD d = new DynamicTypeTests.DynD(); return d.value()"));
+        assertTrue(iae.getMessage().contains("member method") && iae.getMessage().contains("not found"));
+
+        assertEquals('E', exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynE(); return e.letter()"));
+        assertEquals('E', exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynF(); return e.letter()"));
+        assertEquals('G', exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynG(); return e.letter()"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynE(); return e.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynF(); return e.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        assertEquals(1, exec("DynamicTypeTests.DynE e = new DynamicTypeTests.DynG(); return e.value()"));
+
+        assertEquals('E', exec("DynamicTypeTests.DynF f = new DynamicTypeTests.DynF(); return f.letter()"));
+        assertEquals('G', exec("DynamicTypeTests.DynF f = new DynamicTypeTests.DynG(); return f.letter()"));
+        iae = expectScriptThrows(IllegalArgumentException.class,
+                () -> exec("DynamicTypeTests.DynF f = new DynamicTypeTests.DynF(); return f.value()"));
+        assertTrue(iae.getMessage().contains("dynamic method") && iae.getMessage().contains("not found"));
+        assertEquals(1, exec("DynamicTypeTests.DynF f = new DynamicTypeTests.DynG(); return f.value()"));
+
+        assertEquals('G', exec("DynamicTypeTests.DynG g = new DynamicTypeTests.DynG(); return g.letter()"));
+        assertEquals(1, exec("DynamicTypeTests.DynG g = new DynamicTypeTests.DynG(); return g.value()"));
+    }
+}

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/org.elasticsearch.painless.dynamic
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/org.elasticsearch.painless.dynamic
@@ -1,0 +1,34 @@
+class org.elasticsearch.painless.DynamicTypeTests$DynI @dynamic_type {
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynA {
+  ()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynB @dynamic_type {
+  ()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynC {
+  ()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynD @dynamic_type {
+  ()
+  char letter()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynE @dynamic_type {
+  ()
+  char letter()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynF @dynamic_type {
+  ()
+}
+
+class org.elasticsearch.painless.DynamicTypeTests$DynG @dynamic_type {
+  ()
+  char letter()
+  int value()
+}


### PR DESCRIPTION
This change adds dynamic (duck) type resolution to Painless static types using an annotation ( at dynamic_type ) to control which static types are allowed to be dynamically invoked.  This annotation does not chain so any sub classes that also require dynamic type resolution must be annotated as well.

Example:
```
Java:
class A {
}

class B {
   String duck() { returns "duck"; }
}

allow list:
class A @dynamic_type {
}

class B {
  ()
  String duck()
}

Painless:
A a = new B();
a.duck();
```

Normally, this would fail as `a` is statically typed, so the method duck would not be found. With dynamic type resolution, this will succeed by seeing that we have a possible duck method on a sub class and binding the method at runtime instead.