### PR TITLE
Add tests for fields emulation CCS error cases

### DIFF
--- a/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
+++ b/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
@@ -117,6 +117,9 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
             // create a second remote index with "_source : false" to check error behaviour in this case
             String remoteNoSourceIndex = "remote_index_source_disabled";
             String mappings = "{\"_source\":{\"enabled\":false}}";
+            if (UPGRADE_FROM_VERSION.before(Version.V_7_0_0)) {
+                mappings = "{\"_doc\":"+mappings+ "}";
+            }
             remoteClient.indices()
                 .create(
                     new CreateIndexRequest(remoteNoSourceIndex).settings(remoteIndexSettings).mapping(mappings, XContentType.JSON),
@@ -124,7 +127,7 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
                 );
             GetMappingsResponse mapping = remoteClient.indices()
                 .getMapping(new GetMappingsRequest().indices(remoteNoSourceIndex), RequestOptions.DEFAULT);
-            assertEquals("{\"_source\":{\"enabled\":false}}", mapping.mappings().get(remoteNoSourceIndex).source().string());
+            assertEquals(mappings, mapping.mappings().get(remoteNoSourceIndex).source().string());
             int remoteNoSourceNumDocs = indexDocs(remoteClient, remoteNoSourceIndex, between(10, 20));
 
             List<Node> remoteNodes = getNodes(remoteClient.getLowLevelClient());

--- a/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
+++ b/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
@@ -118,7 +118,7 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
             String remoteNoSourceIndex = "remote_index_source_disabled";
             String mappings = "{\"_source\":{\"enabled\":false}}";
             if (UPGRADE_FROM_VERSION.before(Version.V_7_0_0)) {
-                mappings = "{\"_doc\":"+mappings+ "}";
+                mappings = "{\"_doc\":" + mappings + "}";
             }
             remoteClient.indices()
                 .create(

--- a/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
+++ b/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
@@ -99,8 +99,7 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
     public void testFieldsOptionEmulation() throws Exception {
         String localIndex = "test_bwc_fields_index";
         String remoteIndex = "test_bwc_fields_remote_index";
-        try (RestHighLevelClient localClient = newLocalClient(LOGGER);
-             RestHighLevelClient remoteClient = newRemoteClient()) {
+        try (RestHighLevelClient localClient = newLocalClient(LOGGER); RestHighLevelClient remoteClient = newRemoteClient()) {
             localClient.indices()
                 .create(
                     new CreateIndexRequest(localIndex).settings(
@@ -188,7 +187,7 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
                 ObjectPath responseObject = ObjectPath.createFromResponse(response);
                 List<Map<String, Object>> failures = responseObject.evaluate("_shards.failures");
                 assertEquals(1, failures.size());
-                assertEquals(CLUSTER_ALIAS + ":" +remoteNoSourceIndex, responseObject.evaluate("_shards.failures.0.index"));
+                assertEquals(CLUSTER_ALIAS + ":" + remoteNoSourceIndex, responseObject.evaluate("_shards.failures.0.index"));
                 assertEquals("illegal_argument_exception", responseObject.evaluate("_shards.failures.0.reason.type"));
                 assertThat(
                     responseObject.evaluate("_shards.failures.0.reason.reason"),
@@ -198,20 +197,15 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
 
                 // also check for only no-source remote index
                 request = new Request("POST", "/_search");
-                request.addParameter(
-                    "index",
-                    localIndex + "," + CLUSTER_ALIAS + ":" + remoteNoSourceIndex
-                );
+                request.addParameter("index", localIndex + "," + CLUSTER_ALIAS + ":" + remoteNoSourceIndex);
                 request.addParameter("ccs_minimize_roundtrips", minimizeRoundTrips);
                 request.addParameter("enable_fields_emulation", "true");
-                request.setJsonEntity(
-                    "{\"_source\": false, \"fields\": [\"*\"] , \"size\": " + localNumDocs + remoteNoSourceNumDocs + "}"
-                );
+                request.setJsonEntity("{\"_source\": false, \"fields\": [\"*\"] , \"size\": " + localNumDocs + remoteNoSourceNumDocs + "}");
                 response = lowLevelClient.performRequest(request);
                 responseObject = ObjectPath.createFromResponse(response);
                 failures = responseObject.evaluate("_shards.failures");
                 assertEquals(1, failures.size());
-                assertEquals(CLUSTER_ALIAS + ":" +remoteNoSourceIndex, responseObject.evaluate("_shards.failures.0.index"));
+                assertEquals(CLUSTER_ALIAS + ":" + remoteNoSourceIndex, responseObject.evaluate("_shards.failures.0.index"));
                 assertEquals("illegal_argument_exception", responseObject.evaluate("_shards.failures.0.reason.type"));
                 assertThat(
                     responseObject.evaluate("_shards.failures.0.reason.reason"),

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/FieldsOptionEmulationIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/FieldsOptionEmulationIT.java
@@ -209,8 +209,7 @@ public class FieldsOptionEmulationIT extends ESRestTestCase {
     }
 
     public void testFieldOptionNoSourceOnOldIndex() throws Exception {
-        Request matchAllRequestFiltered = new Request("POST",
-            "test_field_*,oldversion_no_source/_search");
+        Request matchAllRequestFiltered = new Request("POST", "test_field_*,oldversion_no_source/_search");
         matchAllRequestFiltered.addParameter("enable_fields_emulation", "true");
         matchAllRequestFiltered.setJsonEntity("{\"_source\":false,\"fields\":[\"*\"]}");
         try (


### PR DESCRIPTION
We added an emulation layer to the "fields" option in #77749 that is able to translate search requests using the "fields" option for pre-7.10 nodes, e.g. in a mixed cluster or CCS use case.
This PR adds tests to those two use cases that assert the current failure behaviour when some of the target indices in earlier version have "_source" disabled. In this case we currently fail the respective shard requests and deliver the error (an IAE) in the response alongside the succesful hits.

Relates to #78620 