### PR TITLE
[DOCS] Add deprecation admon to unfreeze index API

### DIFF
--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -6,9 +6,7 @@
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
-// tag::freeze-api-dep[]
-deprecated::[7.14, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
-// end::freeze-api-dep[]
+include::{es-repo-dir}/indices/apis/freeze.asciidoc[tag=freeze-api-dep]
 
 
 Unfreezes an index.

--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -6,6 +6,11 @@
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
+// tag::freeze-api-dep[]
+deprecated::[7.14, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
+// end::freeze-api-dep[]
+
+
 Unfreezes an index.
 
 [[unfreeze-index-api-request]]


### PR DESCRIPTION
Hey, team! Copying over deprecation warning from [Freeze Index API](https://www.elastic.co/guide/en/elasticsearch/reference/current/freeze-index-api.html) page for parity.