### PR TITLE
[DOCS] Update ESS support for `stack.templates.enabled` docs

### DIFF
--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -34,7 +34,7 @@ Specifies the hosts that can be <<reindex-from-remote,reindexed from remotely>>.
 // end::reindex-remote-whitelist[]
 
 [[stack-templates-enabled]]
-`stack.templates.enabled` {ess-icon}::
+`stack.templates.enabled`::
 +
 --
 (<<dynamic-cluster-setting,Dynamic>>)


### PR DESCRIPTION
The documentation indicates that `stack.templates.enabled` can be used in Elasticsearch Service, but it is not part of the settings allowlist in ESS. This PR makes the documentation match the state of the allowlist.
