### PR TITLE
Mute MlHiddenIndicesFullClusterRestartIT

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -67,6 +67,7 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractFullClusterRest
         XPackRestTestHelper.waitForTemplates(client(), templatesToWaitFor, clusterUnderstandsComposableTemplates);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78913")
     public void testMlIndicesBecomeHidden() throws Exception {
         if (isRunningAgainstOldCluster()) {
             // trigger ML indices creation


### PR DESCRIPTION
Mutes MlHiddenIndicesFullClusterRestartIT which interferes with MlConfigIndexMappingsFullClusterRestartIT

Relates https://github.com/elastic/elasticsearch/issues/78913