### PR TITLE
[ML] adding some new test hooks for inference results testing

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -197,6 +197,11 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
     }
 
     @Override
+    public String getResultsField() {
+        return resultsField;
+    }
+
+    @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put(resultsField, predictionFieldType.transformPredictedValue(value(), valueAsString()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
@@ -30,6 +30,8 @@ public interface InferenceResults extends NamedWriteable, ToXContentFragment {
         }
     }
 
+    String getResultsField();
+
     Map<String, Object> asMap();
 
     Object predictedValue();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
@@ -83,6 +83,7 @@ public class NerResults implements InferenceResults {
         return entityGroups;
     }
 
+    @Override
     public String getResultsField() {
         return resultsField;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResults.java
@@ -56,6 +56,11 @@ public class PyTorchPassThroughResults implements InferenceResults {
     }
 
     @Override
+    public String getResultsField() {
+        return resultsField;
+    }
+
+    @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put(resultsField, inference);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig.DEFAULT_RESULTS_FIELD;
+
 public class RawInferenceResults implements InferenceResults {
 
     public static final String NAME = "raw";
@@ -51,6 +53,11 @@ public class RawInferenceResults implements InferenceResults {
     @Override
     public int hashCode() {
         return Objects.hash(Arrays.hashCode(value), featureImportance);
+    }
+
+    @Override
+    public String getResultsField() {
+        return DEFAULT_RESULTS_FIELD;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -105,6 +105,11 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
     }
 
     @Override
+    public String getResultsField() {
+        return resultsField;
+    }
+
+    @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put(resultsField, value());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResults.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -32,6 +32,10 @@ public class TextEmbeddingResults implements InferenceResults {
     public TextEmbeddingResults(StreamInput in) throws IOException {
         inference = in.readDoubleArray();
         resultsField = in.readString();
+    }
+
+    public String getResultsField() {
+        return resultsField;
     }
 
     public double[] getInference() {
@@ -56,7 +60,9 @@ public class TextEmbeddingResults implements InferenceResults {
 
     @Override
     public Map<String, Object> asMap() {
-        return Collections.singletonMap(resultsField, inference);
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(resultsField, inference);
+        return map;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
@@ -59,6 +59,11 @@ public class WarningInferenceResults implements InferenceResults {
     }
 
     @Override
+    public String getResultsField() {
+        return NAME;
+    }
+
+    @Override
     public Map<String, Object> asMap() {
         Map<String, Object> asMap = new LinkedHashMap<>();
         asMap.put(NAME, warning);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResultsTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResultsTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.results;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class InferenceResultsTestCase<T extends InferenceResults> extends AbstractWireSerializingTestCase<T> {
+
+    public void testWriteToIngestDoc() throws IOException {
+        for (int i = 0 ; i < NUMBER_OF_TEST_RUNS; ++i) {
+            T inferenceResult = createTestInstance();
+            if (randomBoolean()) {
+                inferenceResult = copyInstance(inferenceResult, Version.CURRENT);
+            }
+            IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
+            String parentField = randomAlphaOfLength(10);
+            String modelId = randomAlphaOfLength(10);
+            boolean alreadyHasResult = randomBoolean();
+            if (alreadyHasResult) {
+                document.setFieldValue(parentField, Map.of());
+            }
+            InferenceResults.writeResult(inferenceResult, document, parentField, modelId);
+            assertFieldValues(inferenceResult, document, alreadyHasResult ? parentField + ".1" : parentField);
+        }
+    }
+
+    abstract void assertFieldValues(T createdInstance, IngestDocument document, String resultsField);
+
+    public void testWriteToDocAndSerialize() throws IOException {
+        for (int i = 0 ; i < NUMBER_OF_TEST_RUNS; ++i) {
+            T inferenceResult = createTestInstance();
+            if (randomBoolean()) {
+                inferenceResult = copyInstance(inferenceResult, Version.CURRENT);
+            }
+            IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
+            String parentField = randomAlphaOfLength(10);
+            String modelId = randomAlphaOfLength(10);
+            boolean alreadyHasResult = randomBoolean();
+            if (alreadyHasResult) {
+                document.setFieldValue(parentField, Map.of());
+            }
+            InferenceResults.writeResult(inferenceResult, document, parentField, modelId);
+            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                builder.startObject();
+                Map<IngestDocument.Metadata, Object> metadataMap = document.getMetadata();
+                for (Map.Entry<IngestDocument.Metadata, Object> metadata : metadataMap.entrySet()) {
+                    if (metadata.getValue() != null) {
+                        builder.field(metadata.getKey().getFieldName(), metadata.getValue().toString());
+                    }
+                }
+                Map<String, Object> source = IngestDocument.deepCopyMap(document.getSourceAndMetadata());
+                metadataMap.keySet().forEach(mD -> source.remove(mD.getFieldName()));
+                builder.field("_source", source);
+                builder.field("_ingest", document.getIngestMetadata());
+                builder.endObject();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResultsTests.java
@@ -8,14 +8,14 @@
 package org.elasticsearch.xpack.core.ml.inference.results;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.ingest.IngestDocument;
 
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig.DEFAULT_RESULTS_FIELD;
 import static org.hamcrest.Matchers.hasSize;
 
-public class PyTorchPassThroughResultsTests extends AbstractWireSerializingTestCase<PyTorchPassThroughResults> {
+public class PyTorchPassThroughResultsTests extends InferenceResultsTestCase<PyTorchPassThroughResults> {
     @Override
     protected Writeable.Reader<PyTorchPassThroughResults> instanceReader() {
         return PyTorchPassThroughResults::new;
@@ -40,5 +40,13 @@ public class PyTorchPassThroughResultsTests extends AbstractWireSerializingTestC
         Map<String, Object> asMap = testInstance.asMap();
         assertThat(asMap.keySet(), hasSize(1));
         assertArrayEquals(testInstance.getInference(), (double[][]) asMap.get(DEFAULT_RESULTS_FIELD));
+    }
+
+    @Override
+    void assertFieldValues(PyTorchPassThroughResults createdInstance, IngestDocument document, String resultsField) {
+        assertArrayEquals(
+            createdInstance.getInference(),
+            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), double[][].class)
+        );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResultsTests.java
@@ -8,14 +8,14 @@
 package org.elasticsearch.xpack.core.ml.inference.results;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.ingest.IngestDocument;
 
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig.DEFAULT_RESULTS_FIELD;
 import static org.hamcrest.Matchers.hasSize;
 
-public class TextEmbeddingResultsTests extends AbstractWireSerializingTestCase<TextEmbeddingResults> {
+public class TextEmbeddingResultsTests extends InferenceResultsTestCase<TextEmbeddingResults> {
     @Override
     protected Writeable.Reader<TextEmbeddingResults> instanceReader() {
         return TextEmbeddingResults::new;
@@ -37,5 +37,13 @@ public class TextEmbeddingResultsTests extends AbstractWireSerializingTestCase<T
         Map<String, Object> asMap = testInstance.asMap();
         assertThat(asMap.keySet(), hasSize(1));
         assertArrayEquals(testInstance.getInference(), (double[]) asMap.get(DEFAULT_RESULTS_FIELD), 1e-10);
+    }
+
+    @Override
+    void assertFieldValues(TextEmbeddingResults createdInstance, IngestDocument document, String resultsField) {
+        assertArrayEquals(
+            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), double[].class),
+            createdInstance.getInference(), 1e-10
+        );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
@@ -6,47 +6,15 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.results;
 
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 
-import java.io.IOException;
-import java.util.HashMap;
-
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xpack.core.ml.inference.results.InferenceResults.writeResult;
 import static org.hamcrest.Matchers.equalTo;
 
-public class WarningInferenceResultsTests extends AbstractSerializingTestCase<WarningInferenceResults> {
-
-    private static final ConstructingObjectParser<WarningInferenceResults, Void> PARSER =
-        new ConstructingObjectParser<>("inference_warning",
-            a -> new WarningInferenceResults((String) a[0])
-        );
-
-    static {
-        PARSER.declareString(constructorArg(), new ParseField(WarningInferenceResults.NAME));
-    }
+public class WarningInferenceResultsTests extends InferenceResultsTestCase<WarningInferenceResults> {
 
     public static WarningInferenceResults createRandomResults() {
         return new WarningInferenceResults(randomAlphaOfLength(10));
-    }
-
-    public void testWriteResults() {
-        WarningInferenceResults result = new WarningInferenceResults("foo");
-        IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
-        writeResult(result, document, "result_field", "test");
-
-        assertThat(document.getFieldValue("result_field.warning", String.class), equalTo("foo"));
-
-        result = new WarningInferenceResults("bar");
-        writeResult(result, document, "result_field", "test");
-
-        assertThat(document.getFieldValue("result_field.0.warning", String.class), equalTo("foo"));
-        assertThat(document.getFieldValue("result_field.1.warning", String.class), equalTo("bar"));
     }
 
     @Override
@@ -60,7 +28,10 @@ public class WarningInferenceResultsTests extends AbstractSerializingTestCase<Wa
     }
 
     @Override
-    protected WarningInferenceResults doParseInstance(XContentParser parser) throws IOException {
-        return PARSER.apply(parser, null);
+    void assertFieldValues(WarningInferenceResults createdInstance, IngestDocument document, String resultsField) {
+        assertThat(
+            document.getFieldValue(resultsField + ".warning", String.class),
+            equalTo(createdInstance.getWarning())
+        );
     }
 }


### PR DESCRIPTION
New testing scaffolding for inference ingest testing and
a bug fix for text embedding inference results

The new scaffolding adds tests for:

 - Simple ways to make sure inference results can write to ingest docs
 - That those ingest docs can then be serialized to xcontent if necessary
 - Randomly serializing over the wire for the inference results before writing to ingest docs

