### PR TITLE
Introduce timeout for batched ILM tasks

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -20,6 +20,8 @@ import org.elasticsearch.xpack.core.ilm.Step;
  */
 public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterStateTaskListener {
 
+    static final class TimeoutException extends Exception {}
+
     private final ListenableFuture<Void> listener = new ListenableFuture<>();
 
     protected final Index index;
@@ -63,7 +65,10 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
     @Override
     public final void onFailure(String source, Exception e) {
         listener.onFailure(e);
-        handleFailure(source, e);
+        //we ignore timeout exception, task will be retried on the next cluster state update
+        if (e instanceof TimeoutException == false) {
+            handleFailure(source, e);
+        }
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -49,22 +49,27 @@ import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.LIFECYCLE_ORIGI
 
 class IndexLifecycleRunner {
     private static final Logger logger = LogManager.getLogger(IndexLifecycleRunner.class);
-    private final ThreadPool threadPool;
+    private ThreadPool threadPool;
     private final ClusterService clusterService;
     private final PolicyStepsRegistry stepRegistry;
     private final ILMHistoryStore ilmHistoryStore;
     private final LongSupplier nowSupplier;
 
-    private static final ClusterStateTaskExecutor<IndexLifecycleClusterStateUpdateTask> ILM_TASK_EXECUTOR = (currentState, tasks) -> {
+    private final ClusterStateTaskExecutor<IndexLifecycleClusterStateUpdateTask> ILM_TASK_EXECUTOR = (currentState, tasks) -> {
         ClusterStateTaskExecutor.ClusterTasksResult.Builder<IndexLifecycleClusterStateUpdateTask> builder =
-                ClusterStateTaskExecutor.ClusterTasksResult.builder();
+            ClusterStateTaskExecutor.ClusterTasksResult.builder();
         ClusterState state = currentState;
+        long start = threadPool.relativeTimeInMillis();
         for (IndexLifecycleClusterStateUpdateTask task : tasks) {
-            try {
-                state = task.execute(state);
-                builder.success(task);
-            } catch (Exception e) {
-                builder.failure(task, e);
+            if (threadPool.relativeTimeInMillis() - start < 10000) {
+                try {
+                    state = task.execute(state);
+                    builder.success(task);
+                } catch (Exception e) {
+                    builder.failure(task, e);
+                }
+            } else {
+                builder.failure(task, new IndexLifecycleClusterStateUpdateTask.TimeoutException());
             }
         }
         return builder.build(state);


### PR DESCRIPTION
If there's a lot ILM tasks queued for execution their application can take a long time, preventing other tasks from proceeding and in worst case can cause master to drop. 
This change introduces max time of 10s for single batch. Tasks that didn't make it will be retired on next cluster state update.