### PR TITLE
[7.x] [DOCS] Add reference to PHP client on Bulk API page (#78558)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -142,6 +142,9 @@ JavaScript::
 .NET::
     See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
 
+PHP::
+    See https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/indexing_documents.html#_bulk_indexing[Bulk indexing]
+
 [discrete]
 [[bulk-curl]]
 ===== Submitting bulk requests with cURL


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add reference to PHP client on Bulk API page (#78558)