### PR TITLE
[7.x] Introduce DSL for configuring BWC tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -21,7 +21,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -344,6 +346,14 @@ public class BwcVersions {
         );
     }
 
+    public void withIndexCompatiple(BiConsumer<Version, String> versionAction) {
+        getIndexCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
+
+    public void withIndexCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+        getIndexCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
+
     public List<Version> getWireCompatible() {
         List<Version> wireCompat = new ArrayList<>();
         List<Version> prevMajors = groupByMajor.get(currentVersion.getMajor() - 1);
@@ -356,6 +366,14 @@ public class BwcVersions {
         wireCompat.sort(Version::compareTo);
 
         return unmodifiableList(filterSupportedVersions(wireCompat));
+    }
+
+    public void withWireCompatiple(BiConsumer<Version, String> versionAction) {
+        getWireCompatible().forEach(v -> versionAction.accept(v, "v"+v.toString()));
+    }
+
+    public void withWireCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+        getWireCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v"+v.toString()));
     }
 
     private List<Version> filterSupportedVersions(List<Version> wireCompat) {

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -19,9 +18,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionStr = bwcVersion.toString()
-  String baseName = "v" + bwcVersionStr
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
   /**
    * We execute tests 3 times.
@@ -32,13 +29,13 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
    */
   def localCluster = testClusters.register("${baseName}-local") {
     numberOfNodes = 2
-    versions = [bwcVersionStr, project.version]
+    versions = [bwcVersion.toString(), project.version]
     setting 'cluster.remote.node.attr', 'gateway'
     setting 'xpack.security.enabled', 'false'
   }
   def remoteCluster = testClusters.register("${baseName}-remote") {
     numberOfNodes = 3
-    versions = [bwcVersionStr, project.version]
+    versions = [bwcVersion.toString(), project.version]
     firstNode.setting 'node.attr.gateway', 'true'
     lastNode.setting 'node.attr.gateway', 'true'
     setting 'xpack.security.enabled', 'false'
@@ -48,7 +45,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster localCluster
     useCluster remoteCluster
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr.replace('-SNAPSHOT', '')
+    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
 
     doFirst {
       nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -7,7 +7,6 @@
  */
 
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -16,12 +15,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  def bwcVersionString = bwcVersion.toString();
-  String baseName = "v" + bwcVersionString
-
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
-      versions =  [bwcVersionString, project.version]
+      versions =  [bwcVersion.toString(), project.version]
       numberOfNodes = 2
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '60m'
@@ -49,7 +45,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     systemProperty 'tests.is_old_cluster', 'false'
   }
 
-  String oldVersion = bwcVersionString.minus("-SNAPSHOT")
+  String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
     it.systemProperty 'tests.old_cluster_version', oldVersion
     it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -22,47 +21,40 @@ restResources {
   }
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
-  /* This project runs the core REST tests against a 4 node cluster where two of
+  if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
+    /* This project runs the core REST tests against a 4 node cluster where two of
      the nodes has a different minor.  */
-  def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
-    numberOfNodes = 4
-    setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    setting 'xpack.security.enabled', 'false'
-  }
-
-  tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-    useCluster baseCluster
-    mustRunAfter("precommit")
-    doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
-      // Getting the endpoints causes a wait for the cluster
-      println "Test cluster endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
-      println "Upgrading one node to create a mixed cluster"
-
-      baseCluster.get().nextNodeToNextVersion()
-      // Getting the endpoints causes a wait for the cluster
-      println "Upgrade complete, endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
-      println "Upgrading another node to create a mixed cluster"
-
-      baseCluster.get().nextNodeToNextVersion()
-      nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
+    def baseCluster = testClusters.register(baseName) {
+      versions = [bwcVersion.toString(), project.version]
+      numberOfNodes = 4
+      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'xpack.security.enabled', 'false'
     }
-    systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    onlyIf { project.bwc_tests_enabled }
-  }
 
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#mixedClusterTest"
+    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
+      useCluster baseCluster
+      mustRunAfter("precommit")
+      doFirst {
+        delete("${buildDir}/cluster/shared/repo/${baseName}")
+        // Getting the endpoints causes a wait for the cluster
+        println "Test cluster endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
+        println "Upgrading one node to create a mixed cluster"
+
+        baseCluster.get().nextNodeToNextVersion()
+        // Getting the endpoints causes a wait for the cluster
+        println "Upgrade complete, endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
+        println "Upgrading another node to create a mixed cluster"
+
+        baseCluster.get().nextNodeToNextVersion()
+        nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+        nonInputProperties.systemProperty('tests.clustername', baseName)
+      }
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+      dependsOn "${baseName}#mixedClusterTest"
+    }
   }
 }

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -51,6 +51,8 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
         nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
         nonInputProperties.systemProperty('tests.clustername', baseName)
       }
+      systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      onlyIf { project.bwc_tests_enabled }
     }
 
     tasks.register(bwcTaskName(bwcVersion)) {

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -20,8 +19,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  String baseName = "v${bwcVersion}"
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   String oldClusterName = "${baseName}-old"
   String newClusterName = "${baseName}-new"
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -15,7 +14,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
   /*
    * The goal here is to:
    * <ul>
@@ -30,11 +29,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
    * </ul>
    */
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
   def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -15,12 +14,9 @@ apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v${bwcVersionString}"
-
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
-      version = bwcVersionString
+      version = bwcVersion.toString()
       setting 'http.content_type.required', 'true'
       setting 'xpack.security.enabled', 'true'
       user username: 'admin', password: 'admin-password', role: 'superuser'

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -3,58 +3,50 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 dependencies {
-  testImplementation project(':x-pack:qa')
-  testImplementation(project(xpackModule('ql:test-fixtures')))
-  testImplementation project(path: xpackModule('eql'), configuration: 'default')
+    testImplementation project(':x-pack:qa')
+    testImplementation(project(xpackModule('ql:test-fixtures')))
+    testImplementation project(path: xpackModule('eql'), configuration: 'default')
 }
 
-tasks.named("integTest").configure{ enabled = false}
+tasks.named("integTest").configure { enabled = false }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.10.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
-
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersion
-
-  def cluster = testClusters.register(baseName) {
-      versions = [bwcVersionString, project.version]
-      numberOfNodes = 3
-      testDistribution = 'DEFAULT'
-      setting 'xpack.security.enabled', 'false'
-      setting 'xpack.watcher.enabled', 'false'
-      setting 'xpack.ml.enabled', 'false'
-      setting 'xpack.eql.enabled', 'true'
-      setting 'xpack.license.self_generated.type', 'trial'
-      // for debugging purposes
-      // setting 'logger.org.elasticsearch.xpack.eql.plugin.TransportEqlSearchAction', 'TRACE'
-  }
-
-  tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-    useCluster cluster
-    mustRunAfter("precommit")
-    doFirst {
-      // Getting the endpoints causes a wait for the cluster
-      println "Endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
-      println "Upgrading one node to create a mixed cluster"
-      cluster.get().nextNodeToNextVersion()
-
-      println "Upgrade complete, endpoints are: ${-> testClusters.named(baseName).get().allHttpSocketURI.join(",")}"
-      nonInputProperties.systemProperty('tests.rest.cluster', cluster.map(c->c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
+    def cluster = testClusters.register(baseName) {
+        versions = [bwcVersion.toString(), project.version]
+        numberOfNodes = 3
+        testDistribution = 'DEFAULT'
+        setting 'xpack.security.enabled', 'false'
+        setting 'xpack.watcher.enabled', 'false'
+        setting 'xpack.ml.enabled', 'false'
+        setting 'xpack.eql.enabled', 'true'
+        setting 'xpack.license.self_generated.type', 'trial'
+        // for debugging purposes
+        // setting 'logger.org.elasticsearch.xpack.eql.plugin.TransportEqlSearchAction', 'TRACE'
     }
-    onlyIf { project.bwc_tests_enabled }
-  }
 
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
+    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
+        useCluster cluster
+        mustRunAfter("precommit")
+        doFirst {
+            // Getting the endpoints causes a wait for the cluster
+            println "Endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
+            println "Upgrading one node to create a mixed cluster"
+            cluster.get().nextNodeToNextVersion()
+
+            println "Upgrade complete, endpoints are: ${-> testClusters.named(baseName).get().allHttpSocketURI.join(",")}"
+            nonInputProperties.systemProperty('tests.rest.cluster', cluster.map(c -> c.allHttpSocketURI.join(",")))
+            nonInputProperties.systemProperty('tests.clustername', baseName)
+        }
+        onlyIf { project.bwc_tests_enabled }
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+        dependsOn "${baseName}#mixedClusterTest"
+    }
 }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -71,10 +71,9 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+    BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
       // Compatibility testing for JDBC driver started with version 7.9.0
       if (bwcVersion.onOrAfter(Version.fromString("7.9.0"))) {
-        String baseName = "v${bwcVersion}"
         UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
         Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
           // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -22,17 +21,12 @@ testClusters.configureEach {
 tasks.named("integTest").configure{ enabled = false}
 
 // A bug (https://github.com/elastic/elasticsearch/issues/68439) limits us to perform tests with versions from 7.10.3 onwards
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.10.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
 
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersion
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
-      versions = [bwcVersionString, project.version]
+      versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 3
       testDistribution = 'DEFAULT'
       setting 'xpack.security.enabled', 'false'

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -30,13 +29,10 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  def bwcVersionString = bwcVersion.toString()
-  String baseName = "v"+ bwcVersionString
-
+BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
       testDistribution = "DEFAULT"
-      versions = [bwcVersionString, project.version]
+      versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 2
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       user username: "test_user", password: "x-pack-test-password"
@@ -58,7 +54,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 
-      if (Version.fromString(bwcVersionString).onOrAfter('6.7.0')) {
+      if (bwcVersion.onOrAfter('6.7.0')) {
         setting 'xpack.security.authc.api_key.enabled', 'true'
       }
   }
@@ -68,7 +64,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     useCluster baseCluster
     dependsOn "copyTestNodeKeyMaterial"
     doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
+        delete("${buildDir}/cluster/shared/repo/${baseName}")
     }
     systemProperty 'tests.is_old_cluster', 'true'
     exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
@@ -77,27 +73,27 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
   }
 
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
-    mustRunAfter("precommit")
-    useCluster baseCluster
-    dependsOn "${baseName}#oldClusterTest"
-    doFirst {
-      testClusters.named(baseName).get().goToNextVersion()
-    }
-    systemProperty 'tests.is_old_cluster', 'false'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
-    exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
-    exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
+      mustRunAfter("precommit")
+      useCluster baseCluster
+      dependsOn "${baseName}#oldClusterTest"
+      doFirst {
+          testClusters.named(baseName).get().goToNextVersion()
+      }
+      systemProperty 'tests.is_old_cluster', 'false'
+      exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'
+      exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
+      exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
   }
 
-  String oldVersion = bwcVersionString.minus("-SNAPSHOT")
+  String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
   tasks.matching { it.name.startsWith("${baseName}#") && it.name.endsWith("ClusterTest") }.configureEach {
-    it.systemProperty 'tests.old_cluster_version', oldVersion
-    it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    it.nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
-    it.nonInputProperties.systemProperty('tests.clustername', baseName)
+      it.systemProperty 'tests.old_cluster_version', oldVersion
+      it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      it.nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+      it.nonInputProperties.systemProperty('tests.clustername', baseName)
   }
 
   tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#upgradedClusterTest"
+      dependsOn "${baseName}#upgradedClusterTest"
   }
 }

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-test'
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -13,17 +12,11 @@ dependencies {
 }
 
 // Only run tests for 7.9+, since the node.roles setting was introduced in 7.9.0
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.onOrAfter('7.9.0') }) {
-  if (bwcVersion == VersionProperties.getElasticsearchVersion()) {
-    // Not really a mixed cluster
-    continue;
-  }
-
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.9.0") &&
+        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
@@ -32,7 +25,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
     setting 'xpack.license.self_generated.type', 'trial'
     nodes."${baseName}-0".setting 'node.roles', '["master"]'
     // data_* roles were introduced in 7.10.0, so use 'data' for older versions
-    if (Version.fromString(bwcVersionString).before('7.10.0')) {
+    if (bwcVersion.before('7.10.0')) {
       nodes."${baseName}-1".setting 'node.roles', '["data"]'
     } else {
       nodes."${baseName}-1".setting 'node.roles', '["data_content", "data_hot"]'

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -10,13 +9,10 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
@@ -35,7 +31,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', baseName)
   }
 
-  String oldVersion = bwcVersionString.replace('-SNAPSHOT', '')
+  String oldVersion = bwcVersion.toString().replace('-SNAPSHOT', '')
   tasks.register("${baseName}#oneThirdUpgradedTest", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -10,9 +9,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
   def baseLeaderCluster = testClusters.register("${baseName}-leader") {
       numberOfNodes = 3
@@ -22,7 +19,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   }
   testClusters.matching { it.name.startsWith("${baseName}-") }.configureEach {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [bwcVersion.toString(), project.version]
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
     setting 'xpack.security.enabled', 'false'
@@ -34,7 +31,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster baseLeaderCluster
     useCluster baseFollowerCluster
-    systemProperty 'tests.upgrade_from_version', bwcVersionString.replace('-SNAPSHOT', '')
+    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
 
     doFirst {
       def baseCluster = testClusters.named("${baseName}-${kindExt}").get()

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,4 +1,4 @@
-import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -30,17 +30,15 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
-  String bwcVersionString = bwcVersion.toString()
-  String baseName = "v" + bwcVersionString
-  Version currentBwcVersion = bwcVersion
+BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+  String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
   String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
 
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
-    versions = [bwcVersionString, project.version]
+    versions = [oldVersion, project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
@@ -56,7 +54,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
     keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 
-    if (currentBwcVersion.onOrAfter('7.0.0')) {
+    if (bwcVersion.onOrAfter('7.0.0')) {
       setting 'xpack.security.authc.realms.file.file1.order', '0'
       setting 'xpack.security.authc.realms.native.native1.order', '1'
     } else {
@@ -65,7 +63,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       setting 'xpack.security.authc.realms.native1.type', 'native'
       setting 'xpack.security.authc.realms.native1.order', '1'
     }
-    if (currentBwcVersion.onOrAfter('6.6.0')) {
+    if (bwcVersion.onOrAfter('6.6.0')) {
       setting 'ccr.auto_follow.wait_for_metadata_timeout', '1s'
     }
 
@@ -83,17 +81,15 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     // However, released versions run without assertions, so end users won't
     // be suffering the effects.  This argument effectively removes the
     // incorrect assertion from the older versions used in the BWC tests.
-    if (currentBwcVersion.before('5.6.9') || (currentBwcVersion.onOrAfter('6.0.0') && currentBwcVersion.before('6.2.4'))) {
+    if (bwcVersion.before('5.6.9') || (bwcVersion.onOrAfter('6.0.0') && bwcVersion.before('6.2.4'))) {
       jvmArgs '-da:org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk'
     }
     setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
 
-    if (currentBwcVersion.onOrAfter('7.12.0')) {
+    if (bwcVersion.onOrAfter('7.12.0')) {
       setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
     }
   }
-
-  String oldVersion = bwcVersionString
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     useCluster baseCluster
@@ -111,14 +107,14 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', baseName)
     def toBlackList = []
     // Dataframe transforms were not added until 7.2.0
-    if (Version.fromString(oldVersion).before('7.2.0')) {
+    if (bwcVersion.before('7.2.0')) {
       toBlackList << 'old_cluster/80_transform_jobs_crud/Test put batch transform on old cluster'
     }
     // continuous Dataframe transforms were not added until 7.3.0
-    if (Version.fromString(oldVersion).before('7.3.0')) {
+    if (bwcVersion.before('7.3.0')) {
       toBlackList << 'old_cluster/80_transform_jobs_crud/Test put continuous transform on old cluster'
     }
-    if (Version.fromString(oldVersion).before('7.9.0')) {
+    if (bwcVersion.before('7.9.0')) {
       toBlackList.addAll([
         'old_cluster/90_ml_data_frame_analytics_crud/Put outlier_detection job on the old cluster',
         'old_cluster/90_ml_data_frame_analytics_crud/Put regression job on the old cluster',
@@ -157,13 +153,13 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       'mixed_cluster/121_api_key/Create API key with metadata in a mixed cluster'
     ]
     // transform in mixed cluster is effectively disabled till 7.4, see gh#48019
-    if (Version.fromString(oldVersion).before('7.4.0')) {
+    if (bwcVersion.before('7.4.0')) {
       toBlackList.addAll([
         'mixed_cluster/80_transform_jobs_crud/Test GET, start, and stop old cluster batch transforms',
         'mixed_cluster/80_transform_jobs_crud/Test GET, stop, start, old continuous transforms'
       ])
     }
-    if (Version.fromString(oldVersion).before('7.9.0')) {
+    if (bwcVersion.before('7.9.0')) {
       toBlackList.addAll([
         'mixed_cluster/90_ml_data_frame_analytics_crud/Get old outlier_detection job',
         'mixed_cluster/90_ml_data_frame_analytics_crud/Get old outlier_detection job stats',
@@ -190,7 +186,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.first_round', 'false'
     def toBlackList = []
     // transform in mixed cluster is effectively disabled till 7.4, see gh#48019
-    if (Version.fromString(oldVersion).before('7.4.0')) {
+    if (bwcVersion.before('7.4.0')) {
       toBlackList.addAll([
         'mixed_cluster/80_transform_jobs_crud/Test put batch transform on mixed cluster',
         'mixed_cluster/80_transform_jobs_crud/Test GET, start, and stop old cluster batch transforms',
@@ -198,7 +194,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
         'mixed_cluster/80_transform_jobs_crud/Test GET, stop, start, old continuous transforms'
       ])
     }
-    if (Version.fromString(oldVersion).before('7.9.0')) {
+    if (bwcVersion.before('7.9.0')) {
       toBlackList.addAll([
         'mixed_cluster/90_ml_data_frame_analytics_crud/Get old outlier_detection job',
         'mixed_cluster/90_ml_data_frame_analytics_crud/Get old outlier_detection job stats',
@@ -213,7 +209,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       ])
     }
     // API key metadata requires flattened field type introduced in 7.3.0
-    if (Version.fromString(oldVersion).before('7.3.0')) {
+    if (bwcVersion.before('7.3.0')) {
       toBlackList.addAll([
         'mixed_cluster/121_api_key/Create API key with metadata in a mixed cluster'
       ])
@@ -238,19 +234,19 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     def toBlackList = []
     // Dataframe transforms were not added until 7.2.0
-    if (Version.fromString(oldVersion).before('7.2.0')) {
+    if (bwcVersion.before('7.2.0')) {
       toBlackList << 'upgraded_cluster/80_transform_jobs_crud/Get start, stop, and delete old cluster batch transform'
     }
     // continuous Dataframe transforms were not added until 7.3.0
-    if (Version.fromString(oldVersion).before('7.3.0')) {
+    if (bwcVersion.before('7.3.0')) {
       toBlackList << 'upgraded_cluster/80_transform_jobs_crud/Test GET, stop, delete, old continuous transforms'
     }
     // transform in mixed cluster is effectively disabled till 7.4, see gh#48019
-    if (Version.fromString(oldVersion).before('7.4.0')) {
+    if (bwcVersion.before('7.4.0')) {
       toBlackList << 'upgraded_cluster/80_transform_jobs_crud/Get start, stop mixed cluster batch transform'
       toBlackList << 'upgraded_cluster/80_transform_jobs_crud/Test GET, mixed continuous transforms'
     }
-    if (Version.fromString(oldVersion).before('7.10.0')) {
+    if (bwcVersion.before('7.10.0')) {
       toBlackList.addAll([
         'upgraded_cluster/90_ml_data_frame_analytics_crud/Get old cluster outlier_detection job',
         'upgraded_cluster/90_ml_data_frame_analytics_crud/Get old cluster outlier_detection job stats',
@@ -264,7 +260,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       ])
     }
     // API key metadata requires flattened field type introduced in 7.3.0
-    if (Version.fromString(oldVersion).before('7.3.0')) {
+    if (bwcVersion.before('7.3.0')) {
       toBlackList.addAll([
         'upgraded_cluster/121_api_key/Get the mixed API key in the upgraded cluster'
       ])


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/78597 to 7.x