### PR TITLE
Remove joda uses from client

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/job/config/DateHistogramGroupConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/job/config/DateHistogramGroupConfig.java
@@ -9,17 +9,17 @@ package org.elasticsearch.client.rollup.job.config;
 
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
-import org.elasticsearch.core.Nullable;
-import org.elasticsearch.common.xcontent.ParseField;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -179,7 +179,7 @@ public class DateHistogramGroupConfig implements Validatable, ToXContentObject {
      *     The {@code field} and {@code interval} are required to compute the date histogram for the rolled up documents.
      *     The {@code delay} is optional and can be set to {@code null}. It defines how long to wait before rolling up new documents.
      *     The {@code timeZone} is optional and can be set to {@code null}. When configured, the time zone value  is resolved using
-     *     ({@link DateTimeZone#forID(String)} and must match a time zone identifier provided by the Joda Time library.
+     *     ({@link ZoneId#of(String)} and must match a time zone identifier provided by the Joda Time library.
      * </p>
      * @param field the name of the date field to use for the date histogram (required)
      * @param interval the interval to use for the date histogram (required)

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/QueuedWatch.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/QueuedWatch.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.client.watcher;
 
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.joda.time.DateTime;
+import org.elasticsearch.common.xcontent.ParseField;
 
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 public class QueuedWatch {
@@ -21,8 +21,8 @@ public class QueuedWatch {
         new ConstructingObjectParser<>("watcher_stats_node", true, (args, c) -> new QueuedWatch(
             (String) args[0],
             (String) args[1],
-            DateTime.parse((String) args[2]),
-            DateTime.parse((String) args[3])
+            ZonedDateTime.parse((String) args[2]),
+            ZonedDateTime.parse((String) args[3])
         ));
 
     static {
@@ -35,10 +35,10 @@ public class QueuedWatch {
 
     private final String watchId;
     private final String watchRecordId;
-    private final DateTime triggeredTime;
-    private final DateTime executionTime;
+    private final ZonedDateTime triggeredTime;
+    private final ZonedDateTime executionTime;
 
-    public QueuedWatch(String watchId, String watchRecordId, DateTime triggeredTime, DateTime executionTime) {
+    public QueuedWatch(String watchId, String watchRecordId, ZonedDateTime triggeredTime, ZonedDateTime executionTime) {
         this.watchId = watchId;
         this.watchRecordId = watchRecordId;
         this.triggeredTime = triggeredTime;
@@ -53,11 +53,11 @@ public class QueuedWatch {
         return watchRecordId;
     }
 
-    public DateTime getTriggeredTime() {
+    public ZonedDateTime getTriggeredTime() {
         return triggeredTime;
     }
 
-    public DateTime getExecutionTime() {
+    public ZonedDateTime getExecutionTime() {
         return executionTime;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatchExecutionSnapshot.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatchExecutionSnapshot.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.client.watcher;
 
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.joda.time.DateTime;
+import org.elasticsearch.common.xcontent.ParseField;
 
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -23,8 +23,8 @@ public class WatchExecutionSnapshot {
         new ConstructingObjectParser<>("watcher_stats_node", true, (args, c) -> new WatchExecutionSnapshot(
             (String) args[0],
             (String) args[1],
-            DateTime.parse((String)  args[2]),
-            DateTime.parse((String)  args[3]),
+            ZonedDateTime.parse((String)  args[2]),
+            ZonedDateTime.parse((String)  args[3]),
             ExecutionPhase.valueOf(((String) args[4]).toUpperCase(Locale.ROOT)),
             args[5] == null ? null : ((List<String>) args[5]).toArray(new String[0]),
             args[6] == null ? null : ((List<String>) args[6]).toArray(new String[0])
@@ -42,13 +42,13 @@ public class WatchExecutionSnapshot {
 
     private final String watchId;
     private final String watchRecordId;
-    private final DateTime triggeredTime;
-    private final DateTime executionTime;
+    private final ZonedDateTime triggeredTime;
+    private final ZonedDateTime executionTime;
     private final ExecutionPhase phase;
     private final String[] executedActions;
     private final String[] executionStackTrace;
 
-    public WatchExecutionSnapshot(String watchId, String watchRecordId, DateTime triggeredTime, DateTime executionTime,
+    public WatchExecutionSnapshot(String watchId, String watchRecordId, ZonedDateTime triggeredTime, ZonedDateTime executionTime,
                                   ExecutionPhase phase, String[] executedActions, String[] executionStackTrace) {
         this.watchId = watchId;
         this.watchRecordId = watchRecordId;
@@ -67,11 +67,11 @@ public class WatchExecutionSnapshot {
         return watchRecordId;
     }
 
-    public DateTime getTriggeredTime() {
+    public ZonedDateTime getTriggeredTime() {
         return triggeredTime;
     }
 
-    public DateTime getExecutionTime() {
+    public ZonedDateTime getExecutionTime() {
         return executionTime;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -48,11 +48,12 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
 import java.io.IOException;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -923,7 +924,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     public void testUrlEncode() throws IOException {
         String indexPattern = "<logstash-{now/M}>";
         String expectedIndex = "logstash-" +
-                DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
+            DateTimeFormatter.ofPattern("uuuu.MM.dd").format(ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1).with(LocalTime.MIN));
         {
             IndexRequest indexRequest = new IndexRequest(indexPattern).id("id#1");
             indexRequest.source("field", "value");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -924,7 +925,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     public void testUrlEncode() throws IOException {
         String indexPattern = "<logstash-{now/M}>";
         String expectedIndex = "logstash-" +
-            DateTimeFormatter.ofPattern("uuuu.MM.dd").format(ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1).with(LocalTime.MIN));
+            DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT).format(ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1).with(LocalTime.MIN));
         {
             IndexRequest indexRequest = new IndexRequest(indexPattern).id("id#1");
             indexRequest.source("field", "value");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -925,7 +925,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     public void testUrlEncode() throws IOException {
         String indexPattern = "<logstash-{now/M}>";
         String expectedIndex = "logstash-" +
-            DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT).format(ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1).with(LocalTime.MIN));
+            DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT)
+                .format(ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1).with(LocalTime.MIN));
         {
             IndexRequest indexRequest = new IndexRequest(indexPattern).id("id#1");
             indexRequest.source("field", "value");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformIT.java
@@ -53,10 +53,10 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
-import org.joda.time.Instant;
 import org.junit.After;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/process/DataCountsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/process/DataCountsTests.java
@@ -9,20 +9,24 @@ package org.elasticsearch.client.ml.job.process;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
-import org.joda.time.DateTime;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Date;
 
 public class DataCountsTests extends AbstractXContentTestCase<DataCounts> {
+
+    private static Date randomDate() {
+        return Date.from(ZonedDateTime.now(randomZone()).toInstant());
+    }
 
     public static DataCounts createTestInstance(String jobId) {
         return new DataCounts(jobId, randomIntBetween(1, 1_000_000),
                 randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000),
                 randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000),
                 randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000), randomIntBetween(1, 1_000_000),
-                new DateTime(randomDateTimeZone()).toDate(), new DateTime(randomDateTimeZone()).toDate(),
-                new DateTime(randomDateTimeZone()).toDate(), new DateTime(randomDateTimeZone()).toDate(),
-                new DateTime(randomDateTimeZone()).toDate(), randomBoolean() ? null : Instant.now());
+                randomDate(), randomDate(), randomDate(), randomDate(), randomDate(),
+                randomBoolean() ? null : Instant.now());
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/WatcherStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/WatcherStatsResponseTests.java
@@ -12,10 +12,11 @@ import org.elasticsearch.client.NodesResponseHeader;
 import org.elasticsearch.client.NodesResponseHeaderTestUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -142,7 +143,8 @@ public class WatcherStatsResponseTests extends ESTestCase {
                         }
                     }
                     snapshots.add(new WatchExecutionSnapshot(randomAlphaOfLength(10), randomAlphaOfLength(10),
-                        new DateTime(randomInt(), DateTimeZone.UTC), new DateTime(randomInt(), DateTimeZone.UTC),
+                        ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomInt()), ZoneOffset.UTC),
+                        ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomInt()), ZoneOffset.UTC),
                         randomFrom(ExecutionPhase.values()), actions, stackTrace));
                 }
             }
@@ -153,7 +155,8 @@ public class WatcherStatsResponseTests extends ESTestCase {
                 queuedWatches = new ArrayList<>(queuedWatchCount);
                 for (int j=0; j<queuedWatchCount; j++) {
                     queuedWatches.add(new QueuedWatch(randomAlphaOfLength(10), randomAlphaOfLength(10),
-                        new DateTime(randomInt(), DateTimeZone.UTC), new DateTime(randomInt(), DateTimeZone.UTC)));
+                        ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomInt()), ZoneOffset.UTC),
+                        ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomInt()), ZoneOffset.UTC)));
                 }
             }
 


### PR DESCRIPTION
Joda has been deprecated internally for many years, but a few uses of
joda classes were left in the high level rest client. This commit
changes them to use Java time classes, which matches what the backend
uses internally for these classes.