### PR TITLE
Document how to test a dev version of a 3party dependency

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -169,7 +169,7 @@ and is compliant with our CI builds.
 ```
    allprojects {
      repositories {
-         mavenLocal()
+        maven { url "https://jitpack.io" }
      }
    }
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -220,5 +220,5 @@ As Gradle prefers to use modules whose descriptor has been created from real met
 flat directory repositories cannot be used to override artifacts with real meta-data from other repositories declared in the build.
 For example, if Gradle finds only `jmxri-1.2.1.jar` in a flat directory repository, but `jmxri-1.2.1.pom` in another repository
 that supports meta-data, it will use the second repository to provide the module.
-For the use case of overriding remote artifacts with local ones consider using an Ivy or Maven repository instead whose URL points to a local directory.
+Therefore it is recommended to declare a version that is not resolveable from public repositories we use (e.g. maven central)
 ---

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -203,14 +203,23 @@ a flat directory repository that resolves artifacts from a flat directory on you
 2. Declare a flatDir repository in your root build.gradle file
 
 ```
-repositories {
-    flatDir {
-        dirs 'localRepo'
-    }
+allprojects { 
+  repositories {
+      flatDir {
+          dirs 'localRepo'
+      }
+  }
 }
 ```
 
-3. Update the dependency declaration of the artifact in question to match the custom build version.
+3. Update the dependency declaration of the artifact in question to match the custom build version. For a file named e.g. `jmxri-1.2.1.jar` the 
+  dependency definition would be `:jmxri:1.2.1` as it comes with no group information:
+  
+  ```
+  dependencies {
+      implementation ':jmxri:1.2.1'
+  }
+  ```
 4. Run the gradle build as needed.
 
 ---

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -138,7 +138,7 @@ dependencies {
 
 ## FAQ
 
-### How to test a development version of a third party dependency
+### How do I test a development version of a third party dependency?
 
 To test an unreleased development version of a third party dependency you have several options.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -190,7 +190,7 @@ by JitPack in the background before we can resolve the adhoc built dependency.
 
 **NOTE**
 
-You should only use that approach locally or on a developer branchfor for production dependencies as we do
+You should only use that approach locally or on a developer branch for for production dependencies as we do
 not want to ship unreleased libraries into our releases.
 ---
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -140,7 +140,7 @@ dependencies {
 
 ### How to test a development version of a third party dependency
 
-To test an unreleased third party dependencies you have several options.
+To test an unreleased development version of a third party dependency you have several options.
 
 #### How to use a maven based third party dependency via mavenlocal?
 
@@ -184,13 +184,13 @@ As version you could also use a certain short commit hash or `master-SNAPSHOT`.
 In addition to snapshot builds JitPack supports building Pull Requests. Simply use PR<NR>-SNAPSHOT as the version.
 
 3. Run the gradle build as needed. Keep in mind the initial resolution might take a bit longer as this needs to be built 
-by jitpack in the background before we can resolve the adhoc built dependency. 
+by JitPack in the background before we can resolve the adhoc built dependency. 
 
 ---
 
 **NOTE**
 
-You should only use that locally or on a developer branchfor for production dependencies as we do
+You should only use that approach locally or on a developer branchfor for production dependencies as we do
 not want to ship unreleased libraries into our releases.
 ---
 


### PR DESCRIPTION
- Introduce a FAQ section to BUILDING.MD
- Provide three solutions to test and use a custom third party dependency
in our elasticsearch build