### PR TITLE
Skip loading authorized indices if requests do not need them (#78321)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -460,9 +461,7 @@ public class IndexNameExpressionResolver {
      *         If the data stream, index or alias contains date math then that is resolved too.
      */
     public boolean hasIndexAbstraction(String indexAbstraction, ClusterState state) {
-        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, getSystemIndexAccessLevel(),
-            getSystemIndexAccessPredicate(), getNetNewSystemIndexPredicate());
-        String resolvedAliasOrIndex = DateMathExpressionResolver.resolveExpression(indexAbstraction, context);
+        String resolvedAliasOrIndex = DateMathExpressionResolver.resolveExpression(indexAbstraction);
         return state.metadata().getIndicesLookup().containsKey(resolvedAliasOrIndex);
     }
 
@@ -470,10 +469,7 @@ public class IndexNameExpressionResolver {
      * @return If the specified string is data math expression then this method returns the resolved expression.
      */
     public String resolveDateMathExpression(String dateExpression) {
-        // The data math expression resolver doesn't rely on cluster state or indices options, because
-        // it just resolves the date math to an actual date.
-        return DateMathExpressionResolver.resolveExpression(dateExpression,
-            new Context(null, null, getSystemIndexAccessLevel(), getSystemIndexAccessPredicate(), getNetNewSystemIndexPredicate()));
+        return DateMathExpressionResolver.resolveExpression(dateExpression);
     }
 
     /**
@@ -481,8 +477,7 @@ public class IndexNameExpressionResolver {
      * @return If the specified string is data math expression then this method returns the resolved expression.
      */
     public String resolveDateMathExpression(String dateExpression, long time) {
-        return DateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, time, getSystemIndexAccessLevel(),
-            getSystemIndexAccessPredicate(), getNetNewSystemIndexPredicate()));
+        return DateMathExpressionResolver.resolveExpression(dateExpression, () -> time);
     }
 
     /**
@@ -1217,13 +1212,17 @@ public class IndexNameExpressionResolver {
         public List<String> resolve(final Context context, List<String> expressions) {
             List<String> result = new ArrayList<>(expressions.size());
             for (String expression : expressions) {
-                result.add(resolveExpression(expression, context));
+                result.add(resolveExpression(expression, context::getStartTime));
             }
             return result;
         }
 
+        static String resolveExpression(String expression) {
+            return resolveExpression(expression, System::currentTimeMillis);
+        }
+
         @SuppressWarnings("fallthrough")
-        static String resolveExpression(String expression, final Context context) {
+        static String resolveExpression(String expression, LongSupplier getTime) {
             if (expression.startsWith(EXPRESSION_LEFT_BOUND) == false || expression.endsWith(EXPRESSION_RIGHT_BOUND) == false) {
                 return expression;
             }
@@ -1308,7 +1307,7 @@ public class IndexNameExpressionResolver {
 
                                 DateFormatter formatter = dateFormatter.withZone(timeZone);
                                 DateMathParser dateMathParser = formatter.toDateMathParser();
-                                Instant instant = dateMathParser.parse(mathExpression, context::getStartTime, false, timeZone);
+                                Instant instant = dateMathParser.parse(mathExpression, getTime, false, timeZone);
 
                                 String time = formatter.format(instant);
                                 beforePlaceHolderSb.append(time);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -870,7 +870,7 @@ public class MetadataIndexTemplateService {
      */
     public static List<IndexTemplateMetadata> findV1Templates(Metadata metadata, String indexName, @Nullable Boolean isHidden) {
         final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
-            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+            .resolveExpression(indexName);
         final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final List<IndexTemplateMetadata> matchedTemplates = new ArrayList<>();
         for (IndexTemplateMetadata template: metadata.templates().values()) {
@@ -923,7 +923,7 @@ public class MetadataIndexTemplateService {
     @Nullable
     public static String findV2Template(Metadata metadata, String indexName, boolean isHidden) {
         final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
-            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+            .resolveExpression(indexName);
         final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final Map<ComposableIndexTemplate, String> matchedTemplates = new HashMap<>();
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -366,7 +366,11 @@ public class AuthorizationService {
                     })
                 );
             });
-            final AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier = new CachingAsyncSupplier<>(resolvedIndicesListener ->
+            final AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier = new CachingAsyncSupplier<>(resolvedIndicesListener -> {
+                final ResolvedIndices resolvedIndices = indicesAndAliasesResolver.tryResolveWithoutWildcards(action, request);
+                if (resolvedIndices != null) {
+                    resolvedIndicesListener.onResponse(resolvedIndices);
+                } else {
                     authorizedIndicesSupplier.getAsync(
                         ActionListener.wrap(
                             authorizedIndices ->
@@ -382,11 +386,12 @@ public class AuthorizationService {
                                 }
                             }
                         )
-                    )
-            );
+                    );
+                }
+            });
             authzEngine.authorizeIndexAction(requestInfo, authzInfo, resolvedIndicesAsyncSupplier,
                 metadata.getIndicesLookup(), wrapPreservingContext(new AuthorizationResultListener<>(result ->
-                    handleIndexActionAuthorizationResult(result, requestInfo, requestId, authzInfo, authzEngine, authorizedIndicesSupplier,
+                    handleIndexActionAuthorizationResult(result, requestInfo, requestId, authzInfo, authzEngine,
                         resolvedIndicesAsyncSupplier, metadata, listener),
                     listener::onFailure, requestInfo, requestId, authzInfo), threadContext));
         } else {
@@ -399,7 +404,6 @@ public class AuthorizationService {
     private void handleIndexActionAuthorizationResult(final IndexAuthorizationResult result, final RequestInfo requestInfo,
                                                       final String requestId, final AuthorizationInfo authzInfo,
                                                       final AuthorizationEngine authzEngine,
-                                                      final AsyncSupplier<Set<String>> authorizedIndicesSupplier,
                                                       final AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier,
                                                       final Metadata metadata,
                                                       final ActionListener<Void> listener) {
@@ -449,7 +453,7 @@ public class AuthorizationService {
                 authzInfo,
                 result.getIndicesAccessControl()
             );
-            authorizeBulkItems(requestInfo, authzContext, authzEngine, resolvedIndicesAsyncSupplier, authorizedIndicesSupplier, metadata,
+            authorizeBulkItems(requestInfo, authzContext, authzEngine, resolvedIndicesAsyncSupplier, metadata,
                 requestId,
                 wrapPreservingContext(
                         ActionListener.wrap(ignore -> runRequestInterceptors(requestInfo, authzInfo, authorizationEngine, listener),
@@ -575,7 +579,6 @@ public class AuthorizationService {
      */
     private void authorizeBulkItems(RequestInfo requestInfo, AuthorizationContext bulkAuthzContext,
                                     AuthorizationEngine authzEngine, AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier,
-                                    AsyncSupplier<Set<String>> authorizedIndicesSupplier,
                                     Metadata metadata, String requestId, ActionListener<Void> listener) {
         final Authentication authentication = requestInfo.getAuthentication();
         final AuthorizationInfo authzInfo = bulkAuthzContext.getAuthorizationInfo();
@@ -586,83 +589,81 @@ public class AuthorizationService {
         final Map<String, Set<String>> actionToIndicesMap = new HashMap<>();
         final AuditTrail auditTrail = auditTrailService.get();
 
-        authorizedIndicesSupplier.getAsync(ActionListener.wrap(authorizedIndices -> {
-            resolvedIndicesAsyncSupplier.getAsync(ActionListener.wrap(overallResolvedIndices -> {
-                final Set<String> localIndices = new HashSet<>(overallResolvedIndices.getLocal());
-                for (BulkItemRequest item : request.items()) {
-                    final String itemAction = getAction(item);
-                    String resolvedIndex = resolvedIndexNames.computeIfAbsent(item.index(), key -> {
-                        final ResolvedIndices resolvedIndices =
-                            indicesAndAliasesResolver.resolveIndicesAndAliases(itemAction, item.request(), metadata, authorizedIndices);
-                        if (resolvedIndices.getRemote().size() != 0) {
-                            throw illegalArgument("Bulk item should not write to remote indices, but request writes to "
-                                + String.join(",", resolvedIndices.getRemote()));
-                        }
-                        if (resolvedIndices.getLocal().size() != 1) {
-                            throw illegalArgument("Bulk item should write to exactly 1 index, but request writes to "
-                                + String.join(",", resolvedIndices.getLocal()));
-                        }
-                        final String resolved = resolvedIndices.getLocal().get(0);
-                        if (localIndices.contains(resolved) == false) {
-                            throw illegalArgument("Found bulk item that writes to index " + resolved + " but the request writes to " +
-                                localIndices);
-                        }
-                        return resolved;
-                    });
-
-                    actionToIndicesMap.compute(itemAction, (key, resolvedIndicesSet) -> {
-                        final Set<String> localSet = resolvedIndicesSet != null ? resolvedIndicesSet : new HashSet<>();
-                        localSet.add(resolvedIndex);
-                        return localSet;
-                    });
-                }
-
-                final ActionListener<Collection<Tuple<String, IndexAuthorizationResult>>> bulkAuthzListener =
-                    ActionListener.wrap(collection -> {
-                        final Map<String, IndicesAccessControl> actionToIndicesAccessControl = new HashMap<>();
-                        final AtomicBoolean audit = new AtomicBoolean(false);
-                        collection.forEach(tuple -> {
-                            final IndicesAccessControl existing =
-                                actionToIndicesAccessControl.putIfAbsent(tuple.v1(), tuple.v2().getIndicesAccessControl());
-                            if (existing != null) {
-                                throw new IllegalStateException("a value already exists for action " + tuple.v1());
-                            }
-                            if (tuple.v2().isAuditable()) {
-                                audit.set(true);
-                            }
-                        });
-
-                        for (BulkItemRequest item : request.items()) {
-                            final String resolvedIndex = resolvedIndexNames.get(item.index());
-                            final String itemAction = getAction(item);
-                            final IndicesAccessControl indicesAccessControl = actionToIndicesAccessControl.get(itemAction);
-                            final IndicesAccessControl.IndexAccessControl indexAccessControl
-                                = indicesAccessControl.getIndexPermissions(resolvedIndex);
-                            if (indexAccessControl == null || indexAccessControl.isGranted() == false) {
-                                auditTrail.explicitIndexAccessEvent(requestId, AuditLevel.ACCESS_DENIED, authentication, itemAction,
-                                        resolvedIndex, item.getClass().getSimpleName(), request.remoteAddress(), authzInfo);
-                                item.abort(resolvedIndex, denialException(authentication, itemAction, request,
-                                    IndexAuthorizationResult.getFailureDescription(singletonList(resolvedIndex)), null));
-                            } else if (audit.get()) {
-                                auditTrail.explicitIndexAccessEvent(requestId, AuditLevel.ACCESS_GRANTED, authentication, itemAction,
-                                        resolvedIndex, item.getClass().getSimpleName(), request.remoteAddress(), authzInfo);
-                            }
-                        }
-                        listener.onResponse(null);
-                    }, listener::onFailure);
-                final ActionListener<Tuple<String, IndexAuthorizationResult>> groupedActionListener = wrapPreservingContext(
-                    new GroupedActionListener<>(bulkAuthzListener, actionToIndicesMap.size()), threadContext);
-
-                actionToIndicesMap.forEach((bulkItemAction, indices) -> {
-                    final RequestInfo bulkItemInfo =
-                        new RequestInfo(requestInfo.getAuthentication(), requestInfo.getRequest(), bulkItemAction, bulkAuthzContext);
-                    authzEngine.authorizeIndexAction(bulkItemInfo, authzInfo,
-                        ril -> ril.onResponse(new ResolvedIndices(new ArrayList<>(indices), Collections.emptyList())),
-                        metadata.getIndicesLookup(), ActionListener.wrap(indexAuthorizationResult ->
-                                groupedActionListener.onResponse(new Tuple<>(bulkItemAction, indexAuthorizationResult)),
-                            groupedActionListener::onFailure));
+        resolvedIndicesAsyncSupplier.getAsync(ActionListener.wrap(overallResolvedIndices -> {
+            final Set<String> localIndices = new HashSet<>(overallResolvedIndices.getLocal());
+            for (BulkItemRequest item : request.items()) {
+                final String itemAction = getAction(item);
+                String resolvedIndex = resolvedIndexNames.computeIfAbsent(item.index(), key -> {
+                    final ResolvedIndices resolvedIndices =
+                        indicesAndAliasesResolver.resolveIndicesAndAliasesWithoutWildcards(itemAction, item.request());
+                    if (resolvedIndices.getRemote().size() != 0) {
+                        throw illegalArgument("Bulk item should not write to remote indices, but request writes to "
+                            + String.join(",", resolvedIndices.getRemote()));
+                    }
+                    if (resolvedIndices.getLocal().size() != 1) {
+                        throw illegalArgument("Bulk item should write to exactly 1 index, but request writes to "
+                            + String.join(",", resolvedIndices.getLocal()));
+                    }
+                    final String resolved = resolvedIndices.getLocal().get(0);
+                    if (localIndices.contains(resolved) == false) {
+                        throw illegalArgument("Found bulk item that writes to index " + resolved + " but the request writes to " +
+                            localIndices);
+                    }
+                    return resolved;
                 });
-            }, listener::onFailure));
+
+                actionToIndicesMap.compute(itemAction, (key, resolvedIndicesSet) -> {
+                    final Set<String> localSet = resolvedIndicesSet != null ? resolvedIndicesSet : new HashSet<>();
+                    localSet.add(resolvedIndex);
+                    return localSet;
+                });
+            }
+
+            final ActionListener<Collection<Tuple<String, IndexAuthorizationResult>>> bulkAuthzListener =
+                ActionListener.wrap(collection -> {
+                    final Map<String, IndicesAccessControl> actionToIndicesAccessControl = new HashMap<>();
+                    final AtomicBoolean audit = new AtomicBoolean(false);
+                    collection.forEach(tuple -> {
+                        final IndicesAccessControl existing =
+                            actionToIndicesAccessControl.putIfAbsent(tuple.v1(), tuple.v2().getIndicesAccessControl());
+                        if (existing != null) {
+                            throw new IllegalStateException("a value already exists for action " + tuple.v1());
+                        }
+                        if (tuple.v2().isAuditable()) {
+                            audit.set(true);
+                        }
+                    });
+
+                    for (BulkItemRequest item : request.items()) {
+                        final String resolvedIndex = resolvedIndexNames.get(item.index());
+                        final String itemAction = getAction(item);
+                        final IndicesAccessControl indicesAccessControl = actionToIndicesAccessControl.get(itemAction);
+                        final IndicesAccessControl.IndexAccessControl indexAccessControl
+                            = indicesAccessControl.getIndexPermissions(resolvedIndex);
+                        if (indexAccessControl == null || indexAccessControl.isGranted() == false) {
+                            auditTrail.explicitIndexAccessEvent(requestId, AuditLevel.ACCESS_DENIED, authentication, itemAction,
+                                    resolvedIndex, item.getClass().getSimpleName(), request.remoteAddress(), authzInfo);
+                            item.abort(resolvedIndex, denialException(authentication, itemAction, request,
+                                IndexAuthorizationResult.getFailureDescription(singletonList(resolvedIndex)), null));
+                        } else if (audit.get()) {
+                            auditTrail.explicitIndexAccessEvent(requestId, AuditLevel.ACCESS_GRANTED, authentication, itemAction,
+                                    resolvedIndex, item.getClass().getSimpleName(), request.remoteAddress(), authzInfo);
+                        }
+                    }
+                    listener.onResponse(null);
+                }, listener::onFailure);
+            final ActionListener<Tuple<String, IndexAuthorizationResult>> groupedActionListener = wrapPreservingContext(
+                new GroupedActionListener<>(bulkAuthzListener, actionToIndicesMap.size()), threadContext);
+
+            actionToIndicesMap.forEach((bulkItemAction, indices) -> {
+                final RequestInfo bulkItemInfo =
+                    new RequestInfo(requestInfo.getAuthentication(), requestInfo.getRequest(), bulkItemAction, bulkAuthzContext);
+                authzEngine.authorizeIndexAction(bulkItemInfo, authzInfo,
+                    ril -> ril.onResponse(new ResolvedIndices(new ArrayList<>(indices), Collections.emptyList())),
+                    metadata.getIndicesLookup(), ActionListener.wrap(indexAuthorizationResult ->
+                            groupedActionListener.onResponse(new Tuple<>(bulkItemAction, indexAuthorizationResult)),
+                        groupedActionListener::onFailure));
+            });
         }, listener::onFailure));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -184,7 +184,7 @@ class IndicesAndAliasesResolver {
         for (String name : indices) {
             localIndices.add(nameExpressionResolver.resolveDateMathExpression(name));
         }
-        return new ResolvedIndices(localIndices, List.of());
+        return new ResolvedIndices(localIndices, org.elasticsearch.core.List.of());
     }
 
     ResolvedIndices resolveIndicesAndAliases(String action, IndicesRequest indicesRequest, Metadata metadata,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
@@ -110,6 +111,81 @@ class IndicesAndAliasesResolver {
         return resolveIndicesAndAliases(action, (IndicesRequest) request, metadata, authorizedIndices);
     }
 
+    /**
+     * Attempt to resolve requested indices without expanding any wildcards.
+     * @return The {@link ResolvedIndices} or null if wildcard expansion must be performed.
+     */
+    @Nullable
+    ResolvedIndices tryResolveWithoutWildcards(String action, TransportRequest transportRequest) {
+        // We only take care of IndicesRequest
+        if (false == transportRequest instanceof IndicesRequest) {
+            return null;
+        }
+        final IndicesRequest indicesRequest = (IndicesRequest) transportRequest;
+        if (requiresWildcardExpansion(indicesRequest)) {
+            return null;
+        }
+        // It's safe to cast IndicesRequest since the above test guarantees it
+        return resolveIndicesAndAliasesWithoutWildcards(action, indicesRequest);
+    }
+
+    private boolean requiresWildcardExpansion(IndicesRequest indicesRequest) {
+        // IndicesAliasesRequest requires special handling because it can have wildcards in request body
+        if (indicesRequest instanceof IndicesAliasesRequest) {
+            return true;
+        }
+        // Replaceable requests always require wildcard expansion
+        if (indicesRequest instanceof IndicesRequest.Replaceable) {
+            return true;
+        }
+        // TODO: Strictly speaking we should also check for allowRemoteIndices because resolveIndicesAndAliasesWithoutWildcards
+        //       assumes everything is local indices. It is currently not a practical issue since we don't have any requests
+        //       that are non-replaceable but allowRemoteIndices. We will address this in a separate PR and keep this as is
+        //       to match the existing behaviour.
+        return false;
+    }
+
+    ResolvedIndices resolveIndicesAndAliasesWithoutWildcards(String action, IndicesRequest indicesRequest) {
+        assert false == requiresWildcardExpansion(indicesRequest) : "request must not require wildcard expansion";
+        final String[] indices = indicesRequest.indices();
+        if (indices == null || indices.length == 0) {
+            throw new IllegalArgumentException("the action " + action + " requires explicit index names, but none were provided");
+        }
+        if (IndexNameExpressionResolver.isAllIndices(Arrays.asList(indices))) {
+            throw new IllegalArgumentException(
+                "the action "
+                    + action
+                    + " does not support accessing all indices;"
+                    + " the provided index expression ["
+                    + Strings.arrayToCommaDelimitedString(indices)
+                    + "] is not allowed"
+            );
+        }
+
+        // TODO: Shard level requests have wildcard expanded already and do not need go through this check
+        final List<String> wildcards = Stream.of(indices).filter(Regex::isSimpleMatchPattern).collect(Collectors.toList());
+        if (wildcards.isEmpty() == false) {
+            throw new IllegalArgumentException(
+                "the action "
+                    + action
+                    + " does not support wildcards;"
+                    + " the provided index expression(s) ["
+                    + Strings.collectionToCommaDelimitedString(wildcards)
+                    + "] are not allowed"
+            );
+        }
+
+        //NOTE: shard level requests do support wildcards (as they hold the original indices options) but don't support
+        // replacing their indices.
+        //That is fine though because they never contain wildcards, as they get replaced as part of the authorization of their
+        //corresponding parent request on the coordinating node. Hence wildcards don't need to get replaced nor exploded for
+        // shard level requests.
+        final List<String> localIndices = new ArrayList<>(indices.length);
+        for (String name : indices) {
+            localIndices.add(nameExpressionResolver.resolveDateMathExpression(name));
+        }
+        return new ResolvedIndices(localIndices, List.of());
+    }
 
     ResolvedIndices resolveIndicesAndAliases(String action, IndicesRequest indicesRequest, Metadata metadata,
                                              Set<String> authorizedIndices) {
@@ -180,40 +256,12 @@ class IndicesAndAliasesResolver {
                 replaceable.indices(resolvedIndicesBuilder.build().toArray());
             }
         } else {
-            final String[] indices = indicesRequest.indices();
-            if (indices == null || indices.length == 0) {
-                throw new IllegalArgumentException("the action " + action + " requires explicit index names, but none were provided");
-            }
-            if (IndexNameExpressionResolver.isAllIndices(Arrays.asList(indices))) {
-                throw new IllegalArgumentException(
-                    "the action "
-                        + action
-                        + " does not support accessing all indices;"
-                        + " the provided index expression ["
-                        + Strings.arrayToCommaDelimitedString(indices)
-                        + "] is not allowed"
-                );
-            }
-            final List<String> wildcards = Stream.of(indices).filter(Regex::isSimpleMatchPattern).collect(Collectors.toList());
-            if (wildcards.isEmpty() == false) {
-                throw new IllegalArgumentException(
-                    "the action "
-                        + action
-                        + " does not support wildcards;"
-                        + " the provided index expression(s) ["
-                        + Strings.collectionToCommaDelimitedString(wildcards)
-                        + "] are not allowed"
-                );
-            }
-
-            //NOTE: shard level requests do support wildcards (as they hold the original indices options) but don't support
-            // replacing their indices.
-            //That is fine though because they never contain wildcards, as they get replaced as part of the authorization of their
-            //corresponding parent request on the coordinating node. Hence wildcards don't need to get replaced nor exploded for
-            // shard level requests.
-            for (String name : indices) {
-                resolvedIndicesBuilder.addLocal(nameExpressionResolver.resolveDateMathExpression(name));
-            }
+            // For performance reasons, non-replaceable requests should be directly handled by
+            // resolveIndicesAndAliasesWithoutWildcards instead of being delegated here.
+            // That's why an assertion error is triggered here so that we can catch the erroneous usage in testing.
+            // But we still delegate in production to avoid our (potential) programing error becoming an end-user problem.
+            assert false : "Request [" + indicesRequest + "] is not a replaceable request, but should be.";
+            return resolveIndicesAndAliasesWithoutWildcards(action, indicesRequest);
         }
 
         if (indicesRequest instanceof AliasesRequest) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -302,7 +302,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         //aliases with names starting with '-' or '+' can be created up to version 5.x and can be around in 6.x
         ShardSearchRequest request = mock(ShardSearchRequest.class);
         when(request.indices()).thenReturn(new String[]{"-index10", "-index20", "+index30"});
-        List<String> indices = resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME))
+        List<String> indices = defaultIndicesResolver.resolveIndicesAndAliasesWithoutWildcards(SearchAction.NAME + "[s]", request)
                 .getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index20", "+index30"};
         assertThat(indices, hasSize(expectedIndices.length));
@@ -314,7 +314,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         when(request.indices()).thenReturn(new String[]{"index*"});
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> resolveIndices(SearchAction.NAME + "[s]", request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal()
+            () -> defaultIndicesResolver.resolveIndicesAndAliasesWithoutWildcards(SearchAction.NAME + "[s]", request)
         );
         assertThat(
             exception,
@@ -339,7 +339,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         }
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> resolveIndices(SearchAction.NAME + "[s]", request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal()
+            () -> defaultIndicesResolver.resolveIndicesAndAliasesWithoutWildcards(SearchAction.NAME + "[s]", request)
         );
 
         assertThat(


### PR DESCRIPTION
Some indices requests support expanding wildcards. During authorization,
wildcard expansion is performed against the list of authorized indices
that the user has access to. The expansion (resolvedIndices) are then
used to replace the original indices. These indices requests shares a
common interface of IndicesRequest.Replaceable.

The observation is that indices requests that are not Replaceable do not
need expanding wildcards which in turn remove the need for the list of
authorized indices.

This PR skips loading of authorized indices when the indices requests
are not replaceable, e.g. ShardSearchRequest,
FieldCapabilitiesIndexRequest. This should help the node on the receving
end of the request handling, i.e. handler of fan-out requests.

Backport: #78321
