### PR TITLE
Ensure rest snippets task output directory is cleaned before execution

### DIFF
--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
@@ -66,6 +66,9 @@ class DocsTestPlugin implements Plugin<Project> {
         TaskProvider<RestTestsFromSnippetsTask> buildRestTests = project.tasks.register('buildRestTests', RestTestsFromSnippetsTask) {
             defaultSubstitutions = commonDefaultSubstitutions
             testRoot.convention(restRootDir)
+            doFirst {
+                project.delete(restRootDir)
+            }
         }
 
         // TODO: This effectively makes testRoot not customizable, which we don't do anyway atm

--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/RestTestsFromSnippetsTask.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/RestTestsFromSnippetsTask.groovy
@@ -68,7 +68,6 @@ class RestTestsFromSnippetsTask extends SnippetsTask {
     RestTestsFromSnippetsTask(ObjectFactory objectFactory) {
         testRoot = objectFactory.directoryProperty()
         TestBuilder builder = new TestBuilder()
-        doFirst { outputRoot().delete() }
         perSnippet builder.&handleSnippet
         doLast builder.&checkUnconverted
         doLast builder.&finishLastTest


### PR DESCRIPTION
Adding task actions in a task constructor can result in unexpected behavior. Instead we move this task action into the plugin to ensure it always executes and we don't leave stale files in the task output directory.

Closes #78298