### PR TITLE
Add aggregations/CCS memory leak as a 7.15.0 known issue

### DIFF
--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -7,7 +7,7 @@ Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
 [discrete]
 === Known issues
 
-* Aggregations: When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
+* Aggregations (7.14.0-7.15.0): When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
 roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
 when using scroll, async and point in time searches). This affects Kibana CCS aggregations because Kibana 

--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -7,14 +7,14 @@ Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
 [discrete]
 === Known issues
 
-* Aggregations: When a cross cluster search request is proxied, the memory for the aggregations on the
+* Aggregations: When a cross cluster search (CCS) request is proxied, the memory for the aggregations on the
 proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
 roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
-when using scroll, async and point in time searches). This issue can happen in all modes of remote connections 
+when using scroll, async and point in time searches). This affects Kibana CCS aggregations because Kibana 
+uses async search by default. This issue can also happen in all modes of remote connections 
 configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
 remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
-we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure 
-or cancel the aggregation tasks on the nodes.
+we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure.
 +
 We have fixed this issue in {es} 7.15.1 and later versions. For more details,
 see {es-pull}78404[#78404].

--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -3,6 +3,22 @@
 
 Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
 
+[[known-issues-7.15.0]]
+[discrete]
+=== Known issues
+
+* Aggregations: When a cross cluster search request is proxied, the memory for the aggregations on the
+proxy node will not be freed. The trigger is cross cluster search using aggregations where minimize 
+roundtrips is not effective (e.g. when minimize roundtrips is explicitly disabled, or implicitly disabled 
+when using scroll, async and point in time searches). This issue can happen in all modes of remote connections 
+configured for cross cluster search (sniff and proxy). In sniff mode, we only connect to a subset of the 
+remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
+we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure 
+or cancel the aggregation tasks on the nodes.
++
+We have fixed this issue in {es} 7.15.1 and later versions. For more details,
+see {es-pull}78404[#78404].
+
 [[breaking-7.15.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
Adding this as a known issue (https://github.com/elastic/elasticsearch/pull/78404) to the release notes for 7.15.0 (fix will be in 7.15.1). Thx!
