### PR TITLE
Move DataTier.TIER_PREFERENCE_SETTING registration out of XPackPlugin

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.settings;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -158,6 +159,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
             DiskThresholdDecider.SETTING_IGNORE_DISK_WATERMARKS,
             ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP,
+            DataTier.TIER_PREFERENCE_SETTING,
 
             // validate that built-in similarities don't get redefined
             Setting.groupSetting(

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
@@ -444,7 +445,8 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
             MergeSchedulerConfig.AUTO_THROTTLE_SETTING,
             MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
             MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
-            EngineConfig.INDEX_CODEC_SETTING);
+            EngineConfig.INDEX_CODEC_SETTING,
+            DataTier.TIER_PREFERENCE_SETTING);
 
     public static Settings filter(Settings originalSettings) {
         Settings.Builder settings = Settings.builder().put(originalSettings);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -385,7 +385,6 @@ public class XPackPlugin extends XPackClientPlugin
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = super.getSettings();
         settings.add(SourceOnlySnapshotRepository.SOURCE_ONLY);
-        settings.add(DataTier.TIER_PREFERENCE_SETTING);
         return settings;
     }
 


### PR DESCRIPTION
Follow up to #78668, but also related to #76147

It threw me off that we're still registering this via `XPackPlugin`, so here's a PR that stops doing that. I wish I'd caught this for #78880, but I didn't.

I'm not entirely sure this is a good idea, perhaps there were complicated reasons why it **had** to stay where it was.