### PR TITLE
TSDB: Feature flag is more builds

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -130,6 +130,7 @@ setup:
 ---
 put unsupported setting:
   - do:
+      catch: bad_request
       indices.put_settings:
         index: test-index
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -126,3 +126,11 @@ setup:
      test-index.settings.index.query_string.lenient: "true"
   - match:
      test-index.settings.index.translog.durability: "async"
+
+---
+put unsupported setting:
+  - do:
+      indices.put_settings:
+        index: test-index
+        body:
+          garbage: garbage

--- a/x-pack/plugin/data-streams/qa/rest/build.gradle
+++ b/x-pack/plugin/data-streams/qa/rest/build.gradle
@@ -21,6 +21,9 @@ testClusters.configureEach {
   // disable ILM history, since it disturbs tests using _all
   setting 'indices.lifecycle.history_index_enabled', 'false'
   setting 'xpack.security.enabled', 'false'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 if (BuildParams.inFipsJvm){
   // These fail in CI but only when run as part of checkPart2 and not individually.

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/160_unsupported_setting.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/160_unsupported_setting.yml
@@ -1,0 +1,32 @@
+bad setting fails:
+  - skip:
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/78677
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [tsdbds-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [gargage*]
+          data_stream: {}
+          template:
+            settings:
+              index:
+                number_of_replicas: 0
+                number_of_shards: 2
+                garbage: garbage
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+
+  - do:
+      bulk:
+        refresh: true
+        index: garbage
+        body:
+          - '{"create": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z"}'


### PR DESCRIPTION
This adds the tsdb feature flag for `index.mode` to the data streams
rest tests. Without this the rest tests fail when we run a non-snapshot
build. They more than fail - they trip an assertion.

Closes #78677
