### PR TITLE
[DOCS] Removes LLRC from Java REST book

### DIFF
--- a/docs/java-rest/index.asciidoc
+++ b/docs/java-rest/index.asciidoc
@@ -7,8 +7,6 @@ include::../Versions.asciidoc[]
 
 include::overview.asciidoc[]
 
-include::low-level/index.asciidoc[]
-
 include::high-level/index.asciidoc[]
 
 include::redirects.asciidoc[]


### PR DESCRIPTION
## Overview

This PR removes the low-level REST client docs from the Java REST book.
The book is no longer generated on `master`, so this PR does not produce broken links.