### PR TITLE
[7.15] [DOCS] Added missing backtick for code snippet (#78241)

### DIFF
--- a/docs/reference/indices/field-usage-stats.asciidoc
+++ b/docs/reference/indices/field-usage-stats.asciidoc
@@ -22,7 +22,7 @@ GET /my-index-000001/_field_usage_stats
 [[field-usage-stats-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_field_usage_stats
+`GET /<index>/_field_usage_stats`
 
 [[field-usage-stats-api-request-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Added missing backtick for code snippet (#78241)