### PR TITLE
[7.x] Convert encrypted snapshot license object to LicensedFeature (#78731)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -52,8 +52,6 @@ public class XPackLicenseState {
         MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
         MONITORING_UPDATE_RETENTION(OperationMode.STANDARD, false),
 
-        ENCRYPTED_SNAPSHOT(OperationMode.PLATINUM, true),
-
         CCR(OperationMode.PLATINUM, true),
 
         MACHINE_LEARNING(OperationMode.PLATINUM, true),

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -60,6 +60,8 @@ import java.util.function.Supplier;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
+import static org.elasticsearch.repositories.encrypted.EncryptedRepositoryPlugin.ENCRYPTED_SNAPSHOT_FEATURE;
+
 public class EncryptedRepository extends BlobStoreRepository {
     static final Logger logger = LogManager.getLogger(EncryptedRepository.class);
     // the following constants are fixed by definition
@@ -176,7 +178,7 @@ public class EncryptedRepository extends BlobStoreRepository {
     public Map<String, Object> adaptUserMetadata(Map<String, Object> userMetadata) {
         // because populating the snapshot metadata must be done before the actual snapshot is first initialized,
         // we take the opportunity to validate the license and abort if non-compliant
-        if (false == licenseStateSupplier.get().isAllowed(XPackLicenseState.Feature.ENCRYPTED_SNAPSHOT)) {
+        if (false == ENCRYPTED_SNAPSHOT_FEATURE.checkWithoutTracking(licenseStateSupplier.get())) {
             throw LicenseUtils.newComplianceException("encrypted snapshots");
         }
         Map<String, Object> snapshotUserMetadata = new HashMap<>();

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryPlugin.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryPlugin.java
@@ -21,7 +21,9 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
@@ -39,6 +41,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class EncryptedRepositoryPlugin extends Plugin implements RepositoryPlugin {
+
+    static final LicensedFeature.Momentary ENCRYPTED_SNAPSHOT_FEATURE = LicensedFeature.momentary(
+        null,
+        "encrypted-snapshot",
+        License.OperationMode.PLATINUM
+    );
 
     private static final Boolean ENCRYPTED_REPOSITORY_FEATURE_FLAG_REGISTERED;
     static {
@@ -155,7 +163,7 @@ public class EncryptedRepositoryPlugin extends Plugin implements RepositoryPlugi
                 if (false == (delegatedRepository instanceof BlobStoreRepository) || delegatedRepository instanceof EncryptedRepository) {
                     throw new IllegalArgumentException("Unsupported delegate repository type [" + DELEGATE_TYPE_SETTING.getKey() + "]");
                 }
-                if (false == getLicenseState().checkFeature(XPackLicenseState.Feature.ENCRYPTED_SNAPSHOT)) {
+                if (false == ENCRYPTED_SNAPSHOT_FEATURE.check(getLicenseState())) {
                     logger.warn(
                         new ParameterizedMessage(
                             "Encrypted snapshots are not allowed for the currently installed license [{}]."


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Convert encrypted snapshot license object to LicensedFeature (#78731)