### PR TITLE
Speed up toXContent Collection Serialization in some Spots (#78742)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/GeoIpStatsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/GeoIpStatsResponse.java
@@ -156,7 +156,7 @@ public class GeoIpStatsResponse implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field("files_in_temp", filesInTemp);
+            builder.stringListField("files_in_temp", filesInTemp);
             builder.field("databases", databases.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .map(Map.Entry::getValue)

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/PutAutoFollowPatternRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/PutAutoFollowPatternRequest.java
@@ -74,9 +74,9 @@ public final class PutAutoFollowPatternRequest extends FollowConfig implements V
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(PutFollowRequest.REMOTE_CLUSTER_FIELD.getPreferredName(), remoteCluster);
-        builder.field(LEADER_PATTERNS_FIELD.getPreferredName(), leaderIndexPatterns);
+        builder.stringListField(LEADER_PATTERNS_FIELD.getPreferredName(), leaderIndexPatterns);
         if (leaderIndexExclusionPatterns.isEmpty() == false) {
-            builder.field(LEADER_EXCLUSION_PATTERNS_FIELD.getPreferredName(), leaderIndexExclusionPatterns);
+            builder.stringListField(LEADER_EXCLUSION_PATTERNS_FIELD.getPreferredName(), leaderIndexExclusionPatterns);
         }
         if (followIndexNamePattern != null) {
             builder.field(FOLLOW_PATTERN_FIELD.getPreferredName(), followIndexNamePattern);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
@@ -96,12 +96,12 @@ public final class PutPolicyRequest implements Validatable, ToXContentObject {
         {
             builder.startObject(type);
             {
-                builder.field(NamedPolicy.INDICES_FIELD.getPreferredName(), indices);
+                builder.stringListField(NamedPolicy.INDICES_FIELD.getPreferredName(), indices);
                 if (query != null) {
                     builder.field(NamedPolicy.QUERY_FIELD.getPreferredName(), asMap(query, XContentType.JSON));
                 }
                 builder.field(NamedPolicy.MATCH_FIELD_FIELD.getPreferredName(), matchField);
-                builder.field(NamedPolicy.ENRICH_FIELDS_FIELD.getPreferredName(), enrichFields);
+                builder.stringListField(NamedPolicy.ENRICH_FIELDS_FIELD.getPreferredName(), enrichFields);
             }
             builder.endObject();
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutIndexTemplateRequest.java
@@ -419,7 +419,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         if (template != null) {
             builder.field("template", template);
         } else {
-            builder.field("index_patterns", indexPatterns);
+            builder.stringListField("index_patterns", indexPatterns);
         }
 
         builder.field("order", order);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EvaluateDataFrameRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EvaluateDataFrameRequest.java
@@ -118,7 +118,7 @@ public class EvaluateDataFrameRequest implements ToXContentObject, Validatable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.array(INDEX.getPreferredName(), indices.toArray());
+        builder.stringListField(INDEX.getPreferredName(), indices);
         if (queryConfig != null) {
             builder.field(QUERY.getPreferredName(), queryConfig.getQuery());
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
@@ -139,7 +139,7 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
         builder.startObject();
 
         if (datafeedIds.isEmpty() == false) {
-            builder.field(DATAFEED_IDS.getPreferredName(), datafeedIds);
+            builder.stringListField(DATAFEED_IDS.getPreferredName(), datafeedIds);
         }
 
         if (allowNoMatch != null) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
@@ -139,7 +139,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
         builder.startObject();
 
         if (jobIds.isEmpty() == false) {
-            builder.field(JOB_IDS.getPreferredName(), jobIds);
+            builder.stringListField(JOB_IDS.getPreferredName(), jobIds);
         }
 
         if (allowNoMatch != null) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/UpdateFilterRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/UpdateFilterRequest.java
@@ -103,10 +103,10 @@ public class UpdateFilterRequest extends ActionRequest implements ToXContentObje
             builder.field(MlFilter.DESCRIPTION.getPreferredName(), description);
         }
         if (addItems != null) {
-            builder.field(ADD_ITEMS.getPreferredName(), addItems);
+            builder.stringListField(ADD_ITEMS.getPreferredName(), addItems);
         }
         if (removeItems != null) {
-            builder.field(REMOVE_ITEMS.getPreferredName(), removeItems);
+            builder.stringListField(REMOVE_ITEMS.getPreferredName(), removeItems);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/calendars/Calendar.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/calendars/Calendar.java
@@ -75,7 +75,7 @@ public class Calendar implements ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(ID.getPreferredName(), id);
-        builder.field(JOB_IDS.getPreferredName(), jobIds);
+        builder.stringListField(JOB_IDS.getPreferredName(), jobIds);
         if (description != null) {
             builder.field(DESCRIPTION.getPreferredName(), description);
         }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -24,8 +24,10 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -869,12 +871,90 @@ public final class XContentBuilder implements Closeable, Flushable {
     // Maps & Iterable
     //////////////////////////////////
 
+    public XContentBuilder stringListField(String name, Collection<String> values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startArray();
+        for (String value : values) {
+            value(value);
+        }
+        endArray();
+        return this;
+    }
+
+    public XContentBuilder xContentList(String name, Collection<? extends ToXContent> values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startArray();
+        for (ToXContent value : values) {
+            value(value);
+        }
+        endArray();
+        return this;
+    }
+
+    public XContentBuilder xContentList(String name, ToXContent... values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startArray();
+        for (ToXContent value : values) {
+            value(value);
+        }
+        endArray();
+        return this;
+    }
+
+    public XContentBuilder enumSet(String name, EnumSet<?> values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startArray();
+        for (Enum<?> value : values) {
+            value(value);
+        }
+        endArray();
+        return this;
+    }
+
     public XContentBuilder field(String name, Map<String, Object> values) throws IOException {
         return field(name).map(values);
     }
 
     public XContentBuilder map(Map<String, ?> values) throws IOException {
         return map(values, true, true);
+    }
+
+    public XContentBuilder stringStringMap(String name, Map<String, String> values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startObject();
+        for (Map.Entry<String, String> value : values.entrySet()) {
+            field(value.getKey());
+            value(value.getValue());
+        }
+        return endObject();
+    }
+
+    public XContentBuilder xContentValuesMap(String name, Map<String, ? extends ToXContent> values) throws IOException {
+        field(name);
+        if (values == null) {
+            return nullValue();
+        }
+        startObject();
+        for (Map.Entry<String, ? extends ToXContent> value : values.entrySet()) {
+            field(value.getKey());
+            value(value.getValue());
+        }
+        return endObject();
     }
 
     /** writes a map without the start object and end object headers */
@@ -972,6 +1052,11 @@ public final class XContentBuilder implements Closeable, Flushable {
         }
         field(rawFieldName, percentage);
         return this;
+    }
+
+    public XContentBuilder field(String name, Enum<?> value) throws IOException {
+        field(name);
+        return value(value == null ? null : value.toString());
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -405,9 +405,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(INDICES_FIELD.getPreferredName(), indices);
-            builder.field(ALIASES_FIELD.getPreferredName(), aliases);
-            builder.field(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
+            builder.xContentList(INDICES_FIELD.getPreferredName(), indices);
+            builder.xContentList(ALIASES_FIELD.getPreferredName(), aliases);
+            builder.xContentList(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
             builder.endObject();
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -87,7 +87,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
             for (Map.Entry<String, List<String>> entry : overlappingTemplates.entrySet()) {
                 builder.startObject();
                 builder.field(NAME.getPreferredName(), entry.getKey());
-                builder.field(INDEX_PATTERNS.getPreferredName(), entry.getValue());
+                builder.stringListField(INDEX_PATTERNS.getPreferredName(), entry.getValue());
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -134,13 +134,13 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         builder.field(SEARCHABLE_FIELD.getPreferredName(), isSearchable);
         builder.field(AGGREGATABLE_FIELD.getPreferredName(), isAggregatable);
         if (indices != null) {
-            builder.field(INDICES_FIELD.getPreferredName(), indices);
+            builder.array(INDICES_FIELD.getPreferredName(), indices);
         }
         if (nonSearchableIndices != null) {
-            builder.field(NON_SEARCHABLE_INDICES_FIELD.getPreferredName(), nonSearchableIndices);
+            builder.array(NON_SEARCHABLE_INDICES_FIELD.getPreferredName(), nonSearchableIndices);
         }
         if (nonAggregatableIndices != null) {
-            builder.field(NON_AGGREGATABLE_INDICES_FIELD.getPreferredName(), nonAggregatableIndices);
+            builder.array(NON_AGGREGATABLE_INDICES_FIELD.getPreferredName(), nonAggregatableIndices);
         }
         if (meta.isEmpty() == false) {
             builder.startObject("meta");
@@ -149,7 +149,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             for (Map.Entry<String, Set<String>> entry : entries) {
                 List<String> values = new ArrayList<>(entry.getValue());
                 values.sort(String::compareTo); // provide predictable order
-                builder.field(entry.getKey(), values);
+                builder.stringListField(entry.getKey(), values);
             }
             builder.endObject();
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFailure.java
@@ -46,7 +46,7 @@ public class FieldCapabilitiesFailure implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            builder.field(INDICES_FIELD.getPreferredName(), indices);
+            builder.stringListField(INDICES_FIELD.getPreferredName(), indices);
             builder.startObject(FAILURE_FIELD.getPreferredName());
             {
                 ElasticsearchException.generateFailureXContent(builder, params, exception, true);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -164,11 +164,11 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
             throw new IllegalStateException("cannot serialize non-merged response");
         }
         builder.startObject();
-        builder.field(INDICES_FIELD.getPreferredName(), indices);
+        builder.array(INDICES_FIELD.getPreferredName(), indices);
         builder.field(FIELDS_FIELD.getPreferredName(), responseMap);
         if (this.failures.size() > 0) {
             builder.field(FAILED_INDICES_FIELD.getPreferredName(), getFailedIndices().length);
-            builder.field(FAILURES_FIELD.getPreferredName(), failures);
+            builder.xContentList(FAILURES_FIELD.getPreferredName(), failures);
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -211,7 +211,7 @@ public class MultiGetRequest extends ActionRequest
             builder.field(TYPE.getPreferredName(), type);
             builder.field(ID.getPreferredName(), id);
             builder.field(ROUTING.getPreferredName(), routing);
-            builder.field(STORED_FIELDS.getPreferredName(), storedFields);
+            builder.array(STORED_FIELDS.getPreferredName(), storedFields);
             builder.field(VERSION.getPreferredName(), version);
             builder.field(VERSION_TYPE.getPreferredName(), VersionType.toString(versionType));
             builder.field(SOURCE.getPreferredName(), fetchSourceContext);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -115,7 +115,7 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
             .field(TERM_PARSE_FIELD.getPreferredName(), term)
             .field(LAST_COMMITTED_CONFIGURATION_FIELD.getPreferredName(), lastCommittedConfiguration)
             .field(LAST_ACCEPTED_CONFIGURATION_FIELD.getPreferredName(), lastAcceptedConfiguration)
-            .field(VOTING_CONFIG_EXCLUSIONS_FIELD.getPreferredName(), votingConfigExclusions);
+            .xContentList(VOTING_CONFIG_EXCLUSIONS_FIELD.getPreferredName(), votingConfigExclusions);
     }
 
     public static CoordinationMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -216,12 +216,12 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(INDEX_PATTERNS.getPreferredName(), this.indexPatterns);
+        builder.stringListField(INDEX_PATTERNS.getPreferredName(), this.indexPatterns);
         if (this.template != null) {
             builder.field(TEMPLATE.getPreferredName(), this.template);
         }
         if (this.componentTemplates != null) {
-            builder.field(COMPOSED_OF.getPreferredName(), this.componentTemplates);
+            builder.stringListField(COMPOSED_OF.getPreferredName(), this.componentTemplates);
         }
         if (this.priority != null) {
             builder.field(PRIORITY.getPreferredName(), priority);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -429,7 +429,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         builder.startObject();
         builder.field(NAME_FIELD.getPreferredName(), name);
         builder.field(TIMESTAMP_FIELD_FIELD.getPreferredName(), timeStampField);
-        builder.field(INDICES_FIELD.getPreferredName(), indices);
+        builder.xContentList(INDICES_FIELD.getPreferredName(), indices);
         builder.field(GENERATION_FIELD.getPreferredName(), generation);
         if (metadata != null) {
             builder.field(METADATA_FIELD.getPreferredName(), metadata);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -279,7 +279,7 @@ public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implement
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name);
-        builder.field(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
+        builder.stringListField(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
         if (writeDataStream != null) {
             builder.field(WRITE_DATA_STREAM_FIELD.getPreferredName(), writeDataStream);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -127,11 +127,7 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(DATA_STREAM.getPreferredName());
-        for (Map.Entry<String, DataStream> dataStream : dataStreams.entrySet()) {
-            builder.field(dataStream.getKey(), dataStream.getValue());
-        }
-        builder.endObject();
+        builder.xContentValuesMap(DATA_STREAM.getPreferredName(), dataStreams);
         builder.startObject(DATA_STREAM_ALIASES.getPreferredName());
         for (Map.Entry<String, DataStreamAlias> dataStream : dataStreamAliases.entrySet()) {
             dataStream.getValue().toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1476,8 +1476,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             for (ObjectObjectCursor<String, DiffableStringMap> cursor : indexMetadata.customData) {
-                builder.field(cursor.key);
-                builder.map(cursor.value);
+                builder.stringStringMap(cursor.key, cursor.value);
             }
 
             if (context != Metadata.XContentContext.API) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -390,7 +390,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
             if (indexTemplateMetadata.version() != null) {
                 builder.field("version", indexTemplateMetadata.version());
             }
-            builder.field("index_patterns", indexTemplateMetadata.patterns());
+            builder.stringListField("index_patterns", indexTemplateMetadata.patterns());
 
             builder.startObject("settings");
             indexTemplateMetadata.settings().toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
@@ -77,13 +77,13 @@ public class ItemUsage implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (this.indices != null) {
-            builder.field("indices", this.indices);
+            builder.stringListField("indices", this.indices);
         }
         if (this.dataStreams != null) {
-            builder.field("data_streams", this.dataStreams);
+            builder.stringListField("data_streams", this.dataStreams);
         }
         if (this.composableTemplates != null) {
-            builder.field("composable_templates", this.composableTemplates);
+            builder.stringListField("composable_templates", this.composableTemplates);
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Manifest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Manifest.java
@@ -135,7 +135,7 @@ public class Manifest implements ToXContentFragment {
         builder.field(CURRENT_TERM_PARSE_FIELD.getPreferredName(), currentTerm);
         builder.field(CLUSTER_STATE_VERSION_PARSE_FIELD.getPreferredName(), clusterStateVersion);
         builder.field(GENERATION_PARSE_FIELD.getPreferredName(), globalGeneration);
-        builder.array(INDEX_GENERATIONS_PARSE_FIELD.getPreferredName(), indexEntryList().toArray());
+        builder.xContentList(INDEX_GENERATIONS_PARSE_FIELD.getPreferredName(), indexEntryList());
         return builder;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -525,7 +525,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
             builder.field("failed_attempts", failedAllocations);
         }
         if (failedNodeIds.isEmpty() == false) {
-            builder.field("failed_nodes", failedNodeIds);
+            builder.stringListField("failed_nodes", failedNodeIds);
         }
         builder.field("delayed", delayed);
         String details = getDetails();

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -583,7 +583,7 @@ public class Setting<T> implements ToXContentObject {
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("key", getKey());
-        builder.field("properties", properties);
+        builder.enumSet("properties", properties);
         builder.field("is_group_setting", isGroupSetting());
         builder.field("default", defaultValue.apply(Settings.EMPTY));
         builder.endObject();

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -742,11 +742,7 @@ public final class RepositoryData {
             }
             builder.endArray();
             if (shouldWriteShardGens) {
-                builder.startArray(SHARD_GENERATIONS);
-                for (ShardGeneration gen : shardGenerations.getGens(indexId)) {
-                    builder.value(gen);
-                }
-                builder.endArray();
+                builder.xContentList(SHARD_GENERATIONS, shardGenerations.getGens(indexId));
             }
             builder.endObject();
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
@@ -149,7 +149,7 @@ public class BucketSortPipelineAggregationBuilder extends AbstractPipelineAggreg
 
     @Override
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(SearchSourceBuilder.SORT_FIELD.getPreferredName(), sorts);
+        builder.xContentList(SearchSourceBuilder.SORT_FIELD.getPreferredName(), sorts);
         builder.field(FROM.getPreferredName(), from);
         if (size != null) {
             builder.field(SIZE.getPreferredName(), size);

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1462,7 +1462,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
 
         if (stats != null) {
-            builder.field(STATS_FIELD.getPreferredName(), stats);
+            builder.stringListField(STATS_FIELD.getPreferredName(), stats);
         }
 
         if (extBuilders != null && extBuilders.isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -105,7 +105,7 @@ public class TransportInfo implements ReportingService.Info {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.TRANSPORT);
-        builder.array(Fields.BOUND_ADDRESS, (Object[]) address.boundAddresses());
+        builder.xContentList(Fields.BOUND_ADDRESS, address.boundAddresses());
         builder.field(Fields.PUBLISH_ADDRESS, formatPublishAddressString("transport.publish_address", address.publishAddress()));
         builder.startObject(Fields.PROFILES);
         if (profileAddresses != null && profileAddresses.size() > 0) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
@@ -83,7 +83,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
             builder.field("data_stream_count", dataStreamCount);
             builder.field("backing_indices", backingIndices);
             builder.humanReadableField("total_store_size_bytes", "total_store_size", totalStoreSize);
-            builder.array("data_streams", (Object[]) dataStreams);
+            builder.xContentList("data_streams", dataStreams);
         }
 
         public int getDataStreamCount() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
@@ -173,7 +173,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 builder.startObject();
                 builder.field(DataStream.NAME_FIELD.getPreferredName(), dataStream.getName());
                 builder.field(DataStream.TIMESTAMP_FIELD_FIELD.getPreferredName(), dataStream.getTimeStampField());
-                builder.field(DataStream.INDICES_FIELD.getPreferredName(), dataStream.getIndices());
+                builder.xContentList(DataStream.INDICES_FIELD.getPreferredName(), dataStream.getIndices());
                 builder.field(DataStream.GENERATION_FIELD.getPreferredName(), dataStream.getGeneration());
                 if (dataStream.getMetadata() != null) {
                     builder.field(DataStream.METADATA_FIELD.getPreferredName(), dataStream.getMetadata());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
@@ -66,8 +66,8 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
             builder.startObject();
             ReloadDetails value = indexDetails.getValue();
             builder.field(INDEX_FIELD.getPreferredName(), value.getIndexName());
-            builder.field(RELOADED_ANALYZERS_FIELD.getPreferredName(), value.getReloadedAnalyzers());
-            builder.field(RELOADED_NODE_IDS_FIELD.getPreferredName(), value.getReloadedIndicesNodes());
+            builder.stringListField(RELOADED_ANALYZERS_FIELD.getPreferredName(), value.getReloadedAnalyzers());
+            builder.stringListField(RELOADED_NODE_IDS_FIELD.getPreferredName(), value.getReloadedIndicesNodes());
             builder.endObject();
         }
         builder.endArray();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
@@ -143,9 +143,9 @@ public class AllocateAction implements LifecycleAction {
         if (totalShardsPerNode != null) {
             builder.field(TOTAL_SHARDS_PER_NODE_FIELD.getPreferredName(), totalShardsPerNode);
         }
-        builder.field(INCLUDE_FIELD.getPreferredName(), include);
-        builder.field(EXCLUDE_FIELD.getPreferredName(), exclude);
-        builder.field(REQUIRE_FIELD.getPreferredName(), require);
+        builder.stringStringMap(INCLUDE_FIELD.getPreferredName(), include);
+        builder.stringStringMap(EXCLUDE_FIELD.getPreferredName(), exclude);
+        builder.stringStringMap(REQUIRE_FIELD.getPreferredName(), require);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -64,7 +64,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
     protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
         if (policyStats != null) {
             builder.field("policy_count", policyStats.size());
-            builder.field("policy_stats", policyStats);
+            builder.xContentList("policy_stats", policyStats);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -96,7 +96,7 @@ public class IndexLifecycleMetadata implements XPackMetadataCustom {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(POLICIES_FIELD.getPreferredName(), policyMetadatas);
+        builder.xContentValuesMap(POLICIES_FIELD.getPreferredName(), policyMetadatas);
         builder.field(OPERATION_MODE_FIELD.getPreferredName(), operationMode);
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyMetadata.java
@@ -101,7 +101,7 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(POLICY.getPreferredName(), policy);
-        builder.field(HEADERS.getPreferredName(), headers);
+        builder.stringStringMap(HEADERS.getPreferredName(), headers);
         builder.field(VERSION.getPreferredName(), version);
         builder.field(MODIFIED_DATE.getPreferredName(), modifiedDate);
         builder.field(MODIFIED_DATE_STRING.getPreferredName(), getModifiedDateString());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
@@ -148,7 +148,7 @@ public class Phase implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(MIN_AGE.getPreferredName(), minimumAge.getStringRep());
-        builder.field(ACTIONS_FIELD.getPreferredName(), actions);
+        builder.xContentValuesMap(ACTIONS_FIELD.getPreferredName(), actions);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStep.java
@@ -94,7 +94,7 @@ final class WaitForFollowShardTasksStep extends AsyncWaitStep {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(SHARD_FOLLOW_TASKS.getPreferredName(), shardFollowTaskInfos);
+            builder.xContentList(SHARD_FOLLOW_TASKS.getPreferredName(), shardFollowTaskInfos);
             String message;
             if (shardFollowTaskInfos.size() > 0) {
                 message = "Waiting for [" + shardFollowTaskInfos.size() + "] shard follow tasks to be in sync";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
@@ -72,7 +72,7 @@ public class RemoveIndexLifecyclePolicyAction extends ActionType<RemoveIndexLife
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(HAS_FAILURES_FIELD.getPreferredName(), hasFailures());
-            builder.field(FAILED_INDEXES_FIELD.getPreferredName(), failedIndexes);
+            builder.stringListField(FAILED_INDEXES_FIELD.getPreferredName(), failedIndexes);
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
@@ -64,7 +64,7 @@ public class RollableIndexCaps implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(indexName);
         {
-            builder.field(ROLLUP_JOBS.getPreferredName(), jobCaps);
+            builder.xContentList(ROLLUP_JOBS.getPreferredName(), jobCaps);
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
@@ -107,7 +107,7 @@ public class RollupJobCaps implements Writeable, ToXContentObject {
             builder.startObject(FIELDS.getPreferredName());
             {
                 for (Map.Entry<String, RollupFieldCaps> fieldCap : fieldCapLookup.entrySet()) {
-                    builder.array(fieldCap.getKey(), fieldCap.getValue());
+                    builder.xContentList(fieldCap.getKey(), fieldCap.getValue());
                 }
             }
             builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
@@ -139,7 +139,7 @@ public class MetricConfig implements Writeable, ToXContentObject {
         builder.startObject();
         {
             builder.field(FIELD, field);
-            builder.field(METRICS, metrics);
+            builder.stringListField(METRICS, metrics);
         }
         return builder.endObject();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -251,8 +251,8 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
             builder.field(Fields.GLOBAL.getPreferredName());
             ConfigurableClusterPrivileges.toXContent(builder, params, Arrays.asList(configurableClusterPrivileges));
         }
-        builder.array(Fields.INDICES.getPreferredName(), (Object[]) indicesPrivileges);
-        builder.array(Fields.APPLICATIONS.getPreferredName(), (Object[]) applicationPrivileges);
+        builder.xContentList(Fields.INDICES.getPreferredName(), indicesPrivileges);
+        builder.xContentList(Fields.APPLICATIONS.getPreferredName(), applicationPrivileges);
         if (runAs != null) {
             builder.array(Fields.RUN_AS.getPreferredName(), runAs);
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryItem.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryItem.java
@@ -82,7 +82,7 @@ public class ILMHistoryItem implements ToXContentObject {
         }
         builder.field(SUCCESS.getPreferredName(), success);
         if (executionState != null) {
-            builder.field(EXECUTION_STATE.getPreferredName(), executionState.asMap());
+            builder.stringStringMap(EXECUTION_STATE.getPreferredName(), executionState.asMap());
         }
         if (errorDetails != null) {
             builder.field(ERROR.getPreferredName(), errorDetails);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
@@ -184,7 +184,7 @@ public class RollupIndexCaps implements Writeable, ToXContentFragment {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(rollupIndexName);
-        builder.field(ROLLUP_JOBS.getPreferredName(), jobCaps);
+        builder.xContentList(ROLLUP_JOBS.getPreferredName(), jobCaps);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -320,7 +320,7 @@ public class TransportRollupAction extends AcknowledgedTransportMasterNodeAction
             String defaultMetric = metrics.contains("value_count") ? "value_count" : metrics.get(0);
             builder.startObject(metricConfig.getField())
                 .field("type", AggregateDoubleMetricFieldMapper.CONTENT_TYPE)
-                .array(AggregateDoubleMetricFieldMapper.Names.METRICS, metrics.toArray())
+                .stringListField(AggregateDoubleMetricFieldMapper.Names.METRICS, metrics)
                 .field(AggregateDoubleMetricFieldMapper.Names.DEFAULT_METRIC, defaultMetric)
                 .endObject();
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -1067,7 +1067,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             }
             builder.endArray();
             // the toXContent method of the {@code RoleDescriptor.ApplicationResourcePrivileges) does a good job
-            builder.array(RoleDescriptor.Fields.APPLICATIONS.getPreferredName(), (Object[]) roleDescriptor.getApplicationPrivileges());
+            builder.xContentList(RoleDescriptor.Fields.APPLICATIONS.getPreferredName(), roleDescriptor.getApplicationPrivileges());
             builder.array(RoleDescriptor.Fields.RUN_AS.getPreferredName(), roleDescriptor.getRunAs());
             if (roleDescriptor.getMetadata() != null && false == roleDescriptor.getMetadata().isEmpty()) {
                 // JSON building for the metadata might fail when encountering unknown class types.

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -213,7 +214,7 @@ public class EmailActionTests extends ESTestCase {
                 .field("from", "from@domain")
                 .field("priority", priority.name());
         if (dataAttachment != null) {
-            builder.field("attach_data", dataAttachment);
+            builder.field("attach_data", (ToXContentObject) dataAttachment);
         } else if (randomBoolean()) {
             dataAttachment = org.elasticsearch.xpack.watcher.notification.email.DataAttachment.DEFAULT;
             builder.field("attach_data", true);


### PR DESCRIPTION
Found this when benchmarking large cluster states. When serializing collections we'd mostly
not take any advantage of what we know about the collection contents (like we do in `StreamOutput`).
This PR adds a couple of helpers to the x-content-builder similar to what we have on `StreamOutput`
to allow for faster serializing by avoiding the writer lookup and some self-reference checks.

backport of #78742