### PR TITLE
Indexing_data/l4 is now generally available

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -55,16 +55,12 @@ between nodes. The option `true` will compress all data. The option
 ingest, ccr following (excluding bootstrap), and operations based shard recovery
 (excluding transferring lucene files). Defaults to `false`.
 
-NOTE: The `indexing_data` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
-
 `transport.compression_scheme`::
 (<<static-cluster-setting,Static>>)
 Configures the compression scheme for `transport.compress`. The options are
 `deflate` or `lz4`. If `lz4` is configured and the remote node has not been
 upgraded to a version supporting `lz4`, the traffic will be sent uncompressed.
 Defaults to `deflate`.
-
-NOTE: The `lz4` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
 
 `transport.ping_schedule`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Remove the ESS only marking for indexing_data and lz4 options.

Relates #77130

[Preview](https://elasticsearch_78595.docs-preview.app.elstc.co/diff)