### PR TITLE
Short-Circuit NOOP Mapping Updates Earlier (#77574)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
@@ -9,6 +9,9 @@
 package org.elasticsearch.action.admin.indices.mapping.put;
 
 import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
+import org.elasticsearch.common.compress.CompressedXContent;
+
+import java.io.IOException;
 
 /**
  * Cluster state update request that allows to put a mapping
@@ -17,7 +20,7 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
 
     private String type;
 
-    private String source;
+    private CompressedXContent source;
 
     public PutMappingClusterStateUpdateRequest() {
 
@@ -32,12 +35,16 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
         return this;
     }
 
-    public String source() {
+    public PutMappingClusterStateUpdateRequest(String source) throws IOException {
+        this.source = new CompressedXContent(source);
+    }
+
+    public CompressedXContent source() {
         return source;
     }
 
-    public PutMappingClusterStateUpdateRequest source(String source) {
-        this.source = source;
+    public PutMappingClusterStateUpdateRequest source(String source) throws IOException {
+        this.source = new CompressedXContent(source);
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -134,7 +134,7 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
         final PutMappingClusterStateUpdateRequest updateRequest;
         try {
             updateRequest = new PutMappingClusterStateUpdateRequest(request.source())
-                .indices(concreteIndices)
+                .indices(concreteIndices).type(request.type())
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout());
         } catch (IOException e) {
             wrappedListener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -125,16 +126,22 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
                                      PutMappingRequest request,
                                      ActionListener<AcknowledgedResponse> listener,
                                      MetadataMappingService metadataMappingService) {
-        PutMappingClusterStateUpdateRequest updateRequest = new PutMappingClusterStateUpdateRequest()
-                    .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
-                    .indices(concreteIndices).type(request.type())
-                    .source(request.source());
-
-        metadataMappingService.putMapping(updateRequest, listener.delegateResponse((l, e) -> {
+        final ActionListener<AcknowledgedResponse> wrappedListener = listener.delegateResponse((l, e) -> {
             logger.debug(() -> new ParameterizedMessage("failed to put mappings on indices [{}]",
                     Arrays.asList(concreteIndices)), e);
             l.onFailure(e);
-        }));
+        });
+        final PutMappingClusterStateUpdateRequest updateRequest;
+        try {
+            updateRequest = new PutMappingClusterStateUpdateRequest(request.source())
+                .indices(concreteIndices)
+                .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout());
+        } catch (IOException e) {
+            wrappedListener.onFailure(e);
+            return;
+        }
+
+        metadataMappingService.putMapping(updateRequest, wrappedListener);
     }
 
     static String checkForSystemIndexViolations(SystemIndices systemIndices, Index[] concreteIndices, PutMappingRequest request) {


### PR DESCRIPTION
No need to actually run noop mapping updates or create a new document mapper
if nothing has changed.

backport of #77574