### PR TITLE
Remove uses of Joda from xpack tests (#78660)

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -59,12 +59,12 @@ import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -140,7 +140,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -162,7 +162,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         1,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -226,7 +226,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         50.0,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -258,7 +258,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         141.0,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -290,7 +290,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         275.0,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -322,7 +322,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         270.0,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -354,7 +354,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         440.0,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -408,7 +408,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -430,7 +430,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -452,7 +452,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         1,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -505,7 +505,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         3,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -526,7 +526,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         4,
                         "the_histo.date_histogram.time_zone",
-                        DateTimeZone.UTC.toString(),
+                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
                         "_rollup.id",
                         job.getId()
                     )
@@ -550,7 +550,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
             )
         );
 
-        String timeZone = DateTimeZone.forOffsetHours(-3).getID();
+        String timeZone = ZoneOffset.ofHours(-3).getId();
         String rollupIndex = randomAlphaOfLengthBetween(5, 10);
         String field = "the_histo";
         DateHistogramGroupConfig dateHistoConfig = new CalendarInterval(field, new DateHistogramInterval("1d"), null, timeZone);
@@ -648,7 +648,11 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         for (int i = 0; i < numDocs; i++) {
             // Make sure the timestamp is sufficiently in the past that we don't get bitten
             // by internal rounding, causing no docs to match
-            long timestamp = new DateTime().minusDays(2).minusHours(randomIntBetween(11, 100)).getMillis();
+            long timestamp = ZonedDateTime.now(ZoneOffset.UTC)
+                .minusDays(2)
+                .minusHours(randomIntBetween(11, 100))
+                .toInstant()
+                .toEpochMilli();
             dataset.add(asMap(timestampField, timestamp, valueField, randomLongBetween(1, 100)));
         }
         executeTestCase(dataset, job, System.currentTimeMillis(), (resp) -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexNameResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexNameResolver.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.security.audit.index;
 
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class IndexNameResolver {
 
@@ -21,7 +21,7 @@ public class IndexNameResolver {
         private final DateTimeFormatter formatter;
 
         Rollover(String format) {
-            this.formatter = DateTimeFormat.forPattern(format);
+            this.formatter = DateTimeFormatter.ofPattern(format, Locale.ROOT);
         }
 
         DateTimeFormatter formatter() {
@@ -31,11 +31,11 @@ public class IndexNameResolver {
 
     private IndexNameResolver() {}
 
-    public static String resolve(DateTime timestamp, Rollover rollover) {
-        return rollover.formatter().print(timestamp);
+    public static String resolve(ZonedDateTime timestamp, Rollover rollover) {
+        return rollover.formatter().format(timestamp);
     }
 
-    public static String resolve(String indexNamePrefix, DateTime timestamp, Rollover rollover) {
+    public static String resolve(String indexNamePrefix, ZonedDateTime timestamp, Rollover rollover) {
         return indexNamePrefix + resolve(timestamp, rollover);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -71,19 +71,20 @@ import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import org.elasticsearch.xpack.security.test.SecurityTestUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 import org.junit.Before;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -1417,8 +1418,8 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     }
 
     public void testUnauthorizedDateMathExpressionStrict() {
-        String expectedIndex = "datetime-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
-            new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
+        String expectedIndex = "datetime-" + DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT).format(
+            ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1));
         SearchRequest request = new SearchRequest("<datetime-{now/M}>");
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
@@ -1459,8 +1460,8 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     }
 
     public void testMissingDateMathExpressionStrict() {
-        String expectedIndex = "foobar-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
-            new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
+        String expectedIndex = "foobar-" + DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT).format(
+            ZonedDateTime.now(ZoneOffset.UTC).withDayOfMonth(1));
         SearchRequest request = new SearchRequest("<foobar-{now/M}>");
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -76,6 +76,8 @@ import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -76,8 +76,6 @@ import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/user/XPackUserTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/user/XPackUserTests.java
@@ -18,8 +18,9 @@ import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.security.audit.index.IndexNameResolver;
 import org.hamcrest.Matchers;
-import org.joda.time.DateTime;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
@@ -66,7 +67,7 @@ public class XPackUserTests extends ESTestCase {
     }
 
     private String getAuditLogName() {
-        final DateTime date = new DateTime().plusDays(randomIntBetween(1, 360));
+        final ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC).plusDays(randomIntBetween(1, 360));
         final IndexNameResolver.Rollover rollover = randomFrom(IndexNameResolver.Rollover.values());
         return IndexNameResolver.resolve(IndexAuditTrailField.INDEX_NAME_PREFIX, date, rollover);
     }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -65,10 +65,10 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.joda.time.Instant;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collections;

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -26,12 +26,12 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
-import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Joda was deprecated internally many years ago, but there still exist
some tests that use it to format dates. This commit converts tests in
xpack that need date parsing or printing to use Java time.