### PR TITLE
Treat system indices with unexpected type as needing upgrade

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -165,6 +165,9 @@ public class SystemIndexManager implements ClusterStateListener {
                 indexDescription
             );
             return UpgradeStatus.NEEDS_UPGRADE;
+        } else if (indexState.hasExpectedType == false) {
+            logger.debug("Index {} does not have type [{}], so needs to be upgraded", indexDescription, descriptor.getIndexType());
+            return UpgradeStatus.NEEDS_UPGRADE;
         } else if (indexState.mappingUpToDate) {
             logger.trace("Index {} is up-to-date, no action required", indexDescription);
             return UpgradeStatus.UP_TO_DATE;
@@ -222,6 +225,7 @@ public class SystemIndexManager implements ClusterStateListener {
 
         final boolean isIndexUpToDate = INDEX_FORMAT_SETTING.get(indexMetadata.getSettings()) == descriptor.getIndexFormat();
 
+        final boolean hasExpectedType = hasExpectedType(descriptor, indexMetadata);
         final boolean isMappingIsUpToDate = checkIndexMappingUpToDate(descriptor, indexMetadata);
         final String concreteIndexName = indexMetadata.getIndex().getName();
 
@@ -240,7 +244,7 @@ public class SystemIndexManager implements ClusterStateListener {
             indexHealth = new ClusterIndexHealth(indexMetadata, routingTable).getStatus();
         }
 
-        return new State(indexState, indexHealth, isIndexUpToDate, isMappingIsUpToDate);
+        return new State(indexState, indexHealth, isIndexUpToDate, isMappingIsUpToDate, hasExpectedType);
     }
 
     /**
@@ -254,6 +258,19 @@ public class SystemIndexManager implements ClusterStateListener {
         }
 
         return Version.CURRENT.onOrBefore(readMappingVersion(descriptor, mappingMetadata));
+    }
+
+    /**
+     * Checks whether an index's type matches what the descriptor says. For 7.x indices all types
+     * are "_doc", but a mismatch can occur if the index was created in 6.x with a different type.
+     */
+    private boolean hasExpectedType(SystemIndexDescriptor descriptor, IndexMetadata indexMetadata) {
+        final MappingMetadata mappingMetadata = indexMetadata.mapping();
+        if (mappingMetadata == null) {
+            return false;
+        }
+
+        return descriptor.getIndexType().equals(mappingMetadata.type());
     }
 
     /**
@@ -296,12 +313,15 @@ public class SystemIndexManager implements ClusterStateListener {
         final ClusterHealthStatus indexHealth;
         final boolean isIndexUpToDate;
         final boolean mappingUpToDate;
+        final boolean hasExpectedType;
 
-        State(IndexMetadata.State indexState, ClusterHealthStatus indexHealth, boolean isIndexUpToDate, boolean mappingUpToDate) {
+        State(IndexMetadata.State indexState, ClusterHealthStatus indexHealth, boolean isIndexUpToDate, boolean mappingUpToDate,
+              boolean hasExpectedType) {
             this.indexState = indexState;
             this.indexHealth = indexHealth;
             this.isIndexUpToDate = isIndexUpToDate;
             this.mappingUpToDate = mappingUpToDate;
+            this.hasExpectedType = hasExpectedType;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.core.Map;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.SystemIndexManager.UpgradeStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -113,8 +112,8 @@ public class SystemIndexManagerTests extends ESTestCase {
 
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
             Metadata.builder()
-                .put(getIndexMetadata(d1, null, 6, IndexMetadata.State.OPEN))
-                .put(getIndexMetadata(d2, d2.getMappings(), 6, IndexMetadata.State.OPEN))
+                .put(getIndexMetadata(d1, d1.getIndexType(), null, 6, IndexMetadata.State.OPEN))
+                .put(getIndexMetadata(d2, d2.getIndexType(), d2.getMappings(), 6, IndexMetadata.State.OPEN))
                 .build()
         );
 
@@ -150,7 +149,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
-            Metadata.builder().put(getIndexMetadata(d2, d2.getMappings(), 6, IndexMetadata.State.OPEN)).build()
+            Metadata.builder().put(getIndexMetadata(d2, d2.getIndexType(), d2.getMappings(), 6, IndexMetadata.State.OPEN)).build()
         );
 
         assertThat(eligibleDescriptors, hasSize(1));
@@ -180,7 +179,7 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     /**
-     * Check that the manager won't try to upgrade indices where the `index.format` setting
+     * Check that the manager recognizes the need to upgrade indices where the `index.format` setting
      * is earlier than an expected value.
      */
     public void testManagerSkipsIndicesWithOutdatedFormat() {
@@ -188,6 +187,18 @@ public class SystemIndexManagerTests extends ESTestCase {
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(manager.getUpgradeStatus(markShardsAvailable(createClusterState(5)), DESCRIPTOR), equalTo(UpgradeStatus.NEEDS_UPGRADE));
+    }
+
+    /**
+     * Check that the manager recognizes the need to upgrade indices where the mapping type
+     * differs from the type specified in the descriptor.
+     */
+    public void testManagerSkipsIndicesWithWrongType() {
+        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
+
+        assertThat(manager.getUpgradeStatus(markShardsAvailable(createClusterState("doc", DESCRIPTOR.getMappings())), DESCRIPTOR),
+            equalTo(UpgradeStatus.NEEDS_UPGRADE));
     }
 
     /**
@@ -259,20 +270,24 @@ public class SystemIndexManagerTests extends ESTestCase {
         return createClusterState(mappings, IndexMetadata.State.OPEN);
     }
 
+    private static ClusterState.Builder createClusterState(String type, String mappings) {
+        return createClusterState(type, mappings, 6, IndexMetadata.State.OPEN);
+    }
+
     private static ClusterState.Builder createClusterState(IndexMetadata.State state) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), 6, state);
+        return createClusterState(DESCRIPTOR.getIndexType(), DESCRIPTOR.getMappings(), 6, state);
     }
 
     private static ClusterState.Builder createClusterState(String mappings, IndexMetadata.State state) {
-        return createClusterState(mappings, 6, state);
+        return createClusterState(DESCRIPTOR.getIndexType(), mappings, 6, state);
     }
 
     private static ClusterState.Builder createClusterState(int format) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), format, IndexMetadata.State.OPEN);
+        return createClusterState(DESCRIPTOR.getIndexType(), DESCRIPTOR.getMappings(), format, IndexMetadata.State.OPEN);
     }
 
-    private static ClusterState.Builder createClusterState(String mappings, int format, IndexMetadata.State state) {
-        IndexMetadata.Builder indexMeta = getIndexMetadata(SystemIndexManagerTests.DESCRIPTOR, mappings, format, state);
+    private static ClusterState.Builder createClusterState(String type, String mappings, int format, IndexMetadata.State state) {
+        IndexMetadata.Builder indexMeta = getIndexMetadata(DESCRIPTOR, type, mappings, format, state);
 
         Metadata.Builder metadataBuilder = new Metadata.Builder();
         metadataBuilder.put(indexMeta);
@@ -321,6 +336,7 @@ public class SystemIndexManagerTests extends ESTestCase {
 
     private static IndexMetadata.Builder getIndexMetadata(
         SystemIndexDescriptor descriptor,
+        String type,
         String mappings,
         int format,
         IndexMetadata.State state
@@ -345,7 +361,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         if (mappings != null) {
             try {
                 MappingMetadata mappingMetadata = new MappingMetadata(
-                    MapperService.SINGLE_MAPPING_NAME,
+                    type,
                     XContentHelper.convertToMap(JsonXContent.jsonXContent, mappings, true)
                 );
                 indexMetadata.putMapping(mappingMetadata);


### PR DESCRIPTION
The system indices code that updates index mappings fails if
a system index was originally created in 6.x and has a type
that's not "_doc".

This change treats such indices as requiring upgrade rather
than requiring a mappings update. The mappings update was
failing anyway, so this doesn't really change functionality,
it just removes log spam that was occurring on every cluster
state update until the index mappings were corrected by some
other code.

It is assumed that every system index that didn't have type
"_doc" in 6.x must have separate mappings update code or full
upgrade code outside of the system indices framework.
Certainly this is true for the ML indices that are affected
by this problem.

Backport of #78622