### PR TITLE
[DOCS] Fixes typo in calendar API example

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -159,6 +159,6 @@ period of time:
 
 [source,console]
 --------------------------------------------------
-GET _ml/*/planned-outages/events?start=1635638400000&end=1635724800000
+GET _ml/calendars/planned-outages/events?start=1635638400000&end=1635724800000
 --------------------------------------------------
 // TEST[skip:setup:calendar_outages_addevent]


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/elastic/elasticsearch/pull/78809