### PR TITLE
Add prod warning to Composite Aggregation

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -4,6 +4,10 @@
 <titleabbrev>Composite</titleabbrev>
 ++++
 
+[WARNING]
+While this query _can_ be used in Production, it is more expensive than a normal
+terms aggregation and should be load tested for a use case before go-live.
+
 A multi-bucket aggregation that creates composite buckets from different sources.
 
 Unlike the other `multi-bucket` aggregations, you can use the `composite`

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>Composite</titleabbrev>
 ++++
 
-WARNING: Composite aggregations are expensive. Load test your application before
-deploying composite aggregations in production.
+WARNING: The composite aggregation is expensive. Load test your application
+before deploying a composite aggregation in production.
 
 A multi-bucket aggregation that creates composite buckets from different sources.
 

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -4,9 +4,8 @@
 <titleabbrev>Composite</titleabbrev>
 ++++
 
-[WARNING]
-While this query _can_ be used in Production, it is more expensive than a normal
-terms aggregation and should be load tested for a use case before go-live.
+WARNING: Composite aggregations are expensive. Load test your application that
+before deploying composite aggregations in production.
 
 A multi-bucket aggregation that creates composite buckets from different sources.
 

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>Composite</titleabbrev>
 ++++
 
-WARNING: Composite aggregations are expensive. Load test your application that
-before deploying composite aggregations in production.
+WARNING: Composite aggregations are expensive. Load test your application before
+deploying composite aggregations in production.
 
 A multi-bucket aggregation that creates composite buckets from different sources.
 


### PR DESCRIPTION
The composite aggregation is considered expensive. Users should perform load testing before deploying it in production.

~[7.14 update](http://github.com/elastic/elasticsearch/pull/74559) exacerbated performance concerns on composite aggregations & [fix in discussion](https://github.com/elastic/elasticsearch/pull/78313) is either reverting or will come in 7.16. In the mean time users need disclaimer that before change this search was expensive & esp. now or w/upgrade may impact cluster performance.~

### Preview
https://elasticsearch_78723.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-composite-aggregation.html