### PR TITLE
[DOCS] EQL: Update `runs` syntax

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -695,8 +695,8 @@ until [ process where event.type == "stop" ]
 ====
 
 [discrete]
-[[eql-runs-keyword]]
-=== `with runs` keywords
+[[eql-with-runs-statement]]
+=== `with runs` statement
 
 Use a `with runs` statement to run the same event criteria successively within a
 sequence query. For example:

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -696,16 +696,16 @@ until [ process where event.type == "stop" ]
 
 [discrete]
 [[eql-runs-keyword]]
-=== `runs` keyword
+=== `with runs` keywords
 
-Use a `runs` statement to run the same event criteria successively within a
+Use a `with runs` statement to run the same event criteria successively within a
 sequence query. For example:
 
 [source,eql]
 ----
 sequence
   [ process where event.type == "creation" ]
-  [ library where process.name == "regsvr32.exe" ] runs=3
+  [ library where process.name == "regsvr32.exe" ] with runs=3
   [ registry where true ]
 ----
 
@@ -723,14 +723,14 @@ sequence
 
 The `runs` value must be between `1` and `100` (inclusive).
  
-You can use a `runs` statement with the <<eql-by-keyword,`by` keyword>>. For
-example:
+You can use a `with runs` statement with the <<eql-by-keyword,`by` keyword>>.
+For example:
 
 [source,eql]
 ----
 sequence
   [ process where event.type == "creation" ] by process.executable
-  [ library where process.name == "regsvr32.exe" ] by dll.path runs=3
+  [ library where process.name == "regsvr32.exe" ] by dll.path with runs=3
 ----
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -705,7 +705,7 @@ sequence query. For example:
 ----
 sequence
   [ process where event.type == "creation" ]
-  [ library where process.name == "regsvr32.exe" ] [runs=3]
+  [ library where process.name == "regsvr32.exe" ] runs=3
   [ registry where true ]
 ----
 
@@ -721,8 +721,7 @@ sequence
   [ registry where true ]
 ----
 
-A `runs` statement must be enclosed in square brackets (`[ ]`). The `runs` value
-must be between `1` and `100` (inclusive).
+The `runs` value must be between `1` and `100` (inclusive).
  
 You can use a `runs` statement with the <<eql-by-keyword,`by` keyword>>. For
 example:
@@ -731,7 +730,7 @@ example:
 ----
 sequence
   [ process where event.type == "creation" ] by process.executable
-  [ library where process.name == "regsvr32.exe" ] by dll.path [runs=3]
+  [ library where process.name == "regsvr32.exe" ] by dll.path runs=3
 ----
 
 [discrete]


### PR DESCRIPTION
Updates the EQL syntax docs for PR #78895.

### Preview
https://elasticsearch_78922.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-runs-keyword