### PR TITLE
Load knn vectors format with mmapfs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
+++ b/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
@@ -69,8 +69,8 @@ public enum LuceneFilesExtensions {
     TVM("tvm", "Term Vector Metadata", true, false),
     TVX("tvx", "Term Vector Index", false, false),
     // kNN vectors format
-    VEC("vec", "Vector Data", false, false),
-    VEX("vex", "Vector Index", false, false),
+    VEC("vec", "Vector Data", false, true),
+    VEX("vex", "Vector Index", false, true),
     VEM("vem", "Vector Metadata", true, false);
 
     /**


### PR DESCRIPTION
Before the format used niofs. The current knn vectors implementation is based on
the HNSW algorithm, which is designed for the case where the graph and vectors
are be held in memory. Switching to mmapfs from niofs made a big difference in
ANN benchmarks, speeding up some searches over 3x.

Relates to #78473.