### PR TITLE
Introduce DSL for configuring BWC tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -350,7 +350,7 @@ public class BwcVersions {
     }
 
     public void withIndexCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
-        getIndexCompatible().stream().filter(filter).toList().forEach(v -> versionAction.accept(v, "v"+v.toString()));
+        getIndexCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v"+v.toString()));
     }
 
     public List<Version> getWireCompatible() {
@@ -369,6 +369,11 @@ public class BwcVersions {
     public void withWireCompatiple(BiConsumer<Version, String> versionAction) {
         getWireCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
     }
+
+    public void withWireCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+        getWireCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
+
     private List<Version> filterSupportedVersions(List<Version> wireCompat) {
         return Architecture.current() == Architecture.AARCH64
             ? wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList())

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -7,12 +7,9 @@
  */
 package org.elasticsearch.gradle.internal;
 
-import groovy.lang.Closure;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
-import org.gradle.api.Action;
-import shadow.org.apache.logging.log4j.util.TriConsumer;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -7,10 +7,12 @@
  */
 package org.elasticsearch.gradle.internal;
 
+import groovy.lang.Closure;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.Action;
+import shadow.org.apache.logging.log4j.util.TriConsumer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,6 +26,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -346,6 +349,10 @@ public class BwcVersions {
         getIndexCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
     }
 
+    public void withIndexCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+        getIndexCompatible().stream().filter(filter).toList().forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
+
     public List<Version> getWireCompatible() {
         List<Version> wireCompat = new ArrayList<>();
         List<Version> prevMajors = groupByMajor.get(currentVersion.getMajor() - 1);
@@ -359,6 +366,9 @@ public class BwcVersions {
         return unmodifiableList(filterSupportedVersions(wireCompat));
     }
 
+    public void withWireCompatiple(BiConsumer<Version, String> versionAction) {
+        getWireCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
     private List<Version> filterSupportedVersions(List<Version> wireCompat) {
         return Architecture.current() == Architecture.AARCH64
             ? wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList())

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
+import org.gradle.api.Action;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -338,6 +340,10 @@ public class BwcVersions {
             groupByMajor.get(currentVersion.getMajor()).stream()
         ).collect(Collectors.toList());
         return unmodifiableList(filterSupportedVersions(indexCompatibles));
+    }
+
+    public void withIndexCompatiple(BiConsumer<Version, String> versionAction) {
+        getIndexCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
     }
 
     public List<Version> getWireCompatible() {

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
   /**
    * We execute tests 3 times.

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -19,9 +19,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionStr = bwcVersion.toString()
-  String baseName = "v" + bwcVersionStr
+BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
 
   /**
    * We execute tests 3 times.
@@ -32,13 +30,13 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
    */
   def localCluster = testClusters.register("${baseName}-local") {
     numberOfNodes = 2
-    versions = [bwcVersionStr, project.version]
+    versions = [bwcVersion.toString(), project.version]
     setting 'cluster.remote.node.attr', 'gateway'
     setting 'xpack.security.enabled', 'false'
   }
   def remoteCluster = testClusters.register("${baseName}-remote") {
     numberOfNodes = 3
-    versions = [bwcVersionStr, project.version]
+    versions = [bwcVersion.toString(), project.version]
     firstNode.setting 'node.attr.gateway', 'true'
     lastNode.setting 'node.attr.gateway', 'true'
     setting 'xpack.security.enabled', 'false'
@@ -48,7 +46,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster localCluster
     useCluster remoteCluster
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr.replace('-SNAPSHOT', '')
+    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
 
     doFirst {
       nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -7,7 +7,6 @@
  */
 
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -16,12 +16,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  def bwcVersionString = bwcVersion.toString();
-  String baseName = "v" + bwcVersionString
-
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
-      versions =  [bwcVersionString, project.version]
+      versions =  [bwcVersion.toString(), project.version]
       numberOfNodes = 2
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '60m'
@@ -48,7 +45,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     systemProperty 'tests.is_old_cluster', 'false'
   }
 
-  String oldVersion = bwcVersionString.minus("-SNAPSHOT")
+  String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
     it.systemProperty 'tests.old_cluster_version', oldVersion
     it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -22,51 +22,46 @@ restResources {
   }
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
+BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
-  /* This project runs the core REST tests against a 4 node cluster where two of
+  if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
+    /* This project runs the core REST tests against a 4 node cluster where two of
      the nodes has a different minor.  */
-  def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
-    numberOfNodes = 4
-    setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    setting 'xpack.security.enabled', 'false'
-  }
-
-  tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-    useCluster baseCluster
-    mustRunAfter("precommit")
-    doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
-      // Getting the endpoints causes a wait for the cluster
-      println "Test cluster endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
-      println "Upgrading one node to create a mixed cluster"
-      if (BuildParams.isSnapshotBuild() == false) {
-           baseCluster.get().nodes."${baseName}-0".systemProperty 'es.index_mode_feature_flag_registered', 'true'
-      }
-      baseCluster.get().nextNodeToNextVersion()
-      // Getting the endpoints causes a wait for the cluster
-      println "Upgrade complete, endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
-      println "Upgrading another node to create a mixed cluster"
-      if (BuildParams.isSnapshotBuild() == false) {
-        baseCluster.get().nodes."${baseName}-1".systemProperty 'es.index_mode_feature_flag_registered', 'true'
-      }
-      baseCluster.get().nextNodeToNextVersion()
-      nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
+    def baseCluster = testClusters.register(baseName) {
+      versions = [bwcVersion.toString(), project.version]
+      numberOfNodes = 4
+      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'xpack.security.enabled', 'false'
     }
-    systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    onlyIf { project.bwc_tests_enabled }
-  }
 
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#mixedClusterTest"
+    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
+      useCluster baseCluster
+      mustRunAfter("precommit")
+      doFirst {
+        delete("${buildDir}/cluster/shared/repo/${baseName}")
+        // Getting the endpoints causes a wait for the cluster
+        println "Test cluster endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
+        println "Upgrading one node to create a mixed cluster"
+        if (BuildParams.isSnapshotBuild() == false) {
+          baseCluster.get().nodes."${baseName}-0".systemProperty 'es.index_mode_feature_flag_registered', 'true'
+        }
+        baseCluster.get().nextNodeToNextVersion()
+        // Getting the endpoints causes a wait for the cluster
+        println "Upgrade complete, endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
+        println "Upgrading another node to create a mixed cluster"
+        if (BuildParams.isSnapshotBuild() == false) {
+          baseCluster.get().nodes."${baseName}-1".systemProperty 'es.index_mode_feature_flag_registered', 'true'
+        }
+        baseCluster.get().nextNodeToNextVersion()
+        nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+        nonInputProperties.systemProperty('tests.clustername', baseName)
+      }
+      systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      onlyIf { project.bwc_tests_enabled }
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+      dependsOn "${baseName}#mixedClusterTest"
+    }
   }
 }

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -21,7 +21,7 @@ restResources {
   }
 }
 
-BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
     /* This project runs the core REST tests against a 4 node cluster where two of

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -20,8 +20,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  String baseName = "v${bwcVersion}"
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   String oldClusterName = "${baseName}-old"
   String newClusterName = "${baseName}-new"
 

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
-BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
   /*
    * The goal here is to:
    * <ul>

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
+BuildParams.bwcVersions.withWireCompatiple() { bwcVersion, baseName ->
   /*
    * The goal here is to:
    * <ul>
@@ -30,11 +30,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
    * </ul>
    */
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
   def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -15,12 +15,9 @@ apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v${bwcVersionString}"
-
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
-      version = bwcVersionString
+      version = bwcVersion.toString()
       setting 'xpack.security.enabled', 'true'
       user username: 'admin', password: 'admin-password', role: 'superuser'
   }

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -9,52 +9,45 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 dependencies {
-  testImplementation project(':x-pack:qa')
-  testImplementation(project(xpackModule('ql:test-fixtures')))
-  testImplementation project(path: xpackModule('eql'), configuration: 'default')
+    testImplementation project(':x-pack:qa')
+    testImplementation(project(xpackModule('ql:test-fixtures')))
+    testImplementation project(path: xpackModule('eql'), configuration: 'default')
 }
 
-tasks.named("integTest").configure{ enabled = false}
+tasks.named("integTest").configure { enabled = false }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.10.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
-
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersion
-
-  def cluster = testClusters.register(baseName) {
-      versions = [bwcVersionString, project.version]
-      numberOfNodes = 3
-      testDistribution = 'DEFAULT'
-      setting 'xpack.security.enabled', 'false'
-      setting 'xpack.watcher.enabled', 'false'
-      setting 'xpack.ml.enabled', 'false'
-      setting 'xpack.eql.enabled', 'true'
-      setting 'xpack.license.self_generated.type', 'trial'
-      // for debugging purposes
-      // setting 'logger.org.elasticsearch.xpack.eql.plugin.TransportEqlSearchAction', 'TRACE'
-  }
-
-  tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-    useCluster cluster
-    mustRunAfter("precommit")
-    doFirst {
-      // Getting the endpoints causes a wait for the cluster
-      println "Endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
-      println "Upgrading one node to create a mixed cluster"
-      cluster.get().nextNodeToNextVersion()
-
-      println "Upgrade complete, endpoints are: ${-> testClusters.named(baseName).get().allHttpSocketURI.join(",")}"
-      nonInputProperties.systemProperty('tests.rest.cluster', cluster.map(c->c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
+    def cluster = testClusters.register(baseName) {
+        versions = [bwcVersion.toString(), project.version]
+        numberOfNodes = 3
+        testDistribution = 'DEFAULT'
+        setting 'xpack.security.enabled', 'false'
+        setting 'xpack.watcher.enabled', 'false'
+        setting 'xpack.ml.enabled', 'false'
+        setting 'xpack.eql.enabled', 'true'
+        setting 'xpack.license.self_generated.type', 'trial'
+        // for debugging purposes
+        // setting 'logger.org.elasticsearch.xpack.eql.plugin.TransportEqlSearchAction', 'TRACE'
     }
-    onlyIf { project.bwc_tests_enabled }
-  }
 
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
+    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
+        useCluster cluster
+        mustRunAfter("precommit")
+        doFirst {
+            // Getting the endpoints causes a wait for the cluster
+            println "Endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
+            println "Upgrading one node to create a mixed cluster"
+            cluster.get().nextNodeToNextVersion()
+
+            println "Upgrade complete, endpoints are: ${-> testClusters.named(baseName).get().allHttpSocketURI.join(",")}"
+            nonInputProperties.systemProperty('tests.rest.cluster', cluster.map(c -> c.allHttpSocketURI.join(",")))
+            nonInputProperties.systemProperty('tests.clustername', baseName)
+        }
+        onlyIf { project.bwc_tests_enabled }
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+        dependsOn "${baseName}#mixedClusterTest"
+    }
 }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -71,10 +71,9 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+    BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
       // Compatibility testing for JDBC driver started with version 7.9.0
       if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
-        String baseName = "v${bwcVersion}"
         UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
         Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
           // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -22,17 +22,12 @@ testClusters.configureEach {
 tasks.named("integTest").configure{ enabled = false}
 
 // A bug (https://github.com/elastic/elasticsearch/issues/68439) limits us to perform tests with versions from 7.10.3 onwards
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.10.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersion
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
-      versions = [bwcVersionString, project.version]
+      versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 3
       testDistribution = 'DEFAULT'
       setting 'xpack.security.enabled', 'false'

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -30,7 +30,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withIndexCompatiple((bwcVersion, baseName) -> {
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
         testDistribution = "DEFAULT"
         versions = [bwcVersion.toString(), project.version]
@@ -96,5 +96,4 @@ BuildParams.bwcVersions.withIndexCompatiple((bwcVersion, baseName) -> {
         dependsOn "${baseName}#upgradedClusterTest"
     }
 
-})
-
+}

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -30,72 +30,71 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  def bwcVersionString = bwcVersion.toString();
-  String baseName = "v"+ bwcVersionString;
+BuildParams.bwcVersions.withIndexCompatiple((bwcVersion, baseName) -> {
+    def baseCluster = testClusters.register(baseName) {
+        testDistribution = "DEFAULT"
+        versions = [bwcVersion.toString(), project.version]
+        numberOfNodes = 2
+        setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+        user username: "test_user", password: "x-pack-test-password"
 
-  def baseCluster = testClusters.register(baseName) {
-      testDistribution = "DEFAULT"
-      versions = [bwcVersionString, project.version]
-      numberOfNodes = 2
-      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      user username: "test_user", password: "x-pack-test-password"
+        setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+        // some tests rely on the translog not being flushed
+        setting 'indices.memory.shard_inactive_time', '60m'
+        setting 'xpack.security.enabled', 'true'
+        setting 'xpack.security.transport.ssl.enabled', 'true'
+        setting 'xpack.license.self_generated.type', 'trial'
 
-      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      // some tests rely on the translog not being flushed
-      setting 'indices.memory.shard_inactive_time', '60m'
-      setting 'xpack.security.enabled', 'true'
-      setting 'xpack.security.transport.ssl.enabled', 'true'
-      setting 'xpack.license.self_generated.type', 'trial'
+        extraConfigFile 'testnode.pem', file("${outputDir}/testnode.pem")
+        extraConfigFile 'testnode.crt', file("${outputDir}/testnode.crt")
 
-      extraConfigFile 'testnode.pem', file("${outputDir}/testnode.pem")
-      extraConfigFile 'testnode.crt', file("${outputDir}/testnode.crt")
+        keystore 'xpack.watcher.encryption_key', file("${project.projectDir}/src/test/resources/system_key")
+        setting 'xpack.watcher.encrypt_sensitive_data', 'true'
 
-      keystore 'xpack.watcher.encryption_key', file("${project.projectDir}/src/test/resources/system_key")
-      setting 'xpack.watcher.encrypt_sensitive_data', 'true'
+        setting 'xpack.security.transport.ssl.key', 'testnode.pem'
+        setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
+        keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 
-      setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-      setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-      keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-
-      setting 'xpack.security.authc.api_key.enabled', 'true'
-  }
-
-  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
-    mustRunAfter("precommit")
-    useCluster baseCluster
-    dependsOn "copyTestNodeKeyMaterial"
-    doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
+        setting 'xpack.security.authc.api_key.enabled', 'true'
     }
-    systemProperty 'tests.is_old_cluster', 'true'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
-    exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
-  }
 
-  tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
-    mustRunAfter("precommit")
-    useCluster baseCluster
-    dependsOn "${baseName}#oldClusterTest"
-    doFirst {
-      testClusters.named(baseName).get().goToNextVersion()
+    tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
+        mustRunAfter("precommit")
+        useCluster baseCluster
+        dependsOn "copyTestNodeKeyMaterial"
+        doFirst {
+            delete("${buildDir}/cluster/shared/repo/${baseName}")
+        }
+        systemProperty 'tests.is_old_cluster', 'true'
+        exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
+        exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
+        exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
     }
-    systemProperty 'tests.is_old_cluster', 'false'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
-    exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
-  }
 
-  String oldVersion = bwcVersionString.minus("-SNAPSHOT")
-  tasks.matching { it.name.startsWith("${baseName}#") && it.name.endsWith("ClusterTest") }.configureEach {
-    it.systemProperty 'tests.old_cluster_version', oldVersion
-    it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    it.nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
-    it.nonInputProperties.systemProperty('tests.clustername', baseName)
-  }
+    tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
+        mustRunAfter("precommit")
+        useCluster baseCluster
+        dependsOn "${baseName}#oldClusterTest"
+        doFirst {
+            testClusters.named(baseName).get().goToNextVersion()
+        }
+        systemProperty 'tests.is_old_cluster', 'false'
+        exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
+        exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
+        exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
+    }
 
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#upgradedClusterTest"
-  }
-}
+    String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
+    tasks.matching { it.name.startsWith("${baseName}#") && it.name.endsWith("ClusterTest") }.configureEach {
+        it.systemProperty 'tests.old_cluster_version', oldVersion
+        it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+        it.nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+        it.nonInputProperties.systemProperty('tests.clustername', baseName)
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+        dependsOn "${baseName}#upgradedClusterTest"
+    }
+
+})
+

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -13,17 +13,11 @@ dependencies {
 }
 
 // Only run tests for 7.9+, since the node.roles setting was introduced in 7.9.0
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.9.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
-
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.9.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
     versions = [bwcVersion.toString(), project.version]

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -10,13 +10,10 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
+BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
@@ -35,7 +32,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', baseName)
   }
 
-  String oldVersion = bwcVersionString.replace('-SNAPSHOT', '')
+  String oldVersion = bwcVersion.toString().replace('-SNAPSHOT', '')
   tasks.register("${baseName}#oneThirdUpgradedTest", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -10,9 +10,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
+BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
 
   def baseLeaderCluster = testClusters.register("${baseName}-leader") {
       numberOfNodes = 3
@@ -22,7 +20,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   }
   testClusters.matching { it.name.startsWith("${baseName}-") }.configureEach {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
     setting 'xpack.security.enabled', 'false'
@@ -34,7 +32,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster baseLeaderCluster
     useCluster baseFollowerCluster
-    systemProperty 'tests.upgrade_from_version', bwcVersionString.replace('-SNAPSHOT', '')
+    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
 
     doFirst {
       def baseCluster = testClusters.named("${baseName}-${kindExt}").get()

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
   def baseLeaderCluster = testClusters.register("${baseName}-leader") {
       numberOfNodes = 3

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -30,7 +30,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
   String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -30,16 +31,15 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
+BuildParams.bwcVersions.withWireCompatiple{ bwcVersion, baseName ->
+  String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
   String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
 
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [oldVersion, project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
@@ -91,8 +91,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
     }
   }
-
-  String oldVersion = bwcVersionString
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     useCluster baseCluster


### PR DESCRIPTION
This additional API on BwcVersions makes configuring bwc Tests less errorprone due to strange groovy behaviour when iterating. This is an outcome of issues like https://github.com/elastic/elasticsearch/pull/78567