### PR TITLE
CI fix - remove unsafe assertion in wildcard field  (#78966)

### DIFF
--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedAutomatonQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedAutomatonQuery.java
@@ -15,7 +15,6 @@ import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
@@ -84,8 +83,7 @@ public class BinaryDvConfirmedAutomatonQuery extends Query {
                     public boolean matches() throws IOException {
                         if (values.advanceExact(approxDisi.docID()) == false)
                         {
-                            // Bug if we have an indexed value (i.e an approxQuery) but no doc value.
-                            assert approxQuery instanceof MatchAllDocsQuery;
+                            // Can happen when approxQuery resolves to some form of MatchAllDocs expression
                             return false;
                         }
                         BytesRef arrayOfValues = values.binaryValue();

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -311,7 +311,6 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         assertThat(td.totalHits.value, equalTo(count));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78949")
     public void testSearchResultsVersusKeywordField() throws IOException {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);


### PR DESCRIPTION
Remove unsafe assertion now that wildcard field does not simplify BooleanQuery logic - can’t rely on it rewriting to a plain MatchAllDocsQuery and is sometimes wrapped in other layers
Closes #78949
