### PR TITLE
Save Buffers and FDs in RecoverySourceHandler (#72621)

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -421,9 +421,10 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             metas.add(md);
         }
 
+        // only corrupt files that belong to the lucene index and use one that we don't cache on heap so the corruption on disk has an
+        // effect
         CorruptionUtils.corruptFile(random(), FileSystemUtils.files(tempDir, (p) ->
-            (p.getFileName().toString().equals("write.lock") ||
-                p.getFileName().toString().startsWith("extra")) == false));
+            metas.stream().anyMatch(m -> m.name().equals(p.getFileName().toString()) && m.hashEqualsContents() == false)));
         Store targetStore = newStore(createTempDir(), false);
         MultiFileWriter multiFileWriter = new MultiFileWriter(targetStore, mock(RecoveryState.Index.class), "", logger, () -> {});
         RecoveryTargetHandler target = new TestRecoveryTargetHandler() {


### PR DESCRIPTION
Using the same trick here that we use in snapshotting.
Segment and segment infos files are on heap here in most cases so
no need to allocate a buffer for them or do file IO.
Also, we can size the 0.5M buffer smaller when we know the largest file to
be less than 0.5M.

Both of these changes are probably of trivial effect in production in most cases
but save quite a bit of GC noise in tests where we run small heaps and repeated
large allocations of these buffers might be a source of the random GC slowness
we se here and there.

backport of #72621, #77440