### PR TITLE
[7.15] [DOCS] Adds link that points to Java API Client to HLRC deprecation note. (#78957)

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -6,7 +6,7 @@
 [partintro]
 --
 
-deprecated[7.15.0, The High Level REST Client is deprecated in favour of the Java Client.]
+deprecated[7.15.0, The High Level REST Client is deprecated in favour of the {java-api-client}/index.html[Java API Client].]
 
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as

--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -6,7 +6,7 @@
 [partintro]
 --
 
-deprecated[7.15.0, The High Level REST Client is deprecated in favour of the {java-api-client}/index.html[Java API Client].]
+deprecated[7.15.0, The High Level REST Client is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.x/index.html[Java API Client].]
 
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Adds link that points to Java API Client to HLRC deprecation note. (#78957)