### PR TITLE
Fix ShowKeyStoreCommand test on FIPS (#78243)

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/common/settings/ShowKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/common/settings/ShowKeyStoreCommandTests.java
@@ -38,7 +38,9 @@ public class ShowKeyStoreCommandTests extends KeyStoreCommandTestCase {
     }
 
     public void testErrorOnMissingParameter() throws Exception {
-        createKeystore("");
+        final String password = getPossibleKeystorePassword();
+        createKeystore(password);
+        terminal.addSecretInput(password);
         final UserException e = expectThrows(UserException.class, this::execute);
         assertEquals(ExitCodes.USAGE, e.exitCode);
         assertThat(e.getMessage(), containsString("Must provide a single setting name to show"));


### PR DESCRIPTION
When running under FIPS a keystore must have a password

Backport: #78243 
Resolves: #78734

@tvernum for awareness