### PR TITLE
Remove Joda from remaining xpack tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupActionDateHistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupActionDateHistogramGroupConfig.java
@@ -52,7 +52,8 @@ public abstract class RollupActionDateHistogramGroupConfig implements Writeable,
     public static final String CALENDAR_INTERVAL = "calendar_interval";
     public static final String TIME_ZONE = "time_zone";
 
-    public static final String DEFAULT_TIMEZONE = "UTC";
+    // this should really be ZoneOffset.UTC, but the literal UTC timezone is used because it came from Joda
+    public static final String DEFAULT_TIMEZONE = ZoneId.of("UTC").getId();
     private static final String FIELD = "field";
 
     private static final ConstructingObjectParser<RollupActionDateHistogramGroupConfig, Void> PARSER;

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -37,9 +37,9 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
 import org.elasticsearch.xpack.frozen.FrozenIndices;
-import org.joda.time.Instant;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -123,8 +123,8 @@ public class FrozenIndexIT extends ESIntegTestCase {
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertTrue(timestampFieldRange.isComplete());
-        assertThat(timestampFieldRange.getMin(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").getMillis()));
-        assertThat(timestampFieldRange.getMax(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").getMillis()));
+        assertThat(timestampFieldRange.getMin(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").toEpochMilli()));
+        assertThat(timestampFieldRange.getMax(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").toEpochMilli()));
     }
 
     public void testTimestampFieldTypeExposedByAllIndicesServices() throws Exception {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
@@ -19,8 +19,6 @@ import org.elasticsearch.xpack.idp.saml.support.SamlAuthenticationState;
 import org.elasticsearch.xpack.idp.saml.support.SamlFactory;
 import org.elasticsearch.xpack.idp.saml.support.SamlInit;
 import org.elasticsearch.xpack.idp.saml.support.SamlObjectSigner;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
@@ -115,10 +113,6 @@ public class SuccessfulAuthenticationResponseMessageBuilder {
         conditions.setNotOnOrAfter(now.plus(serviceProvider.getAuthnExpiry()));
         conditions.getAudienceRestrictions().add(restriction);
         return conditions;
-    }
-
-    private DateTime now() {
-        return new DateTime(clock.millis(), DateTimeZone.UTC);
     }
 
     private Subject buildSubject(Instant now, UserServiceAuthentication user, SamlAuthenticationState authnState) {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupJobIdentifierUtilTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupJobIdentifierUtilTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
-import org.joda.time.DateTimeZone;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -399,7 +398,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
 
         final GroupConfig group = new GroupConfig(
             // NOTE same name but wrong type
-            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID()),
+            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId()),
             new HistogramGroupConfig(1L, "baz"), // <-- NOTE right type but wrong name
             null
         );
@@ -428,7 +427,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
             .subAggregation(new AvgAggregationBuilder("the_avg").field("avg_field"));
 
         final GroupConfig group = new GroupConfig(
-            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID())
+            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId())
         );
         final List<MetricConfig> metrics = Arrays.asList(
             new MetricConfig("max_field", singletonList("max")),
@@ -457,7 +456,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
 
         final GroupConfig group = new GroupConfig(
             // interval in job is much higher than agg interval above
-            new DateHistogramGroupConfig.FixedInterval("foo", new DateHistogramInterval("100d"), null, DateTimeZone.UTC.getID())
+            new DateHistogramGroupConfig.FixedInterval("foo", new DateHistogramInterval("100d"), null, ZoneOffset.UTC.getId())
         );
         final RollupJobConfig job = new RollupJobConfig("foo", "index", "rollup", "*/5 * * * * ?", 10, group, emptyList(), null);
         Set<RollupJobCaps> caps = singletonSet(new RollupJobCaps(job));
@@ -481,7 +480,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
 
         final GroupConfig group = new GroupConfig(
             // NOTE different field from the one in the query
-            new DateHistogramGroupConfig.CalendarInterval("bar", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID())
+            new DateHistogramGroupConfig.CalendarInterval("bar", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId())
         );
         final List<MetricConfig> metrics = Arrays.asList(
             new MetricConfig("max_field", singletonList("max")),
@@ -509,7 +508,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
             .subAggregation(new AvgAggregationBuilder("the_avg").field("avg_field"));
 
         final GroupConfig group = new GroupConfig(
-            new DateHistogramGroupConfig.CalendarInterval("bar", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID()),
+            new DateHistogramGroupConfig.CalendarInterval("bar", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId()),
             new HistogramGroupConfig(1L, "baz"), // <-- NOTE right type but wrong name
             null
         );
@@ -538,7 +537,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
             .subAggregation(new AvgAggregationBuilder("the_avg").field("avg_field"));
 
         final GroupConfig group = new GroupConfig(
-            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID()),
+            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId()),
             new HistogramGroupConfig(1L, "baz"), // <-- NOTE right type but wrong name
             null
         );

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -55,11 +55,11 @@ import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
 import org.elasticsearch.xpack.rollup.Rollup;
 import org.hamcrest.core.IsEqual;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -454,7 +454,7 @@ public class SearchActionTests extends ESTestCase {
         SearchRequest request = new SearchRequest(combinedIndices, source);
 
         final GroupConfig groupConfig = new GroupConfig(
-            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, DateTimeZone.UTC.getID())
+            new DateHistogramGroupConfig.CalendarInterval("foo", new DateHistogramInterval("1d"), null, ZoneOffset.UTC.getId())
         );
         final RollupJobConfig job = new RollupJobConfig("foo", "index", "rollup", "*/5 * * * * ?", 10, groupConfig, emptyList(), null);
         Set<RollupJobCaps> caps = singleton(new RollupJobCaps(job));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.zone.ZoneRulesException;
 import java.util.HashMap;
 import java.util.Map;

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
@@ -15,8 +15,9 @@ import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.zone.ZoneRulesException;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,17 +76,17 @@ public class ConfigTests extends ESTestCase {
 
     public void testNullTimeZone() {
         DateHistogramGroupConfig config = new CalendarInterval("foo", DateHistogramInterval.HOUR, null, null);
-        assertThat(config.getTimeZone(), equalTo(DateTimeZone.UTC.getID()));
+        assertThat(config.getTimeZone(), equalTo(ZoneId.of("UTC").getId()));
     }
 
     public void testEmptyTimeZone() {
         DateHistogramGroupConfig config = new CalendarInterval("foo", DateHistogramInterval.HOUR, null, "");
-        assertThat(config.getTimeZone(), equalTo(DateTimeZone.UTC.getID()));
+        assertThat(config.getTimeZone(), equalTo(ZoneId.of("UTC").getId()));
     }
 
     public void testDefaultTimeZone() {
         DateHistogramGroupConfig config = new CalendarInterval("foo", DateHistogramInterval.HOUR);
-        assertThat(config.getTimeZone(), equalTo(DateTimeZone.UTC.getID()));
+        assertThat(config.getTimeZone(), equalTo(ZoneId.of("UTC").getId()));
     }
 
     public void testUnkownTimeZone() {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -44,11 +44,12 @@ import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupIndexerJobStats;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
-import org.joda.time.DateTime;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
             Document document = new Document();
-            long timestamp = new DateTime().minusDays(i).getMillis();
+            long timestamp = ZonedDateTime.now(ZoneOffset.UTC).minusDays(i).toInstant().toEpochMilli();
             document.add(new SortedNumericDocValuesField(timestampField, timestamp));
             document.add(new LongPoint(timestampField, timestamp));
             document.add(new SortedNumericDocValuesField(valueField, randomIntBetween(1, 100)));
@@ -140,7 +141,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
             Document document = new Document();
-            long timestamp = new DateTime().minusDays(i).getMillis();
+            long timestamp = ZonedDateTime.now(ZoneOffset.UTC).minusDays(i).toInstant().toEpochMilli();
             document.add(new SortedNumericDocValuesField(timestampField, timestamp));
             document.add(new LongPoint(timestampField, timestamp));
             document.add(new SortedNumericDocValuesField(valueField, randomIntBetween(1, 100)));
@@ -256,7 +257,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
             Document document = new Document();
-            long timestamp = new DateTime().minusDays(i).getMillis();
+            long timestamp = ZonedDateTime.now(ZoneOffset.UTC).minusDays(i).toInstant().toEpochMilli();
             document.add(new SortedNumericDocValuesField(timestampField, timestamp));
             document.add(new LongPoint(timestampField, timestamp));
             document.add(new SortedNumericDocValuesField(valueField, randomIntBetween(1, 100)));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -137,7 +137,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -158,7 +158,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         1,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -221,7 +221,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         50.0,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -252,7 +252,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         141.0,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -283,7 +283,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         275.0,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -314,7 +314,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         270.0,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -345,7 +345,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "counter.sum.value",
                         440.0,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -398,7 +398,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -419,7 +419,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         2,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -440,7 +440,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         1,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -493,7 +493,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         3,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )
@@ -514,7 +514,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         "the_histo.date_histogram._count",
                         4,
                         "the_histo.date_histogram.time_zone",
-                        "UTC", // TODO: the default is hardcoded from Joda, we should change this
+                        ZoneId.of("UTC").getId(),
                         "_rollup.id",
                         job.getId()
                     )


### PR DESCRIPTION
This commit removes uses of Joda classes from rollup and other xpack
tests still utilizing them, mostly around time zones.