### PR TITLE
[7.x] Replace RoutingTable#shardsWithState(...) with RoutingNodes#unassigned(...) (#78931)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -456,7 +456,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      */
     public static int getNumberOfDelayedUnassigned(ClusterState state) {
         int count = 0;
-        for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
+        for (ShardRouting shard : state.getRoutingNodes().unassigned()) {
             if (shard.unassignedInfo().isDelayed()) {
                 count++;
             }
@@ -471,9 +471,8 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      */
     public static long findNextDelayedAllocation(long currentNanoTime, ClusterState state) {
         Metadata metadata = state.metadata();
-        RoutingTable routingTable = state.routingTable();
         long nextDelayNanos = Long.MAX_VALUE;
-        for (ShardRouting shard : routingTable.shardsWithState(ShardRoutingState.UNASSIGNED)) {
+        for (ShardRouting shard : state.getRoutingNodes().unassigned()) {
             UnassignedInfo unassignedInfo = shard.unassignedInfo();
             if (unassignedInfo.isDelayed()) {
                 Settings indexSettings = metadata.index(shard.index()).getSettings();

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -21,7 +21,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -320,7 +319,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
 
     private static Set<SnapshotShard> listOfSnapshotShards(final ClusterState state) {
         final Set<SnapshotShard> snapshotShards = new HashSet<>();
-        for (ShardRouting shardRouting : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
+        for (ShardRouting shardRouting : state.getRoutingNodes().unassigned()) {
             if (shardRouting.primary() && shardRouting.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
                 final RecoverySource.SnapshotRecoverySource snapshotRecoverySource = (RecoverySource.SnapshotRecoverySource) shardRouting
                     .recoverySource();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Replace RoutingTable#shardsWithState(...) with RoutingNodes#unassigned(...) (#78931)