### PR TITLE
Fix *ScriptFieldTypeTests with sorts

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -74,7 +74,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
         final double dMissingValue = (Double) missingObject(missingValue, reversed);
         // NOTE: it's important to pass null as a missing value in the constructor so that
         // the comparator doesn't check docsWithField since we replace missing values in select()
-        return new DoubleComparator(numHits, null, null, reversed, sortPos) {
+        DoubleComparator comparator = new DoubleComparator(numHits, null, null, reversed, sortPos) {
             @Override
             public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
                 return new DoubleLeafComparator(context) {
@@ -90,6 +90,9 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
                 };
             }
         };
+        // TODO: when LUCENE-10154 is available, instead of disableSkipping this comparator should implement `getPointValue`
+        comparator.disableSkipping();
+        return comparator;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -67,7 +67,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
         final float fMissingValue = (Float) missingObject(missingValue, reversed);
         // NOTE: it's important to pass null as a missing value in the constructor so that
         // the comparator doesn't check docsWithField since we replace missing values in select()
-        return new FloatComparator(numHits, null, null, reversed, sortPos) {
+        FloatComparator comparator = new FloatComparator(numHits, null, null, reversed, sortPos) {
             @Override
             public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
                 return new FloatLeafComparator(context) {
@@ -78,6 +78,9 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
                 };
             }
         };
+        // TODO: when LUCENE-10154 is available, instead of disableSkipping this comparator should implement `getPointValue`
+        comparator.disableSkipping();
+        return comparator;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -90,7 +90,7 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
         final long lMissingValue = (Long) missingObject(missingValue, reversed);
         // NOTE: it's important to pass null as a missing value in the constructor so that
         // the comparator doesn't check docsWithField since we replace missing values in select()
-        return new LongComparator(numHits, null, null, reversed, sortPos) {
+        LongComparator comparator = new LongComparator(numHits, null, null, reversed, sortPos) {
             @Override
             public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
                 return new LongLeafComparator(context) {
@@ -101,6 +101,9 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
                 };
             }
         };
+        // TODO: when LUCENE-10154 is available, instead of disableSkipping this comparator should implement `getPointValue`
+        comparator.disableSkipping();
+        return comparator;
     }
 
     @Override


### PR DESCRIPTION
Disable sort optimization with points for comparators used in
scripts, as they don't provide points.

This is a temporary fix, for a permanent fix these comparators
should implement `getPoints` once LUCENE-10154 is available.

Backport for #78563

Closes #78315