### PR TITLE
[ML] Make get scheduled events endpoint and spec consistent with docs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -14,7 +14,8 @@
         {
           "path":"/_ml/calendars/{calendar_id}/events",
           "methods":[
-            "GET"
+            "GET",
+            "POST"
           ],
           "parts":{
             "calendar_id":{
@@ -46,6 +47,9 @@
         "type":"int",
         "description":"Specifies a max number of events to get"
       }
+    },
+    "body":{
+      "description":"The job_id, start, end, from and size parameters optionally sent in the body"
     }
   }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/calendar/RestGetCalendarEventsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/calendar/RestGetCalendarEventsAction.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
 
@@ -30,7 +31,9 @@ public class RestGetCalendarEventsAction extends BaseRestHandler {
     public List<Route> routes() {
         return List.of(
             Route.builder(GET, BASE_PATH + "calendars/{" + Calendar.ID + "}/events")
-                .replaces(GET, PRE_V7_BASE_PATH + "calendars/{" + Calendar.ID + "}/events", RestApiVersion.V_7).build()
+                .replaces(GET, PRE_V7_BASE_PATH + "calendars/{" + Calendar.ID + "}/events", RestApiVersion.V_7).build(),
+            Route.builder(POST, BASE_PATH + "calendars/{" + Calendar.ID + "}/events")
+                .replaces(POST, PRE_V7_BASE_PATH + "calendars/{" + Calendar.ID + "}/events", RestApiVersion.V_7).build()
         );
     }
 


### PR DESCRIPTION
The docs for the get scheduled events endpoint stated that the
arguments could be sent in a request body instead of in URL
arguments. The spec was inconsistent with this.

Additionally, GET endpoints that allow a request body need to
support POST too, for the benefit of clients that do not support
GETs with bodies.

This change adds the option to POST a get scheduled events
request and adjusts the spec to permit this.

Relates to elastic/elasticsearch-specification#852