### PR TITLE
Fixes testCancellationDuringAggregation test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -192,6 +192,12 @@ public class SearchCancellationIT extends ESIntegTestCase {
 
     public void testCancellationDuringAggregation() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
+        // This test is only meaningful with at least 2 shards to trigger reduce
+        int numberOfShards = between(2, 5);
+        createIndex("test", Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build());
         indexTestData();
 
         logger.info("Executing search");


### PR DESCRIPTION
The SearchCancellationIT#testCancellationDuringAggregation only works when
real reduce takes place and therefore needs at least 2 shards to be present.

Relates to #71021
