### PR TITLE
EQL: Refine repeatable queries

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -241,7 +241,7 @@ expected_event_ids = [
 name = "sequenceWithMoreThan10Results-Runs"
 query = '''
 sequence by unique_pid
-  [any where true] [runs=2]
+  [any where true] with runs=2
   [any where serial_event_id < 72]
 '''
 expected_event_ids = [

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -561,7 +561,7 @@ name = "sequenceOneManyMany-Runs"
 query = '''
 sequence
   [process where serial_event_id == 1]
-  [process where true] [runs=2]
+  [process where true] with runs=2
 '''
 expected_event_ids = [1, 2, 3]
 
@@ -582,7 +582,7 @@ name = "sequenceConditionManyMany-Runs"
 query = '''
 sequence
   [process where serial_event_id <= 3]
-  [process where true] [runs=2]
+  [process where true] with runs=2
 '''
 expected_event_ids = [1, 2, 3,
                       2, 3, 4,
@@ -613,7 +613,7 @@ expected_event_ids = [1, 2, 3]
 name = "sequenceManyManyCondition-Runs"
 query = '''
 sequence
-  [process where true] [runs=2]
+  [process where true] with runs=2
   [process where serial_event_id <= 3]
 '''
 expected_event_ids = [1, 2, 3]
@@ -637,7 +637,7 @@ name = "sequenceThreeManyCondition1-Runs"
 query = '''
 sequence
   [process where serial_event_id <= 4]
-  [process where true] [runs=3]
+  [process where true] with runs=3
 '''
 expected_event_ids = [1, 2, 3, 4,
                       2, 3, 4, 5,
@@ -663,7 +663,7 @@ query = '''
 sequence
   [process where true]
   [process where serial_event_id <= 4]
-  [process where true] [runs=2]
+  [process where true] with runs=2
 '''
 expected_event_ids = [1, 2, 3, 4,
                       2, 3, 4, 5,
@@ -685,7 +685,7 @@ expected_event_ids = [1, 2, 3, 4,
 name = "sequenceThreeManyCondition3-Runs"
 query = '''
 sequence
-  [process where true] [runs=2]
+  [process where true] with runs=2
   [process where serial_event_id <= 4]
   [process where true]
 '''
@@ -707,7 +707,7 @@ expected_event_ids = [1, 2, 3, 4]
 name = "sequenceThreeManyCondition4-Runs"
 query = '''
 sequence
-  [process where true] [runs=3]
+  [process where true] with runs=3
   [process where serial_event_id <= 4]
 '''
 expected_event_ids = [1, 2, 3, 4]
@@ -754,7 +754,7 @@ name = "fourSequencesByPidWithUntil1-Runs"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
-  [file where opcode == 0]    by unique_pid  [runs=3]
+  [file where opcode == 0]    by unique_pid  with runs=3
 until
   [file where opcode == 2]    by unique_pid
 '''
@@ -779,7 +779,7 @@ name = "fourSequencesByPidWithUntil2-Runs"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
-  [file where opcode == 0]    by unique_pid  [runs=3]
+  [file where opcode == 0]    by unique_pid  with runs=3
 until
   [file where opcode == 200]  by unique_pid
 '''
@@ -813,7 +813,7 @@ name = "fourSequencesByPid-Runs"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
-  [file where opcode == 0]    by unique_pid  [runs=3]
+  [file where opcode == 0]    by unique_pid  with runs=3
 '''
 expected_event_ids = [54, 55, 61, 67]
 
@@ -834,7 +834,7 @@ name = "fourSequencesByPidAndProcessPath1-Runs"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid,  process_path
-  [file where opcode == 0]    by unique_pid,  process_path [runs=3]
+  [file where opcode == 0]    by unique_pid,  process_path with runs=3
 '''
 expected_event_ids = [54, 55, 61, 67]
 
@@ -856,7 +856,7 @@ name = "fourSequencesByPidAndProcessPathWithUntil-Runs"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid,  process_path
-  [file where opcode == 0]    by unique_pid,  process_path [runs=3]
+  [file where opcode == 0]    by unique_pid,  process_path with runs=3
 until
   [file where opcode == 200]  by unique_pid,  process_path
 '''
@@ -867,8 +867,8 @@ name = "fourSequencesByPidAndProcessPathWithUntil-RunsExtra"
 query = '''
 sequence
   [process where opcode == 1] by unique_pid,  process_path
-  [file where opcode == 0]    by unique_pid,  process_path [runs=2]
-  [file where opcode == 0]    by unique_pid,  process_path [runs=1]
+  [file where opcode == 0]    by unique_pid,  process_path with runs=2
+  [file where opcode == 0]    by unique_pid,  process_path with runs=1
 until
   [file where opcode == 200]  by unique_pid,  process_path
 '''
@@ -1026,7 +1026,7 @@ expected_event_ids = [1, 2,
 name = "doubleSameSequence-Runs"
 query = '''
 sequence
-  [process where serial_event_id < 5] [runs=2]
+  [process where serial_event_id < 5] with runs=2
 '''
 expected_event_ids = [1, 2,
                       2, 3,
@@ -1056,7 +1056,7 @@ expected_event_ids = [55, 61]
 name = "doubleSameSequenceWithBy-Runs"
 query = '''
 sequence
-  [file where opcode==0] by unique_pid  [runs=2]
+  [file where opcode==0] by unique_pid  with runs=2
 | head 1
 '''
 expected_event_ids = [55, 61]
@@ -1087,7 +1087,7 @@ expected_event_ids = [55, 61]
 name = "doubleSameSequenceWithByUntilAndHead1-Runs"
 query = '''
 sequence
-  [file where opcode==0 and file_name:"*.exe"] by unique_pid [runs=2]
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid with runs=2
 until [process where opcode==5000] by unique_ppid
 | head 1
 '''
@@ -1108,7 +1108,7 @@ expected_event_ids = []
 name = "doubleSameSequenceWithByUntilAndHead2-Runs"
 query = '''
 sequence
-  [file where opcode==0 and file_name:"*.exe"] by unique_pid [runs=2]
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid with runs=2
 until [process where opcode==1] by unique_ppid
 | head 1
 '''

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
@@ -396,7 +396,7 @@ filters = [
 ]
 query = '''
 sequence by source_address, hostname with maxspan=5s
-  [security where hostname != "newyork" and event_id == 4625] [runs=4]
+  [security where hostname != "newyork" and event_id == 4625] with runs=4
 '''
 time = 2.8286166191101074
 type = "sequence"
@@ -433,7 +433,7 @@ filters = [
 ]
 query = '''
 sequence by source_address, hostname with maxspan=10s
-  [security where hostname != "newyork" and event_id == 4625] [runs=3]
+  [security where hostname != "newyork" and event_id == 4625] with runs=3
 '''
 time = 2.765869617462158
 type = "sequence"

--- a/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
+++ b/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
@@ -56,7 +56,7 @@ joinTerm
    ;
 
 sequenceTerm
-   : subquery (by=joinKeys)? (LB key=IDENTIFIER ASGN value=number RB)?
+   : subquery (by=joinKeys)? (WITH key=IDENTIFIER ASGN value=number)?
    ;
 
 subquery

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
@@ -845,9 +845,8 @@ class EqlBaseParser extends Parser {
     public SubqueryContext subquery() {
       return getRuleContext(SubqueryContext.class,0);
     }
-    public TerminalNode LB() { return getToken(EqlBaseParser.LB, 0); }
+    public TerminalNode WITH() { return getToken(EqlBaseParser.WITH, 0); }
     public TerminalNode ASGN() { return getToken(EqlBaseParser.ASGN, 0); }
-    public TerminalNode RB() { return getToken(EqlBaseParser.RB, 0); }
     public JoinKeysContext joinKeys() {
       return getRuleContext(JoinKeysContext.class,0);
     }
@@ -893,24 +892,22 @@ class EqlBaseParser extends Parser {
         }
       }
 
-      setState(154);
+      setState(152);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
-      case 1:
+      _la = _input.LA(1);
+      if (_la==WITH) {
         {
         setState(148);
-        match(LB);
+        match(WITH);
         setState(149);
         ((SequenceTermContext)_localctx).key = match(IDENTIFIER);
         setState(150);
         match(ASGN);
         setState(151);
         ((SequenceTermContext)_localctx).value = number();
-        setState(152);
-        match(RB);
         }
-        break;
       }
+
       }
     }
     catch (RecognitionException re) {
@@ -955,11 +952,11 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(156);
+      setState(154);
       match(LB);
-      setState(157);
+      setState(155);
       eventFilter();
-      setState(158);
+      setState(156);
       match(RB);
       }
     }
@@ -1003,7 +1000,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(160);
+      setState(158);
       eventFilter();
       }
     }
@@ -1053,28 +1050,28 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(164);
+      setState(162);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case ANY:
         {
-        setState(162);
+        setState(160);
         match(ANY);
         }
         break;
       case STRING:
       case IDENTIFIER:
         {
-        setState(163);
+        setState(161);
         ((EventFilterContext)_localctx).event = eventValue();
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(166);
+      setState(164);
       match(WHERE);
-      setState(167);
+      setState(165);
       expression();
       }
     }
@@ -1118,7 +1115,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(169);
+      setState(167);
       booleanExpression(0);
       }
     }
@@ -1248,7 +1245,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(178);
+      setState(176);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
       case 1:
@@ -1257,9 +1254,9 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(172);
+        setState(170);
         match(NOT);
-        setState(173);
+        setState(171);
         booleanExpression(5);
         }
         break;
@@ -1268,11 +1265,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ProcessCheckContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(174);
+        setState(172);
         ((ProcessCheckContext)_localctx).relationship = match(IDENTIFIER);
-        setState(175);
+        setState(173);
         match(OF);
-        setState(176);
+        setState(174);
         subquery();
         }
         break;
@@ -1281,13 +1278,13 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanDefaultContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(177);
+        setState(175);
         valueExpression();
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(188);
+      setState(186);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1295,7 +1292,7 @@ class EqlBaseParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(186);
+          setState(184);
           _errHandler.sync(this);
           switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
           case 1:
@@ -1303,11 +1300,11 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(180);
+            setState(178);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(181);
+            setState(179);
             ((LogicalBinaryContext)_localctx).operator = match(AND);
-            setState(182);
+            setState(180);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(3);
             }
             break;
@@ -1316,18 +1313,18 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(183);
+            setState(181);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(184);
+            setState(182);
             ((LogicalBinaryContext)_localctx).operator = match(OR);
-            setState(185);
+            setState(183);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(2);
             }
             break;
           }
           } 
         }
-        setState(190);
+        setState(188);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
       }
@@ -1406,14 +1403,14 @@ class EqlBaseParser extends Parser {
     ValueExpressionContext _localctx = new ValueExpressionContext(_ctx, getState());
     enterRule(_localctx, 32, RULE_valueExpression);
     try {
-      setState(196);
+      setState(194);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
       case 1:
         _localctx = new ValueExpressionDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(191);
+        setState(189);
         operatorExpression(0);
         }
         break;
@@ -1421,11 +1418,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ComparisonContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(192);
+        setState(190);
         ((ComparisonContext)_localctx).left = operatorExpression(0);
-        setState(193);
+        setState(191);
         comparisonOperator();
-        setState(194);
+        setState(192);
         ((ComparisonContext)_localctx).right = operatorExpression(0);
         }
         break;
@@ -1544,7 +1541,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(205);
+      setState(203);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case FALSE:
@@ -1562,14 +1559,14 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(199);
+        setState(197);
         primaryExpression();
-        setState(201);
+        setState(199);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
         case 1:
           {
-          setState(200);
+          setState(198);
           predicate();
           }
           break;
@@ -1582,7 +1579,7 @@ class EqlBaseParser extends Parser {
         _localctx = new ArithmeticUnaryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(203);
+        setState(201);
         ((ArithmeticUnaryContext)_localctx).operator = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1593,7 +1590,7 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(204);
+        setState(202);
         operatorExpression(3);
         }
         break;
@@ -1601,7 +1598,7 @@ class EqlBaseParser extends Parser {
         throw new NoViableAltException(this);
       }
       _ctx.stop = _input.LT(-1);
-      setState(215);
+      setState(213);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1609,7 +1606,7 @@ class EqlBaseParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(213);
+          setState(211);
           _errHandler.sync(this);
           switch ( getInterpreter().adaptivePredict(_input,23,_ctx) ) {
           case 1:
@@ -1617,9 +1614,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(207);
+            setState(205);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(208);
+            setState(206);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ASTERISK) | (1L << SLASH) | (1L << PERCENT))) != 0)) ) {
@@ -1630,7 +1627,7 @@ class EqlBaseParser extends Parser {
               _errHandler.reportMatch(this);
               consume();
             }
-            setState(209);
+            setState(207);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(3);
             }
             break;
@@ -1639,9 +1636,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(210);
+            setState(208);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(211);
+            setState(209);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1652,14 +1649,14 @@ class EqlBaseParser extends Parser {
               _errHandler.reportMatch(this);
               consume();
             }
-            setState(212);
+            setState(210);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(2);
             }
             break;
           }
           } 
         }
-        setState(217);
+        setState(215);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       }
@@ -1728,23 +1725,23 @@ class EqlBaseParser extends Parser {
     enterRule(_localctx, 36, RULE_predicate);
     int _la;
     try {
-      setState(247);
+      setState(245);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(219);
+        setState(217);
         _errHandler.sync(this);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(218);
+          setState(216);
           match(NOT);
           }
         }
 
-        setState(221);
+        setState(219);
         ((PredicateContext)_localctx).kind = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==IN || _la==IN_INSENSITIVE) ) {
@@ -1755,32 +1752,50 @@ class EqlBaseParser extends Parser {
           _errHandler.reportMatch(this);
           consume();
         }
-        setState(222);
+        setState(220);
         match(LP);
-        setState(223);
+        setState(221);
         expression();
-        setState(228);
+        setState(226);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(224);
+          setState(222);
           match(COMMA);
-          setState(225);
+          setState(223);
           expression();
           }
           }
-          setState(230);
+          setState(228);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(231);
+        setState(229);
         match(RP);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
+        {
+        setState(231);
+        ((PredicateContext)_localctx).kind = _input.LT(1);
+        _la = _input.LA(1);
+        if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LIKE) | (1L << LIKE_INSENSITIVE) | (1L << REGEX) | (1L << REGEX_INSENSITIVE) | (1L << SEQ))) != 0)) ) {
+          ((PredicateContext)_localctx).kind = (Token)_errHandler.recoverInline(this);
+        }
+        else {
+          if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
+          _errHandler.reportMatch(this);
+          consume();
+        }
+        setState(232);
+        constant();
+        }
+        break;
+      case 3:
+        enterOuterAlt(_localctx, 3);
         {
         setState(233);
         ((PredicateContext)_localctx).kind = _input.LT(1);
@@ -1794,44 +1809,26 @@ class EqlBaseParser extends Parser {
           consume();
         }
         setState(234);
-        constant();
-        }
-        break;
-      case 3:
-        enterOuterAlt(_localctx, 3);
-        {
-        setState(235);
-        ((PredicateContext)_localctx).kind = _input.LT(1);
-        _la = _input.LA(1);
-        if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LIKE) | (1L << LIKE_INSENSITIVE) | (1L << REGEX) | (1L << REGEX_INSENSITIVE) | (1L << SEQ))) != 0)) ) {
-          ((PredicateContext)_localctx).kind = (Token)_errHandler.recoverInline(this);
-        }
-        else {
-          if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-          _errHandler.reportMatch(this);
-          consume();
-        }
-        setState(236);
         match(LP);
-        setState(237);
+        setState(235);
         constant();
-        setState(242);
+        setState(240);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(238);
+          setState(236);
           match(COMMA);
-          setState(239);
+          setState(237);
           constant();
           }
           }
-          setState(244);
+          setState(242);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(245);
+        setState(243);
         match(RP);
         }
         break;
@@ -1942,14 +1939,14 @@ class EqlBaseParser extends Parser {
     PrimaryExpressionContext _localctx = new PrimaryExpressionContext(_ctx, getState());
     enterRule(_localctx, 38, RULE_primaryExpression);
     try {
-      setState(256);
+      setState(254);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         _localctx = new ConstantDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(249);
+        setState(247);
         constant();
         }
         break;
@@ -1957,7 +1954,7 @@ class EqlBaseParser extends Parser {
         _localctx = new FunctionContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(250);
+        setState(248);
         functionExpression();
         }
         break;
@@ -1965,7 +1962,7 @@ class EqlBaseParser extends Parser {
         _localctx = new DereferenceContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(251);
+        setState(249);
         qualifiedName();
         }
         break;
@@ -1973,11 +1970,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ParenthesizedExpressionContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(252);
+        setState(250);
         match(LP);
-        setState(253);
+        setState(251);
         expression();
-        setState(254);
+        setState(252);
         match(RP);
         }
         break;
@@ -2037,37 +2034,37 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(258);
+      setState(256);
       ((FunctionExpressionContext)_localctx).name = functionName();
-      setState(259);
+      setState(257);
       match(LP);
-      setState(268);
+      setState(266);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER) | (1L << QUOTED_IDENTIFIER) | (1L << TILDE_IDENTIFIER))) != 0)) {
         {
-        setState(260);
+        setState(258);
         expression();
-        setState(265);
+        setState(263);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(261);
+          setState(259);
           match(COMMA);
-          setState(262);
+          setState(260);
           expression();
           }
           }
-          setState(267);
+          setState(265);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(270);
+      setState(268);
       match(RP);
       }
     }
@@ -2111,7 +2108,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(272);
+      setState(270);
       _la = _input.LA(1);
       if ( !(_la==IDENTIFIER || _la==TILDE_IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2224,14 +2221,14 @@ class EqlBaseParser extends Parser {
     ConstantContext _localctx = new ConstantContext(_ctx, getState());
     enterRule(_localctx, 44, RULE_constant);
     try {
-      setState(278);
+      setState(276);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(274);
+        setState(272);
         match(NULL);
         }
         break;
@@ -2240,7 +2237,7 @@ class EqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(275);
+        setState(273);
         number();
         }
         break;
@@ -2249,7 +2246,7 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(276);
+        setState(274);
         booleanValue();
         }
         break;
@@ -2257,7 +2254,7 @@ class EqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(277);
+        setState(275);
         string();
         }
         break;
@@ -2309,7 +2306,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(280);
+      setState(278);
       _la = _input.LA(1);
       if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << NEQ) | (1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -2361,7 +2358,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(282);
+      setState(280);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -2434,44 +2431,44 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(284);
+      setState(282);
       identifier();
-      setState(296);
+      setState(294);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,35,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
-          setState(294);
+          setState(292);
           _errHandler.sync(this);
           switch (_input.LA(1)) {
           case DOT:
             {
-            setState(285);
+            setState(283);
             match(DOT);
-            setState(286);
+            setState(284);
             identifier();
             }
             break;
           case LB:
             {
-            setState(287);
+            setState(285);
             match(LB);
-            setState(289); 
+            setState(287); 
             _errHandler.sync(this);
             _la = _input.LA(1);
             do {
               {
               {
-              setState(288);
+              setState(286);
               match(INTEGER_VALUE);
               }
               }
-              setState(291); 
+              setState(289); 
               _errHandler.sync(this);
               _la = _input.LA(1);
             } while ( _la==INTEGER_VALUE );
-            setState(293);
+            setState(291);
             match(RB);
             }
             break;
@@ -2480,7 +2477,7 @@ class EqlBaseParser extends Parser {
           }
           } 
         }
-        setState(298);
+        setState(296);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,35,_ctx);
       }
@@ -2526,7 +2523,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(299);
+      setState(297);
       _la = _input.LA(1);
       if ( !(_la==IDENTIFIER || _la==QUOTED_IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2581,14 +2578,14 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(301);
+      setState(299);
       number();
-      setState(303);
+      setState(301);
       _errHandler.sync(this);
       _la = _input.LA(1);
       if (_la==IDENTIFIER) {
         {
-        setState(302);
+        setState(300);
         ((TimeUnitContext)_localctx).unit = match(IDENTIFIER);
         }
       }
@@ -2656,14 +2653,14 @@ class EqlBaseParser extends Parser {
     NumberContext _localctx = new NumberContext(_ctx, getState());
     enterRule(_localctx, 56, RULE_number);
     try {
-      setState(307);
+      setState(305);
       _errHandler.sync(this);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(305);
+        setState(303);
         match(DECIMAL_VALUE);
         }
         break;
@@ -2671,7 +2668,7 @@ class EqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(306);
+        setState(304);
         match(INTEGER_VALUE);
         }
         break;
@@ -2717,7 +2714,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(309);
+      setState(307);
       match(STRING);
       }
     }
@@ -2761,7 +2758,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(311);
+      setState(309);
       _la = _input.LA(1);
       if ( !(_la==STRING || _la==IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2813,7 +2810,7 @@ class EqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\64\u013c\4\2\t\2"+
+    "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\64\u013a\4\2\t\2"+
     "\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
     "\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -2824,105 +2821,104 @@ class EqlBaseParser extends Parser {
     "\br\n\b\r\b\16\bs\3\b\3\b\5\bx\n\b\3\t\3\t\3\t\3\t\3\t\7\t\177\n\t\f\t"+
     "\16\t\u0082\13\t\5\t\u0084\n\t\3\n\3\n\3\n\3\n\7\n\u008a\n\n\f\n\16\n"+
     "\u008d\13\n\3\13\3\13\5\13\u0091\n\13\3\f\3\f\5\f\u0095\n\f\3\f\3\f\3"+
-    "\f\3\f\3\f\3\f\5\f\u009d\n\f\3\r\3\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17"+
-    "\u00a7\n\17\3\17\3\17\3\17\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\5\21\u00b5\n\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u00bd\n\21\f\21\16"+
-    "\21\u00c0\13\21\3\22\3\22\3\22\3\22\3\22\5\22\u00c7\n\22\3\23\3\23\3\23"+
-    "\5\23\u00cc\n\23\3\23\3\23\5\23\u00d0\n\23\3\23\3\23\3\23\3\23\3\23\3"+
-    "\23\7\23\u00d8\n\23\f\23\16\23\u00db\13\23\3\24\5\24\u00de\n\24\3\24\3"+
-    "\24\3\24\3\24\3\24\7\24\u00e5\n\24\f\24\16\24\u00e8\13\24\3\24\3\24\3"+
-    "\24\3\24\3\24\3\24\3\24\3\24\3\24\7\24\u00f3\n\24\f\24\16\24\u00f6\13"+
-    "\24\3\24\3\24\5\24\u00fa\n\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\5\25"+
-    "\u0103\n\25\3\26\3\26\3\26\3\26\3\26\7\26\u010a\n\26\f\26\16\26\u010d"+
-    "\13\26\5\26\u010f\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\5\30\u0119"+
-    "\n\30\3\31\3\31\3\32\3\32\3\33\3\33\3\33\3\33\3\33\6\33\u0124\n\33\r\33"+
-    "\16\33\u0125\3\33\7\33\u0129\n\33\f\33\16\33\u012c\13\33\3\34\3\34\3\35"+
-    "\3\35\5\35\u0132\n\35\3\36\3\36\5\36\u0136\n\36\3\37\3\37\3 \3 \3 \2\4"+
-    " $!\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>\2"+
-    "\13\3\2 !\3\2\"$\3\2\7\b\5\2\n\13\21\22\30\30\4\2//\61\61\3\2\32\37\4"+
-    "\2\6\6\24\24\3\2/\60\4\2,,//\2\u014a\2@\3\2\2\2\4C\3\2\2\2\6F\3\2\2\2"+
-    "\bP\3\2\2\2\nR\3\2\2\2\fW\3\2\2\2\16k\3\2\2\2\20y\3\2\2\2\22\u0085\3\2"+
-    "\2\2\24\u008e\3\2\2\2\26\u0092\3\2\2\2\30\u009e\3\2\2\2\32\u00a2\3\2\2"+
-    "\2\34\u00a6\3\2\2\2\36\u00ab\3\2\2\2 \u00b4\3\2\2\2\"\u00c6\3\2\2\2$\u00cf"+
-    "\3\2\2\2&\u00f9\3\2\2\2(\u0102\3\2\2\2*\u0104\3\2\2\2,\u0112\3\2\2\2."+
-    "\u0118\3\2\2\2\60\u011a\3\2\2\2\62\u011c\3\2\2\2\64\u011e\3\2\2\2\66\u012d"+
-    "\3\2\2\28\u012f\3\2\2\2:\u0135\3\2\2\2<\u0137\3\2\2\2>\u0139\3\2\2\2@"+
-    "A\5\6\4\2AB\7\2\2\3B\3\3\2\2\2CD\5\36\20\2DE\7\2\2\3E\5\3\2\2\2FJ\5\b"+
-    "\5\2GI\5\20\t\2HG\3\2\2\2IL\3\2\2\2JH\3\2\2\2JK\3\2\2\2K\7\3\2\2\2LJ\3"+
-    "\2\2\2MQ\5\f\7\2NQ\5\16\b\2OQ\5\32\16\2PM\3\2\2\2PN\3\2\2\2PO\3\2\2\2"+
-    "Q\t\3\2\2\2RS\7\27\2\2ST\7\f\2\2TU\7\31\2\2UV\58\35\2V\13\3\2\2\2W`\7"+
-    "\23\2\2XZ\5\22\n\2Y[\5\n\6\2ZY\3\2\2\2Z[\3\2\2\2[a\3\2\2\2\\^\5\n\6\2"+
-    "]_\5\22\n\2^]\3\2\2\2^_\3\2\2\2_a\3\2\2\2`X\3\2\2\2`\\\3\2\2\2`a\3\2\2"+
-    "\2ac\3\2\2\2bd\5\26\f\2cb\3\2\2\2de\3\2\2\2ec\3\2\2\2ef\3\2\2\2fi\3\2"+
-    "\2\2gh\7\25\2\2hj\5\26\f\2ig\3\2\2\2ij\3\2\2\2j\r\3\2\2\2km\7\t\2\2ln"+
-    "\5\22\n\2ml\3\2\2\2mn\3\2\2\2no\3\2\2\2oq\5\24\13\2pr\5\24\13\2qp\3\2"+
-    "\2\2rs\3\2\2\2sq\3\2\2\2st\3\2\2\2tw\3\2\2\2uv\7\25\2\2vx\5\24\13\2wu"+
-    "\3\2\2\2wx\3\2\2\2x\17\3\2\2\2yz\7+\2\2z\u0083\7/\2\2{\u0080\5 \21\2|"+
-    "}\7&\2\2}\177\5 \21\2~|\3\2\2\2\177\u0082\3\2\2\2\u0080~\3\2\2\2\u0080"+
-    "\u0081\3\2\2\2\u0081\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0083{\3\2\2\2"+
-    "\u0083\u0084\3\2\2\2\u0084\21\3\2\2\2\u0085\u0086\7\5\2\2\u0086\u008b"+
-    "\5\36\20\2\u0087\u0088\7&\2\2\u0088\u008a\5\36\20\2\u0089\u0087\3\2\2"+
-    "\2\u008a\u008d\3\2\2\2\u008b\u0089\3\2\2\2\u008b\u008c\3\2\2\2\u008c\23"+
-    "\3\2\2\2\u008d\u008b\3\2\2\2\u008e\u0090\5\30\r\2\u008f\u0091\5\22\n\2"+
-    "\u0090\u008f\3\2\2\2\u0090\u0091\3\2\2\2\u0091\25\3\2\2\2\u0092\u0094"+
-    "\5\30\r\2\u0093\u0095\5\22\n\2\u0094\u0093\3\2\2\2\u0094\u0095\3\2\2\2"+
-    "\u0095\u009c\3\2\2\2\u0096\u0097\7\'\2\2\u0097\u0098\7/\2\2\u0098\u0099"+
-    "\7\31\2\2\u0099\u009a\5:\36\2\u009a\u009b\7(\2\2\u009b\u009d\3\2\2\2\u009c"+
-    "\u0096\3\2\2\2\u009c\u009d\3\2\2\2\u009d\27\3\2\2\2\u009e\u009f\7\'\2"+
-    "\2\u009f\u00a0\5\34\17\2\u00a0\u00a1\7(\2\2\u00a1\31\3\2\2\2\u00a2\u00a3"+
-    "\5\34\17\2\u00a3\33\3\2\2\2\u00a4\u00a7\7\4\2\2\u00a5\u00a7\5> \2\u00a6"+
-    "\u00a4\3\2\2\2\u00a6\u00a5\3\2\2\2\u00a7\u00a8\3\2\2\2\u00a8\u00a9\7\26"+
-    "\2\2\u00a9\u00aa\5\36\20\2\u00aa\35\3\2\2\2\u00ab\u00ac\5 \21\2\u00ac"+
-    "\37\3\2\2\2\u00ad\u00ae\b\21\1\2\u00ae\u00af\7\r\2\2\u00af\u00b5\5 \21"+
-    "\7\u00b0\u00b1\7/\2\2\u00b1\u00b2\7\17\2\2\u00b2\u00b5\5\30\r\2\u00b3"+
-    "\u00b5\5\"\22\2\u00b4\u00ad\3\2\2\2\u00b4\u00b0\3\2\2\2\u00b4\u00b3\3"+
-    "\2\2\2\u00b5\u00be\3\2\2\2\u00b6\u00b7\f\4\2\2\u00b7\u00b8\7\3\2\2\u00b8"+
-    "\u00bd\5 \21\5\u00b9\u00ba\f\3\2\2\u00ba\u00bb\7\20\2\2\u00bb\u00bd\5"+
-    " \21\4\u00bc\u00b6\3\2\2\2\u00bc\u00b9\3\2\2\2\u00bd\u00c0\3\2\2\2\u00be"+
-    "\u00bc\3\2\2\2\u00be\u00bf\3\2\2\2\u00bf!\3\2\2\2\u00c0\u00be\3\2\2\2"+
-    "\u00c1\u00c7\5$\23\2\u00c2\u00c3\5$\23\2\u00c3\u00c4\5\60\31\2\u00c4\u00c5"+
-    "\5$\23\2\u00c5\u00c7\3\2\2\2\u00c6\u00c1\3\2\2\2\u00c6\u00c2\3\2\2\2\u00c7"+
-    "#\3\2\2\2\u00c8\u00c9\b\23\1\2\u00c9\u00cb\5(\25\2\u00ca\u00cc\5&\24\2"+
-    "\u00cb\u00ca\3\2\2\2\u00cb\u00cc\3\2\2\2\u00cc\u00d0\3\2\2\2\u00cd\u00ce"+
-    "\t\2\2\2\u00ce\u00d0\5$\23\5\u00cf\u00c8\3\2\2\2\u00cf\u00cd\3\2\2\2\u00d0"+
-    "\u00d9\3\2\2\2\u00d1\u00d2\f\4\2\2\u00d2\u00d3\t\3\2\2\u00d3\u00d8\5$"+
-    "\23\5\u00d4\u00d5\f\3\2\2\u00d5\u00d6\t\2\2\2\u00d6\u00d8\5$\23\4\u00d7"+
-    "\u00d1\3\2\2\2\u00d7\u00d4\3\2\2\2\u00d8\u00db\3\2\2\2\u00d9\u00d7\3\2"+
-    "\2\2\u00d9\u00da\3\2\2\2\u00da%\3\2\2\2\u00db\u00d9\3\2\2\2\u00dc\u00de"+
-    "\7\r\2\2\u00dd\u00dc\3\2\2\2\u00dd\u00de\3\2\2\2\u00de\u00df\3\2\2\2\u00df"+
-    "\u00e0\t\4\2\2\u00e0\u00e1\7)\2\2\u00e1\u00e6\5\36\20\2\u00e2\u00e3\7"+
-    "&\2\2\u00e3\u00e5\5\36\20\2\u00e4\u00e2\3\2\2\2\u00e5\u00e8\3\2\2\2\u00e6"+
-    "\u00e4\3\2\2\2\u00e6\u00e7\3\2\2\2\u00e7\u00e9\3\2\2\2\u00e8\u00e6\3\2"+
-    "\2\2\u00e9\u00ea\7*\2\2\u00ea\u00fa\3\2\2\2\u00eb\u00ec\t\5\2\2\u00ec"+
-    "\u00fa\5.\30\2\u00ed\u00ee\t\5\2\2\u00ee\u00ef\7)\2\2\u00ef\u00f4\5.\30"+
-    "\2\u00f0\u00f1\7&\2\2\u00f1\u00f3\5.\30\2\u00f2\u00f0\3\2\2\2\u00f3\u00f6"+
-    "\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5\u00f7\3\2\2\2\u00f6"+
-    "\u00f4\3\2\2\2\u00f7\u00f8\7*\2\2\u00f8\u00fa\3\2\2\2\u00f9\u00dd\3\2"+
-    "\2\2\u00f9\u00eb\3\2\2\2\u00f9\u00ed\3\2\2\2\u00fa\'\3\2\2\2\u00fb\u0103"+
-    "\5.\30\2\u00fc\u0103\5*\26\2\u00fd\u0103\5\64\33\2\u00fe\u00ff\7)\2\2"+
-    "\u00ff\u0100\5\36\20\2\u0100\u0101\7*\2\2\u0101\u0103\3\2\2\2\u0102\u00fb"+
-    "\3\2\2\2\u0102\u00fc\3\2\2\2\u0102\u00fd\3\2\2\2\u0102\u00fe\3\2\2\2\u0103"+
-    ")\3\2\2\2\u0104\u0105\5,\27\2\u0105\u010e\7)\2\2\u0106\u010b\5\36\20\2"+
-    "\u0107\u0108\7&\2\2\u0108\u010a\5\36\20\2\u0109\u0107\3\2\2\2\u010a\u010d"+
-    "\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2\2\2\u010c\u010f\3\2\2\2\u010d"+
-    "\u010b\3\2\2\2\u010e\u0106\3\2\2\2\u010e\u010f\3\2\2\2\u010f\u0110\3\2"+
-    "\2\2\u0110\u0111\7*\2\2\u0111+\3\2\2\2\u0112\u0113\t\6\2\2\u0113-\3\2"+
-    "\2\2\u0114\u0119\7\16\2\2\u0115\u0119\5:\36\2\u0116\u0119\5\62\32\2\u0117"+
-    "\u0119\5<\37\2\u0118\u0114\3\2\2\2\u0118\u0115\3\2\2\2\u0118\u0116\3\2"+
-    "\2\2\u0118\u0117\3\2\2\2\u0119/\3\2\2\2\u011a\u011b\t\7\2\2\u011b\61\3"+
-    "\2\2\2\u011c\u011d\t\b\2\2\u011d\63\3\2\2\2\u011e\u012a\5\66\34\2\u011f"+
-    "\u0120\7%\2\2\u0120\u0129\5\66\34\2\u0121\u0123\7\'\2\2\u0122\u0124\7"+
-    "-\2\2\u0123\u0122\3\2\2\2\u0124\u0125\3\2\2\2\u0125\u0123\3\2\2\2\u0125"+
-    "\u0126\3\2\2\2\u0126\u0127\3\2\2\2\u0127\u0129\7(\2\2\u0128\u011f\3\2"+
-    "\2\2\u0128\u0121\3\2\2\2\u0129\u012c\3\2\2\2\u012a\u0128\3\2\2\2\u012a"+
-    "\u012b\3\2\2\2\u012b\65\3\2\2\2\u012c\u012a\3\2\2\2\u012d\u012e\t\t\2"+
-    "\2\u012e\67\3\2\2\2\u012f\u0131\5:\36\2\u0130\u0132\7/\2\2\u0131\u0130"+
-    "\3\2\2\2\u0131\u0132\3\2\2\2\u01329\3\2\2\2\u0133\u0136\7.\2\2\u0134\u0136"+
-    "\7-\2\2\u0135\u0133\3\2\2\2\u0135\u0134\3\2\2\2\u0136;\3\2\2\2\u0137\u0138"+
-    "\7,\2\2\u0138=\3\2\2\2\u0139\u013a\t\n\2\2\u013a?\3\2\2\2(JPZ^`eimsw\u0080"+
-    "\u0083\u008b\u0090\u0094\u009c\u00a6\u00b4\u00bc\u00be\u00c6\u00cb\u00cf"+
-    "\u00d7\u00d9\u00dd\u00e6\u00f4\u00f9\u0102\u010b\u010e\u0118\u0125\u0128"+
-    "\u012a\u0131\u0135";
+    "\f\3\f\5\f\u009b\n\f\3\r\3\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17\u00a5\n"+
+    "\17\3\17\3\17\3\17\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u00b3"+
+    "\n\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u00bb\n\21\f\21\16\21\u00be\13"+
+    "\21\3\22\3\22\3\22\3\22\3\22\5\22\u00c5\n\22\3\23\3\23\3\23\5\23\u00ca"+
+    "\n\23\3\23\3\23\5\23\u00ce\n\23\3\23\3\23\3\23\3\23\3\23\3\23\7\23\u00d6"+
+    "\n\23\f\23\16\23\u00d9\13\23\3\24\5\24\u00dc\n\24\3\24\3\24\3\24\3\24"+
+    "\3\24\7\24\u00e3\n\24\f\24\16\24\u00e6\13\24\3\24\3\24\3\24\3\24\3\24"+
+    "\3\24\3\24\3\24\3\24\7\24\u00f1\n\24\f\24\16\24\u00f4\13\24\3\24\3\24"+
+    "\5\24\u00f8\n\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\5\25\u0101\n\25\3"+
+    "\26\3\26\3\26\3\26\3\26\7\26\u0108\n\26\f\26\16\26\u010b\13\26\5\26\u010d"+
+    "\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\5\30\u0117\n\30\3\31\3\31"+
+    "\3\32\3\32\3\33\3\33\3\33\3\33\3\33\6\33\u0122\n\33\r\33\16\33\u0123\3"+
+    "\33\7\33\u0127\n\33\f\33\16\33\u012a\13\33\3\34\3\34\3\35\3\35\5\35\u0130"+
+    "\n\35\3\36\3\36\5\36\u0134\n\36\3\37\3\37\3 \3 \3 \2\4 $!\2\4\6\b\n\f"+
+    "\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>\2\13\3\2 !\3\2\""+
+    "$\3\2\7\b\5\2\n\13\21\22\30\30\4\2//\61\61\3\2\32\37\4\2\6\6\24\24\3\2"+
+    "/\60\4\2,,//\2\u0148\2@\3\2\2\2\4C\3\2\2\2\6F\3\2\2\2\bP\3\2\2\2\nR\3"+
+    "\2\2\2\fW\3\2\2\2\16k\3\2\2\2\20y\3\2\2\2\22\u0085\3\2\2\2\24\u008e\3"+
+    "\2\2\2\26\u0092\3\2\2\2\30\u009c\3\2\2\2\32\u00a0\3\2\2\2\34\u00a4\3\2"+
+    "\2\2\36\u00a9\3\2\2\2 \u00b2\3\2\2\2\"\u00c4\3\2\2\2$\u00cd\3\2\2\2&\u00f7"+
+    "\3\2\2\2(\u0100\3\2\2\2*\u0102\3\2\2\2,\u0110\3\2\2\2.\u0116\3\2\2\2\60"+
+    "\u0118\3\2\2\2\62\u011a\3\2\2\2\64\u011c\3\2\2\2\66\u012b\3\2\2\28\u012d"+
+    "\3\2\2\2:\u0133\3\2\2\2<\u0135\3\2\2\2>\u0137\3\2\2\2@A\5\6\4\2AB\7\2"+
+    "\2\3B\3\3\2\2\2CD\5\36\20\2DE\7\2\2\3E\5\3\2\2\2FJ\5\b\5\2GI\5\20\t\2"+
+    "HG\3\2\2\2IL\3\2\2\2JH\3\2\2\2JK\3\2\2\2K\7\3\2\2\2LJ\3\2\2\2MQ\5\f\7"+
+    "\2NQ\5\16\b\2OQ\5\32\16\2PM\3\2\2\2PN\3\2\2\2PO\3\2\2\2Q\t\3\2\2\2RS\7"+
+    "\27\2\2ST\7\f\2\2TU\7\31\2\2UV\58\35\2V\13\3\2\2\2W`\7\23\2\2XZ\5\22\n"+
+    "\2Y[\5\n\6\2ZY\3\2\2\2Z[\3\2\2\2[a\3\2\2\2\\^\5\n\6\2]_\5\22\n\2^]\3\2"+
+    "\2\2^_\3\2\2\2_a\3\2\2\2`X\3\2\2\2`\\\3\2\2\2`a\3\2\2\2ac\3\2\2\2bd\5"+
+    "\26\f\2cb\3\2\2\2de\3\2\2\2ec\3\2\2\2ef\3\2\2\2fi\3\2\2\2gh\7\25\2\2h"+
+    "j\5\26\f\2ig\3\2\2\2ij\3\2\2\2j\r\3\2\2\2km\7\t\2\2ln\5\22\n\2ml\3\2\2"+
+    "\2mn\3\2\2\2no\3\2\2\2oq\5\24\13\2pr\5\24\13\2qp\3\2\2\2rs\3\2\2\2sq\3"+
+    "\2\2\2st\3\2\2\2tw\3\2\2\2uv\7\25\2\2vx\5\24\13\2wu\3\2\2\2wx\3\2\2\2"+
+    "x\17\3\2\2\2yz\7+\2\2z\u0083\7/\2\2{\u0080\5 \21\2|}\7&\2\2}\177\5 \21"+
+    "\2~|\3\2\2\2\177\u0082\3\2\2\2\u0080~\3\2\2\2\u0080\u0081\3\2\2\2\u0081"+
+    "\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0083{\3\2\2\2\u0083\u0084\3\2\2\2"+
+    "\u0084\21\3\2\2\2\u0085\u0086\7\5\2\2\u0086\u008b\5\36\20\2\u0087\u0088"+
+    "\7&\2\2\u0088\u008a\5\36\20\2\u0089\u0087\3\2\2\2\u008a\u008d\3\2\2\2"+
+    "\u008b\u0089\3\2\2\2\u008b\u008c\3\2\2\2\u008c\23\3\2\2\2\u008d\u008b"+
+    "\3\2\2\2\u008e\u0090\5\30\r\2\u008f\u0091\5\22\n\2\u0090\u008f\3\2\2\2"+
+    "\u0090\u0091\3\2\2\2\u0091\25\3\2\2\2\u0092\u0094\5\30\r\2\u0093\u0095"+
+    "\5\22\n\2\u0094\u0093\3\2\2\2\u0094\u0095\3\2\2\2\u0095\u009a\3\2\2\2"+
+    "\u0096\u0097\7\27\2\2\u0097\u0098\7/\2\2\u0098\u0099\7\31\2\2\u0099\u009b"+
+    "\5:\36\2\u009a\u0096\3\2\2\2\u009a\u009b\3\2\2\2\u009b\27\3\2\2\2\u009c"+
+    "\u009d\7\'\2\2\u009d\u009e\5\34\17\2\u009e\u009f\7(\2\2\u009f\31\3\2\2"+
+    "\2\u00a0\u00a1\5\34\17\2\u00a1\33\3\2\2\2\u00a2\u00a5\7\4\2\2\u00a3\u00a5"+
+    "\5> \2\u00a4\u00a2\3\2\2\2\u00a4\u00a3\3\2\2\2\u00a5\u00a6\3\2\2\2\u00a6"+
+    "\u00a7\7\26\2\2\u00a7\u00a8\5\36\20\2\u00a8\35\3\2\2\2\u00a9\u00aa\5 "+
+    "\21\2\u00aa\37\3\2\2\2\u00ab\u00ac\b\21\1\2\u00ac\u00ad\7\r\2\2\u00ad"+
+    "\u00b3\5 \21\7\u00ae\u00af\7/\2\2\u00af\u00b0\7\17\2\2\u00b0\u00b3\5\30"+
+    "\r\2\u00b1\u00b3\5\"\22\2\u00b2\u00ab\3\2\2\2\u00b2\u00ae\3\2\2\2\u00b2"+
+    "\u00b1\3\2\2\2\u00b3\u00bc\3\2\2\2\u00b4\u00b5\f\4\2\2\u00b5\u00b6\7\3"+
+    "\2\2\u00b6\u00bb\5 \21\5\u00b7\u00b8\f\3\2\2\u00b8\u00b9\7\20\2\2\u00b9"+
+    "\u00bb\5 \21\4\u00ba\u00b4\3\2\2\2\u00ba\u00b7\3\2\2\2\u00bb\u00be\3\2"+
+    "\2\2\u00bc\u00ba\3\2\2\2\u00bc\u00bd\3\2\2\2\u00bd!\3\2\2\2\u00be\u00bc"+
+    "\3\2\2\2\u00bf\u00c5\5$\23\2\u00c0\u00c1\5$\23\2\u00c1\u00c2\5\60\31\2"+
+    "\u00c2\u00c3\5$\23\2\u00c3\u00c5\3\2\2\2\u00c4\u00bf\3\2\2\2\u00c4\u00c0"+
+    "\3\2\2\2\u00c5#\3\2\2\2\u00c6\u00c7\b\23\1\2\u00c7\u00c9\5(\25\2\u00c8"+
+    "\u00ca\5&\24\2\u00c9\u00c8\3\2\2\2\u00c9\u00ca\3\2\2\2\u00ca\u00ce\3\2"+
+    "\2\2\u00cb\u00cc\t\2\2\2\u00cc\u00ce\5$\23\5\u00cd\u00c6\3\2\2\2\u00cd"+
+    "\u00cb\3\2\2\2\u00ce\u00d7\3\2\2\2\u00cf\u00d0\f\4\2\2\u00d0\u00d1\t\3"+
+    "\2\2\u00d1\u00d6\5$\23\5\u00d2\u00d3\f\3\2\2\u00d3\u00d4\t\2\2\2\u00d4"+
+    "\u00d6\5$\23\4\u00d5\u00cf\3\2\2\2\u00d5\u00d2\3\2\2\2\u00d6\u00d9\3\2"+
+    "\2\2\u00d7\u00d5\3\2\2\2\u00d7\u00d8\3\2\2\2\u00d8%\3\2\2\2\u00d9\u00d7"+
+    "\3\2\2\2\u00da\u00dc\7\r\2\2\u00db\u00da\3\2\2\2\u00db\u00dc\3\2\2\2\u00dc"+
+    "\u00dd\3\2\2\2\u00dd\u00de\t\4\2\2\u00de\u00df\7)\2\2\u00df\u00e4\5\36"+
+    "\20\2\u00e0\u00e1\7&\2\2\u00e1\u00e3\5\36\20\2\u00e2\u00e0\3\2\2\2\u00e3"+
+    "\u00e6\3\2\2\2\u00e4\u00e2\3\2\2\2\u00e4\u00e5\3\2\2\2\u00e5\u00e7\3\2"+
+    "\2\2\u00e6\u00e4\3\2\2\2\u00e7\u00e8\7*\2\2\u00e8\u00f8\3\2\2\2\u00e9"+
+    "\u00ea\t\5\2\2\u00ea\u00f8\5.\30\2\u00eb\u00ec\t\5\2\2\u00ec\u00ed\7)"+
+    "\2\2\u00ed\u00f2\5.\30\2\u00ee\u00ef\7&\2\2\u00ef\u00f1\5.\30\2\u00f0"+
+    "\u00ee\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2\u00f0\3\2\2\2\u00f2\u00f3\3\2"+
+    "\2\2\u00f3\u00f5\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f5\u00f6\7*\2\2\u00f6"+
+    "\u00f8\3\2\2\2\u00f7\u00db\3\2\2\2\u00f7\u00e9\3\2\2\2\u00f7\u00eb\3\2"+
+    "\2\2\u00f8\'\3\2\2\2\u00f9\u0101\5.\30\2\u00fa\u0101\5*\26\2\u00fb\u0101"+
+    "\5\64\33\2\u00fc\u00fd\7)\2\2\u00fd\u00fe\5\36\20\2\u00fe\u00ff\7*\2\2"+
+    "\u00ff\u0101\3\2\2\2\u0100\u00f9\3\2\2\2\u0100\u00fa\3\2\2\2\u0100\u00fb"+
+    "\3\2\2\2\u0100\u00fc\3\2\2\2\u0101)\3\2\2\2\u0102\u0103\5,\27\2\u0103"+
+    "\u010c\7)\2\2\u0104\u0109\5\36\20\2\u0105\u0106\7&\2\2\u0106\u0108\5\36"+
+    "\20\2\u0107\u0105\3\2\2\2\u0108\u010b\3\2\2\2\u0109\u0107\3\2\2\2\u0109"+
+    "\u010a\3\2\2\2\u010a\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010c\u0104\3\2"+
+    "\2\2\u010c\u010d\3\2\2\2\u010d\u010e\3\2\2\2\u010e\u010f\7*\2\2\u010f"+
+    "+\3\2\2\2\u0110\u0111\t\6\2\2\u0111-\3\2\2\2\u0112\u0117\7\16\2\2\u0113"+
+    "\u0117\5:\36\2\u0114\u0117\5\62\32\2\u0115\u0117\5<\37\2\u0116\u0112\3"+
+    "\2\2\2\u0116\u0113\3\2\2\2\u0116\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117"+
+    "/\3\2\2\2\u0118\u0119\t\7\2\2\u0119\61\3\2\2\2\u011a\u011b\t\b\2\2\u011b"+
+    "\63\3\2\2\2\u011c\u0128\5\66\34\2\u011d\u011e\7%\2\2\u011e\u0127\5\66"+
+    "\34\2\u011f\u0121\7\'\2\2\u0120\u0122\7-\2\2\u0121\u0120\3\2\2\2\u0122"+
+    "\u0123\3\2\2\2\u0123\u0121\3\2\2\2\u0123\u0124\3\2\2\2\u0124\u0125\3\2"+
+    "\2\2\u0125\u0127\7(\2\2\u0126\u011d\3\2\2\2\u0126\u011f\3\2\2\2\u0127"+
+    "\u012a\3\2\2\2\u0128\u0126\3\2\2\2\u0128\u0129\3\2\2\2\u0129\65\3\2\2"+
+    "\2\u012a\u0128\3\2\2\2\u012b\u012c\t\t\2\2\u012c\67\3\2\2\2\u012d\u012f"+
+    "\5:\36\2\u012e\u0130\7/\2\2\u012f\u012e\3\2\2\2\u012f\u0130\3\2\2\2\u0130"+
+    "9\3\2\2\2\u0131\u0134\7.\2\2\u0132\u0134\7-\2\2\u0133\u0131\3\2\2\2\u0133"+
+    "\u0132\3\2\2\2\u0134;\3\2\2\2\u0135\u0136\7,\2\2\u0136=\3\2\2\2\u0137"+
+    "\u0138\t\n\2\2\u0138?\3\2\2\2(JPZ^`eimsw\u0080\u0083\u008b\u0090\u0094"+
+    "\u009a\u00a4\u00b2\u00ba\u00bc\u00c4\u00c9\u00cd\u00d5\u00d7\u00db\u00e4"+
+    "\u00f2\u00f7\u0100\u0109\u010c\u0116\u0123\u0126\u0128\u012f\u0133";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
@@ -180,7 +180,7 @@ public class LogicalPlanTests extends ESTestCase {
     }
 
     public void testRepeatedQuery() throws Exception {
-        LogicalPlan plan = parser.createStatement("sequence " + " [any where true] [runs=2]" + " [any where true]");
+        LogicalPlan plan = parser.createStatement("sequence " + " [any where true] with runs=2" + " [any where true]");
         plan = defaultPipes(plan);
         assertEquals(Sequence.class, plan.getClass());
         Sequence seq = (Sequence) plan;

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
@@ -224,7 +224,7 @@ public class QueryTranslatorFailTests extends AbstractQueryTranslatorTestCase {
     public void testSequenceWithIncorrectOption() throws Exception {
         EqlClientException e = expectThrows(EqlClientException.class, () -> plan("sequence [any where true] with repeat=123"));
         String msg = e.getMessage();
-        assertEquals("line 1:29: Unrecognized option [repeat], expecting [runs]", msg);
+        assertEquals("line 1:33: Unrecognized option [repeat], expecting [runs]", msg);
     }
 
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
@@ -222,7 +222,7 @@ public class QueryTranslatorFailTests extends AbstractQueryTranslatorTestCase {
     }
 
     public void testSequenceWithIncorrectOption() throws Exception {
-        EqlClientException e = expectThrows(EqlClientException.class, () -> plan("sequence [any where true] [repeat=123]"));
+        EqlClientException e = expectThrows(EqlClientException.class, () -> plan("sequence [any where true] with repeat=123"));
         String msg = e.getMessage();
         assertEquals("line 1:29: Unrecognized option [repeat], expecting [runs]", msg);
     }


### PR DESCRIPTION
Allow individual queries within a sequence to be repeated through a
dedicated keyword without having physical duplication.
Change from using [runs=2] to "with runs=2"

Before:

sequence
queryA [runs=2]
queryB
queryC [runs=3]
queryD

Now:

sequence
queryA with runs=2
queryB
queryC with runs=3
queryD

Which essentially is the same as:

sequence
queryA
queryA
queryB
queryC
queryC
queryC
queryD

but more concise.

Supersedes #75082