### PR TITLE
[7.x] [DOCS] Fix system index refs in restore tutorial (#78582)

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -97,10 +97,11 @@ stream before restoring it. To prevent the accidental re-creation of the index
 or data stream, we recommend you temporarily stop all indexing until the restore
 operation is complete.
 
-WARNING: Don't use the <<indices-delete-index,delete index API>> to target the
-`*` or `.*` wildcard expression. If you use {es}'s security features, this will
-delete system indices required for authentication. To delete all regular
-indices, use `*,-.*` instead.
+WARNING: Don't use the <<indices-delete-index,delete index API>> to
+target the `*` or `.*` wildcard pattern. If you use {es}'s security features,
+this will delete system indices required for authentication. Instead, target the
+`*,-.*` wildcard pattern to exclude these system indices and other index names
+that begin with a dot (`.`).
 
 [source,console]
 ----
@@ -116,9 +117,10 @@ By default, a restore request attempts to restore all indices and data
 streams in the snapshot, including system indices. If your cluster already
 contains one or more of these system indices, the request will return an error.
 
-To avoid this error, specify the indices and data streams to restore. To
-exclude system indices, append the `-.*` wildcard pattern. To restore all
-indices and data streams except system indices, use `*,-.*`.
+To avoid this error, specify the indices and data streams to restore. To exclude
+system indices and other index names that begin with a dot (`.`), append the
+`-.*` wildcard pattern. To restore all indices and data streams except dot
+indices, use `*,-.*`.
 
 [source,console]
 ----
@@ -321,8 +323,7 @@ PUT _cluster/settings
 ----
 // TEST[setup:setup-snapshots]
 
-. Delete all existing indices and data streams on the cluster, including all
-system indices.
+. Delete existing indices and data streams on the cluster.
 +
 [source,console]
 ----


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix system index refs in restore tutorial (#78582)