### PR TITLE
[7.15] [DOCS] Add aggregations/CCS memory leak as a 7.14.x known issue (#78728)

### DIFF
--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -3,6 +3,26 @@
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
+[[known-issues-7.14.2]]
+[discrete]
+=== Known issues
+
+// tag::ccs-agg-mem-known-issue[]
+* Aggregations: In {es} 7.14.0–7.15.0, when a {ccs} ({ccs-init}) request is proxied, the memory for the aggregations on the
+proxy node will not be freed. The trigger is {ccs} using aggregations where minimize 
+roundtrips is not effective (for example, when minimize roundtrips is explicitly disabled, or implicitly disabled 
+when using scroll, async and point-in-time searches).
++
+This affects {kib} {ccs-init} aggregations because {kib} 
+uses async search by default. This issue can also happen in all modes of remote connections 
+configured for {ccs} (sniff and proxy). In sniff mode, we only connect to a subset of the 
+remote nodes (by default 3). So if the remote node we want to send a request to is not one of those 3, 
+we must send the request as a proxy request. The workaround is to periodically restart nodes with heap pressure.
++
+We have fixed this issue in {es} 7.15.1 and later versions. For more details,
+see {es-pull}78404[#78404].
+// end::ccs-agg-mem-known-issue[]
+
 [[enhancement-7.14.2]]
 [float]
 === Enhancements
@@ -33,6 +53,12 @@ Snapshot/Restore::
 == {es} version 7.14.1
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
+[[known-issues-7.14.1]]
+[discrete]
+=== Known issues
+
+include::7.14.asciidoc[tag=ccs-agg-mem-known-issue]
 
 [[enhancement-7.14.1]]
 [float]
@@ -128,6 +154,12 @@ Packaging::
 == {es} version 7.14.0
 
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
+[[known-issues-7.14.0]]
+[discrete]
+=== Known issues
+
+include::7.14.asciidoc[tag=ccs-agg-mem-known-issue]
 
 [[breaking-7.14.0]]
 [float]

--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -3,6 +3,12 @@
 
 Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
 
+[[known-issues-7.15.0]]
+[discrete]
+=== Known issues
+
+include::7.14.asciidoc[tag=ccs-agg-mem-known-issue]
+
 [[breaking-7.15.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add aggregations/CCS memory leak as a 7.14.x known issue (#78728)