### PR TITLE
[Transform] HLRC cleanups

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformRequestConverters.java
@@ -38,10 +38,9 @@ final class TransformRequestConverters {
     private TransformRequestConverters() {}
 
     static Request putTransform(PutTransformRequest putRequest) throws IOException {
-        String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_transform")
-                .addPathPart(putRequest.getConfig().getId())
-                .build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
+            .addPathPart(putRequest.getConfig().getId())
+            .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putRequest, REQUEST_BODY_CONTENT_TYPE));
         if (putRequest.getDeferValidation() != null) {
@@ -50,25 +49,23 @@ final class TransformRequestConverters {
         return request;
     }
 
-    static Request updateTransform(UpdateTransformRequest updateDataFrameTransformRequest) throws IOException {
-        String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_transform")
-            .addPathPart(updateDataFrameTransformRequest.getId())
+    static Request updateTransform(UpdateTransformRequest updateTransformRequest) throws IOException {
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
+            .addPathPart(updateTransformRequest.getId())
             .addPathPart("_update")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        request.setEntity(createEntity(updateDataFrameTransformRequest, REQUEST_BODY_CONTENT_TYPE));
-        if (updateDataFrameTransformRequest.getDeferValidation() != null) {
-            request.addParameter(DEFER_VALIDATION, Boolean.toString(updateDataFrameTransformRequest.getDeferValidation()));
+        request.setEntity(createEntity(updateTransformRequest, REQUEST_BODY_CONTENT_TYPE));
+        if (updateTransformRequest.getDeferValidation() != null) {
+            request.addParameter(DEFER_VALIDATION, Boolean.toString(updateTransformRequest.getDeferValidation()));
         }
         return request;
     }
 
     static Request getTransform(GetTransformRequest getRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_transform")
-                .addPathPart(Strings.collectionToCommaDelimitedString(getRequest.getId()))
-                .build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
+            .addPathPart(Strings.collectionToCommaDelimitedString(getRequest.getId()))
+            .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         if (getRequest.getPageParams() != null && getRequest.getPageParams().getFrom() != null) {
             request.addParameter(PageParams.FROM.getPreferredName(), getRequest.getPageParams().getFrom().toString());
@@ -86,10 +83,7 @@ final class TransformRequestConverters {
     }
 
     static Request deleteTransform(DeleteTransformRequest deleteRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_transform")
-                .addPathPart(deleteRequest.getId())
-                .build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform").addPathPart(deleteRequest.getId()).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         if (deleteRequest.getForce() != null) {
             request.addParameter(FORCE, Boolean.toString(deleteRequest.getForce()));
@@ -98,11 +92,10 @@ final class TransformRequestConverters {
     }
 
     static Request startTransform(StartTransformRequest startRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_transform")
-                .addPathPart(startRequest.getId())
-                .addPathPartAsIs("_start")
-                .build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
+            .addPathPart(startRequest.getId())
+            .addPathPartAsIs("_start")
+            .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
         if (startRequest.getTimeout() != null) {
@@ -113,8 +106,7 @@ final class TransformRequestConverters {
     }
 
     static Request stopTransform(StopTransformRequest stopRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_transform")
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
             .addPathPart(stopRequest.getId())
             .addPathPartAsIs("_stop")
             .build();
@@ -151,11 +143,10 @@ final class TransformRequestConverters {
     }
 
     static Request getTransformStats(GetTransformStatsRequest statsRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_transform")
-                .addPathPart(statsRequest.getId())
-                .addPathPartAsIs("_stats")
-                .build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_transform")
+            .addPathPart(statsRequest.getId())
+            .addPathPartAsIs("_stats")
+            .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         if (statsRequest.getPageParams() != null && statsRequest.getPageParams().getFrom() != null) {
             request.addParameter(PageParams.FROM.getPreferredName(), statsRequest.getPageParams().getFrom().toString());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformRequestConvertersTests.java
@@ -29,11 +29,11 @@ import org.elasticsearch.client.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.client.transform.transforms.TransformConfigUpdateTests;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -58,9 +58,8 @@ public class TransformRequestConvertersTests extends ESTestCase {
         return new NamedXContentRegistry(namedXContents);
     }
 
-    public void testPutDataFrameTransform() throws IOException {
-        PutTransformRequest putRequest = new PutTransformRequest(
-                TransformConfigTests.randomTransformConfig());
+    public void testPutTransform() throws IOException {
+        PutTransformRequest putRequest = new PutTransformRequest(TransformConfigTests.randomTransformConfig());
         Request request = TransformRequestConverters.putTransform(putRequest);
         assertThat(request.getParameters(), not(hasKey("defer_validation")));
         assertEquals(HttpPut.METHOD_NAME, request.getMethod());
@@ -75,11 +74,12 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertThat(request.getParameters(), hasEntry("defer_validation", Boolean.toString(putRequest.getDeferValidation())));
     }
 
-    public void testUpdateDataFrameTransform() throws IOException {
+    public void testUpdateTransform() throws IOException {
         String transformId = randomAlphaOfLength(10);
         UpdateTransformRequest updateDataFrameTransformRequest = new UpdateTransformRequest(
             TransformConfigUpdateTests.randomTransformConfigUpdate(),
-            transformId);
+            transformId
+        );
         Request request = TransformRequestConverters.updateTransform(updateDataFrameTransformRequest);
         assertThat(request.getParameters(), not(hasKey("defer_validation")));
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
@@ -91,11 +91,13 @@ public class TransformRequestConvertersTests extends ESTestCase {
         }
         updateDataFrameTransformRequest.setDeferValidation(true);
         request = TransformRequestConverters.updateTransform(updateDataFrameTransformRequest);
-        assertThat(request.getParameters(),
-            hasEntry("defer_validation", Boolean.toString(updateDataFrameTransformRequest.getDeferValidation())));
+        assertThat(
+            request.getParameters(),
+            hasEntry("defer_validation", Boolean.toString(updateDataFrameTransformRequest.getDeferValidation()))
+        );
     }
 
-    public void testDeleteDataFrameTransform() {
+    public void testDeleteTransform() {
         DeleteTransformRequest deleteRequest = new DeleteTransformRequest("foo");
         Request request = TransformRequestConverters.deleteTransform(deleteRequest);
 
@@ -110,7 +112,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertThat(request.getParameters(), hasEntry("force", "true"));
     }
 
-    public void testStartDataFrameTransform() {
+    public void testStartTransform() {
         String id = randomAlphaOfLength(10);
         TimeValue timeValue = null;
         if (randomBoolean()) {
@@ -130,7 +132,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         }
     }
 
-    public void testStopDataFrameTransform() {
+    public void testStopTransform() {
         String id = randomAlphaOfLength(10);
         Boolean waitForCompletion = null;
         if (randomBoolean()) {
@@ -177,7 +179,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertEquals(stopRequest.getAllowNoMatch(), Boolean.parseBoolean(request.getParameters().get(ALLOW_NO_MATCH)));
     }
 
-    public void testPreviewDataFrameTransform() throws IOException {
+    public void testPreviewTransform() throws IOException {
         PreviewTransformRequest previewRequest = new PreviewTransformRequest(TransformConfigTests.randomTransformConfig());
         Request request = TransformRequestConverters.previewTransform(previewRequest);
 
@@ -190,7 +192,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         }
     }
 
-    public void testPreviewDataFrameTransformById() throws IOException {
+    public void testPreviewTransformById() throws IOException {
         String transformId = randomAlphaOfLengthBetween(1, 10);
         PreviewTransformRequest previewRequest = new PreviewTransformRequest(transformId);
         Request request = TransformRequestConverters.previewTransform(previewRequest);
@@ -200,7 +202,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertThat(request.getEntity(), nullValue());
     }
 
-    public void testGetDataFrameTransformStats() {
+    public void testGetTransformStats() {
         GetTransformStatsRequest getStatsRequest = new GetTransformStatsRequest("foo");
         Request request = TransformRequestConverters.getTransformStats(getStatsRequest);
 
@@ -230,7 +232,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertThat(request.getParameters(), hasEntry("allow_no_match", "false"));
     }
 
-    public void testGetDataFrameTransform() {
+    public void testGetTransform() {
         GetTransformRequest getRequest = new GetTransformRequest("bar");
         Request request = TransformRequestConverters.getTransform(getRequest);
 
@@ -260,7 +262,7 @@ public class TransformRequestConvertersTests extends ESTestCase {
         assertThat(request.getParameters(), hasEntry("allow_no_match", "false"));
     }
 
-    public void testGetDataFrameTransform_givenMulitpleIds() {
+    public void testGetTransform_givenMulitpleIds() {
         GetTransformRequest getRequest = new GetTransformRequest("foo", "bar", "baz");
         Request request = TransformRequestConverters.getTransform(getRequest);
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
@@ -50,10 +50,10 @@ import org.elasticsearch.client.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.client.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.client.transform.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.After;
 
 import java.io.IOException;
@@ -445,7 +445,7 @@ public class TransformDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testDeleteDataFrameTransform() throws IOException, InterruptedException {
+    public void testDeleteTransform() throws IOException, InterruptedException {
         createIndex("source-data");
 
         RestHighLevelClient client = highLevelClient();
@@ -670,7 +670,7 @@ public class TransformDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testGetDataFrameTransform() throws IOException, InterruptedException {
+    public void testGetTransform() throws IOException, InterruptedException {
         createIndex("source-data");
 
         GroupConfig groupConfig = GroupConfig.builder().groupBy("reviewer", TermsGroupSource.builder().setField("user_id").build()).build();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/StartTransformRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/StartTransformRequestTests.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.containsString;
 
-public class StartDataFrameTransformRequestTests extends ESTestCase {
+public class StartTransformRequestTests extends ESTestCase {
     public void testValidate_givenNullId() {
         StartTransformRequest request = new StartTransformRequest(null, null);
         Optional<ValidationException> validate = request.validate();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/UpdateTransformResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/UpdateTransformResponseTests.java
@@ -10,10 +10,10 @@ package org.elasticsearch.client.transform;
 
 import org.elasticsearch.client.transform.transforms.TransformConfigTests;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -21,16 +21,15 @@ import java.util.List;
 
 import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 
-public class UpdateDataFrameTransformResponseTests extends ESTestCase {
+public class UpdateTransformResponseTests extends ESTestCase {
 
     public void testXContentParser() throws IOException {
-        xContentTester(this::createParser,
-                UpdateDataFrameTransformResponseTests::createTestInstance,
-                UpdateDataFrameTransformResponseTests::toXContent,
-                UpdateTransformResponse::fromXContent)
-                .assertToXContentEquivalence(false)
-                .supportsUnknownFields(false)
-                .test();
+        xContentTester(
+            this::createParser,
+            UpdateTransformResponseTests::createTestInstance,
+            UpdateTransformResponseTests::toXContent,
+            UpdateTransformResponse::fromXContent
+        ).assertToXContentEquivalence(false).supportsUnknownFields(false).test();
     }
 
     private static UpdateTransformResponse createTestInstance() {


### PR DESCRIPTION
removes some "data frame" leftovers in transform code, no functional changes

(Formatting changes are due to applying the latest spotless code formatting rules)