### PR TITLE
[7.15] [DOCS] Mention option to return String in sort context (#76105)

### DIFF
--- a/docs/painless/painless-contexts/painless-sort-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-sort-context.asciidoc
@@ -20,8 +20,9 @@ Use a Painless script to
 
 *Return*
 
-`double`::
-        The score for the specified document.
+`double` or `String`::
+        The sort key. The return type depends on the value of the `type` parameter
+        in the script sort config (`"number"` or `"string"`).
 
 *API*
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Mention option to return String in sort context (#76105)