### PR TITLE
Convert watcher license object to LicensedFeature

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -48,7 +48,7 @@ public class XPackLicenseState {
         SECURITY_TOKEN_SERVICE(OperationMode.STANDARD, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),
-        
+
         MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
         MONITORING_UPDATE_RETENTION(OperationMode.STANDARD, false),
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -48,9 +48,7 @@ public class XPackLicenseState {
         SECURITY_TOKEN_SERVICE(OperationMode.STANDARD, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),
-
-        WATCHER(OperationMode.STANDARD, true),
-        // TODO: should just check WATCHER directly?
+        
         MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
         MONITORING_UPDATE_RETENTION(OperationMode.STANDARD, false),
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherConstants.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.watcher;
+
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
+
+public class WatcherConstants {
+
+    public static final LicensedFeature.Momentary WATCHER_FEATURE =
+        LicensedFeature.momentary(null, "watcher", License.OperationMode.STANDARD);
+
+    // no construction
+    private WatcherConstants() {}
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.watcher.actions.throttler;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 
 import java.time.Clock;
@@ -39,7 +40,7 @@ public class ActionThrottler implements Throttler {
 
     @Override
     public Result throttle(String actionId, WatchExecutionContext ctx) {
-        if (licenseState.checkFeature(XPackLicenseState.Feature.WATCHER) == false) {
+        if (WatcherConstants.WATCHER_FEATURE.check(licenseState) == false) {
             return Result.throttle(LICENSE, "watcher license does not allow action execution");
         }
         if (periodThrottler != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
 import org.elasticsearch.license.MockLicenseState;
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
@@ -6,9 +6,11 @@
  */
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 
 import static org.hamcrest.Matchers.is;
@@ -25,8 +27,8 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         Throttler.Result expectedResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -40,8 +42,8 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result expectedResult = Throttler.Result.throttle(Throttler.Type.PERIOD, "_reason");
         when(periodThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -56,8 +58,8 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(periodResult);
         Throttler.Result ackResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason_ack");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -71,8 +73,8 @@ public class WatchThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mock(WatchExecutionContext.class);
         when(periodThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -84,8 +86,8 @@ public class WatchThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mock(WatchExecutionContext.class);
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -97,8 +99,8 @@ public class WatchThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mock(WatchExecutionContext.class);
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(false);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(false);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.elasticsearch.xpack.core.action.GetDataStreamAction;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.TriggeredWatchStoreField;
@@ -518,7 +519,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
     protected void ensureLicenseEnabled() throws Exception {
         assertBusy(() -> {
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                assertThat(licenseState.checkFeature(XPackLicenseState.Feature.WATCHER), is(true));
+                assertThat(WatcherConstants.WATCHER_FEATURE.check(licenseState), is(true));
             }
         });
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureTransportAction;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 
 public class WatcherInfoTransportAction extends XPackInfoFeatureTransportAction {
 
@@ -36,7 +37,7 @@ public class WatcherInfoTransportAction extends XPackInfoFeatureTransportAction 
 
     @Override
     public boolean available() {
-        return licenseState.isAllowed(XPackLicenseState.Feature.WATCHER);
+        return WatcherConstants.WATCHER_FEATURE.checkWithoutTracking(licenseState);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.WatcherFeatureSetUsage;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsAction;
@@ -70,14 +71,14 @@ public class WatcherUsageTransportAction extends XPackUsageFeatureTransportActio
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList());
                     Counters mergedCounters = Counters.merge(countersPerNode);
-                    WatcherFeatureSetUsage usage =
-                        new WatcherFeatureSetUsage(licenseState.isAllowed(Feature.WATCHER), true, mergedCounters.toNestedMap());
+                    WatcherFeatureSetUsage usage = new WatcherFeatureSetUsage(
+                        WatcherConstants.WATCHER_FEATURE.checkWithoutTracking(licenseState), true, mergedCounters.toNestedMap());
                     listener.onResponse(new XPackUsageFeatureResponse(usage));
                 }, listener::onFailure));
             }
         } else {
-            WatcherFeatureSetUsage usage =
-                new WatcherFeatureSetUsage(licenseState.isAllowed(Feature.WATCHER), false, Collections.emptyMap());
+            WatcherFeatureSetUsage usage = new WatcherFeatureSetUsage(
+                WatcherConstants.WATCHER_FEATURE.checkWithoutTracking(licenseState), false, Collections.emptyMap());
             listener.onResponse(new XPackUsageFeatureResponse(usage));
         }
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 
 abstract class WatcherTransportAction<Request extends ActionRequest, Response extends ActionResponse>
         extends HandledTransportAction<Request, Response> {
@@ -36,7 +37,7 @@ abstract class WatcherTransportAction<Request extends ActionRequest, Response ex
 
     @Override
     protected final void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        if (licenseState.checkFeature(XPackLicenseState.Feature.WATCHER)) {
+        if (WatcherConstants.WATCHER_FEATURE.check(licenseState)) {
             doExecute(request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.WATCHER));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -27,6 +28,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
+import org.elasticsearch.xpack.core.watcher.WatcherConstants;
 import org.elasticsearch.xpack.core.watcher.WatcherFeatureSetUsage;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
@@ -52,12 +54,12 @@ import static org.mockito.Mockito.when;
 
 public class WatcherInfoTransportActionTests extends ESTestCase {
 
-    private XPackLicenseState licenseState;
+    private MockLicenseState licenseState;
     private Client client;
 
     @Before
     public void init() throws Exception {
-        licenseState = mock(XPackLicenseState.class);
+        licenseState = mock(MockLicenseState.class);
         client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
@@ -69,7 +71,7 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
         WatcherInfoTransportAction featureSet = new WatcherInfoTransportAction(
             mock(TransportService.class), mock(ActionFilters.class), Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isAllowed(XPackLicenseState.Feature.WATCHER)).thenReturn(available);
+        when(licenseState.isAllowed(WatcherConstants.WATCHER_FEATURE)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.license.MockLicenseState;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;


### PR DESCRIPTION
This commit moves the watcher license checks to use the new
LicensedFeature class.