### PR TITLE
Fix system property resolution at configuration time

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesLoader.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesLoader.java
@@ -43,9 +43,8 @@ public class VersionPropertiesLoader {
             );
         }
         String qualifier = providers.systemProperty("build.version_qualifier")
-                .orElse("")
                 .forUseAtConfigurationTime()
-                .get();
+                .getOrElse("");
         if (qualifier.isEmpty() == false) {
             if (qualifier.matches("(alpha|beta|rc)\\d+") == false) {
                 throw new IllegalStateException("Invalid qualifier: " + qualifier);
@@ -53,9 +52,8 @@ public class VersionPropertiesLoader {
             elasticsearch += "-" + qualifier;
         }
         final String buildSnapshotSystemProperty = providers.systemProperty("build.snapshot")
-                .orElse("true")
                 .forUseAtConfigurationTime()
-                .get();
+                .getOrElse("true");
         switch (buildSnapshotSystemProperty) {
             case "true":
                 elasticsearch += "-SNAPSHOT";

--- a/build-tools-internal/src/main/groovy/elasticsearch.authenticated-testclusters.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.authenticated-testclusters.gradle
@@ -22,7 +22,7 @@ tasks.withType(StandaloneRestIntegTestTask).configureEach {
     systemProperty 'tests.rest.cluster.password', clusterCredentials.password
 }
 
-testClusters.all {
+testClusters.configureEach {
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.license.self_generated.type', 'trial'
     user clusterCredentials

--- a/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
@@ -15,8 +15,8 @@ import org.elasticsearch.gradle.testclusters.RunTask
 
 testClusters.register("runTask") {
     testDistribution = providers.systemProperty('run.distribution').orElse('default').forUseAtConfigurationTime().get()
-    if (providers.systemProperty('run.distribution').orElse('default').forUseAtConfigurationTime().get() == 'default') {
-      String licenseType = providers.systemProperty("run.license_type").orElse("basic").forUseAtConfigurationTime().get()
+    if (providers.systemProperty('run.distribution').forUseAtConfigurationTime().getOrElse('default') == 'default') {
+      String licenseType = providers.systemProperty("run.license_type").forUseAtConfigurationTime().getOrElse("basic")
       if (licenseType == 'trial') {
         setting 'xpack.ml.enabled', 'true'
         setting 'xpack.graph.enabled', 'true'

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -65,7 +65,7 @@ tasks.named("preProcessFixture").configure {
 
 dockerCompose {
   tcpPortsToIgnoreWhenWaiting = [9600, 9601]
-  if ('default'.equalsIgnoreCase(providers.systemProperty('tests.distribution').orElse('default').forUseAtConfigurationTime().get())) {
+  if ('default'.equalsIgnoreCase(providers.systemProperty('tests.distribution').forUseAtConfigurationTime().getOrElse('default'))) {
     useComposeFiles = ['docker-compose.yml']
   } else {
     useComposeFiles = ['docker-compose-oss.yml']

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -16,7 +16,7 @@ repositories {
     forRepository {
       ivy {
         name "ml-cpp"
-        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').forUseAtConfigurationTime().get()
+        url providers.systemProperty('build.ml_cpp.repo').forUseAtConfigurationTime().orElse('https://prelert-artifacts.s3.amazonaws.com').get()
         metadataSources {
           // no repository metadata, look directly for the artifact
           artifact()


### PR DESCRIPTION
This fixes system property resolution when running the build with `--configuration-cache`

One step closer to make use of configuration cache