### PR TITLE
Add Utility to Wrap List Unmodifiable if Non-Empty (#78894)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -25,12 +25,12 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -76,7 +76,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         for (IntObjectCursor<IndexShardRoutingTable> cursor : shards) {
             allActiveShards.addAll(cursor.value.activeShards());
         }
-        this.allActiveShards = Collections.unmodifiableList(allActiveShards);
+        this.allActiveShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(allActiveShards);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.routing;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.ExponentiallyWeightedMovingAverage;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -109,10 +110,10 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
         this.allShardsStarted = allShardsStarted;
         this.primary = primary;
-        this.replicas = Collections.unmodifiableList(replicas);
-        this.activeShards = Collections.unmodifiableList(activeShards);
-        this.assignedShards = Collections.unmodifiableList(assignedShards);
-        this.allInitializingShards = Collections.unmodifiableList(allInitializingShards);
+        this.replicas = CollectionUtils.wrapUnmodifiableOrEmptySingleton(replicas);
+        this.activeShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(activeShards);
+        this.assignedShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(assignedShards);
+        this.allInitializingShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(allInitializingShards);
         this.allAllocationIds = Collections.unmodifiableSet(allAllocationIds);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -370,4 +370,9 @@ public class CollectionUtils {
         concatList.addAll(listB);
         return concatList;
     }
+
+    public static <E> List<E> wrapUnmodifiableOrEmptySingleton(List<E> list) {
+        return list.isEmpty() ? org.elasticsearch.core.List.of() : Collections.unmodifiableList(list);
+    }
+
 }


### PR DESCRIPTION
Saving some memory in these which can easily use up tens of MBs for large index counts
just for duplicate empty lists in some cases.

backport of #78894 