### PR TITLE
Ensure build tools integration tests run when running check task

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -273,3 +273,5 @@ tasks.register("integTest", Test) {
   classpath = sourceSets.integTest.runtimeClasspath
   useJUnitPlatform()
 }
+
+tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -22,8 +22,8 @@ import java.nio.file.Paths
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-import static org.elasticsearch.gradle.internal.JdkDownloadPlugin.VENDOR_ADOPTIUM
-import static org.elasticsearch.gradle.internal.JdkDownloadPlugin.VENDOR_OPENJDK
+import static org.elasticsearch.gradle.JdkDownloadPlugin.VENDOR_ADOPTIUM
+import static org.elasticsearch.gradle.JdkDownloadPlugin.VENDOR_OPENJDK
 
 class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
 


### PR DESCRIPTION
We want to ensure we run the build tools integration tests when running the `check` task. Also fix some broken imports that were causing compilation of integration tests to fail.