### PR TITLE
[DOCS] Fixes ML get calendars API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -39,15 +39,29 @@ For more information, see
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
+[[ml-get-calendar-query-parms]]
+== {api-query-parms-title}
+
+`from`::
+    (Optional, integer) Skips the specified number of calendars. This parameter
+    is supported only when you omit the `<calendar_id>`. Defaults to `0`.
+
+`size`::
+    (Optional, integer) Specifies the maximum number of calendars to obtain.
+    This parameter is supported only when you omit the `<calendar_id>`. Defaults
+    to `10000`.
+
 [[ml-get-calendar-request-body]]
 == {api-request-body-title}
 
 `page`.`from`::
-    (Optional, integer) Skips the specified number of calendars. Defaults to `0`.
+    (Optional, integer) Skips the specified number of calendars. This object is 
+    supported only when you omit the `<calendar_id>`. Defaults to `0`.
 
 `page`.`size`::
     (Optional, integer) Specifies the maximum number of calendars to obtain.
-    Defaults to `0`.
+    This object is  supported only when you omit the `<calendar_id>`. Defaults
+    to `10000`.
 
 [[ml-get-calendar-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -49,7 +49,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 `size`::
     (Optional, integer) Specifies the maximum number of calendars to obtain.
     This parameter is supported only when you omit the `<calendar_id>`. Defaults
-    to `10000`.
+    to `100`.
 
 [[ml-get-calendar-request-body]]
 == {api-request-body-title}
@@ -61,7 +61,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 `page`.`size`::
     (Optional, integer) Specifies the maximum number of calendars to obtain.
     This object is  supported only when you omit the `<calendar_id>`. Defaults
-    to `10000`.
+    to `100`.
 
 [[ml-get-calendar-results]]
 == {api-response-body-title}


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-specification/pull/852

This PR fixes the default value for the size parameter in the [get calendars API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html). It also adds missing query parameters and clarifies when "from" and "size" can be used.

###  Preview

https://elasticsearch_78808.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html