### PR TITLE
[7.x] [DOCS] Update `runs` syntax (#78922)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -695,17 +695,17 @@ until [ process where event.type == "stop" ]
 ====
 
 [discrete]
-[[eql-runs-keyword]]
-=== `runs` keyword
+[[eql-with-runs-statement]]
+=== `with runs` statement
 
-Use a `runs` statement to run the same event criteria successively within a
+Use a `with runs` statement to run the same event criteria successively within a
 sequence query. For example:
 
 [source,eql]
 ----
 sequence
   [ process where event.type == "creation" ]
-  [ library where process.name == "regsvr32.exe" ] [runs=3]
+  [ library where process.name == "regsvr32.exe" ] with runs=3
   [ registry where true ]
 ----
 
@@ -721,17 +721,16 @@ sequence
   [ registry where true ]
 ----
 
-A `runs` statement must be enclosed in square brackets (`[ ]`). The `runs` value
-must be between `1` and `100` (inclusive).
+The `runs` value must be between `1` and `100` (inclusive).
  
-You can use a `runs` statement with the <<eql-by-keyword,`by` keyword>>. For
-example:
+You can use a `with runs` statement with the <<eql-by-keyword,`by` keyword>>.
+For example:
 
 [source,eql]
 ----
 sequence
   [ process where event.type == "creation" ] by process.executable
-  [ library where process.name == "regsvr32.exe" ] by dll.path [runs=3]
+  [ library where process.name == "regsvr32.exe" ] by dll.path with runs=3
 ----
 
 [discrete]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,11 +30,12 @@ Other versions:
 
 // tag::notable-highlights[]
 [discrete]
-=== EQL: `runs` keyword for repeated events
+=== EQL: `with runs` statements for repeated events
 
-In 7.16, we added the `runs` keyword to EQL sequence queries. Sometimes you want
-to find a sequence that contains an event multiple times in succession. Rather
-than type the same event criteria multiple times, you can use a `runs` statement
-to declare the criteria once and run it successively. For more details, check
-out the {ref}/eql-syntax.html#eql-runs-keyword[EQL syntax documentation].
+In 7.16, we added the `with runs` statement syntax to EQL sequence queries.
+Sometimes you want to find a sequence that contains an event multiple times in
+succession. Rather than type the same event criteria multiple times, you can use
+a `with runs` statement to declare the criteria once and run it successively.
+For more details, check out the
+{ref}/eql-syntax.html#eql-with-runs-statement[EQL syntax documentation].
 // end::notable-highlights[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Update `runs` syntax (#78922)