### PR TITLE
Convert graph license object to LicensedFeature (#78656)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -58,8 +58,6 @@ public class XPackLicenseState {
 
         CCR(OperationMode.PLATINUM, true),
 
-        GRAPH(OperationMode.PLATINUM, true),
-
         MACHINE_LEARNING(OperationMode.PLATINUM, true),
 
         LOGSTASH(OperationMode.STANDARD, true),

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/Graph.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/Graph.java
@@ -15,6 +15,8 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
@@ -36,8 +38,9 @@ import static java.util.Collections.singletonList;
 public class Graph extends Plugin implements ActionPlugin {
 
     public static final String NAME = "graph";
-    protected final boolean enabled;
+    public static final LicensedFeature.Momentary GRAPH_FEATURE = LicensedFeature.momentary(null, "graph", License.OperationMode.PLATINUM);
 
+    protected final boolean enabled;
 
     public Graph(Settings settings) {
         this.enabled = XPackSettings.GRAPH_ENABLED.get(settings);

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
@@ -36,7 +36,7 @@ public class GraphFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.GRAPH);
+        return licenseState != null && Graph.GRAPH_FEATURE.checkWithoutTracking(licenseState);
     }
 
     @Override

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
@@ -49,6 +49,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.graph.action.GraphExploreAction;
+import org.elasticsearch.xpack.graph.Graph;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -93,7 +94,7 @@ public class TransportGraphExploreAction extends HandledTransportAction<GraphExp
 
     @Override
     protected void doExecute(Task task, GraphExploreRequest request, ActionListener<GraphExploreResponse> listener) {
-        if (licenseState.checkFeature(XPackLicenseState.Feature.GRAPH)) {
+        if (Graph.GRAPH_FEATURE.check(licenseState)) {
             new AsyncGraphAction(request, listener).start();
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.GRAPH));

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphFeatureSetTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphFeatureSetTests.java
@@ -31,7 +31,7 @@ public class GraphFeatureSetTests extends ESTestCase {
     public void testAvailable() throws Exception {
         GraphFeatureSet featureSet = new GraphFeatureSet(Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isAllowed(XPackLicenseState.Feature.GRAPH)).thenReturn(available);
+        when(Graph.GRAPH_FEATURE.checkWithoutTracking(licenseState)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();
         featureSet.usage(future);


### PR DESCRIPTION
This commit moves the graph license checks to use the new
LicensedFeature class.