### PR TITLE
Preventing a server crash if the logger is initialized too early

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -69,7 +69,9 @@ public class LogConfigurator {
     private static final StatusListener ERROR_LISTENER = new StatusConsoleListener(Level.ERROR) {
         @Override
         public void log(StatusData data) {
-            error.set(true);
+            if (data.getMessage().getFormattedMessage().startsWith("No Log4j 2 configuration file found") == false) {
+                error.set(true);
+            }
             super.log(data);
         }
     };


### PR DESCRIPTION
LogConfiguration intends to throw an exception if an ERROR level message is logged. However just calling
LogManager.getLogger(getLoggerName(parentLoggerName));
results in an ERROR-level message being logged if log4j has not been configured. The result is that even
writing info-level log messages before log4j is configured results in a server crash. I discovered this by putting a
"pidfile" setting in elasticsearch.yaml. That is a deprecated setting so it logs a warning. However it happens before
logging is initialized, so it crashes the server.
I haven't tracked down what has changed recently to cause this. I don't think that it's the default level of logging
for deprecations, because this happens before we even log the deprecation. Maybe a log4j version update?
This commit makes it so that the "No Log4j 2 configuration file found..." error log does not cause failure, since that
is the expected state at this point anyway.
Here is the stack trace:
```
16:16:22.840 [main] CRITICAL org.elasticsearch.deprecation.common.settings.Settings - [pidfile] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
2021-10-01 16:16:32,962 main ERROR No Log4j 2 configuration file found. Using default configuration (logging only errors to the console), or user programmatically provided configurations. Set system property 'log4j2.debug' to show Log4j 2 internal initialization logging. See https://logging.apache.org/log4j/2.x/manual/configuration.html for instructions on how to configure Log4j 2
Exception in thread "main" java.lang.IllegalStateException: status logger logged an error before logging was configured
	at org.elasticsearch.common.logging.LogConfigurator.checkErrorListener(LogConfigurator.java:140)
	at org.elasticsearch.common.logging.LogConfigurator.configure(LogConfigurator.java:113)
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:350)
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:167)
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:158)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:75)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:114)
	at org.elasticsearch.cli.Command.main(Command.java:79)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:123)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:81)
```