### PR TITLE
Fix SettingsTests.testEmptyFilterMap

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -421,7 +421,6 @@ public class SettingsTests extends ESTestCase {
         assertThat(key2.names(), containsInAnyOrder("foo", "bog", "baz", "else"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78691")
     public void testEmptyFilterMap() {
         Settings.Builder builder = Settings.builder();
         builder.put("a", "a1");
@@ -431,23 +430,7 @@ public class SettingsTests extends ESTestCase {
         builder.put("a.b.c.d", "ab3");
 
         Settings filteredSettings = builder.build().filter((k) -> false);
-        assertEquals(0, filteredSettings.size());
-
-        assertFalse(filteredSettings.keySet().contains("a.c"));
-        assertFalse(filteredSettings.keySet().contains("a"));
-        assertFalse(filteredSettings.keySet().contains("a.b"));
-        assertFalse(filteredSettings.keySet().contains("a.b.c"));
-        assertFalse(filteredSettings.keySet().contains("a.b.c.d"));
-        assertFalse(filteredSettings.keySet().remove("a.b"));
-        assertNull(filteredSettings.get("a.b"));
-        assertNull(filteredSettings.get("a.b.c"));
-        assertNull(filteredSettings.get("a.b.c.d"));
-
-        Iterator<String> iterator = filteredSettings.keySet().iterator();
-        for (int i = 0; i < 10; i++) {
-            assertFalse(iterator.hasNext());
-        }
-        expectThrows(NoSuchElementException.class, () -> iterator.next());
+        assertSame(Settings.EMPTY, filteredSettings);
     }
 
     public void testEmpty() {


### PR DESCRIPTION
The behavior of the keyset.remove method is dependent on the JVM
that is executing the tests. Depending on whether we use the
JDK11+ version of the singleton set from `Set.of()` or the
`Collections.emptySet()` with older JVMs we will either get
an exception or a false return for trying to remove from the keyset.

Instead of trying to align the behavior here across JVM versions (if we wanted to do that, we should fix `core.Set.copyOf()` 
to return sets with 100% equivalent behavior across JVM versions IMO) I think
it's easiest to simply assert that the filtered settings are the empty
singleton here which makes the other assertions irrelevant.

closes #78691
