### PR TITLE
Remove flaky queue resizing tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
@@ -110,64 +110,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         executor.awaitTermination(10, TimeUnit.SECONDS);
     }
 
-    public void testAutoQueueSizingWithMin() throws Exception {
-        ThreadContext context = new ThreadContext(Settings.EMPTY);
-        ResizableBlockingQueue<Runnable> queue =
-                new ResizableBlockingQueue<>(ConcurrentCollections.<Runnable>newBlockingQueue(),
-                        5000);
-
-        int threads = randomIntBetween(1, 5);
-        int measureWindow = randomIntBetween(10, 100);
-        int min = randomIntBetween(4981, 4999);
-        logger.info("--> auto-queue with a measurement window of {} tasks", measureWindow);
-        QueueResizingEsThreadPoolExecutor executor =
-                new QueueResizingEsThreadPoolExecutor(
-                        "test-threadpool", threads, threads, 1000,
-                        TimeUnit.MILLISECONDS, queue, min, 100000, slowWrapper(), measureWindow, TimeValue.timeValueMillis(1),
-                        EsExecutors.daemonThreadFactory("queuetest"), new EsAbortPolicy(), context);
-        executor.prestartAllCoreThreads();
-        logger.info("--> executor: {}", executor);
-
-        // Execute a task multiple times that takes 1m
-        executeTask(executor, (measureWindow * 5));
-
-        // The queue capacity should decrease, but no lower than the minimum
-        assertBusy(() -> {
-            assertThat(queue.capacity(), equalTo(min));
-        });
-        executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-    }
-
-    public void testAutoQueueSizingWithMax() throws Exception {
-        ThreadContext context = new ThreadContext(Settings.EMPTY);
-        ResizableBlockingQueue<Runnable> queue =
-                new ResizableBlockingQueue<>(ConcurrentCollections.<Runnable>newBlockingQueue(),
-                        5000);
-
-        int threads = randomIntBetween(1, 5);
-        int measureWindow = randomIntBetween(10, 100);
-        int max = randomIntBetween(5010, 5024);
-        logger.info("--> auto-queue with a measurement window of {} tasks", measureWindow);
-        QueueResizingEsThreadPoolExecutor executor =
-                new QueueResizingEsThreadPoolExecutor(
-                        "test-threadpool", threads, threads, 1000,
-                        TimeUnit.MILLISECONDS, queue, 10, max, fastWrapper(), measureWindow, TimeValue.timeValueMillis(1),
-                        EsExecutors.daemonThreadFactory("queuetest"), new EsAbortPolicy(), context);
-        executor.prestartAllCoreThreads();
-        logger.info("--> executor: {}", executor);
-
-        // Execute a task multiple times that takes 1ms
-        executeTask(executor, measureWindow * 3);
-
-        // The queue capacity should increase, but no higher than the maximum
-        assertBusy(() -> {
-            assertThat(queue.capacity(), equalTo(max));
-        });
-        executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-    }
-
     public void testExecutionEWMACalculation() throws Exception {
         ThreadContext context = new ThreadContext(Settings.EMPTY);
         ResizableBlockingQueue<Runnable> queue =


### PR DESCRIPTION
The min and max queue resizing tests sometimes fail due to timing
issues. Since the queue resizing is already removed for 8.0 (#52280),
there is less incentive to debug the flakiness. Given there are some
other tests of queue resizing, and the feature is already removed in
upcoming versions of ES, this commit removes the flaky tests.

closes #71476