### PR TITLE
TSDB: Add feature flag to more builds

### DIFF
--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
@@ -22,6 +23,12 @@ testClusters.register('remote-cluster')
 tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.rest.suite', 'remote_cluster'
+}
+
+testClusters.configureEach {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 
 testClusters.matching{ it.name == 'remote-cluster' }.configureEach {

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -99,3 +99,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     dependsOn tasks.named("${baseName}#upgradedClusterTest")
   }
 }
+
+testClusters.configureEach {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
+}

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -218,6 +218,10 @@ testClusters.configureEach {
   extraConfigFile nodeKey.name, nodeKey
   extraConfigFile nodeCert.name, nodeCert
   extraConfigFile serviceTokens.name, serviceTokens
+
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 
 tasks.register('enforceApiSpecsConvention').configure {

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
@@ -61,6 +62,13 @@ testClusters.matching {it.name == "follow-cluster" }.configureEach {
     { "\"${leaderCluster.get().getAllTransportPortURI().join(",")}\"" }
   setting 'cluster.remote.middle_cluster.seeds',
     { "\"${middleCluster.get().getAllTransportPortURI().join(",")}\"" }
+}
+
+
+testClusters.configureEach {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -175,8 +175,8 @@ setup:
 ---
 histogram with time series mappings:
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/78443"
+      version: " - 7.99.99"
+      reason: time series mode added in 8.0.0
 
   - do:
 


### PR DESCRIPTION
When we run the build in non-snapshot mode we don't enable feature flags
by default. This would cause the tests for tsdb to fail. So we enable
the tsdb feature flag in every build that needs it. There were a few
builds that needed it that didn't have it. This adds it to those builds.

Closes #78443
Closes #78598
