### PR TITLE
Remove uses of Joda from most server tests (#78654)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -35,13 +35,11 @@ import org.elasticsearch.search.lookup.FieldLookup;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -50,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -995,10 +994,10 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type", mapping));
         ensureGreen("test");
 
-        DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
-        org.joda.time.format.DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd");
+        ZonedDateTime date = ZonedDateTime.of(1990, 12, 29, 0, 0, 0, 0, ZoneOffset.UTC);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd", Locale.ROOT);
 
-        index("test", "type", "1", "text_field", "foo", "date_field", formatter.print(date));
+        index("test", "type", "1", "text_field", "foo", "date_field", formatter.format(date));
         refresh("test");
 
         SearchRequestBuilder builder = client().prepareSearch().setQuery(matchAllQuery())
@@ -1058,10 +1057,10 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type", mapping));
         ensureGreen("test");
 
-        DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
-        org.joda.time.format.DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd");
+        ZonedDateTime date = ZonedDateTime.of(1990, 12, 29, 0, 0, 0, 0, ZoneOffset.UTC);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd", Locale.ROOT);
 
-        index("test", "type", "1", "text_field", "foo", "date_field", formatter.print(date));
+        index("test", "type", "1", "text_field", "foo", "date_field", formatter.format(date));
         refresh("test");
 
         SearchRequestBuilder builder = client().prepareSearch().setQuery(matchAllQuery())

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -25,9 +25,9 @@ import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.joda.time.Instant;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -16,18 +16,20 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.DateMathExpressionResolver;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class DateMathExpressionResolverTests extends ESTestCase {
 
@@ -36,6 +38,15 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         ClusterState.builder(new ClusterName("_name")).build(), IndicesOptions.strictExpand(),
         SystemIndexAccessLevel.NONE
     );
+
+    private static ZonedDateTime dateFromMillis(long millis) {
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+    }
+
+    private static String formatDate(String pattern, ZonedDateTime zonedDateTime) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(pattern, Locale.ROOT);
+        return dateFormatter.format(zonedDateTime);
+    }
 
     public void testNormal() throws Exception {
         int numIndexExpressions = randomIntBetween(1, 9);
@@ -55,11 +66,11 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         List<String> result = expressionResolver.resolve(context, indexExpressions);
         assertThat(result.size(), equalTo(3));
         assertThat(result.get(0),
-            equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
         assertThat(result.get(1),
-            equalTo(".watch_history-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".watch_history-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
         assertThat(result.get(2),
-            equalTo("logstash-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo("logstash-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testEmpty() throws Exception {
@@ -77,30 +88,30 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         List<String> result = expressionResolver.resolve(context, Arrays.asList("<.text1-{now/d}-text2-{now/M}>"));
         assertThat(result.size(), equalTo(1));
         assertThat(result.get(0), equalTo(".text1-"
-                + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))
+                + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))
                 + "-text2-"
-                + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC).withDayOfMonth(1))));
+                + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()).withDayOfMonth(1))));
     }
 
     public void testExpression_CustomFormat() throws Exception {
         List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{yyyy.MM.dd}}>"));
         assertThat(results.size(), equalTo(1));
         assertThat(results.get(0),
-            equalTo(".marvel-" + DateTimeFormat.forPattern("yyyy.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_EscapeStatic() throws Exception {
         List<String> result = expressionResolver.resolve(context, Arrays.asList("<.mar\\{v\\}el-{now/d}>"));
         assertThat(result.size(), equalTo(1));
         assertThat(result.get(0),
-            equalTo(".mar{v}el-" + DateTimeFormat.forPattern("yyyy.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".mar{v}el-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_EscapeDateFormat() throws Exception {
         List<String> result = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{'\\{year\\}'yyyy}}>"));
         assertThat(result.size(), equalTo(1));
         assertThat(result.get(0),
-            equalTo(".marvel-" + DateTimeFormat.forPattern("'{year}'yyyy").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".marvel-" + formatDate("'{year}'yyyy", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_MixedArray() throws Exception {
@@ -110,39 +121,42 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         assertThat(result.size(), equalTo(4));
         assertThat(result.get(0), equalTo("name1"));
         assertThat(result.get(1),
-            equalTo(".marvel-" + DateTimeFormat.forPattern("yyyy.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+            equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
         assertThat(result.get(2), equalTo("name2"));
         assertThat(result.get(3), equalTo(".logstash-" +
-            DateTimeFormat.forPattern("yyyy.MM").print(new DateTime(context.getStartTime(), UTC).withDayOfMonth(1))));
+            formatDate("uuuu.MM", dateFromMillis(context.getStartTime()).withDayOfMonth(1))));
     }
 
     public void testExpression_CustomTimeZoneInIndexName() throws Exception {
-        DateTimeZone timeZone;
+        ZoneId timeZone;
         int hoursOffset;
         int minutesOffset = 0;
         if (randomBoolean()) {
             hoursOffset = randomIntBetween(-12, 14);
-            timeZone = DateTimeZone.forOffsetHours(hoursOffset);
+            timeZone = ZoneOffset.ofHours(hoursOffset);
         } else {
             hoursOffset = randomIntBetween(-11, 13);
             minutesOffset = randomIntBetween(0, 59);
-            timeZone = DateTimeZone.forOffsetHoursMinutes(hoursOffset, minutesOffset);
+            if (hoursOffset < 0) {
+                minutesOffset = -minutesOffset;
+            }
+            timeZone = ZoneOffset.ofHoursMinutes(hoursOffset, minutesOffset);
         }
-        DateTime now;
+        ZonedDateTime now;
         if (hoursOffset >= 0) {
             // rounding to next day 00:00
-            now = DateTime.now(UTC).plusHours(hoursOffset).plusMinutes(minutesOffset)
-                .withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+            now = ZonedDateTime.now(ZoneOffset.UTC).plusHours(hoursOffset).plusMinutes(minutesOffset)
+                .withHour(0).withMinute(0).withSecond(0);
         } else {
             // rounding to today 00:00
-            now = DateTime.now(UTC).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+            now = ZonedDateTime.now(ZoneOffset.UTC).withHour(0).withMinute(0).withSecond(0);
         }
-        Context context = new Context(this.context.getState(), this.context.getOptions(), now.getMillis(),
+        Context context = new Context(this.context.getState(), this.context.getOptions(), now.toInstant().toEpochMilli(),
             SystemIndexAccessLevel.NONE, name -> false, name -> false);
-        List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{yyyy.MM.dd|" + timeZone.getID() + "}}>"));
+        List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{yyyy.MM.dd|" + timeZone.getId() + "}}>"));
         assertThat(results.size(), equalTo(1));
         logger.info("timezone: [{}], now [{}], name: [{}]", timeZone, now, results.get(0));
-        assertThat(results.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("yyyy.MM.dd").print(now.withZone(timeZone))));
+        assertThat(results.get(0), equalTo(".marvel-" + formatDate("uuuu.MM.dd", now.withZoneSameInstant(timeZone))));
     }
 
     public void testExpressionInvalidUnescaped() throws Exception {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.OffsetTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -20,11 +20,10 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.time.Instant;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -298,10 +297,10 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeOptionalBytesReference(new BytesArray("test"));
         out.writeOptionalDouble(null);
         out.writeOptionalDouble(1.2);
-        out.writeTimeZone(DateTimeZone.forID("CET"));
-        out.writeOptionalTimeZone(DateTimeZone.getDefault());
+        out.writeZoneId(ZoneId.of("CET"));
+        out.writeOptionalZoneId(ZoneId.systemDefault());
         out.writeOptionalTimeZone(null);
-        out.writeGenericValue(new DateTime(123456, DateTimeZone.forID("America/Los_Angeles")));
+        out.writeGenericValue(ZonedDateTime.ofInstant(Instant.ofEpochMilli(123456), ZoneId.of("America/Los_Angeles")));
         final OffsetTime offsetNow = OffsetTime.now(randomZone());
         out.writeGenericValue(offsetNow);
         final byte[] bytes = BytesReference.toBytes(out.bytes());
@@ -333,8 +332,8 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat(in.readOptionalBytesReference(), equalTo(new BytesArray("test")));
         assertNull(in.readOptionalDouble());
         assertThat(in.readOptionalDouble(), closeTo(1.2, 0.0001));
-        assertEquals(DateTimeZone.forID("CET"), in.readTimeZone());
-        assertEquals(DateTimeZone.getDefault(), in.readOptionalTimeZone());
+        assertEquals(ZoneId.of("CET"), in.readZoneId());
+        assertEquals(ZoneId.systemDefault(), in.readOptionalZoneId());
         assertNull(in.readOptionalTimeZone());
         Object dt = in.readGenericValue();
         assertThat(dt, instanceOf(JodaCompatibleZonedDateTime.class));

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -19,20 +19,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Instant;
-import org.joda.time.ReadableInstant;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -53,14 +47,15 @@ import java.time.Period;
 import java.time.Year;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -402,78 +397,21 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         }
     }
 
-    public void testReadableInstant() throws Exception {
-        assertResult("{'instant':null}", () -> builder().startObject().timeField("instant", (ReadableInstant) null).endObject());
-        assertResult("{'instant':null}", () -> builder().startObject().field("instant").timeValue((ReadableInstant) null).endObject());
-
-        final DateTime t1 = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC);
-
-        String expected = "{'t1':'2016-01-01T00:00:00.000Z'}";
-        assertResult(expected, () -> builder().startObject().timeField("t1", t1).endObject());
-        assertResult(expected, () -> builder().startObject().field("t1").timeValue(t1).endObject());
-
-        final DateTime t2 = new DateTime(2016, 12, 25, 7, 59, 42, 213, DateTimeZone.UTC);
-
-        expected = "{'t2':'2016-12-25T07:59:42.213Z'}";
-        assertResult(expected, () -> builder().startObject().timeField("t2", t2).endObject());
-        assertResult(expected, () -> builder().startObject().field("t2").timeValue(t2).endObject());
-
-        final DateTimeFormatter formatter = randomFrom(ISODateTimeFormat.basicDate(), ISODateTimeFormat.dateTimeNoMillis());
-        final DateTime t3 = DateTime.now();
-
-        expected = "{'t3':'" + formatter.print(t3) + "'}";
-        assertResult(expected, () -> builder().startObject().timeField("t3", formatter.print(t3)).endObject());
-        assertResult(expected, () -> builder().startObject().field("t3").value(formatter.print(t3)).endObject());
-
-        final DateTime t4 = new DateTime(randomDateTimeZone());
-
-        expected = "{'t4':'" + formatter.print(t4) + "'}";
-        assertResult(expected, () -> builder().startObject().timeField("t4", formatter.print(t4)).endObject());
-        assertResult(expected, () -> builder().startObject().field("t4").value(formatter.print(t4)).endObject());
-
-        long date = Math.abs(randomLong() % (2 * (long) 10e11)); // 1970-01-01T00:00:00Z - 2033-05-18T05:33:20.000+02:00
-        final DateTime t5 = new DateTime(date, randomDateTimeZone());
-
-        expected = "{'t5':'" + XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(t5) + "'}";
-        assertResult(expected, () -> builder().startObject().timeField("t5", t5).endObject());
-        assertResult(expected, () -> builder().startObject().field("t5").timeValue(t5).endObject());
-
-        expected = "{'t5':'" + formatter.print(t5) + "'}";
-        assertResult(expected, () -> builder().startObject().timeField("t5", formatter.print(t5)).endObject());
-        assertResult(expected, () -> builder().startObject().field("t5").value(formatter.print(t5)).endObject());
-
-        Instant i1 = new Instant(1451606400000L); // 2016-01-01T00:00:00.000Z
-        expected = "{'i1':'2016-01-01T00:00:00.000Z'}";
-        assertResult(expected, () -> builder().startObject().timeField("i1", i1).endObject());
-        assertResult(expected, () -> builder().startObject().field("i1").timeValue(i1).endObject());
-
-        Instant i2 = new Instant(1482652782213L); // 2016-12-25T07:59:42.213Z
-        expected = "{'i2':'" + formatter.print(i2) + "'}";
-        assertResult(expected, () -> builder().startObject().timeField("i2", formatter.print(i2)).endObject());
-        assertResult(expected, () -> builder().startObject().field("i2").value(formatter.print(i2)).endObject());
-    }
-
     public void testDate() throws Exception {
         assertResult("{'date':null}", () -> builder().startObject().timeField("date", (Date) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((Date) null).endObject());
 
-        final Date d1 = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).toDate();
+        final Date d1 = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1).endObject());
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timeValue(d1).endObject());
 
-        final Date d2 = new DateTime(2016, 12, 25, 7, 59, 42, 213, DateTimeZone.UTC).toDate();
+        final Date d2 = Date.from(ZonedDateTime.of(2016, 12, 25, 7, 59, 42, 213000000, ZoneOffset.UTC).toInstant());
         assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().timeField("d2", d2).endObject());
         assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().field("d2").timeValue(d2).endObject());
-
-        final DateTimeFormatter formatter = randomFrom(ISODateTimeFormat.basicDate(), ISODateTimeFormat.dateTimeNoMillis());
-        final Date d3 = DateTime.now().toDate();
-
-        String expected = "{'d3':'" + formatter.print(d3.getTime()) + "'}";
-        assertResult(expected, () -> builder().startObject().field("d3").value(formatter.print(d3.getTime())).endObject());
     }
 
     public void testDateField() throws Exception {
-        final Date d = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).toDate();
+        final Date d = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
 
         assertResult("{'date_in_millis':1451606400000}", () -> builder()
                 .startObject()
@@ -487,7 +425,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testCalendar() throws Exception {
-        Calendar calendar = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).toCalendar(Locale.ROOT);
+        Calendar calendar = GregorianCalendar.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         assertResult("{'calendar':'2016-01-01T00:00:00.000Z'}", () -> builder()
                 .startObject()
                     .field("calendar")
@@ -653,17 +591,13 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final String paths = Constants.WINDOWS ? "{'objects':['a\\\\b\\\\c','d\\\\e']}" : "{'objects':['a/b/c','d/e']}";
         objects.put(paths, new Object[]{PathUtils.get("a", "b", "c"), PathUtils.get("d", "e")});
 
-        final DateTimeFormatter formatter = XContentElasticsearchExtension.DEFAULT_DATE_PRINTER;
-        final Date d1 = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).toDate();
-        final Date d2 = new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).toDate();
-        objects.put("{'objects':['" + formatter.print(d1.getTime()) + "','" + formatter.print(d2.getTime()) + "']}", new Object[]{d1, d2});
+        final DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+        final Date d1 = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        final Date d2 = Date.from(ZonedDateTime.of(2015, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        objects.put("{'objects':['2016-01-01T00:00:00.000Z','2015-01-01T00:00:00.000Z']}", new Object[]{d1, d2});
 
-        final DateTime dt1 = DateTime.now();
-        final DateTime dt2 = new DateTime(2016, 12, 25, 7, 59, 42, 213, DateTimeZone.UTC);
-        objects.put("{'objects':['" + formatter.print(dt1) + "','2016-12-25T07:59:42.213Z']}", new Object[]{dt1, dt2});
-
-        final Calendar c1 = new DateTime(2012, 7, 7, 10, 23, DateTimeZone.UTC).toCalendar(Locale.ROOT);
-        final Calendar c2 = new DateTime(2014, 11, 16, 19, 36, DateTimeZone.UTC).toCalendar(Locale.ROOT);
+        final Calendar c1 = GregorianCalendar.from(ZonedDateTime.of(2012, 7, 7, 10, 23, 0, 0, ZoneOffset.UTC));
+        final Calendar c2 = GregorianCalendar.from(ZonedDateTime.of(2014, 11, 16, 19, 36, 0, 0, ZoneOffset.UTC));
         objects.put("{'objects':['2012-07-07T10:23:00.000Z','2014-11-16T19:36:00.000Z']}", new Object[]{c1, c2});
 
         final ToXContent x1 = (builder, params) -> builder.startObject().field("f1", "v1").field("f2", 2).array("f3", 3, 4, 5).endObject();
@@ -701,14 +635,10 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final String path = Constants.WINDOWS ? "{'object':'a\\\\b\\\\c'}" : "{'object':'a/b/c'}";
         object.put(path, PathUtils.get("a", "b", "c"));
 
-        final DateTimeFormatter formatter = XContentElasticsearchExtension.DEFAULT_DATE_PRINTER;
-        final Date d1 = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).toDate();
-        object.put("{'object':'" + formatter.print(d1.getTime()) + "'}", d1);
+        final Date d1 = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0,0, ZoneOffset.UTC).toInstant());
+        object.put("{'object':'" + "2016-01-01T00:00:00.000Z" + "'}", d1);
 
-        final DateTime d2 = DateTime.now();
-        object.put("{'object':'" + formatter.print(d2) + "'}", d2);
-
-        final Calendar c1 = new DateTime(2010, 1, 1, 0, 0, DateTimeZone.UTC).toCalendar(Locale.ROOT);
+        final Calendar c1 = GregorianCalendar.from(ZonedDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         object.put("{'object':'2010-01-01T00:00:00.000Z'}", c1);
 
         final ToXContent x1 = (builder, params) -> builder.startObject().field("f1", "v1").field("f2", 2).array("f3", 3, 4, 5).endObject();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -38,10 +38,10 @@ import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.query.DateRangeIncludingNowQuery;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
 
@@ -84,8 +84,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         DateMathParser alternateFormat = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
         doTestIsFieldWithinQuery(ft, reader, null, null);
         doTestIsFieldWithinQuery(ft, reader, null, alternateFormat);
-        doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, null);
-        doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, alternateFormat);
+        doTestIsFieldWithinQuery(ft, reader, ZoneOffset.UTC, null);
+        doTestIsFieldWithinQuery(ft, reader, ZoneOffset.UTC, alternateFormat);
 
         QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
 
@@ -98,28 +98,28 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
     }
 
     private void doTestIsFieldWithinQuery(DateFieldType ft, DirectoryReader reader,
-            DateTimeZone zone, DateMathParser alternateFormat) throws IOException {
+                                          ZoneId zone, DateMathParser alternateFormat) throws IOException {
         QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2016-01-02", "2016-06-20",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2016-01-02", "2016-02-12",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2014-01-02", "2015-02-12",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2016-05-11", "2016-08-30",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.WITHIN, ft.isFieldWithinQuery(reader, "2015-09-25", "2016-05-29",
-                randomBoolean(), randomBoolean(), null, null, context));
+                randomBoolean(), randomBoolean(), zone, null, context));
         assertEquals(Relation.WITHIN, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
-                true, true, null, null, context));
+                true, true, zone, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
-                false, false, null, null, context));
+                false, false, zone, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
-                false, true, null, null, context));
+                false, true, zone, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
-                true, false, null, null, context));
+                true, false, zone, null, context));
     }
 
     public void testValueFormat() {

--- a/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.query.DistanceFeatureQueryBuilder.Origin;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -41,7 +40,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
                 break;
             case DATE_FIELD_NAME:
                 long randomDateMills = randomLongBetween(0, 2_000_000_000_000L);
-                origin = randomBoolean() ? new Origin(randomDateMills) : new Origin(new DateTime(randomDateMills).toString());
+                origin = randomBoolean() ? new Origin(randomDateMills) : new Origin(Instant.ofEpochMilli(randomDateMills).toString());
                 pivot = randomTimeValue(1, 1000, "d", "h", "ms", "s", "m");
                 break;
             default: // DATE_NANOS_FIELD_NAME

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -293,8 +293,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                ZonedDateTime.parse("2014-11-01T00:00:00.000+00").toInstant().toEpochMilli(),
-                ZonedDateTime.parse("2014-12-08T23:59:59.999+00").toInstant().toEpochMilli()),
+                ZonedDateTime.parse("2014-11-01T00:00:00.000Z").toInstant().toEpochMilli(),
+                ZonedDateTime.parse("2014-12-08T23:59:59.999Z").toInstant().toEpochMilli()),
                 parsedQuery);
 
         query = "{\n" +
@@ -310,8 +310,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                ZonedDateTime.parse("2014-11-30T23:59:59.999+00").toInstant().toEpochMilli() + 1,
-                ZonedDateTime.parse("2014-12-08T00:00:00.000+00").toInstant().toEpochMilli() - 1),
+                ZonedDateTime.parse("2014-11-30T23:59:59.999Z").toInstant().toEpochMilli() + 1,
+                ZonedDateTime.parse("2014-12-08T00:00:00.000Z").toInstant().toEpochMilli() - 1),
                 parsedQuery);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -30,8 +30,6 @@ import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -264,8 +262,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
 
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                DateTime.parse("2012-01-01T00:00:00.000+00").getMillis(),
-                DateTime.parse("2030-01-01T00:00:00.000+00").getMillis() - 1),
+                ZonedDateTime.parse("2012-01-01T00:00:00.000+00").toInstant().toEpochMilli(),
+                ZonedDateTime.parse("2030-01-01T00:00:00.000+00").toInstant().toEpochMilli() - 1),
                 parsedQuery);
 
         // Test Invalid format
@@ -295,8 +293,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                DateTime.parse("2014-11-01T00:00:00.000+00").getMillis(),
-                DateTime.parse("2014-12-08T23:59:59.999+00").getMillis()),
+                ZonedDateTime.parse("2014-11-01T00:00:00.000+00").toInstant().toEpochMilli(),
+                ZonedDateTime.parse("2014-12-08T23:59:59.999+00").toInstant().toEpochMilli()),
                 parsedQuery);
 
         query = "{\n" +
@@ -312,8 +310,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                DateTime.parse("2014-11-30T23:59:59.999+00").getMillis() + 1,
-                DateTime.parse("2014-12-08T00:00:00.000+00").getMillis() - 1),
+                ZonedDateTime.parse("2014-11-30T23:59:59.999+00").toInstant().toEpochMilli() + 1,
+                ZonedDateTime.parse("2014-12-08T00:00:00.000+00").toInstant().toEpochMilli() - 1),
                 parsedQuery);
     }
 
@@ -394,8 +392,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 return Relation.WITHIN;
             }
         };
-        DateTime queryFromValue = new DateTime(2015, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
-        DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
+        ZonedDateTime queryFromValue = ZonedDateTime.of(2015, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        ZonedDateTime queryToValue = ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         query.from(queryFromValue);
         query.to(queryToValue);
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
@@ -430,8 +428,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 return Relation.WITHIN;
             }
         };
-        DateTime queryFromValue = new DateTime(2015, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
-        DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
+        ZonedDateTime queryFromValue = ZonedDateTime.of(2015, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        ZonedDateTime queryToValue = ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         query.from(queryFromValue);
         query.to(queryToValue);
         query.timeZone(randomZone().getId());
@@ -455,8 +453,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 return Relation.DISJOINT;
             }
         };
-        DateTime queryFromValue = new DateTime(2015, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
-        DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
+        ZonedDateTime queryFromValue = ZonedDateTime.of(2015, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        ZonedDateTime queryToValue = ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         query.from(queryFromValue);
         query.to(queryToValue);
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
@@ -472,8 +470,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 return Relation.INTERSECTS;
             }
         };
-        DateTime queryFromValue = new DateTime(2015, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
-        DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
+        ZonedDateTime queryFromValue = ZonedDateTime.of(2015, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        ZonedDateTime queryToValue = ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         query.from(queryFromValue);
         query.to(queryToValue);
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext();

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -262,8 +262,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
 
         assertEquals(LongPoint.newRangeQuery(DATE_FIELD_NAME,
-                ZonedDateTime.parse("2012-01-01T00:00:00.000+00").toInstant().toEpochMilli(),
-                ZonedDateTime.parse("2030-01-01T00:00:00.000+00").toInstant().toEpochMilli() - 1),
+                ZonedDateTime.parse("2012-01-01T00:00:00.000Z").toInstant().toEpochMilli(),
+                ZonedDateTime.parse("2030-01-01T00:00:00.000Z").toInstant().toEpochMilli() - 1),
                 parsedQuery);
 
         // Test Invalid format

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -54,10 +54,11 @@ import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -230,7 +231,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
             offset = randomFrom(DistanceUnit.values()).toString(randomDouble());
             break;
         case DATE_FIELD_NAME:
-            origin = new DateTime(System.currentTimeMillis() - randomIntBetween(0, 1000000), DateTimeZone.UTC).toString();
+            origin = ZonedDateTime.ofInstant(
+                Instant.ofEpochMilli(System.currentTimeMillis() - randomIntBetween(0, 1000000)), ZoneOffset.UTC).toString();
             scale = randomTimeValue(1, 1000, "d", "h", "ms", "s", "m");
             offset = randomPositiveTimeValue();
             break;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateScriptMocksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateScriptMocksPlugin.java
@@ -10,9 +10,10 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.search.lookup.LeafDocLookup;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -37,18 +38,21 @@ public class DateScriptMocksPlugin extends MockScriptPlugin {
             String fieldname = (String) params.get("fieldname");
             return docLookup.get(fieldname);
         });
-        scripts.put(
-            DOUBLE_PLUS_ONE_MONTH,
-            params -> new DateTime(Double.valueOf((double) params.get("_value")).longValue(), DateTimeZone.UTC).plusMonths(1).getMillis()
-        );
-        scripts.put(LONG_PLUS_ONE_MONTH, params -> new DateTime((long) params.get("_value"), DateTimeZone.UTC).plusMonths(1).getMillis());
+        scripts.put(DOUBLE_PLUS_ONE_MONTH, params -> {
+            Instant instant = Instant.ofEpochMilli(Double.valueOf((double) params.get("_value")).longValue());
+            return ZonedDateTime.ofInstant(instant, ZoneOffset.UTC).plusMonths(1).toInstant().toEpochMilli();
+        });
+        scripts.put(LONG_PLUS_ONE_MONTH, params -> {
+            Instant instant = Instant.ofEpochMilli((long) params.get("_value"));
+            return ZonedDateTime.ofInstant(instant, ZoneOffset.UTC).plusMonths(1).toInstant().toEpochMilli();
+        });
         return scripts;
     }
 
     @Override
     protected Map<String, Function<Map<String, Object>, Object>> nonDeterministicPluginScripts() {
         Map<String, Function<Map<String, Object>, Object>> scripts = new HashMap<>();
-        scripts.put(CURRENT_DATE, params -> new DateTime().getMillis());
+        scripts.put(CURRENT_DATE, params -> ZonedDateTime.now().toInstant().toEpochMilli());
         return scripts;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -13,9 +13,9 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,7 +33,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
         super.setUp();
         format = randomNumericDocValueFormat();
 
-        Function<DateTime, DateTime> interval = randomFrom(
+        Function<ZonedDateTime, ZonedDateTime> interval = randomFrom(
             dateTime -> dateTime.plusSeconds(1),
             dateTime -> dateTime.plusMinutes(1),
             dateTime -> dateTime.plusHours(1),
@@ -45,13 +45,13 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
         final int numRanges = randomNumberOfBuckets();
         final List<Tuple<Double, Double>> listOfRanges = new ArrayList<>(numRanges);
 
-        DateTime date = new DateTime(DateTimeZone.UTC);
-        double start = date.getMillis();
+        ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC);
+        double start = date.toInstant().toEpochMilli();
         double end = 0;
         for (int i = 0; i < numRanges; i++) {
-            double from = date.getMillis();
+            double from = date.toInstant().toEpochMilli();
             date = interval.apply(date);
-            double to = date.getMillis();
+            double to = date.toInstant().toEpochMilli();
             if (to > end) {
                 end = to;
             }


### PR DESCRIPTION
Joda was deprecated internally many years ago, but there still exist
some tests that used it to format dates. This commit converts most tests
in server that need date parsing or printing to use Java time.