### PR TITLE
Handle empty /proc/self/cgroup file

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -295,7 +295,6 @@ public class OsProbe {
     @SuppressForbidden(reason = "access /proc/self/cgroup")
     List<String> readProcSelfCgroup() throws IOException {
         final List<String> lines = Files.readAllLines(PathUtils.get("/proc/self/cgroup"));
-        assert lines != null && lines.isEmpty() == false;
         return lines;
     }
 
@@ -577,6 +576,11 @@ public class OsProbe {
         }
 
         List<String> lines = readProcSelfCgroup();
+
+        // On some older Linux kernels /proc/self/cgroup can exist, but be empty sometimes
+        if (lines.isEmpty()) {
+            return false;
+        }
 
         // cgroup v2
         if (lines.size() == 1 && lines.get(0).startsWith("0::")) {


### PR DESCRIPTION
Older versions of the Linux kernel, e.g. 4.1.12 which
is found in OEL-6, can sometimes have empty cgroup file
causing a test assertion. This change removes the
assert and handles the empty file like a non-existent
file.

Closes https://github.com/elastic/elasticsearch/issues/77833