### PR TITLE
[7.x][DOCS] Redirects links in Java REST Client book

### DIFF
--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -142,7 +142,7 @@ transitive dependencies:
 === Initialization
 
 A `RestHighLevelClient` instance needs a 
-{java-api-client}java-rest-low-usage-initialization.html[REST low-level client builder]
+{java-api-client}/java-rest-low-usage-initialization.html[REST low-level client builder]
 to be built as follows:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -141,7 +141,8 @@ transitive dependencies:
 [[java-rest-high-getting-started-initialization]]
 === Initialization
 
-A `RestHighLevelClient` instance needs a <<java-rest-low-usage-initialization,REST low-level client builder>>
+A `RestHighLevelClient` instance needs a 
+{java-api-client}java-rest-low-usage-initialization.html[REST low-level client builder]
 to be built as follows:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/migration.asciidoc
+++ b/docs/java-rest/high-level/migration.asciidoc
@@ -62,7 +62,7 @@ TransportClient transportClient = new PreBuiltTransportClient(settings)
 
 The initialization of a `RestHighLevelClient` is different. It requires to provide
 a 
-{java-api-client}java-rest-low-usage-initialization.html[low-level client builder] 
+{java-api-client}/java-rest-low-usage-initialization.html[low-level client builder] 
 as a constructor argument:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/migration.asciidoc
+++ b/docs/java-rest/high-level/migration.asciidoc
@@ -61,8 +61,9 @@ TransportClient transportClient = new PreBuiltTransportClient(settings)
 --------------------------------------------------
 
 The initialization of a `RestHighLevelClient` is different. It requires to provide
-a <<java-rest-low-usage-initialization,low-level client builder>> as a constructor
-argument:
+a 
+{java-api-client}java-rest-low-usage-initialization.html[low-level client builder] 
+as a constructor argument:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/overview.asciidoc
+++ b/docs/java-rest/overview.asciidoc
@@ -3,10 +3,10 @@
 
 The Java REST Client comes in 2 flavors:
 
-* <<java-rest-low>>: the official low-level client for Elasticsearch.
-It allows to communicate with an Elasticsearch cluster through http.
-Leaves requests marshalling and responses un-marshalling to users.
-It is compatible with all Elasticsearch versions.
+* {java-api-client}java-rest-low.html[Java Low Level REST Client]: the official 
+low-level client for Elasticsearch. It allows to communicate with an 
+Elasticsearch cluster through http. Leaves requests marshalling and responses 
+un-marshalling to users. It is compatible with all Elasticsearch versions.
 
 * <<java-rest-high>>: the official high-level client for Elasticsearch.
 Based on the low-level client, it exposes API specific methods and takes care

--- a/docs/java-rest/overview.asciidoc
+++ b/docs/java-rest/overview.asciidoc
@@ -3,7 +3,7 @@
 
 The Java REST Client comes in 2 flavors:
 
-* {java-api-client}java-rest-low.html[Java Low Level REST Client]: the official 
+* {java-api-client}/java-rest-low.html[Java Low Level REST Client]: the official 
 low-level client for Elasticsearch. It allows to communicate with an 
 Elasticsearch cluster through http. Leaves requests marshalling and responses 
 un-marshalling to users. It is compatible with all Elasticsearch versions.


### PR DESCRIPTION
## Overview

This PR changes links that point to the old LLRC docs and redirects them to the new LLRC chapter in the Java API book.

Related to https://github.com/elastic/elasticsearch/pull/78670