### PR TITLE
Simplify TestCluster extraJar configuration

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -31,26 +31,20 @@ if (BuildParams.inFipsJvm) {
         copy 'fips_java.policy'
         copy 'cacerts.bcfks'
       }
+      def extraFipsJarsConfiguration = configurations.detachedConfiguration(bcFips, bcTlsFips)
 
       project.afterEvaluate {
-        def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
         // ensure that bouncycastle is on classpath for the all of test types, must happen in evaluateAfter since the rest tests explicitly
         // set the class path to help maintain pure black box testing, and here we are adding to that classpath
         tasks.withType(Test).configureEach { Test test ->
-          test.setClasspath(test.getClasspath().plus(extraFipsJars))
+          test.setClasspath(test.getClasspath().plus(extraFipsJarsConfiguration))
         }
       }
 
       pluginManager.withPlugin("elasticsearch.testclusters") {
-        afterEvaluate {
-          // This afterEvaluate hooks is required to avoid deprecated configuration resolution
-          // This configuration can be removed once system modules are available
-          def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
-          testClusters.configureEach {
-            extraFipsJars.files.each {
-              extraJarFile it
-            }
-          }
+        // This configuration can be removed once system modules are available
+        testClusters.configureEach {
+            extraJarFiles extraFipsJarsConfiguration
         }
         tasks.withType(TestClustersAware).configureEach {
           dependsOn 'fipsResources'

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -206,7 +206,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
             testClusters {
               myCluster {
                 testDistribution = 'default'
-                extraJarFile(file('${someJar().absolutePath}'))
+                extraJarFiles(files('${someJar().absolutePath}'))
               }
             }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -14,6 +14,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.file.ArchiveOperations;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logger;
@@ -391,8 +392,8 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     }
 
     @Override
-    public void extraJarFile(File from) {
-        nodes.all(node -> node.extraJarFile(from));
+    public void extraJarFiles(FileCollection from) {
+        nodes.all(node -> node.extraJarFiles(from));
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -140,7 +140,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final LazyPropertyMap<String, CharSequence> environment = new LazyPropertyMap<>("Environment", this);
     private final LazyPropertyList<CharSequence> jvmArgs = new LazyPropertyList<>("JVM arguments", this);
     private final LazyPropertyMap<String, File> extraConfigFiles = new LazyPropertyMap<>("Extra config files", this, FileEntry::new);
-    private final LazyPropertyList<File> extraJarFiles = new LazyPropertyList<>("Extra jar files", this);
+    private final LazyPropertyList<FileCollection> extraJarConfigurations = new LazyPropertyList<>("Extra jar files", this);
     private final List<Map<String, String>> credentials = new ArrayList<>();
     final LinkedHashMap<String, String> defaultConfig = new LinkedHashMap<>();
 
@@ -585,7 +585,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private boolean canUseSharedDistribution() {
         // using original location can be too long due to MAX_PATH restrictions on windows CI
         // TODO revisit when moving to shorter paths on CI by using Teamcity
-        return OS.current() != OS.WINDOWS && extraJarFiles.size() == 0 && modules.size() == 0 && plugins.size() == 0;
+        return OS.current() != OS.WINDOWS && extraJarConfigurations.size() == 0 && modules.size() == 0 && plugins.size() == 0;
     }
 
     private void logToProcessStdout(String message) {
@@ -648,10 +648,18 @@ public class ElasticsearchNode implements TestClusterConfiguration {
      * //TODO: Remove this when system modules are available
      */
     private void copyExtraJars() {
+        List<File> extraJarFiles = this.extraJarConfigurations.stream()
+                .flatMap(fileCollection -> fileCollection.getFiles().stream())
+                .collect(Collectors.toList());
+
         if (extraJarFiles.isEmpty() == false) {
-            logToProcessStdout("Setting up " + extraJarFiles.size() + " additional jar dependencies");
+            logToProcessStdout("Setting up " + this.extraJarConfigurations.size() + " additional jar dependencies");
         }
         extraJarFiles.forEach(from -> {
+            if (from.getName().endsWith(".jar") == false) {
+                throw new IllegalArgumentException("extra jar file " + from.toString() + " doesn't appear to be a JAR");
+            }
+
             Path destination = getDistroDir().resolve("lib").resolve(from.getName());
             try {
                 Files.copy(from.toPath(), destination, StandardCopyOption.REPLACE_EXISTING);
@@ -700,11 +708,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     @Override
-    public void extraJarFile(File from) {
-        if (from.toString().endsWith(".jar") == false) {
-            throw new IllegalArgumentException("extra jar file " + from.toString() + " doesn't appear to be a JAR");
-        }
-        extraJarFiles.add(from);
+    public void extraJarFiles(FileCollection from) {
+        extraJarConfigurations.add(from);
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterConfiguration.java
@@ -9,6 +9,7 @@ package org.elasticsearch.gradle.testclusters;
 
 import org.elasticsearch.gradle.FileSupplier;
 import org.elasticsearch.gradle.PropertyNormalization;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
@@ -90,7 +91,7 @@ public interface TestClusterConfiguration {
 
     void extraConfigFile(String destination, File from, PropertyNormalization normalization);
 
-    void extraJarFile(File from);
+    void extraJarFiles(FileCollection from);
 
     void user(Map<String, String> userSpec);
 


### PR DESCRIPTION
Allow passing FileCollection instead of single Jar files. This makes using the API way easier
as gradle configurations for resolving jars do not need to be resolved eagerly