### PR TITLE
[7.x] Fix Gradle integration with Intellij IDEA (#78290)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -88,7 +88,7 @@ if (providers.systemProperty('idea.active').forUseAtConfigurationTime().getOrNul
   tasks.register('buildDependencyArtifacts') {
     group = 'ide'
     description = 'Builds artifacts needed as dependency for IDE modules'
-    dependsOn ':plugins:repository-hdfs:hadoop-common:shadowJar', ':plugins:repository-azure:azure-storage-blob:shadowJar'
+    dependsOn ':plugins:repository-hdfs:hadoop-client-api:shadowJar', ':plugins:repository-azure:azure-storage-blob:shadowJar'
   }
 
   idea {


### PR DESCRIPTION
Backports #78290 to 7.x:

In #76897 the `hadoop-common` module was renamed to `hadoop-client-ide`, but
the change wasn't reflected in `elasticsearch.ide.gradle` script.
Because of that an IDE import started failing with the
`Task with path ':plugins:repository-hdfs:hadoop-common:shadowJar" not found` error.