### PR TITLE
Add aggregations/CCS memory leak as a 7.14.x known issue

### DIFF
--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -14,8 +14,7 @@ when using scroll, async and point in time searches). This affects Kibana CCS ag
 uses async search by default. This issue can also happen in all modes of remote connections 
 configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
-we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure 
-or cancel the aggregation tasks on the nodes.
+we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure.
 +
 We have fixed this issue in {es} 7.15.1 and later versions. For more details,
 see {es-pull}78404[#78404].

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -7,12 +7,12 @@ Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 [discrete]
 === Known issues
 
-* Aggregations (7.14.0-7.15.0): When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
-proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
-roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
-when using scroll, async and point in time searches). This affects Kibana CCS aggregations because Kibana 
+* Aggregations: In {es} 7.14.0–7.15.0, when a {css} ({css-init}) request is proxied, the memory for the aggregations on the
+proxy node will not be freed. The trigger is {css} using aggregations where minimize 
+roundtrips is not effective (for example, when minimize roundtrips is explicitly disabled, or implicitly disabled 
+when using scroll, async and point-in-time searches). This affects {kib} {css-init} aggregations because {kib} 
 uses async search by default. This issue can also happen in all modes of remote connections 
-configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
+configured for {ccs} (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
 we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure.
 +

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -3,6 +3,22 @@
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
+[[known-issues-7.14.2]]
+[discrete]
+=== Known issues
+
+* Aggregations: When a cross cluster search request is proxied, the memory for the aggregations on the
+proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
+roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
+when using scroll, async and point in time searches). This issue can happen in all modes of remote connections 
+configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
+remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
+we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure 
+or cancel the aggregation tasks on the nodes.
++
+We have fixed this issue in {es} 7.15.1 and later versions. For more details,
+see {es-pull}78404[#78404].
+
 [[enhancement-7.14.2]]
 [float]
 === Enhancements

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -7,6 +7,7 @@ Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 [discrete]
 === Known issues
 
+// tag::ccs-agg-mem-known-issue[]
 * Aggregations: In {es} 7.14.0–7.15.0, when a {ccs} ({ccs-init}) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is {ccs} using aggregations where minimize 
 roundtrips is not effective (for example, when minimize roundtrips is explicitly disabled, or implicitly disabled 
@@ -20,6 +21,7 @@ we must send the request as a proxy request. The workaround is to periodically r
 +
 We have fixed this issue in {es} 7.15.1 and later versions. For more details,
 see {es-pull}78404[#78404].
+// end::ccs-agg-mem-known-issue[]
 
 [[enhancement-7.14.2]]
 [float]
@@ -51,6 +53,12 @@ Snapshot/Restore::
 == {es} version 7.14.1
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
+[[known-issues-7.14.1]]
+[discrete]
+=== Known issues
+
+include::7.14.asciidoc[tag=ccs-agg-mem-known-issue]
 
 [[enhancement-7.14.1]]
 [float]
@@ -146,6 +154,12 @@ Packaging::
 == {es} version 7.14.0
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
+[[known-issues-7.14.0]]
+[discrete]
+=== Known issues
+
+include::7.14.asciidoc[tag=ccs-agg-mem-known-issue]
 
 [[breaking-7.14.0]]
 [float]

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -7,10 +7,12 @@ Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 [discrete]
 === Known issues
 
-* Aggregations: In {es} 7.14.0–7.15.0, when a {css} ({css-init}) request is proxied, the memory for the aggregations on the
-proxy node will not be freed. The trigger is {css} using aggregations where minimize 
+* Aggregations: In {es} 7.14.0–7.15.0, when a {ccs} ({ccs-init}) request is proxied, the memory for the aggregations on the
+proxy node will not be freed. The trigger is {ccs} using aggregations where minimize 
 roundtrips is not effective (for example, when minimize roundtrips is explicitly disabled, or implicitly disabled 
-when using scroll, async and point-in-time searches). This affects {kib} {css-init} aggregations because {kib} 
+when using scroll, async and point-in-time searches).
++
+This affects {kib} {ccs-init} aggregations because {kib} 
 uses async search by default. This issue can also happen in all modes of remote connections 
 configured for {ccs} (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -7,10 +7,11 @@ Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 [discrete]
 === Known issues
 
-* Aggregations: When a cross cluster search request is proxied, the memory for the aggregations on the
+* Aggregations: When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
 roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
-when using scroll, async and point in time searches). This issue can happen in all modes of remote connections 
+when using scroll, async and point in time searches). This means Kibana CCS+aggregation requests are affected because it 
+uses async search by default. This issue can also happen in all modes of remote connections 
 configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
 we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure 

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -3,11 +3,9 @@
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
-[[known-issues-7.14.0 to 7.14.2]]
-[discrete]
 === Known issues
 
-* Aggregations: When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
+* Aggregations (7.14.0-7.15.0): When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
 roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
 when using scroll, async and point in time searches). This affects Kibana CCS aggregations because Kibana 

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -3,6 +3,8 @@
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
+[[known-issues-7.14.2]]
+[discrete]
 === Known issues
 
 * Aggregations (7.14.0-7.15.0): When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -10,7 +10,7 @@ Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 * Aggregations: When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
 roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
-when using scroll, async and point in time searches). This means Kibana CCS+aggregation requests are affected because it 
+when using scroll, async and point in time searches). This affects Kibana CCS aggregations because Kibana 
 uses async search by default. This issue can also happen in all modes of remote connections 
 configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -3,7 +3,7 @@
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
-[[known-issues-7.14.2]]
+[[known-issues-7.14.0 to 7.14.2]]
 [discrete]
 === Known issues
 


### PR DESCRIPTION
Adding this as a known issue (https://github.com/elastic/elasticsearch/pull/78404) to the release notes for 7.14.x (fix will be in 7.15.1). Thx!
