### PR TITLE
[6.8] [DOCS] Fixes ML get scheduled events API (#78809)

### DIFF
--- a/docs/reference/ml/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/get-calendar-event.asciidoc
@@ -38,8 +38,7 @@ calendars by using `_all`.
 
 `job_id`::
   (Optional, string) Specifies to get events for a specific {anomaly-job}
-  identifier or job group. It must be used with a calendar identifier of `_all`
-  or `*`.
+  identifier or job group. It must be used with a calendar identifier of `_all`.
 
 `size`::
   (Optional, integer) Specifies the maximum number of events to obtain. Defaults
@@ -47,26 +46,6 @@ calendars by using `_all`.
 
 `start`::
   (Optional, string) Specifies to get events with timestamps after this time.
-
-
-==== Request Body
-
-`end`::
-    (string) Specifies to get events with timestamps earlier than this time.
-
-`job_id`::
-    (string) Specifies to get events for a specific {anomaly-job}
-    identifier or job group. It must be used with a calendar identifier of `_all`
-    or `*`.
-
-`page.from`::
-    (integer) Skips the specified number of events.
-
-`page.size`::
-    (integer) Specifies the maximum number of events to obtain.
-
-`start`::
-    (string) Specifies to get events with timestamps after this time.
 
 ==== Results
 
@@ -138,6 +117,6 @@ period of time:
 
 [source,console]
 --------------------------------------------------
-GET _ml/*/planned-outages/events?start=1635638400000&end=1635724800000
+GET _xpack/ml/calendars/planned-outages/events?start=1635638400000&end=1635724800000
 --------------------------------------------------
 // TEST[skip:setup:calendar_outages_addevent]

--- a/docs/reference/ml/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/get-calendar-event.asciidoc
@@ -27,15 +27,42 @@ calendars by using `_all`.
 `calendar_id` (required)::
   (string) Identifier for the calendar.
 
+==== Query Parameters
+
+`end`::
+  (Optional, string) Specifies to get events with timestamps earlier than this
+  time.
+
+`from`::
+  (Optional, integer) Skips the specified number of events. Defaults to `0`.
+
+`job_id`::
+  (Optional, string) Specifies to get events for a specific {anomaly-job}
+  identifier or job group. It must be used with a calendar identifier of `_all`
+  or `*`.
+
+`size`::
+  (Optional, integer) Specifies the maximum number of events to obtain. Defaults
+  to `100`.
+
+`start`::
+  (Optional, string) Specifies to get events with timestamps after this time.
+
+
 ==== Request Body
 
 `end`::
     (string) Specifies to get events with timestamps earlier than this time.
 
-`from`::
+`job_id`::
+    (string) Specifies to get events for a specific {anomaly-job}
+    identifier or job group. It must be used with a calendar identifier of `_all`
+    or `*`.
+
+`page.from`::
     (integer) Skips the specified number of events.
 
-`size`::
+`page.size`::
     (integer) Specifies the maximum number of events to obtain.
 
 `start`::
@@ -105,3 +132,12 @@ The API returns the following results:
 // TESTRESPONSE[s/Ly8LJGEBMTCMA-qz49st/$body.$_path/]
 
 For more information about these properties, see <<ml-event-resource>>.
+
+The following example retrieves scheduled events that occur within a specific
+period of time:
+
+[source,console]
+--------------------------------------------------
+GET _ml/*/planned-outages/events?start=1635638400000&end=1635724800000
+--------------------------------------------------
+// TEST[skip:setup:calendar_outages_addevent]


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [DOCS] Fixes ML get scheduled events API (#78809)

Also removes request body, since in tests on 6.8.19, any request objects such as:

> GET _xpack/ml/calendars/planned-outages/events
{
  "page":{
    "from": 0,
    "size": 5
  },
  "start": "1640390300000",
  "end": "1640476900000"
}

Returns errors:

> {
  "error": {
    "root_cause": [
      {
        "type": "x_content_parse_exception",
        "reason": "[2:3] [cluster:admin/xpack/ml/calendars/events/post] unknown field [page], parser not found"
      }
    ],
    "type": "x_content_parse_exception",
    "reason": "[2:3] [cluster:admin/xpack/ml/calendars/events/post] unknown field [page], parser not found"
  },
  "status": 400
}