### PR TITLE
[DOCS] Add Beats config example for ingest pipelines

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -276,7 +276,7 @@ pipeline, even if neither is specified.
 === Pipelines for {beats}
 
 To add an ingest pipeline to an Elastic Beat, specify the `pipeline`
-parameter under `output.elasticsearch` in `<BEAT_NAME>beat.yml`. For example,
+parameter under `output.elasticsearch` in `<BEAT_NAME>.yml`. For example,
 for {filebeat}, you'd specify `pipeline` in `filebeat.yml`.
 
 [source,yaml]

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -272,6 +272,21 @@ final pipeline. {es} applies this pipeline after the request or default
 pipeline, even if neither is specified.
 
 [discrete]
+[[pipelines-for-beats]]
+=== Pipelines for {beats}
+
+To add an ingest pipeline to an Elastic Beat, specify the `pipeline`
+parameter under `output.elasticsearch` in `<BEAT_NAME>beat.yml`. For example,
+for {filebeat}, you'd specify `pipeline` in `filebeat.yml`.
+
+[source,yaml]
+----
+output.elasticsearch:
+  hosts: ["localhost:9200"]
+  pipeline: my-pipeline
+----
+
+[discrete]
 [[pipelines-for-fleet-elastic-agent]]
 === Pipelines for {fleet} and {agent}
 


### PR DESCRIPTION
The Elasticsearch ingest pipeline docs cover pipelines for Fleet and
Elastic Agent. However, the docs don't cover Beats. This adds 'em.

Relates to elastic/beats#28239.

### Preview
https://elasticsearch_78633.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ingest.html#pipelines-for-beats