### PR TITLE
[7.x][DOCS] Removes LLRC from Java REST book

### DIFF
--- a/docs/java-rest/index.asciidoc
+++ b/docs/java-rest/index.asciidoc
@@ -7,8 +7,6 @@ include::../Versions.asciidoc[]
 
 include::overview.asciidoc[]
 
-include::low-level/index.asciidoc[]
-
 include::high-level/index.asciidoc[]
 
 include::redirects.asciidoc[]


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commit to the 7.x branch: [DOCS] Removes LLRC from Java REST book #78602

**DO NOT merge before https://github.com/elastic/elasticsearch/pull/78674**