### PR TITLE
Changing name of shards field in node/stats api to shard_stats #78531

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -960,11 +960,11 @@ Time in milliseconds
 recovery operations were delayed due to throttling.
 =======
 
-`shards`::
+`shards_stats`::
 (object)
 Contains statistics about all shards assigned to the node.
 +
-.Properties of `shards`
+.Properties of `shard_stats`
 [%collapsible%open]
 =======
 `total_count`::

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,3 +1,5 @@
+
+   
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -128,7 +128,7 @@
                 "store",
                 "warmer",
                 "suggest",
-                "shards"
+                "shard_stats"
               ],
               "description":"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."
             }
@@ -177,7 +177,7 @@
                 "store",
                 "warmer",
                 "suggest",
-                "shards"
+                "shard_stats"
               ],
               "description":"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."
             },

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -109,7 +109,7 @@
   - is_false:  nodes.$node_id.indices.segments
   - is_false:  nodes.$node_id.indices.translog
   - is_false:  nodes.$node_id.indices.recovery
-  - is_false:  nodes.$node_id.indices.shards
+  - is_false:  nodes.$node_id.indices.shard_stats
 
 ---
 "Metric - multi":
@@ -167,7 +167,7 @@
   - is_false:  nodes.$node_id.indices.segments
   - is_false:  nodes.$node_id.indices.translog
   - is_true:   nodes.$node_id.indices.recovery
-  - is_false:  nodes.$node_id.indices.shards
+  - is_false:  nodes.$node_id.indices.shard_stats
 
 ---
 "Metric - _all include_segment_file_sizes":
@@ -225,7 +225,7 @@
   - is_true:   nodes.$node_id.indices.segments
   - is_false:  nodes.$node_id.indices.translog
   - is_false:  nodes.$node_id.indices.recovery
-  - is_false:  nodes.$node_id.indices.shards
+  - is_false:  nodes.$node_id.indices.shard_stats
   - is_true:   nodes.$node_id.indices.segments.file_sizes
 
 ---
@@ -257,7 +257,7 @@
   - is_true:   nodes.$node_id.indices.segments
   - is_false:  nodes.$node_id.indices.translog
   - is_false:  nodes.$node_id.indices.recovery
-  - is_false:  nodes.$node_id.indices.shards
+  - is_false:  nodes.$node_id.indices.shard_stats
 
 ---
 "Metric - _all include_unloaded_segments":
@@ -321,10 +321,10 @@
   # null and cannot be tested here
 
 ---
-"Metric - blank for indices shards":
+"Metric - blank for indices shard_stats":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.14.99"
+      version: " - 7.16.1"
       reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
@@ -334,14 +334,14 @@
   - do:
       nodes.stats: {}
 
-  - is_true:  nodes.$node_id.indices.shards
-  - match: { nodes.$node_id.indices.shards.total_count: 0 }
+  - is_true:  nodes.$node_id.indices.shard_stats
+  - match: { nodes.$node_id.indices.shard_stats.total_count: 0 }
 
 ---
-"Metric - _all for indices shards":
+"Metric - _all for indices shard_stats":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.14.99"
+      version: " - 7.16.1"
       reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
@@ -351,16 +351,16 @@
   - do:
       nodes.stats: { metric: _all }
 
-  - is_true:  nodes.$node_id.indices.shards
-  - match: { nodes.$node_id.indices.shards.total_count: 0 }
+  - is_true:  nodes.$node_id.indices.shard_stats
+  - match: { nodes.$node_id.indices.shard_stats.total_count: 0 }
 
 
 ---
-"indices shards total count test":
+"indices shard_stats total count test":
 
   - skip:
       features: ["allowed_warnings", arbitrary_key]
-      version: " - 7.14.99"
+      version: " - 7.16.1"
       reason:  "total shard count added in version 7.15.0"
 
   - do:
@@ -387,4 +387,4 @@
   - do:
       nodes.stats: { metric: _all }
 
-  - gte: { nodes.$node_id.indices.shards.total_count: 1 }
+  - gte: { nodes.$node_id.indices.shard_stats.total_count: 1 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -324,8 +324,8 @@
 "Metric - blank for indices shard_stats":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.16.1"
-      reason:  "total shard count added in version 7.15.0"
+      version: " - 7.15.0"
+      reason:  "total shard count added in version 7.15.0, and fixed in 7.15.1"
   - do:
       nodes.info: {}
   - set:
@@ -341,8 +341,8 @@
 "Metric - _all for indices shard_stats":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.16.1"
-      reason:  "total shard count added in version 7.15.0"
+      version: " - 7.15.0"
+      reason:  "total shard count added in version 7.15.0, and fixed in 7.15.1"
   - do:
       nodes.info: {}
   - set:
@@ -360,8 +360,8 @@
 
   - skip:
       features: ["allowed_warnings", arbitrary_key]
-      version: " - 7.16.1"
-      reason:  "total shard count added in version 7.15.0"
+      version: " - 7.15.0"
+      reason:  "total shard count added in version 7.15.0, and fixed in 7.15.1"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -232,7 +232,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         // 14 was previously used for Suggest
         RequestCache("request_cache", 15),
         Recovery("recovery", 16),
-        Shards("shards", 18);
+        Shards("shard_stats", 18);
 
         private final String restName;
         private final int index;

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardCountStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardCountStats.java
@@ -56,7 +56,7 @@ public class ShardCountStats implements Writeable, ToXContentFragment {
     }
 
     static final class Fields {
-        static final String SHARDS = "shards";
+        static final String SHARDS = "shard_stats";
         static final String TOTAL_COUNT = "total_count";
     }
 


### PR DESCRIPTION
If the _nodes/stats API received a level=shards request parameter, then the response would have two "shards" fields,
which would cause problems with json parsers. This commit renames the "shards" field that currently only contains
"total_count" to "shard_stats".
Relates #78311 #75433 #78531