### PR TITLE
[DOCS] Fixes ML get scheduled events API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -26,8 +26,8 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 
 You can get scheduled event information for multiple calendars in a single
 API request by using a comma-separated list of ids or a wildcard expression.
-You can get scheduled event information for all calendars by using `_all`,
-by specifying `*` as the `<calendar_id>`, or by omitting the `<calendar_id>`.
+You can get scheduled event information for all calendars by using `_all` or `*`
+as the `<calendar_id>`.
 
 For more information, see
 {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
@@ -39,6 +39,28 @@ For more information, see
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
+[[ml-get-calendar-event-query-parms]]
+== {api-query-parms-title}
+
+`end`::
+  (Optional, string) Specifies to get events with timestamps earlier than this
+  time.
+
+`from`::
+  (Optional, integer) Skips the specified number of events. Defaults to `0`.
+
+`job_id`::
+  (Optional, string) Specifies to get events for a specific {anomaly-job}
+  identifier or job group. It must be used with a calendar identifier of `_all`
+  or `*`.
+
+`size`::
+  (Optional, integer) Specifies the maximum number of events to obtain. Defaults
+  to `100`.
+
+`start`::
+  (Optional, string) Specifies to get events with timestamps after this time.
+
 [[ml-get-calendar-event-request-body]]
 == {api-request-body-title}
 
@@ -47,17 +69,22 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
     time. Defaults to unset, which means results are not
     limited to specific timestamps.
 
-`from`::
+`job_id`::
+    (Optional, string) Specifies to get events for a specific {anomaly-job}
+    identifier or job group. It must be used with a calendar identifier of `_all`
+    or `*`.
+
+`page.from`::
     (Optional, integer) Skips the specified number of events. Defaults to `0`.
 
-`size`::
+`page.size`::
     (Optional, integer) Specifies the maximum number of events to obtain.
     Defaults to `100`.
 
 `start`::
     (Optional, string) Specifies to get events with timestamps after this time.
-    Defaults to unset, which means results are not limited to
-    specific timestamps.
+    Defaults to unset, which means results are not limited to specific
+    timestamps.
 
 [[ml-get-calendar-event-results]]
 == {api-response-body-title}
@@ -126,3 +153,12 @@ The API returns the following results:
 // TESTRESPONSE[s/LS8LJGEBMTCMA-qz49st/$body.$_path/]
 // TESTRESPONSE[s/Li8LJGEBMTCMA-qz49st/$body.$_path/]
 // TESTRESPONSE[s/Ly8LJGEBMTCMA-qz49st/$body.$_path/]
+
+The following example retrieves scheduled events that occur within a specific
+period of time:
+
+[source,console]
+--------------------------------------------------
+GET _ml/*/planned-outages/events?start=1635638400000&end=1635724800000
+--------------------------------------------------
+// TEST[skip:setup:calendar_outages_addevent]


### PR DESCRIPTION
Related to elastic/elasticsearch-specification#852

This PR fixes the [get scheduled events API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html). It:

* adds the missing query parameters section,
* adds a missing "job_id" option,
* adds the missing "page" object for the "from" and "size" options, 
* adds an example that shows the use of some query parameters
* removes phrase about "omitting the `<calendar_id>`", since this results in an error

### Preview

https://elasticsearch_78809.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html