### PR TITLE
[DOCS] Add info about FIPS and Java 17

### DIFF
--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -16,6 +16,13 @@ line tools.
 *Impact* +
 Use Java 11 or higher. Attempts to run {es} 8.0 using earlier Java versions will
 fail.
+
+Note that there is not yet a FIPS-certified security module for Java 17 
+that you can use when running Elasticsearch 8.0 in FIPS 140-2 mode. 
+If you run in FIPS 140-2 mode, you will either need to request an exception 
+from your security organization to upgrade to Elasticsearch 8.0, 
+or remain on Elasticsearch 7.x until Java 17 is certified.
+
 ====
 
 .JAVA_HOME is no longer supported.

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -3,6 +3,16 @@
 
 [partintro]
 --
+ifeval::["{release-state}"!="released"]
+[[upgrade-pre-release]]
+IMPORTANT: This documentation is for a pre-release of {es} {minor-version}. 
+Upgrades from pre-release builds are not supported and
+could result in errors or data loss. 
+If you upgrade from a released version to a pre-release verion for testing, 
+discard the contents of the cluster when you are done.
+Do not attempt to upgrade to the final release. 
+endif::[]
+
 {es} can usually be upgraded using a <<rolling-upgrades,Rolling upgrade>>
 process so upgrading does not interrupt service. Rolling upgrades are supported:
 
@@ -16,7 +26,7 @@ endif::[]
 
 [TIP]
 ====
-For rolling upgrades between major versions (e.g., 5.6 to 6.8), we recommend
+For rolling upgrades between major versions, we recommend
 using the {kibana-ref}/upgrade-assistant.html[Kibana Upgrade Assistant].
 
 The upgrade assistant identifies deprecated settings in your cluster and guides
@@ -26,7 +36,9 @@ We also recommend checking your <<deprecation-logging,deprecation logs>> for any
 other functionality that may have changed.
 ====
 
-The following table shows the recommended upgrade paths to {version}.
+[discrete]
+[[upgrade-paths]]
+=== Upgrade paths to {version}
 
 [cols="<1,3",options="header",]
 |====
@@ -69,12 +81,18 @@ To upgrade directly to {version} from 6.7 or earlier, you must shut down the
 cluster, install {version}, and restart. For more information, see
 <<restart-upgrade, Full cluster restart upgrade>>.
 
-[WARNING]
-====
+[discrete]
+[[upgrade-downgrade]]
+=== Downgrades
+
 In-place downgrades to earlier versions are *not* supported. To downgrade to an
 earlier version, <<snapshots-restore-snapshot,restore a snapshot>> taken prior
 to the version upgrade.
-====
+
+
+[discrete]
+[[upgrade-index-compatibility]]
+=== Index compatibility
 
 {es} can read indices created in the previous major version. If you
 have indices created in 5.x or before, you must reindex or delete them
@@ -87,17 +105,11 @@ When upgrading to a new version of {es}, you need to upgrade each
 of the products in your Elastic Stack. For more information, see the
 {stack-ref}/upgrading-elastic-stack.html[Elastic Stack Installation and Upgrade Guide].
 
-ifeval::["{release-state}"!="released"]
-[[upgrade-pre-release]]
-NOTE: This documentation is for {es} version {version}, which is not yet
-released. You may run a pre-release build of {es} for testing, and you may
-upgrade from an earlier released version to a pre-release build of {es}
-{version} if permitted by the compatibility table above, but upgrading from a
-pre-release build to another build (whether released or not) is unsupported.
-Upgrading a pre-release build may result in errors or may appear to succeed
-having silently lost some data. You should discard the contents of a cluster
-running a pre-release build before using a different build.
-endif::[]
+[discrete]
+[[upgrade-fips-java17]]
+=== FIPS Compliance and Java 17
+
+include::{xes-repo-dir}/security/fips-java17.asciidoc[]
 
 --
 

--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -27,6 +27,12 @@ For {es}, adherence to FIPS 140-2 is ensured by
 [discrete]
 === Upgrade considerations
 
+[IMPORTANT] 
+==== 
+include::fips-java17.asciidoc[]
+====
+
+
 If you plan to upgrade your existing cluster to a version that can be run in
 a FIPS 140-2 configured JVM, we recommend to first perform a rolling
 upgrade to the new version in your existing JVM and perform all necessary

--- a/x-pack/docs/en/security/fips-java17.asciidoc
+++ b/x-pack/docs/en/security/fips-java17.asciidoc
@@ -1,0 +1,9 @@
+{es} 8.0 requires Java 17 or later.  
+There is not yet a FIPS-certified security module for Java 17 
+that you can use when running {es} 8.0 in FIPS 140-2 mode.
+If you run in FIPS 140-2 mode, you will either need to request
+an exception from your security organization to upgrade to {es} 8.0, 
+or remain on {es} 7.x until Java 17 is certified. 
+ifeval::["{release-state}"=="released"]
+Alternatively, consider using {ess} in the FedRAMP-certified GovCloud region.
+endif::[]


### PR DESCRIPTION
Java 17 will be required in 8.0, but there will be a lag before it is FIPS certified. This PR adds a warning about that to the FIPS & Upgrade topics. 