### PR TITLE
Apply the reader wrapper on can_match source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1134,7 +1134,7 @@ public abstract class Engine implements Closeable {
                 throw new AlreadyClosedException("SearcherSupplier was closed");
             }
             final Searcher searcher = acquireSearcherInternal(source);
-            return CAN_MATCH_SEARCH_SOURCE.equals(source) ? searcher : wrapper.apply(searcher);
+            return wrapper.apply(searcher);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -761,7 +761,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         searchRequest.source(new SearchSourceBuilder().query(new MatchNoneQueryBuilder()));
         assertFalse(service.canMatch(new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1,
             new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, -1, null)).canMatch());
-        assertEquals(0, numWrapInvocations.get());
+        assertEquals(6, numWrapInvocations.get());
 
         ShardSearchRequest request = new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1,
             new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, -1, null);
@@ -782,12 +782,13 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         SearchShardTask task = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
+        assertEquals(8, numWrapInvocations.get());
         service.executeQueryPhase(request, task, new ActionListener<SearchPhaseResult>() {
             @Override
             public void onResponse(SearchPhaseResult searchPhaseResult) {
                 try {
                     // make sure that the wrapper is called when the query is actually executed
-                    assertEquals(1, numWrapInvocations.get());
+                    assertEquals(9, numWrapInvocations.get());
                 } finally {
                     latch.countDown();
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/frozen/RewriteCachingDirectoryReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/frozen/RewriteCachingDirectoryReader.java
@@ -94,7 +94,8 @@ final class RewriteCachingDirectoryReader extends DirectoryReader {
 
     @Override
     public CacheHelper getReaderCacheHelper() {
-        throw new UnsupportedOperationException();
+        // this reader is used for fast operations that don't require caching
+        return null;
     }
 
     // except of a couple of selected methods everything else will

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetReader.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
+import org.elasticsearch.transport.Transports;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -177,6 +178,7 @@ public final class DocumentSubsetReader extends SequentialStoredFieldsLeafReader
         if (numDocs == -1) {
             synchronized (this) {
                 if (numDocs == -1) {
+                    assert Transports.assertNotTransportThread("resolving role query");
                     try {
                         roleQueryBits = bitsetCache.getBitSet(roleQuery, in.getContext());
                         numDocs = getNumDocs(in, roleQuery, roleQueryBits);


### PR DESCRIPTION
Today we don't wrap the original index reader with the reader wrapper
plugin if it is acquired from the can_match source. We've made this distinction
to ensure that the wrapper plugin doesn't perform any IO during the
can_match phase.
Now that the security layer loads the role query lazily, this change
removes the special path and applies the wrapper in all cases.
It also adds an assert to ensure that the loading of the role query
is never done on a transport thread.