### PR TITLE
[DOCS] Fix SLM status response

### DIFF
--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -20,7 +20,7 @@ Retrieves the status of {slm} ({slm-init}).
 
 Returns the status of the {slm-init} plugin. 
 The `operation_mode` field in the response shows one of three states: 
-`STARTED`, `STOPPING`, or `STOPPED`. 
+`STARTED`, `RUNNING`, `STOPPING`, or `STOPPED`. 
 You halt and restart the {slm-init} plugin with the
 <<slm-api-stop, stop>> and <<slm-api-start, start>>  APIs.
 

--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -20,7 +20,7 @@ Retrieves the status of {slm} ({slm-init}).
 
 Returns the status of the {slm-init} plugin. 
 The `operation_mode` field in the response shows one of three states: 
-`STARTED`, `RUNNING`, `STOPPING`, or `STOPPED`. 
+`RUNNING`, `STOPPING`, or `STOPPED`. 
 You halt and restart the {slm-init} plugin with the
 <<slm-api-stop, stop>> and <<slm-api-start, start>>  APIs.
 


### PR DESCRIPTION
The get SLM status API will only return one of three statuses: `RUNNING`, `STOPPING`, or `STOPPED`.

This corrects the docs to remove the `STARTED` status and document the `RUNNING` status.