### PR TITLE
[DOCS] Fix default value for closed indices

### DIFF
--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -25,7 +25,7 @@ When set to `true`, you must specify the index name to <<indices-delete-index,de
 Enables <<indices-close,closing of open indices>> in {es}. If `false`, you
 cannot close open indices. Defaults to `true`.
 +
-IMPORTANT: Closed indices are a data loss risk because they are not included when you make cluster configuration changes, such as scaling to a different capacity, failover, and many other operations. Additionally, closed indices can lead to inaccurate disk space counts. We strongly recommend leaving this set to `true`.
+NOTE: Closed indices still consume a significant amount of disk space.
 
 [[reindex-remote-whitelist]]
 // tag::reindex-remote-whitelist[]

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -22,9 +22,9 @@ When set to `true`, you must specify the index name to <<indices-delete-index,de
 // tag::cluster-indices-close-enable-tag[]
 `cluster.indices.close.enable` {ess-icon}::
 (<<dynamic-cluster-setting,Dynamic>>)
-Enables <<indices-open-close,opening of closed indices>> in {es}. You might enable this setting temporarily to change the analyzer configuration for an existing index. We strongly recommend leaving this set to `false` (the default) otherwise.
+Enables <<indices-open-close,opening of closed indices>> in {es}. You might enable this setting temporarily to change the analyzer configuration for an existing index. Defaults to `true`.
 +
-IMPORTANT: Closed indices are a data loss risk because they are not included when you make cluster configuration changes, such as scaling to a different capacity, failover, and many other operations. Additionally, closed indices can lead to inaccurate disk space counts.
+IMPORTANT: Closed indices are a data loss risk because they are not included when you make cluster configuration changes, such as scaling to a different capacity, failover, and many other operations. Additionally, closed indices can lead to inaccurate disk space counts. We strongly recommend leaving this set to `true`.
 
 [[reindex-remote-whitelist]]
 // tag::reindex-remote-whitelist[]

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -22,7 +22,8 @@ When set to `true`, you must specify the index name to <<indices-delete-index,de
 // tag::cluster-indices-close-enable-tag[]
 `cluster.indices.close.enable` {ess-icon}::
 (<<dynamic-cluster-setting,Dynamic>>)
-Enables <<indices-open-close,opening of closed indices>> in {es}. You might enable this setting temporarily to change the analyzer configuration for an existing index. Defaults to `true`.
+Enables <<indices-close,closing of open indices>> in {es}. If `false`, you
+cannot close open indices. Defaults to `true`.
 +
 IMPORTANT: Closed indices are a data loss risk because they are not included when you make cluster configuration changes, such as scaling to a different capacity, failover, and many other operations. Additionally, closed indices can lead to inaccurate disk space counts. We strongly recommend leaving this set to `true`.
 


### PR DESCRIPTION
#57953 introduced changes that added ESS icons to many Elasticsearch settings. As part of those changes, the default value for `cluster.indices.close.enable` was indicated as `false`, when it should be `true`. This PR updates the default value to `true`. 

Closes #78877
