### PR TITLE
[DOCS] Fix system index refs in restore tutorial

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -101,8 +101,8 @@ WARNING: If the
 <<action-destructive-requires-name,`action.destructive_requires_name`>> cluster
 setting is `false`, don't use the <<indices-delete-index,delete index API>> to
 target the `*` or `.*` wildcard expression. If you use {es}'s security features,
-this will delete system indices required for authentication. To delete all
-regular indices, use `*,-.*` instead.
+this will delete system indices required for authentication. Instead, use
+`*,-.*` to exclude system indices.
 
 [source,console]
 ----
@@ -119,8 +119,7 @@ streams in the snapshot, including system indices. If your cluster already
 contains one or more of these system indices, the request will return an error.
 
 To avoid this error, specify the indices and data streams to restore. To
-exclude system indices, append the `-.*` wildcard pattern. To restore all
-indices and data streams except system indices, use `*,-.*`.
+exclude system indices, append the `-.*` wildcard pattern.
 
 [source,console]
 ----
@@ -323,8 +322,7 @@ PUT _cluster/settings
 ----
 // TEST[setup:setup-snapshots]
 
-. Delete all existing indices and data streams on the cluster, including all
-system indices.
+. Delete existing indices and data streams on the cluster.
 +
 [source,console]
 ----

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -121,7 +121,8 @@ contains one or more of these system indices, the request will return an error.
 
 To avoid this error, specify the indices and data streams to restore. To exclude
 system indices and other index names that begin with a dot (`.`), append the
-`-.*` wildcard pattern.
+`-.*` wildcard pattern. To restore all indices and data streams except dot
+indices, use `*,-.*`.
 
 [source,console]
 ----

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -100,9 +100,10 @@ operation is complete.
 WARNING: If the
 <<action-destructive-requires-name,`action.destructive_requires_name`>> cluster
 setting is `false`, don't use the <<indices-delete-index,delete index API>> to
-target the `*` or `.*` wildcard expression. If you use {es}'s security features,
-this will delete system indices required for authentication. Instead, use
-`*,-.*` to exclude system indices.
+target the `*` or `.*` wildcard pattern. If you use {es}'s security features,
+this will delete system indices required for authentication. Instead, target the
+`*,-.*` wildcard pattern to exclude these system indices and other index names
+that begin with a dot (`.`).
 
 [source,console]
 ----
@@ -118,8 +119,9 @@ By default, a restore request attempts to restore all indices and data
 streams in the snapshot, including system indices. If your cluster already
 contains one or more of these system indices, the request will return an error.
 
-To avoid this error, specify the indices and data streams to restore. To
-exclude system indices, append the `-.*` wildcard pattern.
+To avoid this error, specify the indices and data streams to restore. To exclude
+system indices and other index names that begin with a dot (`.`), append the
+`-.*` wildcard pattern.
 
 [source,console]
 ----


### PR DESCRIPTION
Fixes a couple of erroneous references related to system indices in the snapshot restore tutorial:

* Calling the delete index API on `*` will only delete
  some system indices, such as the `.security`. It won't delete others, such as
  `.geoip_databases`.

* Not all dot indices are system indices. Some are just hidden indices.

Relates to #76929

### Preview
https://elasticsearch_78582.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshots-restore-snapshot.html