### PR TITLE
Revert "Make NodeEnvironment.indexPaths singular (#72438)"

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.InternalTestCluster.RestartCallback;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -179,7 +180,12 @@ public class MetadataNodesIT extends ESIntegTestCase {
 
     private boolean indexDirectoryExists(String nodeName, Index index) {
         NodeEnvironment nodeEnv = ((InternalTestCluster) cluster()).getInstance(NodeEnvironment.class, nodeName);
-        return Files.exists(nodeEnv.indexPath(index));
+        for (Path path : nodeEnv.indexPaths(index)) {
+            if (Files.exists(path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ImmutableOpenMap<String, IndexMetadata> getIndicesMetadataOnNode(String nodeName) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -452,7 +452,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
 
     private Path indexDirectory(String server, Index index) {
         NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
-        return env.indexPath(index);
+        final Path[] paths = env.indexPaths(index);
+        assert paths.length == 1;
+        return paths[0];
     }
 
     private Path shardDirectory(String server, Index index, int shard) {

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -694,10 +694,10 @@ public final class NodeEnvironment  implements Closeable {
      * @param indexSettings settings for the index being deleted
      */
     public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings, Consumer<Path[]> listener) throws IOException {
-        final Path indexPath = indexPath(index);
-        logger.trace("deleting index {} directory: [{}]", index, indexPath);
-        listener.accept(new Path[] { indexPath });
-        IOUtils.rm(indexPath);
+        final Path[] indexPaths = indexPaths(index);
+        logger.trace("deleting index {} directory, paths({}): [{}]", index, indexPaths.length, indexPaths);
+        listener.accept(indexPaths);
+        IOUtils.rm(indexPaths);
         if (indexSettings.hasCustomDataPath()) {
             Path customLocation = resolveIndexCustomLocation(indexSettings.customDataPath(), index.getUUID());
             logger.trace("deleting custom index {} directory [{}]", index, customLocation);
@@ -941,9 +941,13 @@ public final class NodeEnvironment  implements Closeable {
     /**
      * Returns all index paths.
      */
-    public Path indexPath(Index index) {
+    public Path[] indexPaths(Index index) {
         assertEnvIsLocked();
-        return nodePaths[0].resolve(index);
+        Path[] indexPaths = new Path[nodePaths.length];
+        for (int i = 0; i < nodePaths.length; i++) {
+            indexPaths[i] = nodePaths[i].resolve(index);
+        }
+        return indexPaths;
     }
 
 

--- a/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -142,7 +142,7 @@ public class MetaStateService {
      */
     @Nullable
     public IndexMetadata loadIndexState(Index index) throws IOException {
-        return INDEX_METADATA_FORMAT.loadLatestState(logger, namedXContentRegistry, nodeEnv.indexPath(index));
+        return INDEX_METADATA_FORMAT.loadLatestState(logger, namedXContentRegistry, nodeEnv.indexPaths(index));
     }
 
     /**
@@ -205,7 +205,7 @@ public class MetaStateService {
         logger.trace("[{}] writing state, reason [{}]", index, reason);
         try {
             long generation = INDEX_METADATA_FORMAT.write(indexMetadata,
-                    nodeEnv.indexPath(indexMetadata.getIndex()));
+                    nodeEnv.indexPaths(indexMetadata.getIndex()));
             logger.trace("[{}] state written", index);
             return generation;
         } catch (WriteStateException ex) {
@@ -246,7 +246,7 @@ public class MetaStateService {
      * @param currentGeneration current state generation to keep in the index directory.
      */
     public void cleanupIndex(Index index, long currentGeneration) {
-        INDEX_METADATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.indexPath(index));
+        INDEX_METADATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.indexPaths(index));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
@@ -318,7 +318,7 @@ public abstract class MetadataStateFormat<T> {
      * @param currentGeneration state generation to keep.
      * @param locations         state paths.
      */
-    public void cleanupOldFiles(final long currentGeneration, Path... locations) {
+    public void cleanupOldFiles(final long currentGeneration, Path[] locations) {
         final String fileNameToKeep = getStateFileName(currentGeneration);
         for (Path location : locations) {
             logger.trace("cleanupOldFiles: cleaning up {}", location);

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -346,7 +346,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             return;
         }
         try {
-            IndexMetadata.FORMAT.writeAndCleanup(getMetadata(), nodeEnv.indexPath(index()));
+            IndexMetadata.FORMAT.writeAndCleanup(getMetadata(), nodeEnv.indexPaths(index()));
         } catch (WriteStateException e) {
             logger.warn(() -> new ParameterizedMessage("failed to write dangling indices state for index {}", index()), e);
         }
@@ -358,7 +358,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             return;
         }
         try {
-            MetadataStateFormat.deleteMetaState(nodeEnv.indexPath(index()));
+            MetadataStateFormat.deleteMetaState(nodeEnv.indexPaths(index()));
         } catch (IOException e) {
             logger.warn(() -> new ParameterizedMessage("failed to delete dangling indices state for index {}", index()), e);
         }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -940,7 +940,7 @@ public class IndicesService extends AbstractLifecycleComponent
             }
             // this is a pure protection to make sure this index doesn't get re-imported as a dangling index.
             // we should in the future rather write a tombstone rather than wiping the metadata.
-            MetadataStateFormat.deleteMetaState(nodeEnv.indexPath(index));
+            MetadataStateFormat.deleteMetaState(nodeEnv.indexPaths(index));
         }
     }
 
@@ -1029,7 +1029,7 @@ public class IndicesService extends AbstractLifecycleComponent
         if (clusterState.metadata().index(index) != null) {
             throw new IllegalStateException("Cannot delete index [" + index + "], it is still part of the cluster state.");
         }
-        if (nodeEnv.hasNodeFile() && Files.exists(nodeEnv.indexPath(index))) {
+        if (nodeEnv.hasNodeFile() && FileSystemUtils.exists(nodeEnv.indexPaths(index))) {
             final IndexMetadata metadata;
             try {
                 metadata = metaStateService.loadIndexState(index);

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -227,10 +227,11 @@ public class NodeRepurposeCommandTests extends ESTestCase {
                         .build());
                 }
             }
-            Path path = env.indexPath(INDEX);
-            for (int i = 0; i < shardCount; ++i) {
-                Files.createDirectories(path.resolve(Integer.toString(shardDataDirNumber)));
-                shardDataDirNumber += randomIntBetween(1,10);
+            for (Path path : env.indexPaths(INDEX)) {
+                for (int i = 0; i < shardCount; ++i) {
+                    Files.createDirectories(path.resolve(Integer.toString(shardDataDirNumber)));
+                    shardDataDirNumber += randomIntBetween(1,10);
+                }
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -62,7 +63,6 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.hamcrest.RegexMatcher;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -351,7 +351,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
                                                           .metadata(Metadata.builder(csWithIndex.metadata()).remove(index.getName()))
                                                           .build();
         indicesService.verifyIndexIsDeleted(index, withoutIndex);
-        assertFalse("index files should be deleted", Files.exists(nodeEnv.indexPath(index)));
+        assertFalse("index files should be deleted", FileSystemUtils.exists(nodeEnv.indexPaths(index)));
     }
 
     public void testDanglingIndicesWithAliasConflict() throws Exception {


### PR DESCRIPTION
This reverts commit 2a446ad4f792df693cb7fcbf0bc07293ec1cbe08.

This revert was conflict free.

relates #78525
relates #71205