### PR TITLE
Revert Adding config so that some tests will break if over-the-wire encryption fails (#78409)

### DIFF
--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
@@ -14,7 +14,6 @@
               path: "/user/elasticsearch/test/repository_create"
               security:
                 principal: "elasticsearch@BUILD.ELASTIC.CO"
-              conf.dfs.encrypt.data.transfer.cipher.suites: "AES/CTR/NoPadding"
 
     # Get repository
     - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
@@ -15,7 +15,6 @@
             path: "/user/elasticsearch/test/snapshot"
             security:
               principal: "elasticsearch@BUILD.ELASTIC.CO"
-            conf.dfs.encrypt.data.transfer.cipher.suites: "AES/CTR/NoPadding"
 
   # Create index
   - do:

--- a/test/fixtures/hdfs2-fixture/src/main/java/hdfs/MiniHDFS.java
+++ b/test/fixtures/hdfs2-fixture/src/main/java/hdfs/MiniHDFS.java
@@ -84,7 +84,6 @@ public class MiniHDFS {
             cfg.set(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, "true");
             cfg.set(DFSConfigKeys.IGNORE_SECURE_PORTS_FOR_TESTING_KEY, "true");
             cfg.set(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_KEY, "true");
-            cfg.set(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_CIPHER_SUITES_KEY, "AES/CTR/NoPadding");
         }
 
         UserGroupInformation.setConfiguration(cfg);


### PR DESCRIPTION
This commit reverts #78409 because #78409 intentionally fails the build when over-the-wire encryption fails. Unfortunately
over-the-wire encryption is broken on the hadoop 2 client on java 9+, and we're still supporting the hadoop 2 client.
Reverting that commit for now.