### PR TITLE
Fix Snapshot Getting Stuck if Snapshot Queued after Delete has Shard in State MISSING

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2707,7 +2707,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                             : "Missing assignment for [" + sid + "]";
                                         updatedAssignmentsBuilder.put(sid, ShardSnapshotStatus.MISSING);
                                     } else {
-                                        markShardReassigned(shardId, reassignedShardIds);
+                                        if (updated.isActive()) {
+                                            markShardReassigned(shardId, reassignedShardIds);
+                                        }
                                         updatedAssignmentsBuilder.put(sid, updated);
                                     }
                                 }


### PR DESCRIPTION
It's in the title. If we reassign a shard to `MISSING` then we must keep assigning tasks for that shard
in the case of clones and/or keep marking those shards `MISSING` on subsequent snapshots as well.

