### PR TITLE
Mute HttpExporterResourceTests.testTemplateCheckBlocksAfterSuccessfulVersion

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -119,6 +119,7 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
         verifyNoMoreInteractions(client);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78736")
     public void testTemplateCheckBlocksAfterSuccessfulVersion() {
         final Exception exception = failureGetException();
         final boolean firstSucceeds = randomBoolean();


### PR DESCRIPTION
Mute `HttpExporterResourceTests.testTemplateCheckBlocksAfterSuccessfulVersion` and waiting a fix in https://github.com/elastic/elasticsearch/issues/78736