### PR TITLE
Filtering setting deprecation info API messages based on a setting

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -39,6 +39,19 @@ expressions are supported.
 When you specify this parameter, only deprecations for the specified
 data streams or indices are returned.
 
+[[migration-api-settings]]
+==== Settings
+
+You can use the following settings to control the behavior of the deprecation info API:
+
+[[skip_deprecated_settings]]
+// tag::skip_deprecated_settings-tag[]
+`deprecation.skip_deprecated_settings`
+(<<dynamic-cluster-setting,Dynamic>>)
+Defaults to an empty list. Set to a list of setting names to be ignored by the deprecation info API. Any
+deprecations related to settings in this list will not be returned by the API. Simple wildcard matching is supported.
+// end::skip_deprecated_settings-tag[]
+
 [[migration-api-example]]
 ==== {api-examples-title}
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.deprecation.DeprecationChecks.SKIP_DEPRECATIONS_SETTING;
 import static org.elasticsearch.xpack.deprecation.logging.DeprecationIndexingComponent.WRITE_DEPRECATION_LOGS_TO_INDEX;
 
 /**
@@ -94,6 +95,8 @@ public class Deprecation extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return org.elasticsearch.core.List.of(WRITE_DEPRECATION_LOGS_TO_INDEX);
+        return org.elasticsearch.core.List.of(
+            WRITE_DEPRECATION_LOGS_TO_INDEX,
+            SKIP_DEPRECATIONS_SETTING);
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -36,7 +36,8 @@ public class DeprecationChecks {
             "deprecation.skip_deprecated_settings",
             Collections.emptyList(),
             Function.identity(),
-            new Setting.Property[] {Setting.Property.NodeScope, Setting.Property.Dynamic}
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
         );
 
     private DeprecationChecks() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -29,6 +30,14 @@ import java.util.stream.Stream;
  * by the {@link DeprecationInfoAction}.
  */
 public class DeprecationChecks {
+
+    public static final Setting<List<String>> SKIP_DEPRECATIONS_SETTING =
+        Setting.listSetting(
+            "deprecation.skip_deprecated_settings",
+            Collections.emptyList(),
+            Function.identity(),
+            new Setting.Property[] {Setting.Property.NodeScope, Setting.Property.Dynamic}
+        );
 
     private DeprecationChecks() {
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -90,6 +90,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                 new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN),
                 state
             );
+            List<String> skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
             pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(
                 deprecationIssues -> {
                     listener.onResponse(
@@ -100,7 +101,8 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                             response,
                             INDEX_SETTINGS_CHECKS,
                             CLUSTER_SETTINGS_CHECKS,
-                            deprecationIssues
+                            deprecationIssues,
+                            skipTheseDeprecatedSettings
                         )
                     );
                 },

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -47,7 +47,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Settings settings;
     private final NamedXContentRegistry xContentRegistry;
-    private List<String> skipTheseDeprecatedSettings;
+    private volatile List<String> skipTheseDeprecatedSettings;
 
     @Inject
     public TransportDeprecationInfoAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -90,7 +90,12 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                 new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN),
                 state
             );
-            List<String> skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
+            final List<String> skipTheseDeprecatedSettings;
+            if (DeprecationChecks.SKIP_DEPRECATIONS_SETTING.exists(clusterService.state().metadata().settings())) {
+                skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(state.metadata().settings());
+            } else {
+                skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
+            }
             pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(
                 deprecationIssues -> {
                     listener.onResponse(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -47,7 +47,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Settings settings;
     private final NamedXContentRegistry xContentRegistry;
-    private volatile List<String> skipTheseDeprecatedSettings;
+    private volatile List<String> skipTheseDeprecations;
 
     @Inject
     public TransportDeprecationInfoAction(Settings settings, TransportService transportService, ClusterService clusterService,
@@ -60,14 +60,14 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.settings = settings;
         this.xContentRegistry = xContentRegistry;
-        skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
+        skipTheseDeprecations = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
         // Safe to register this here because it happens synchronously before the cluster service is started:
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DeprecationChecks.SKIP_DEPRECATIONS_SETTING,
-            this::updateHideDeprecationsSetting);
+            this::setSkipDeprecations);
     }
 
-    private <T> void updateHideDeprecationsSetting(List<String> hideDeprecationsSetting) {
-        this.skipTheseDeprecatedSettings = hideDeprecationsSetting;
+    private <T> void setSkipDeprecations(List<String> skipDeprecations) {
+        this.skipTheseDeprecations = Collections.unmodifiableList(skipDeprecations);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                             INDEX_SETTINGS_CHECKS,
                             CLUSTER_SETTINGS_CHECKS,
                             deprecationIssues,
-                            skipTheseDeprecatedSettings
+                            skipTheseDeprecations
                         )
                     );
                 },

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -35,7 +35,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     private final Settings settings;
     private final XPackLicenseState licenseState;
     private final PluginsService pluginsService;
-    private List<String> skipTheseDeprecatedSettings;
+    private volatile List<String> skipTheseDeprecatedSettings;
 
     @Inject
     public TransportNodeDeprecationCheckAction(Settings settings, ThreadPool threadPool, XPackLicenseState licenseState,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -75,7 +75,12 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     NodesDeprecationCheckAction.NodeResponse nodeOperation(NodesDeprecationCheckAction.NodeRequest request,
                                                            List<DeprecationChecks.NodeDeprecationCheck<Settings, PluginsAndModules,
                                                                ClusterState, XPackLicenseState, DeprecationIssue>> nodeSettingsChecks) {
-        List<String> skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
+        final List<String> skipTheseDeprecatedSettings;
+        if (DeprecationChecks.SKIP_DEPRECATIONS_SETTING.exists(clusterService.state().metadata().settings())) {
+            skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(clusterService.state().metadata().settings());
+        } else {
+            skipTheseDeprecatedSettings = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
+        }
         Settings filteredSettings = settings.filter(setting -> Regex.simpleMatch(skipTheseDeprecatedSettings, setting) == false);
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(nodeSettingsChecks,
             (c) -> c.apply(filteredSettings, pluginsService.info(), clusterService.state(), licenseState));

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue.Level;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -115,7 +117,8 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
             nodeDeprecationIssues,
             indexSettingsChecks,
             clusterSettingsChecks,
-            Collections.emptyMap());
+            Collections.emptyMap(),
+            Collections.emptyList());
 
         if (clusterIssueFound) {
             assertThat(response.getClusterSettingsIssues(), equalTo(Collections.singletonList(foundIssue)));
@@ -139,6 +142,71 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         } else {
             assertTrue(response.getIndexSettingsIssues().isEmpty());
         }
+    }
+
+    public void testFromWithHiddenSettings() throws IOException {
+
+        Settings.Builder settingsBuilder = settings(Version.CURRENT);
+        settingsBuilder.put("some.deprecated.property", "someValue1");
+        settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
+        settingsBuilder.put("some.undeprecated.property", "someValue3");
+        settingsBuilder.putList("some.undeprecated.list.property", org.elasticsearch.core.List.of("someValue4", "someValue5"));
+        Settings inputSettings = settingsBuilder.build();
+        Metadata metadata = Metadata.builder().put(IndexMetadata.builder("test")
+            .settings(inputSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0))
+            .persistentSettings(inputSettings)
+            .build();
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
+        IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
+        AtomicReference<Settings> visibleClusterSettings = new AtomicReference<>();
+        List<Function<ClusterState, DeprecationIssue>> clusterSettingsChecks =
+            Collections.unmodifiableList(Arrays.asList(
+                (s) -> {
+                    visibleClusterSettings.set(s.getMetadata().settings());
+                    return null;
+                }
+            ));
+        AtomicReference<Settings> visibleIndexSettings = new AtomicReference<>();
+        List<Function<IndexMetadata, DeprecationIssue>> indexSettingsChecks =
+            Collections.unmodifiableList(Arrays.asList(
+                (idx) -> {
+                    visibleIndexSettings.set(idx.getSettings());
+                    return null;
+                }
+            ));
+
+        NodesDeprecationCheckResponse nodeDeprecationIssues = new NodesDeprecationCheckResponse(
+            new ClusterName(randomAlphaOfLength(5)),
+            emptyList(),
+            emptyList());
+
+        DeprecationInfoAction.Request request = new DeprecationInfoAction.Request(Strings.EMPTY_ARRAY);
+        DeprecationInfoAction.Response.from(state,
+            resolver,
+            request,
+            nodeDeprecationIssues,
+            indexSettingsChecks,
+            clusterSettingsChecks,
+            Collections.emptyMap(),
+            org.elasticsearch.core.List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+
+        settingsBuilder = settings(Version.CURRENT);
+        settingsBuilder.put("some.undeprecated.property", "someValue3");
+        settingsBuilder.putList("some.undeprecated.list.property", org.elasticsearch.core.List.of("someValue4", "someValue5"));
+        Settings expectedSettings = settingsBuilder.build();
+        Settings resultClusterSettings = visibleClusterSettings.get();
+        Assert.assertNotNull(resultClusterSettings);
+        Assert.assertEquals(expectedSettings, visibleClusterSettings.get());
+        Settings resultIndexSettings = visibleIndexSettings.get();
+        Assert.assertNotNull(resultIndexSettings);
+        Assert.assertTrue(resultIndexSettings.get("some.undeprecated.property").equals("someValue3"));
+        Assert.assertTrue(resultIndexSettings.getAsList("some.undeprecated.list.property")
+            .equals(org.elasticsearch.core.List.of("someValue4", "someValue5")));
+        Assert.assertFalse(resultIndexSettings.hasValue("some.deprecated.property"));
+        Assert.assertFalse(resultIndexSettings.hasValue("some.other.bad.deprecated.property"));
     }
 
     public void testCtorFailure() {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
@@ -144,7 +144,7 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         }
     }
 
-    public void testFromWithHiddenSettings() throws IOException {
+    public void testRemoveSkippedSettings() throws IOException {
 
         Settings.Builder settingsBuilder = settings(Version.CURRENT);
         settingsBuilder.put("some.deprecated.property", "someValue1");

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.List;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.junit.Assert;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
+
+    public void testNodeOperation() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put("some.deprecated.property", "someValue1");
+        settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
+        settingsBuilder.put("some.undeprecated.property", "someValue3");
+        settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+        Settings inputSettings = settingsBuilder.build();
+        ThreadPool threadPool = null;
+        final XPackLicenseState licenseState = null;
+        ClusterService clusterService = Mockito.mock(ClusterService.class);
+        DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
+        TransportService transportService = Mockito.mock(TransportService.class);
+        Mockito.when(transportService.getLocalNode()).thenReturn(node);
+        PluginsService pluginsService = Mockito.mock(PluginsService.class);
+        ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
+        TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
+            inputSettings,
+            threadPool,
+            licenseState,
+            clusterService,
+            transportService,
+            pluginsService,
+            actionFilters
+        );
+        NodesDeprecationCheckAction.NodeRequest nodeRequest = null;
+        AtomicReference<Settings> visibleSettings = new AtomicReference<>();
+        DeprecationChecks.NodeDeprecationCheck<Settings, PluginsAndModules,
+            ClusterState, XPackLicenseState, DeprecationIssue> nodeSettingCheck = (settings, p, c, l) -> {
+            visibleSettings.set(settings);
+            return null;
+        };
+        java.util.List<DeprecationChecks.NodeDeprecationCheck<Settings, PluginsAndModules,
+            ClusterState, XPackLicenseState, DeprecationIssue>> nodeSettingsChecks = List.of(nodeSettingCheck);
+        transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
+        settingsBuilder = Settings.builder();
+        settingsBuilder.put("some.undeprecated.property", "someValue3");
+        settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+        Settings expectedSettings = settingsBuilder.build();
+        Assert.assertNotNull(visibleSettings.get());
+        Assert.assertEquals(expectedSettings, visibleSettings.get());
+    }
+}

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -83,14 +83,16 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
 
         // Testing that the setting is dynamically updatable:
         Settings newSettings = Settings.builder().putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.undeprecated.list.property")).build();
+            List.of("some.undeprecated.property")).build();
         clusterSettings.applySettings(newSettings);
         transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.deprecated.property", "someValue1");
         settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
-        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
+        // This is the node setting (since this is the node deprecation check), not the cluster setting:
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
         expectedSettings = settingsBuilder.build();
         Assert.assertNotNull(visibleSettings.get());
         Assert.assertEquals(expectedSettings, visibleSettings.get());

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -13,8 +13,10 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.List;
+import org.elasticsearch.core.Set;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.ESTestCase;
@@ -34,21 +36,18 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
         settingsBuilder.put("some.undeprecated.property", "someValue3");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
-        // making sure that the property is picked up from cluster state rather than from node settings:
-        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
-        Settings inputSettings = settingsBuilder.build();
-        Settings.Builder clusterSettingsBuilder = Settings.builder();
-        clusterSettingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
             List.of("some.deprecated.property", "some.other.*.deprecated.property"));
-        Settings clusterInputSettings = clusterSettingsBuilder.build();
+        Settings inputSettings = settingsBuilder.build();
         ThreadPool threadPool = null;
         final XPackLicenseState licenseState = null;
         Metadata metadata = Mockito.mock(Metadata.class);
-        Mockito.when(metadata.settings()).thenReturn(clusterInputSettings);
         ClusterState clusterState = Mockito.mock(ClusterState.class);
         Mockito.when(clusterState.metadata()).thenReturn(metadata);
         ClusterService clusterService = Mockito.mock(ClusterService.class);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
+        ClusterSettings clusterSettings = new ClusterSettings(inputSettings, Set.of(DeprecationChecks.SKIP_DEPRECATIONS_SETTING));
+        Mockito.when((clusterService.getClusterSettings())).thenReturn(clusterSettings);
         DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
         TransportService transportService = Mockito.mock(TransportService.class);
         Mockito.when(transportService.getLocalNode()).thenReturn(node);
@@ -76,13 +75,16 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.undeprecated.property", "someValue3");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
-        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
         Settings expectedSettings = settingsBuilder.build();
         Assert.assertNotNull(visibleSettings.get());
         Assert.assertEquals(expectedSettings, visibleSettings.get());
 
-        // Now test that the skip setting is picked up from node settings if not in cluster state:
-        Mockito.when(metadata.settings()).thenReturn(Settings.EMPTY);
+        // Testing that the setting is dynamically updatable:
+        Settings newSettings = Settings.builder().putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.undeprecated.list.property")).build();
+        clusterSettings.applySettings(newSettings);
         transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.deprecated.property", "someValue1");

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.deprecation;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -33,12 +34,21 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
         settingsBuilder.put("some.undeprecated.property", "someValue3");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
-        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+        // making sure that the property is picked up from cluster state rather than from node settings:
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
         Settings inputSettings = settingsBuilder.build();
+        Settings.Builder clusterSettingsBuilder = Settings.builder();
+        clusterSettingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
+            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+        Settings clusterInputSettings = clusterSettingsBuilder.build();
         ThreadPool threadPool = null;
         final XPackLicenseState licenseState = null;
+        Metadata metadata = Mockito.mock(Metadata.class);
+        Mockito.when(metadata.settings()).thenReturn(clusterInputSettings);
+        ClusterState clusterState = Mockito.mock(ClusterState.class);
+        Mockito.when(clusterState.metadata()).thenReturn(metadata);
         ClusterService clusterService = Mockito.mock(ClusterService.class);
+        Mockito.when(clusterService.state()).thenReturn(clusterState);
         DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
         TransportService transportService = Mockito.mock(TransportService.class);
         Mockito.when(transportService.getLocalNode()).thenReturn(node);
@@ -66,9 +76,20 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.undeprecated.property", "someValue3");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
-        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.deprecated.property", "some.other.*.deprecated.property"));
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
         Settings expectedSettings = settingsBuilder.build();
+        Assert.assertNotNull(visibleSettings.get());
+        Assert.assertEquals(expectedSettings, visibleSettings.get());
+
+        // Now test that the skip setting is picked up from node settings if not in cluster state:
+        Mockito.when(metadata.settings()).thenReturn(Settings.EMPTY);
+        transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
+        settingsBuilder = Settings.builder();
+        settingsBuilder.put("some.deprecated.property", "someValue1");
+        settingsBuilder.put("some.other.bad.deprecated.property", "someValue2");
+        settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
+        settingsBuilder.putList(DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(), List.of("some.undeprecated.property"));
+        expectedSettings = settingsBuilder.build();
         Assert.assertNotNull(visibleSettings.get());
         Assert.assertEquals(expectedSettings, visibleSettings.get());
     }


### PR DESCRIPTION
This commit adds the ability to configure a list of settings that will be ignored by the deprecation info
API. Any deprecation messages for any of the settings given will be suppressed.