### PR TITLE
Add a system property to forcibly format everything

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -196,7 +196,7 @@ def projectPathsToExclude = [
 
 subprojects {
   plugins.withType(ElasticsearchJavaPlugin).whenPluginAdded {
-    if (projectPathsToExclude.contains(project.path) == false) {
+    if (projectPathsToExclude.contains(project.path) == false || System.getProperty("es.format.everything") != null) {
       project.apply plugin: "com.diffplug.spotless"
 
 

--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -196,7 +196,8 @@ def projectPathsToExclude = [
 
 subprojects {
   plugins.withType(ElasticsearchJavaPlugin).whenPluginAdded {
-    if (projectPathsToExclude.contains(project.path) == false || System.getProperty("es.format.everything") != null) {
+    if (projectPathsToExclude.contains(project.path) == false ||
+        providers.systemProperty("es.format.everything").forUseAtConfigurationTime().isPresent()) {
       project.apply plugin: "com.diffplug.spotless"
 
 


### PR DESCRIPTION
In order to make it easier to migrate to an automatically-formatted world, add a system property that causes Spotless to format every Java project, ignoring the exclusion list.