### PR TITLE
[7.x] [DOCS] Add deprecation admon to unfreeze index API (#78886)

### DIFF
--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -6,6 +6,9 @@
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
+include::{es-repo-dir}/indices/apis/freeze.asciidoc[tag=freeze-api-dep]
+
+
 Unfreezes an index.
 
 [[unfreeze-index-api-request]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add deprecation admon to unfreeze index API (#78886)