### PR TITLE
Remove Joda from serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -31,8 +31,6 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.xcontent.XContentType;
-import org.joda.time.DateTimeZone;
-import org.joda.time.ReadableInstant;
 
 import java.io.EOFException;
 import java.io.FileNotFoundException;
@@ -721,14 +719,6 @@ public abstract class StreamOutput extends OutputStream {
                         o.writeLong(((Date) v).getTime());
                     }),
             entry(
-                    ReadableInstant.class,
-                    (o, v) -> {
-                        o.writeByte((byte) 13);
-                        final ReadableInstant instant = (ReadableInstant) v;
-                        o.writeString(instant.getZone().getID());
-                        o.writeLong(instant.getMillis());
-                    }),
-            entry(
                     BytesReference.class,
                     (o, v) -> {
                         o.writeByte((byte) 14);
@@ -827,8 +817,6 @@ public abstract class StreamOutput extends OutputStream {
             return Map.class;
         } else if (value instanceof Set) {
             return Set.class;
-        } else if (value instanceof ReadableInstant) {
-            return ReadableInstant.class;
         } else if (value instanceof BytesReference) {
             return BytesReference.class;
         } else {
@@ -1143,29 +1131,10 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Write a {@linkplain DateTimeZone} to the stream.
-     */
-    public void writeTimeZone(DateTimeZone timeZone) throws IOException {
-        writeString(timeZone.getID());
-    }
-
-    /**
      * Write a {@linkplain ZoneId} to the stream.
      */
     public void writeZoneId(ZoneId timeZone) throws IOException {
         writeString(timeZone.getId());
-    }
-
-    /**
-     * Write an optional {@linkplain DateTimeZone} to the stream.
-     */
-    public void writeOptionalTimeZone(@Nullable DateTimeZone timeZone) throws IOException {
-        if (timeZone == null) {
-            writeBoolean(false);
-        } else {
-            writeBoolean(true);
-            writeTimeZone(timeZone);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
@@ -15,18 +15,10 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentBuilderExtension;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Instant;
-import org.joda.time.MutableDateTime;
-import org.joda.time.ReadableInstant;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
-import org.joda.time.tz.CachedDateTimeZone;
-import org.joda.time.tz.FixedDateTimeZone;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -53,7 +45,6 @@ import java.util.function.Function;
  */
 public class XContentElasticsearchExtension implements XContentBuilderExtension {
 
-    public static final DateTimeFormatter DEFAULT_DATE_PRINTER = ISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC);
     public static final DateFormatter DEFAULT_FORMATTER = DateFormatter.forPattern("strict_date_optional_time_nanos");
     public static final DateFormatter LOCAL_TIME_FORMATTER = DateFormatter.forPattern("HH:mm:ss.SSS");
     public static final DateFormatter OFFSET_TIME_FORMATTER = DateFormatter.forPattern("HH:mm:ss.SSSZZZZZ");
@@ -64,11 +55,6 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
 
         // Fully-qualified here to reduce ambiguity around our (ES') Version class
         writers.put(org.apache.lucene.util.Version.class, (b, v) -> b.value(Objects.toString(v)));
-        writers.put(DateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
-        writers.put(CachedDateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
-        writers.put(FixedDateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
-        writers.put(MutableDateTime.class, XContentBuilder::timeValue);
-        writers.put(DateTime.class, XContentBuilder::timeValue);
         writers.put(TimeValue.class, (b, v) -> b.value(v.toString()));
         writers.put(ZonedDateTime.class, XContentBuilder::timeValue);
         writers.put(OffsetDateTime.class, XContentBuilder::timeValue);
@@ -115,14 +101,11 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
     @Override
     public Map<Class<?>, Function<Object, Object>> getDateTransformers() {
         Map<Class<?>, Function<Object, Object>> transformers = new HashMap<>();
-        transformers.put(Date.class, d -> DEFAULT_DATE_PRINTER.print(((Date) d).getTime()));
-        transformers.put(DateTime.class, d -> DEFAULT_DATE_PRINTER.print((DateTime) d));
-        transformers.put(MutableDateTime.class, d -> DEFAULT_DATE_PRINTER.print((MutableDateTime) d));
-        transformers.put(ReadableInstant.class, d -> DEFAULT_DATE_PRINTER.print((ReadableInstant) d));
-        transformers.put(Long.class, d -> DEFAULT_DATE_PRINTER.print((long) d));
-        transformers.put(Calendar.class, d -> DEFAULT_DATE_PRINTER.print(((Calendar) d).getTimeInMillis()));
-        transformers.put(GregorianCalendar.class, d -> DEFAULT_DATE_PRINTER.print(((Calendar) d).getTimeInMillis()));
-        transformers.put(Instant.class, d -> DEFAULT_DATE_PRINTER.print((Instant) d));
+        transformers.put(Date.class, d -> DEFAULT_FORMATTER.format(((Date) d).toInstant()));
+        transformers.put(Long.class, d -> DEFAULT_FORMATTER.format(Instant.ofEpochMilli((long) d)));
+        transformers.put(Calendar.class, d -> DEFAULT_FORMATTER.format(((Calendar) d).toInstant()));
+        transformers.put(GregorianCalendar.class, d -> DEFAULT_FORMATTER.format(((Calendar) d).toInstant()));
+        transformers.put(Instant.class, d -> DEFAULT_FORMATTER.format((Instant) d));
         transformers.put(ZonedDateTime.class, d -> DEFAULT_FORMATTER.format((ZonedDateTime) d));
         transformers.put(OffsetDateTime.class, d -> DEFAULT_FORMATTER.format((OffsetDateTime) d));
         transformers.put(OffsetTime.class, d -> OFFSET_TIME_FORMATTER.format((OffsetTime) d));

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestResponseListener;
 
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -146,9 +147,9 @@ public class RestCatRecoveryAction extends AbstractCatAction {
                 t.startRow();
                 t.addCell(index);
                 t.addCell(state.getShardId().id());
-                t.addCell(XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(state.getTimer().startTime()));
+                t.addCell(XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(state.getTimer().startTime())));
                 t.addCell(state.getTimer().startTime());
-                t.addCell(XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(state.getTimer().stopTime()));
+                t.addCell(XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(state.getTimer().stopTime())));
                 t.addCell(state.getTimer().stopTime());
                 t.addCell(new TimeValue(state.getTimer().time()));
                 t.addCell(state.getRecoverySource().getType().toString().toLowerCase(Locale.ROOT));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -62,8 +63,8 @@ public class IndexGraveyardTests extends ESTestCase {
         if (graveyard.getTombstones().size() > 0) {
             // check that date properly printed
             assertThat(Strings.toString(graveyard, false, true),
-                containsString(XContentElasticsearchExtension.DEFAULT_DATE_PRINTER
-                        .print(graveyard.getTombstones().get(0).getDeleteDateInMillis())));
+                containsString(XContentElasticsearchExtension.DEFAULT_FORMATTER
+                        .format(Instant.ofEpochMilli(graveyard.getTombstones().get(0).getDeleteDateInMillis()))));
         }
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         parser.nextToken(); // the beginning of the parser

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -299,7 +299,6 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeOptionalDouble(1.2);
         out.writeZoneId(ZoneId.of("CET"));
         out.writeOptionalZoneId(ZoneId.systemDefault());
-        out.writeOptionalTimeZone(null);
         out.writeGenericValue(ZonedDateTime.ofInstant(Instant.ofEpochMilli(123456), ZoneId.of("America/Los_Angeles")));
         final OffsetTime offsetNow = OffsetTime.now(randomZone());
         out.writeGenericValue(offsetNow);
@@ -334,7 +333,6 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat(in.readOptionalDouble(), closeTo(1.2, 0.0001));
         assertEquals(ZoneId.of("CET"), in.readZoneId());
         assertEquals(ZoneId.systemDefault(), in.readOptionalZoneId());
-        assertNull(in.readOptionalTimeZone());
         Object dt = in.readGenericValue();
         assertThat(dt, instanceOf(ZonedDateTime.class));
         ZonedDateTime zdt = (ZonedDateTime)dt;

--- a/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -177,9 +177,9 @@ public class XContentBuilderTests extends ESTestCase {
 
     public void testDateTypesConversion() throws Exception {
         Date date = new Date();
-        String expectedDate = XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(date.getTime());
+        String expectedDate = XContentElasticsearchExtension.DEFAULT_FORMATTER.format(date.toInstant());
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"), Locale.ROOT);
-        String expectedCalendar = XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(calendar.getTimeInMillis());
+        String expectedCalendar = XContentElasticsearchExtension.DEFAULT_FORMATTER.format(calendar.toInstant());
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         builder.startObject().timeField("date", date).endObject();
         assertThat(Strings.toString(builder), equalTo("{\"date\":\"" + expectedDate + "\"}"));

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatRecoveryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatRecoveryActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ESTestCase;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -151,9 +152,9 @@ public class RestCatRecoveryActionTests extends ESTestCase {
             final List<Object> expectedValues = Arrays.asList(
                     "index",
                     i,
-                    XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(state.getTimer().startTime()),
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(state.getTimer().startTime())),
                     state.getTimer().startTime(),
-                    XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(state.getTimer().stopTime()),
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(state.getTimer().stopTime())),
                     state.getTimer().stopTime(),
                     new TimeValue(state.getTimer().time()),
                     state.getRecoverySource().getType().name().toLowerCase(Locale.ROOT),

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -151,9 +151,9 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 "  \"id\" : \"id\",\n" +
                 "  \"is_partial\" : true,\n" +
                 "  \"is_running\" : true,\n" +
-                "  \"start_time\" : \"" + XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(date.getTime()) + "\",\n" +
+                "  \"start_time\" : \"" + XContentElasticsearchExtension.DEFAULT_FORMATTER.format(date.toInstant()) + "\",\n" +
                 "  \"start_time_in_millis\" : " + date.getTime() + ",\n" +
-                "  \"expiration_time\" : \"" + XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(date.getTime()) + "\",\n" +
+                "  \"expiration_time\" : \"" + XContentElasticsearchExtension.DEFAULT_FORMATTER.format(date.toInstant()) + "\",\n" +
                 "  \"expiration_time_in_millis\" : " + date.getTime() + "\n" +
                 "}", Strings.toString(builder));
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -66,7 +66,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
                 details.append(String.format(
                     Locale.ROOT,
                     " The model snapshot's latest record timestamp is [%s]",
-                    XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(modelSnapshot.getLatestRecordTimeStamp().getTime())
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(modelSnapshot.getLatestRecordTimeStamp().toInstant())
                 ));
             }
             return Optional.of(new DeprecationIssue(DeprecationIssue.Level.CRITICAL,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -398,7 +399,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                                 "Passing currently perceived capacity as down scale delay has not been satisfied; configured delay [%s]"
                                     + "last detected scale down event [%s]. Will request scale down in approximately [%s]",
                                 DOWN_SCALE_DELAY.get(configuration).getStringRep(),
-                                XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(scaleDownDetected),
+                                XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(scaleDownDetected)),
                                 TimeValue.timeValueMillis(msLeftToScale).getStringRep()
                             )
                         )
@@ -595,7 +596,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                 "not scaling down as the current scale down delay [{}] is not satisfied." +
                     " The last time scale down was detected [{}]. Calculated scaled down capacity [{}] ",
                 downScaleDelay.getStringRep(),
-                XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(scaleDownDetected),
+                XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(scaleDownDetected)),
                 scaleDownDecisionResult.requiredCapacity()));
             return new AutoscalingDeciderResult(
                 context.currentCapacity(),
@@ -606,7 +607,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                             "Passing currently perceived capacity as down scale delay has not been satisfied; configured delay [%s]"
                                 + "last detected scale down event [%s]. Will request scale down in approximately [%s]",
                             downScaleDelay.getStringRep(),
-                            XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(scaleDownDetected),
+                            XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(scaleDownDetected)),
                             TimeValue.timeValueMillis(msLeftToScale).getStringRep()
                         )
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -213,7 +213,7 @@ class DatafeedJob {
                 Date endTime = new Date((lastBucket.getEpoch() + lastBucket.getBucketSpan()) * 1000);
 
                 String msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA, totalRecordsMissing,
-                    XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(lastBucket.getTimestamp().getTime()));
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(lastBucket.getTimestamp().toInstant()));
 
                 Annotation annotation = createDelayedDataAnnotation(missingDataBuckets.get(0).getBucket().getTimestamp(), endTime, msg);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -751,13 +751,12 @@ public class AutodetectProcessManager implements ClusterStateListener {
             msgBuilder.append("] with latest_record_timestamp [");
             Date snapshotLatestRecordTimestamp = modelSnapshot.getLatestRecordTimeStamp();
             msgBuilder.append(snapshotLatestRecordTimestamp == null ? "N/A" :
-                    XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(
-                            snapshotLatestRecordTimestamp.getTime()));
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(snapshotLatestRecordTimestamp.toInstant()));
         }
         msgBuilder.append("], job latest_record_timestamp [");
         Date jobLatestRecordTimestamp = autodetectParams.dataCounts().getLatestRecordTimeStamp();
         msgBuilder.append(jobLatestRecordTimestamp == null ? "N/A"
-                : XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(jobLatestRecordTimestamp.getTime()));
+                : XContentElasticsearchExtension.DEFAULT_FORMATTER.format(jobLatestRecordTimestamp.toInstant()));
         msgBuilder.append("]");
         String msg = msgBuilder.toString();
         logger.info("[{}] {}", jobId, msg);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -288,7 +288,7 @@ public class DatafeedJobTests extends ESTestCase {
 
         String msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA,
             10,
-            XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(2000));
+            XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(2000)));
 
         long annotationCreateTime = currentTime;
         {  // What we expect the created annotation to be indexed as
@@ -335,7 +335,7 @@ public class DatafeedJobTests extends ESTestCase {
 
         msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA,
             15,
-            XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(6000));
+            XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(6000)));
 
         long annotationUpdateTime = currentTime;
         {  // What we expect the updated annotation to be indexed as


### PR DESCRIPTION
This commit removes the remaining uses of Joda from xcontent and
streaminput/streamoutput. In the case of streams, the read side simply
now parses the timezone+millis into a ZonedDateTime. On the write side
there were already no remaining uses. For xcontent serialization, most
of the remaining uses were utlizing a Joda date formatter for printing
Java Date and Calendar objects.