### PR TITLE
[7.x] Fix minimum runtime version for build tools (#78998)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.function.Function;
 
 abstract class VersionPropertiesBuildService implements BuildService<VersionPropertiesBuildService.Params>, AutoCloseable {
 
@@ -42,7 +41,7 @@ abstract class VersionPropertiesBuildService implements BuildService<VersionProp
 
     private JavaVersion resolveMinimumJavaVersion(File infoPath) {
         final JavaVersion minimumJavaVersion;
-        File minimumJavaInfoSource = new File(infoPath, "src/main/resources/minimumCompilerVersion");
+        File minimumJavaInfoSource = new File(infoPath, "src/main/resources/minimumRuntimeVersion");
         try {
             String versionString = FileUtils.readFileToString(minimumJavaInfoSource);
             minimumJavaVersion = JavaVersion.toVersion(versionString);

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
@@ -33,24 +33,12 @@ abstract class VersionPropertiesBuildService implements BuildService<VersionProp
         try {
             File propertiesInputFile = new File(infoPath, "version.properties");
             properties = VersionPropertiesLoader.loadBuildSrcVersion(propertiesInputFile, providerFactory);
-            properties.computeIfAbsent("minimumJava", s -> resolveMinimumJavaVersion(infoPath));
+            properties.put("minimumJava", 11);
         } catch (IOException e) {
             throw new GradleException("Cannot load VersionPropertiesBuildService", e);
         }
     }
-
-    private JavaVersion resolveMinimumJavaVersion(File infoPath) {
-        final JavaVersion minimumJavaVersion;
-        File minimumJavaInfoSource = new File(infoPath, "src/main/resources/minimumRuntimeVersion");
-        try {
-            String versionString = FileUtils.readFileToString(minimumJavaInfoSource);
-            minimumJavaVersion = JavaVersion.toVersion(versionString);
-        } catch (IOException e) {
-            throw new GradleException("Cannot resolve minimum compiler version via VersionPropertiesBuildService", e);
-        }
-        return minimumJavaVersion;
-    }
-
+    
     public Properties getProperties() {
         return properties;
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix minimum runtime version for build tools (#78998)