### PR TITLE
Update ThreadPoolTypes

### DIFF
--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -102,7 +102,7 @@ Maximum number of tasks permitted in the queue for the current thread pool.
 Configured fixed number of active threads allowed in the current thread pool.
 
 `type`, `t`::
-Type of thread pool. Returned values are `fixed` or `scaling`.
+Type of thread pool. Returned values are `fixed`, `fixed_auto_queue_size`, `direct`, or `scaling`.
 
 --
 


### PR DESCRIPTION
Hey team! In local testing, I was returning `fixed_auto_queue_size` from `GET _cat/thread_pool?v&h=nn,n,active,type` & wasn't sure how to interpret. From [this doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-thread-pool.html#cat-thread-pool-query-params) it appears to be an unexpected value, but from [this code](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java#L83-L86) it should exist as well as `direct` (has note to remove in 9.0 but that's a ways off).