### PR TITLE
Allow indices lookup to be built lazily

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
@@ -89,7 +89,7 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
             .put(IndexMetadata.builder(targetIndexMetadata)
                 .putCustom(ILM_CUSTOM_METADATA_KEY, relevantTargetCustomData.build().asMap()));
 
-        return ClusterState.builder(clusterState).metadata(newMetadata).build();
+        return ClusterState.builder(clusterState).metadata(newMetadata.build(false)).build();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopySettingsStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopySettingsStep.java
@@ -87,7 +87,7 @@ public class CopySettingsStep extends ClusterStateActionStep {
             .put(IndexMetadata.builder(targetIndexMetadata)
                 .settingsVersion(targetIndexMetadata.getSettingsVersion() + 1)
                 .settings(settings));
-        return ClusterState.builder(clusterState).metadata(newMetaData).build();
+        return ClusterState.builder(clusterState).metadata(newMetaData.build(false)).build();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -93,7 +93,8 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
         return ClusterState.builder(clusterState)
             .metadata(Metadata.builder(clusterState.getMetadata())
                 .put(IndexMetadata.builder(indexMetaData)
-                    .putCustom(ILM_CUSTOM_METADATA_KEY, newCustomData.build().asMap())))
+                    .putCustom(ILM_CUSTOM_METADATA_KEY, newCustomData.build().asMap()))
+                .build(false))
             .build();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
@@ -90,7 +90,7 @@ public class GenerateUniqueIndexNameStep extends ClusterStateActionStep {
 
         IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexMetadata);
         indexMetadataBuilder.putCustom(ILM_CUSTOM_METADATA_KEY, newCustomData.build().asMap());
-        newClusterStateBuilder.metadata(Metadata.builder(clusterState.getMetadata()).put(indexMetadataBuilder));
+        newClusterStateBuilder.metadata(Metadata.builder(clusterState.getMetadata()).put(indexMetadataBuilder).build(false));
         return newClusterStateBuilder.build();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStep.java
@@ -68,7 +68,7 @@ public final class InitializePolicyContextStep extends ClusterStateActionStep {
         indexMetadataBuilder.putCustom(ILM_CUSTOM_METADATA_KEY, newCustomData.build().asMap());
 
         newClusterStateBuilder.metadata(
-            Metadata.builder(clusterState.getMetadata()).put(indexMetadataBuilder)
+            Metadata.builder(clusterState.getMetadata()).put(indexMetadataBuilder).build(false)
         );
         return newClusterStateBuilder.build();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
@@ -51,7 +51,7 @@ public final class PhaseCacheManagement {
         final IndexMetadata idxMeta = state.metadata().index(index);
         Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
         refreshPhaseDefinition(metadataBuilder, idxMeta, updatedPolicy);
-        return ClusterState.builder(state).metadata(metadataBuilder).build();
+        return ClusterState.builder(state).metadata(metadataBuilder.build(false)).build();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class PhaseCacheManagement {
                                                       final LifecyclePolicyMetadata newPolicy, XPackLicenseState licenseState) {
         Metadata.Builder mb = Metadata.builder(state.metadata());
         if (updateIndicesForPolicy(mb, state, xContentRegistry, client, oldPolicy, newPolicy, licenseState)) {
-            return ClusterState.builder(state).metadata(mb).build();
+            return ClusterState.builder(state).metadata(mb.build(false)).build();
         }
         return state;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStep.java
@@ -97,7 +97,7 @@ public class ReplaceDataStreamBackingIndexStep extends ClusterStateActionStep {
 
         Metadata.Builder newMetaData = Metadata.builder(clusterState.getMetadata())
             .put(dataStream.getDataStream().replaceBackingIndex(index, targetIndexMetadata.getIndex()));
-        return ClusterState.builder(clusterState).metadata(newMetaData).build();
+        return ClusterState.builder(clusterState).metadata(newMetaData.build(false)).build();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateRolloverLifecycleDateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateRolloverLifecycleDateStep.java
@@ -70,7 +70,7 @@ public class UpdateRolloverLifecycleDateStep extends ClusterStateActionStep {
         IndexMetadata.Builder newIndexMetadata = IndexMetadata.builder(indexMetadata);
         newIndexMetadata.putCustom(ILM_CUSTOM_METADATA_KEY, newLifecycleState.build().asMap());
         return ClusterState.builder(currentState).metadata(Metadata.builder(currentState.metadata())
-            .put(newIndexMetadata)).build();
+            .put(newIndexMetadata).build(false)).build();
     }
 
     private static String getRolloverTarget(Index index, ClusterState currentState) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -67,6 +67,8 @@ class IndexLifecycleRunner {
                 builder.failure(task, e);
             }
         }
+        // Trigger indices lookup creation and related validation
+        state.metadata().getIndicesLookup();
         return builder.build(state);
     };
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -344,7 +344,8 @@ public final class IndexLifecycleTransition {
         ClusterState.Builder newClusterStateBuilder = ClusterState.builder(clusterState);
         newClusterStateBuilder.metadata(Metadata.builder(clusterState.getMetadata())
             .put(IndexMetadata.builder(clusterState.getMetadata().index(index))
-                .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.asMap())));
+                .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.asMap()))
+            .build(false));
         return newClusterStateBuilder;
     }
 


### PR DESCRIPTION
Backport #78745 to 7.x branch.

Overloaded the Metadata.Builder.build() method by adding a parameter that controls when to build indices lookup.
By default the indices lookup is always build.

When cluster state updates are batched in ilm, then built the indices lookup lazily. Because during batching only the final cluster state is used, then for the many intermediate cluster states we avoids building the indices lookup, which in a cluster with many indices can improve the performance of publishing cluster states significantly.

Relates to #77466