### PR TITLE
[DOCS] Redirects link in client integration docs

### DIFF
--- a/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
@@ -83,7 +83,7 @@ es-secondary-authorization: ApiKey <TOKEN> <1>
 For more information about using {security-features} with the language
 specific clients, refer to:
 
-* {java-rest}/_basic_authentication.html[Java]
+* {java-api-client}/_basic_authentication.html[Java]
 * {jsclient-current}/auth-reference.html[JavaScript]
 * https://www.elastic.co/guide/en/elasticsearch/client/net-api/master/configuration-options.html[.NET]
 * https://metacpan.org/pod/Search::Elasticsearch::Cxn::HTTPTiny#CONFIGURATION[Perl]


### PR DESCRIPTION
## Overview

This PR redirects a link in the Secure the Elastic Stack guide that points to the old Java book. After the PR is merged, the link points to the new client.

Related to https://github.com/elastic/docs/pull/2229

**DO NOT merge before https://github.com/elastic/docs/pull/2236**

### Preview

[HTTP Clients](https://elasticsearch_78613.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/http-clients.html)