### PR TITLE
Revert "Convert index path listeners to single path (#72511)"

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -325,12 +325,12 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
         public List<IndexFoldersDeletionListener> getIndexFoldersDeletionListeners() {
             return List.of(new IndexFoldersDeletionListener() {
                 @Override
-                public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
+                public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
                     deletedIndices.add(index);
                 }
 
                 @Override
-                public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
+                public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
                     deletedShards.computeIfAbsent(shardId.getIndex(), i -> new ArrayList<>()).add(shardId);
                 }
             });

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -553,7 +553,7 @@ public final class NodeEnvironment  implements Closeable {
     public void deleteShardDirectorySafe(
         ShardId shardId,
         IndexSettings indexSettings,
-        Consumer<Path> listener
+        Consumer<Path[]> listener
     ) throws IOException, ShardLockObtainFailedException {
         final Path path = availableShardPath(shardId);
         logger.trace("deleting shard {} directory, path: [{}]", shardId, path);
@@ -606,21 +606,21 @@ public final class NodeEnvironment  implements Closeable {
     public void deleteShardDirectoryUnderLock(
         ShardLock lock,
         IndexSettings indexSettings,
-        Consumer<Path> listener
+        Consumer<Path[]> listener
     ) throws IOException {
         final ShardId shardId = lock.getShardId();
         assert isShardLocked(shardId) : "shard " + shardId + " is not locked";
         final Path path = availableShardPath(shardId);
         logger.trace("acquiring locks for {}, path: [{}]", shardId, path);
         acquireFSLockForPaths(indexSettings, path);
-        listener.accept(path);
+        listener.accept(new Path[] { path });
         IOUtils.rm(path);
         if (indexSettings.hasCustomDataPath()) {
             Path customLocation = resolveCustomLocation(indexSettings.customDataPath(), shardId);
             logger.trace("acquiring lock for {}, custom path: [{}]", shardId, customLocation);
             acquireFSLockForPaths(indexSettings, customLocation);
             logger.trace("deleting custom shard {} directory [{}]", shardId, customLocation);
-            listener.accept(customLocation);
+            listener.accept(new Path[]{customLocation});
             IOUtils.rm(customLocation);
         }
         logger.trace("deleted shard {} directory, path: [{}]", shardId, path);
@@ -676,7 +676,7 @@ public final class NodeEnvironment  implements Closeable {
         Index index,
         long lockTimeoutMS,
         IndexSettings indexSettings,
-        Consumer<Path> listener
+        Consumer<Path[]> listener
     ) throws IOException, ShardLockObtainFailedException {
         final List<ShardLock> locks = lockAllForIndex(index, indexSettings, "deleting index directory", lockTimeoutMS);
         try {
@@ -689,19 +689,19 @@ public final class NodeEnvironment  implements Closeable {
     /**
      * Deletes an indexes data directory recursively.
      * Note: this method assumes that the shard lock is acquired
-     *  @param index the index to delete
+     *
+     * @param index the index to delete
      * @param indexSettings settings for the index being deleted
-     * @param listener
      */
-    public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings, Consumer<Path> listener) throws IOException {
+    public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings, Consumer<Path[]> listener) throws IOException {
         final Path indexPath = indexPath(index);
         logger.trace("deleting index {} directory: [{}]", index, indexPath);
-        listener.accept(indexPath);
+        listener.accept(new Path[] { indexPath });
         IOUtils.rm(indexPath);
         if (indexSettings.hasCustomDataPath()) {
             Path customLocation = resolveIndexCustomLocation(indexSettings.customDataPath(), index.getUUID());
             logger.trace("deleting custom index {} directory [{}]", index, customLocation);
-            listener.accept(customLocation);
+            listener.accept(new Path[]{customLocation});
             IOUtils.rm(customLocation);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -411,8 +411,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             } catch (IllegalStateException ex) {
                 logger.warn("{} failed to load shard path, trying to remove leftover", shardId);
                 try {
-                    ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, this.indexSettings, shardPath ->
-                        indexFoldersDeletionListener.beforeShardFoldersDeleted(shardId, this.indexSettings, shardPath));
+                    ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, this.indexSettings, shardPaths ->
+                        indexFoldersDeletionListener.beforeShardFoldersDeleted(shardId, this.indexSettings, shardPaths));
                     path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings.customDataPath());
                 } catch (Exception inner) {
                     ex.addSuppressed(inner);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -167,7 +167,7 @@ public final class ShardPath {
         final NodeEnvironment env,
         final ShardLock lock,
         final IndexSettings indexSettings,
-        final Consumer<Path> listener
+        final Consumer<Path[]> listener
     ) throws IOException {
         final String indexUUID = indexSettings.getUUID();
         final Path path = env.availableShardPath(lock.getShardId());
@@ -178,7 +178,7 @@ public final class ShardPath {
                 logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
                 assert Files.isDirectory(path) : path + " is not a directory";
                 NodeEnvironment.acquireFSLockForPaths(indexSettings, path);
-                listener.accept(path);
+                listener.accept(new Path[]{path});
                 IOUtils.rm(path);
             }
         }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -981,7 +981,7 @@ public class IndicesService extends AbstractLifecycleComponent
             throw new IllegalStateException("Can't delete shard " + shardId + " (cause: " + shardDeletionCheckResult + ")");
         }
         nodeEnv.deleteShardDirectorySafe(shardId, indexSettings,
-            path -> indexFoldersDeletionListeners.beforeShardFoldersDeleted(shardId, indexSettings, path));
+            paths -> indexFoldersDeletionListeners.beforeShardFoldersDeleted(shardId, indexSettings, paths));
         logger.debug("{} deleted shard reason [{}]", shardId, reason);
 
         if (canDeleteIndexContents(shardId.getIndex())) {

--- a/server/src/main/java/org/elasticsearch/indices/store/CompositeIndexFoldersDeletionListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/CompositeIndexFoldersDeletionListener.java
@@ -30,10 +30,10 @@ public class CompositeIndexFoldersDeletionListener implements IndexStorePlugin.I
     }
 
     @Override
-    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
+    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
         for (IndexStorePlugin.IndexFoldersDeletionListener listener : listeners) {
             try {
-                listener.beforeIndexFoldersDeleted(index, indexSettings, indexPath);
+                listener.beforeIndexFoldersDeleted(index, indexSettings, indexPaths);
             } catch (Exception e) {
                 assert false : new AssertionError(e);
                 throw e;
@@ -42,10 +42,10 @@ public class CompositeIndexFoldersDeletionListener implements IndexStorePlugin.I
     }
 
     @Override
-    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
+    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
         for (IndexStorePlugin.IndexFoldersDeletionListener listener : listeners) {
             try {
-                listener.beforeShardFoldersDeleted(shardId, indexSettings, shardPath);
+                listener.beforeShardFoldersDeleted(shardId, indexSettings, shardPaths);
             } catch (Exception e) {
                 assert false : new AssertionError(e);
                 throw e;

--- a/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
@@ -83,22 +83,24 @@ public interface IndexStorePlugin {
      */
     interface IndexFoldersDeletionListener {
         /**
-         * Invoked before the folders of an index are deleted from disk. The folder's {@link Path} may or may not
+         * Invoked before the folders of an index are deleted from disk. The list of folders contains {@link Path}s that may or may not
          * exist on disk. Shard locks are expected to be acquired at the time this method is invoked.
+         *
          * @param index         the {@link Index} of the index whose folders are going to be deleted
          * @param indexSettings settings for the index whose folders are going to be deleted
-         * @param indexPath    the path of the folders that will be deleted
+         * @param indexPaths    the paths of the folders that are going to be deleted
          */
-        void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath);
+        void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths);
 
         /**
-         * Invoked before the folders of a shard are deleted from disk. The folder's {@link Path} may or may not
+         * Invoked before the folders of a shard are deleted from disk. The list of folders contains {@link Path}s that may or may not
          * exist on disk. Shard locks are expected to be acquired at the time this method is invoked.
+         *
          * @param shardId       the {@link ShardId} of the shard whose folders are going to be deleted
          * @param indexSettings index settings of the shard whose folders are going to be deleted
-         * @param shardPath    the path of the folder that will be deleted
+         * @param shardPaths    the paths of the folders that are going to be deleted
          */
-        void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath);
+        void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -200,8 +200,8 @@ public class NodeEnvironmentTests extends ESTestCase {
         Files.createDirectories(path.resolve("1"));
 
         expectThrows(ShardLockObtainFailedException.class,
-            () -> env.deleteShardDirectorySafe(new ShardId(index, 0), idxSettings, shardPath -> {
-                assert false : "should not be called " + shardPath;
+            () -> env.deleteShardDirectorySafe(new ShardId(index, 0), idxSettings, shardPaths -> {
+                assert false : "should not be called " + shardPaths;
             }));
 
         path = env.indexPath(index);
@@ -209,10 +209,12 @@ public class NodeEnvironmentTests extends ESTestCase {
         assertTrue(Files.exists(path.resolve("1")));
 
         {
-            SetOnce<Path> listener = new SetOnce<>();
+            SetOnce<Path[]> listener = new SetOnce<>();
             env.deleteShardDirectorySafe(new ShardId(index, 1), idxSettings, listener::set);
-            Path deletedPath = listener.get();
-            assertThat(deletedPath, equalTo(env.nodePaths()[0].resolve(index).resolve("1")));
+            Path[] deletedPaths = listener.get();
+            for (int i = 0; i < env.nodePaths().length; i++) {
+                assertThat(deletedPaths[i], equalTo(env.nodePaths()[i].resolve(index).resolve("1")));
+            }
         }
 
         path = env.indexPath(index);
@@ -261,9 +263,9 @@ public class NodeEnvironmentTests extends ESTestCase {
         start.countDown();
         blockLatch.await();
 
-        final SetOnce<Path> listener = new SetOnce<>();
+        final SetOnce<Path[]> listener = new SetOnce<>();
         env.deleteIndexDirectorySafe(index, 5000, idxSettings, listener::set);
-        assertThat(listener.get(), equalTo(env.indexPath(index)));
+        assertThat(listener.get()[0], equalTo(env.indexPath(index)));
         assertNull(threadException.get());
 
         path = env.indexPath(index);

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -122,11 +122,11 @@ public class IndexModuleTests extends ESTestCase {
 
     private IndexStorePlugin.IndexFoldersDeletionListener indexDeletionListener = new IndexStorePlugin.IndexFoldersDeletionListener() {
         @Override
-        public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
+        public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
         }
 
         @Override
-        public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
+        public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
         }
     };
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexFoldersDeletionListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexFoldersDeletionListener.java
@@ -45,7 +45,7 @@ public class SearchableSnapshotIndexFoldersDeletionListener implements IndexStor
     }
 
     @Override
-    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
+    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
         if (isSearchableSnapshotStore(indexSettings.getSettings())) {
             for (int shard = 0; shard < indexSettings.getNumberOfShards(); shard++) {
                 markShardAsEvictedInCache(new ShardId(index, shard), indexSettings);
@@ -54,7 +54,7 @@ public class SearchableSnapshotIndexFoldersDeletionListener implements IndexStor
     }
 
     @Override
-    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
+    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
         if (isSearchableSnapshotStore(indexSettings.getSettings())) {
             markShardAsEvictedInCache(shardId, indexSettings);
         }


### PR DESCRIPTION
This reverts commit fd138f578b9bfc434fa3736d58e0c8a8433573cd.

The revert was effectively conflict free, there was only a very minor
static import that needed fixing.

relates #78525
relates #71205