### PR TITLE
[DOCS] Document `ABORTED` snapshot status

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -284,32 +284,29 @@ Number of shards that failed to be included in the snapshot.
 ====
 
 `state`::
+(string) Current status of the snapshot.
 +
---
-(string)
-The snapshot `state` can be one of the following values:
-
 .Values for `state`
 [%collapsible%open]
 ====
-`IN_PROGRESS`::
-  The snapshot is currently running.
-
-`SUCCESS`::
-  The snapshot finished and all shards were stored successfully.
+`ABORTED`::
+The snapshot was cancelled by a <<delete-snapshot-api,delete snapshot request>>.
 
 `FAILED`::
-  The snapshot finished with an error and failed to store any data.
+The snapshot finished with an error and failed to store any data.
+
+`IN_PROGRESS`::
+The snapshot is currently running.
 
 `PARTIAL`::
-  The global cluster state was stored, but data of at least one shard was not stored successfully.
-  The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
-  that were not processed correctly.
+The global cluster state was stored, but data of at least one shard was not stored successfully.
+The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
+that were not processed correctly.
 
-`ABORTED`::
-  The snapshot process was manually stopped via deletion. If believed stuck, do rolling cluster restart.
+`SUCCESS`::
+The snapshot finished and all shards were stored successfully.
 ====
---
+
 `next`::
 (string)
 If the request contained a size limit and there might be more results, a `next` field will be added to the response and can be used as the

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -284,29 +284,32 @@ Number of shards that failed to be included in the snapshot.
 ====
 
 `state`::
-(string) Current status of the snapshot.
 +
+--
+(string)
+The snapshot `state` can be one of the following values:
+
 .Values for `state`
 [%collapsible%open]
 ====
-`ABORTED`::
-The snapshot was cancelled by a <<delete-snapshot-api,delete snapshot request>>.
-
-`FAILED`::
-The snapshot finished with an error and failed to store any data.
-
 `IN_PROGRESS`::
-The snapshot is currently running.
-
-`PARTIAL`::
-The global cluster state was stored, but data of at least one shard was not stored successfully.
-The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
-that were not processed correctly.
+  The snapshot is currently running.
 
 `SUCCESS`::
-The snapshot finished and all shards were stored successfully.
-====
+  The snapshot finished and all shards were stored successfully.
 
+`FAILED`::
+  The snapshot finished with an error and failed to store any data.
+
+`PARTIAL`::
+  The global cluster state was stored, but data of at least one shard was not stored successfully.
+  The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
+  that were not processed correctly.
+
+`ABORTED`::
+  The snapshot process was manually stopped via deletion. If believed stuck, do rolling cluster restart.
+====
+--
 `next`::
 (string)
 If the request contained a size limit and there might be more results, a `next` field will be added to the response and can be used as the

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -305,6 +305,9 @@ The snapshot `state` can be one of the following values:
   The global cluster state was stored, but data of at least one shard was not stored successfully.
   The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
   that were not processed correctly.
+
+`ABORTED`::
+  The snapshot process was manually stopped via deletion. If believed stuck, do rolling cluster restart.
 ====
 --
 `next`::


### PR DESCRIPTION
This appears to occur on earlier versions but as recent as 2018 (2). Noting per code examples status, though undocumented, still exists as potential status (1). Only known resolution is cluster rolling restart.

(1) code examples
- https://github.com/elastic/elasticsearch/search?q=snapshot+status+aborted
- https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java#L152-L162

(2) issue examples
- https://github.com/elastic/elasticsearch/issues/5958
- https://discuss.elastic.co/t/aborted-snapshot-blocks-doing-snapshot/17523
- https://discuss.elastic.co/t/snapshot-operation-stuck-in-progress-delete-command-doesnt-work/36951
- https://discuss.elastic.co/t/removing-aborted-snapshot/132879
https://discuss.elastic.co/t/snapshot-in-progress-for-long-time-how-do-i-delete-it/17199