### PR TITLE
Fix DataTierTests package and add a validation test

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
@@ -175,6 +175,7 @@ public class DataTier {
         }
     }
 
+    // visible for testing
     static final class DataTierSettingValidator implements Setting.Validator<String> {
 
         private static final Collection<Setting<?>> dependencies = List.of(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
@@ -175,7 +175,7 @@ public class DataTier {
         }
     }
 
-    private static final class DataTierSettingValidator implements Setting.Validator<String> {
+    static final class DataTierSettingValidator implements Setting.Validator<String> {
 
         private static final Collection<Setting<?>> dependencies = List.of(
             IndexModule.INDEX_STORE_TYPE_SETTING,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -1,17 +1,17 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
-package org.elasticsearch.xpack.core;
+package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -160,7 +160,7 @@ public class DataTierTests extends ESTestCase {
         // good values
         validator.validate(null);
         validator.validate("");
-        validator.validate(" ");
+        validator.validate(" "); // a little surprising
         validator.validate(DATA_WARM);
         validator.validate(DATA_WARM + "," + DATA_HOT);
         validator.validate(DATA_WARM + ","); // a little surprising

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.DataTier.DataTierSettingValidator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
@@ -151,5 +152,23 @@ public class DataTierTests extends ESTestCase {
             nodesList.add(node);
         }
         return nodesList;
+    }
+
+    public void testDataTierSettingValidator() {
+        DataTierSettingValidator validator = new DataTierSettingValidator();
+
+        // good values
+        validator.validate(null);
+        validator.validate("");
+        validator.validate(" ");
+        validator.validate(DATA_WARM);
+        validator.validate(DATA_WARM + "," + DATA_HOT);
+        validator.validate(DATA_WARM + ","); // a little surprising
+
+        // bad values
+        expectThrows(IllegalArgumentException.class, () -> validator.validate(" " + DATA_WARM));
+        expectThrows(IllegalArgumentException.class, () -> validator.validate(DATA_WARM + " "));
+        expectThrows(IllegalArgumentException.class, () -> validator.validate(DATA_WARM + ", "));
+        expectThrows(IllegalArgumentException.class, () -> validator.validate(DATA_WARM + ", " + DATA_HOT));
     }
 }


### PR DESCRIPTION
Follow up to #78668, but also related to #76147

Moved the class to follow the movement of DataTier itself, and also added a relatively simple validation test so that we don't accidentally change the behavior here.