### PR TITLE
Update question: index recovery

### DIFF
--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -121,7 +121,7 @@ Reading index metadata and copying bytes from source to destination.
 `INIT`::
 Recovery has not started.
 
-`START`::
+`VERIFY_INDEX`::
 Starting the recovery process; opening the index for use.
 
 `TRANSLOG`::

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -107,25 +107,25 @@ to a different node in the same cluster.
 --
 (String)
 Recovery stage.
-Returned values include:
-
-`DONE`::
-Complete.
-
-`FINALIZE`::
-Cleanup.
-
-`INDEX`::
-Reading index metadata and copying bytes from source to destination.
+Returned values can include:
 
 `INIT`::
 Recovery has not started.
 
+`INDEX`::
+Reading index metadata and copying bytes from source to destination.
+
 `VERIFY_INDEX`::
-Starting the recovery process; opening the index for use.
+Verifying the integrity of the index.
 
 `TRANSLOG`::
-Replaying transaction log .
+Replaying transaction log.
+
+`FINALIZE`::
+Cleanup.
+
+`DONE`::
+Complete.
 --
 
 `primary`::


### PR DESCRIPTION
Hello, team! I'm trying to understand possible recovery stages for myself per [this doc > `STAGE`](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html#index-recovery-api-response-body) as compared to [this code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java#L41-L91) ([part2](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java#L187-L223)). However, I'm not finding the expected reference to `STAGE:start` & instead am finding reference to `STAGE:verify_index`. I may be missing a code-to-human translation somewhere. Will you double check for me? 🙏🏼