### PR TITLE
Speed up Data Tier Allocation Decider + Related Settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1168,19 +1168,20 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Version> versionSetting(final String key, final Version defaultValue, Property... properties) {
-        return new Setting<>(key, s -> Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), properties);
+        return new Setting<>(key, Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), properties);
     }
 
     public static Setting<Float> floatSetting(String key, float defaultValue, Property... properties) {
-        return new Setting<>(key, (s) -> Float.toString(defaultValue), Float::parseFloat, properties);
+        return new Setting<>(key, Float.toString(defaultValue), Float::parseFloat, properties);
     }
 
     public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, Property... properties) {
+        final boolean isFiltered = isFiltered(properties);
         return new Setting<>(key, (s) -> Float.toString(defaultValue), (s) -> {
             float value = Float.parseFloat(s);
             if (value < minValue) {
                 String err = "Failed to parse value" +
-                    (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
+                    (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
                 throw new IllegalArgumentException(err);
             }
             return value;
@@ -1192,38 +1193,44 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Property... properties) {
-        return new Setting<>(key, (s) -> Integer.toString(defaultValue),
-            (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Integer.toString(defaultValue), s -> parseInt(s, minValue, maxValue, key, isFiltered), properties);
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Property... properties) {
-        return new Setting<>(key, (s) -> Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered(properties)),
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered),
             properties);
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Validator<Integer> validator,
                                               Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered(properties)), validator,
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered), validator,
             properties);
     }
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key, isFiltered), properties);
     }
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue,
                                               Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, maxValue, key, isFiltered), properties);
     }
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Validator<Integer> validator,
                                               Property... properties) {
+        final boolean isFiltered = isFiltered(properties);
         return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw,
-            (s) -> parseInt(s, minValue, key, isFiltered(properties)),validator, properties);
+            (s) -> parseInt(s, minValue, key, isFiltered),validator, properties);
     }
 
     public static Setting<Long> longSetting(String key, long defaultValue, long minValue, Property... properties) {
-        return new Setting<>(key, (s) -> Long.toString(defaultValue), (s) -> parseLong(s, minValue, key, isFiltered(properties)),
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, key, isFiltered),
             properties);
     }
 
@@ -1315,25 +1322,30 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Property... properties) {
-        return new Setting<>(key, (s) -> Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered), properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, Property... properties) {
-        return new Setting<>(key, fallbackSetting, b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, fallbackSetting, b -> parseBoolean(b, key, isFiltered), properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, Validator<Boolean> validator,
                                                Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, b -> parseBoolean(b, key,
-            isFiltered(properties)), validator, properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, b -> parseBoolean(b, key, isFiltered),
+            validator, properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Validator<Boolean> validator, Property... properties) {
-        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)), validator, properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered), validator, properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, Function<Settings, String> defaultValueFn, Property... properties) {
-        return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered), properties);
     }
 
     static boolean parseBoolean(String b, String key, boolean isFiltered) {
@@ -1349,7 +1361,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, ByteSizeValue value, Property... properties) {
-        return byteSizeSetting(key, (s) -> value.toString(), properties);
+        return new Setting<>(key, value.getStringRep(), (s) -> ByteSizeValue.parseBytesSizeValue(s, key), properties);
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, Setting<ByteSizeValue> fallbackSetting,
@@ -1364,13 +1376,7 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, ByteSizeValue defaultValue, ByteSizeValue minValue,
                                                          ByteSizeValue maxValue, Property... properties) {
-        return byteSizeSetting(key, (s) -> defaultValue.getStringRep(), minValue, maxValue, properties);
-    }
-
-    public static Setting<ByteSizeValue> byteSizeSetting(String key, Function<Settings, String> defaultValue,
-                                                         ByteSizeValue minValue, ByteSizeValue maxValue,
-                                                         Property... properties) {
-        return new Setting<>(key, defaultValue, (s) -> parseByteSize(s, minValue, maxValue, key), properties);
+        return new Setting<>(key, defaultValue.getStringRep(), s -> parseByteSize(s, minValue, maxValue, key), properties);
     }
 
     public static ByteSizeValue parseByteSize(String s, ByteSizeValue minValue, ByteSizeValue maxValue, String key) {
@@ -1673,15 +1679,13 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<TimeValue> timeSetting(
             final String key, Function<Settings, TimeValue> defaultValue, final TimeValue minValue, final Property... properties) {
-        final SimpleKey simpleKey = new SimpleKey(key);
-        return new Setting<>(simpleKey, s -> defaultValue.apply(s).getStringRep(),
+        return new Setting<>(key, s -> defaultValue.apply(s).getStringRep(),
             minTimeValueParser(key, minValue, isFiltered(properties)), properties);
     }
 
     public static Setting<TimeValue> timeSetting(
           final String key, TimeValue defaultValue, final TimeValue minValue, final TimeValue maxValue, final Property... properties) {
-        final SimpleKey simpleKey = new SimpleKey(key);
-        return new Setting<>(simpleKey, s -> defaultValue.getStringRep(),
+        return new Setting<>(key, defaultValue.getStringRep(),
             minMaxTimeValueParser(key, minValue, maxValue, isFiltered(properties)), properties);
     }
 
@@ -1771,15 +1775,16 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Property... properties) {
+        final boolean isFiltered = isFiltered(properties);
         return new Setting<>(key, (s) -> Double.toString(defaultValue), (s) -> {
             final double d = Double.parseDouble(s);
             if (d < minValue) {
-                String err = "Failed to parse value" + (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key +
+                String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key +
                     "] must be >= " + minValue;
                 throw new IllegalArgumentException(err);
             }
             if (d > maxValue) {
-                String err = "Failed to parse value" + (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key +
+                String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key +
                     "] must be <= " + maxValue;
                 throw new IllegalArgumentException(err);
             }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -321,7 +321,21 @@ public final class Settings implements ToXContentFragment {
      * returns the default value provided.
      */
     public Boolean getAsBoolean(String setting, Boolean defaultValue) {
-        return Booleans.parseBoolean(get(setting), defaultValue);
+        final Object found = settings.get(setting);
+        if (found == null) {
+            return defaultValue;
+        }
+        if (found instanceof Boolean) {
+            return (Boolean) found;
+        }
+        final String asString = found.toString();
+        switch (asString) {
+            case "true":
+                return true;
+            case "false":
+                return false;
+        }
+        return Booleans.parseBoolean(asString, defaultValue);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -257,7 +257,7 @@ public final class IndexSettings {
      * TODO: Remove this setting in 9.0.
      **/
     public static final Setting<ByteSizeValue> INDEX_TRANSLOG_RETENTION_SIZE_SETTING =
-        Setting.byteSizeSetting("index.translog.retention.size", settings -> "-1", Property.Dynamic, Property.IndexScope);
+        Setting.byteSizeSetting("index.translog.retention.size", ByteSizeValue.MINUS_ONE, Property.Dynamic, Property.IndexScope);
 
     /**
      * Controls the maximum length of time since a retention lease is created or renewed before it is considered expired.

--- a/server/src/main/java/org/elasticsearch/snapshots/SearchableSnapshotsSettings.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SearchableSnapshotsSettings.java
@@ -25,7 +25,7 @@ public final class SearchableSnapshotsSettings {
     private SearchableSnapshotsSettings() {}
 
     public static boolean isSearchableSnapshotStore(Settings indexSettings) {
-        return SEARCHABLE_SNAPSHOT_STORE_TYPE.equals(INDEX_STORE_TYPE_SETTING.get(indexSettings));
+        return SEARCHABLE_SNAPSHOT_STORE_TYPE.equals(indexSettings.get(INDEX_STORE_TYPE_SETTING.getKey()));
     }
 
     public static boolean isPartialSearchableSnapshotIndex(Settings indexSettings) {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderService.java
@@ -39,7 +39,7 @@ public class FrozenShardsDeciderService implements AutoscalingDeciderService {
     static final ByteSizeValue DEFAULT_MEMORY_PER_SHARD = ByteSizeValue.ofBytes(MAX_MEMORY.getBytes() / 2000);
     public static final Setting<ByteSizeValue> MEMORY_PER_SHARD = Setting.byteSizeSetting(
         "memory_per_shard",
-        (ignored) -> DEFAULT_MEMORY_PER_SHARD.getStringRep(),
+        DEFAULT_MEMORY_PER_SHARD,
         ByteSizeValue.ZERO,
         ByteSizeValue.ofBytes(Long.MAX_VALUE)
     );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -211,13 +211,10 @@ public class DataTierAllocationDecider extends AllocationDecider {
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier) :
             "tier " + singleTier + " is an invalid tier name";
-        if (nodes.getDataNodes().isEmpty() == false) {
-            return true;
-        }
         for (ObjectCursor<DiscoveryNode> node : nodes.getNodes().values()) {
             for (DiscoveryNodeRole discoveryNodeRole : node.value.getRoles()) {
                 String s = discoveryNodeRole.roleName();
-                if (s.equals(singleTier)) {
+                if (s.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || s.equals(singleTier)) {
                     return true;
                 }
             }


### PR DESCRIPTION
* Short circuit some string splitting loops where possible.
* Fix very inefficient setting methods that would loop the properties
on every lookup and/or build the default value string on every default lookup.
* Use plain setting get instead of the setings instance get for very hot setting
* Simplify hot path for `getAsBoolean`

relates #77466 

addressed part of https://github.com/elastic/elasticsearch/issues/77974 by making the boolean setting much cheaper