### PR TITLE
Adapt version after backport #77776

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumRequest.java
@@ -76,7 +76,7 @@ public class NodeTermsEnumRequest extends TransportRequest implements IndicesReq
         for (int i = 0; i < numShards; i++) {
             shardIds.add(new ShardId(in));
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_15_1)) {
             originalIndices = OriginalIndices.readOriginalIndices(in);
         } else {
             String[] indicesNames = shardIds.stream()
@@ -107,7 +107,7 @@ public class NodeTermsEnumRequest extends TransportRequest implements IndicesReq
         for (ShardId shardId : shardIds) {
             shardId.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_15_1)) {
             OriginalIndices.writeOriginalIndices(originalIndices, out);
         }
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 7.9.99"
-      reason:  TODO temporary version skip while we wait for backport to 7.x of search_after properties
+      version: " - 7.15.0"
+      reason:  original indices are propagated correctly in 7.15.1
       features: headers
   - do:
       cluster.health:


### PR DESCRIPTION
This change adapts the wire version now that #77776 is propagated to 7.15.1.