### PR TITLE
[7.x] Convert Autoscaling license object to use LicensedFeature (#78540)

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -78,6 +80,12 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
             throw new IllegalArgumentException("es.autoscaling_feature_flag_registered is no longer supported");
         }
     }
+
+    static final LicensedFeature.Momentary AUTOSCALING_FEATURE = LicensedFeature.momentary(
+        null,
+        "autoscaling",
+        License.OperationMode.ENTERPRISE
+    );
 
     private final List<AutoscalingExtension> autoscalingExtensions;
     private final SetOnce<ClusterService> clusterService = new SetOnce<>();

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingLicenseChecker.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingLicenseChecker.java
@@ -7,11 +7,10 @@
 
 package org.elasticsearch.xpack.autoscaling;
 
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.xpack.core.XPackPlugin;
-
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
+
+import static org.elasticsearch.xpack.core.XPackPlugin.getSharedLicenseState;
 
 /**
  * Encapsulates license checking for autoscaling.
@@ -24,7 +23,7 @@ public class AutoscalingLicenseChecker {
      * Constructs an autoscaling license checker with the default rule based on the license state for checking if autoscaling is allowed.
      */
     AutoscalingLicenseChecker() {
-        this(() -> XPackPlugin.getSharedLicenseState().checkFeature(XPackLicenseState.Feature.AUTOSCALING));
+        this(() -> Autoscaling.AUTOSCALING_FEATURE.check(getSharedLicenseState()));
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -74,9 +74,7 @@ public class XPackLicenseState {
 
         SPATIAL_GEO_LINE(OperationMode.GOLD, true),
 
-        OPERATOR_PRIVILEGES(OperationMode.ENTERPRISE, true),
-
-        AUTOSCALING(OperationMode.ENTERPRISE, true);
+        OPERATOR_PRIVILEGES(OperationMode.ENTERPRISE, true);
 
         // NOTE: this is temporary. The Feature enum will go away in favor of LicensedFeature.
         // Embedding the feature instance here is a stopgap to allow smaller initial PR,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Convert Autoscaling license object to use LicensedFeature (#78540)