### PR TITLE
Fix failures in CompositeAggregatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -2847,9 +2847,6 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     document.clear();
                     addToDocument(id, document, fields);
                     indexWriter.addDocument(document);
-                    if (frequently()) {
-                        indexWriter.commit();
-                    }
                     id++;
                 }
                 if (forceMerge) {


### PR DESCRIPTION
The random tests in `CompositeAggregatorTests` create lots of segments since #78313. That can lead to out of memory in tests.
The additional commits were added to simulate the multi-segments case but the random index writer should already perform some random overcommits.

Closes #78919