### PR TITLE
[DOCS] Update the 8.0 Java breaking change for consistency

### DIFF
--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -6,23 +6,22 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-.Java 11 is required.
+.Java 17 is required.
 [%collapsible]
 ====
 *Details* +
-Java 11 or higher is now required to run {es} and any of its command
+Java 17 or higher is now required to run {es} and any of its command
 line tools.
 
 *Impact* +
-Use Java 11 or higher. Attempts to run {es} 8.0 using earlier Java versions will
+Use Java 17 or higher. Attempts to run {es} 8.0 using earlier Java versions will
 fail.
 
-Note that there is not yet a FIPS-certified security module for Java 17 
-that you can use when running Elasticsearch 8.0 in FIPS 140-2 mode. 
+There is not yet a FIPS-certified security module for Java 17 
+that you can use when running {es} 8.0 in FIPS 140-2 mode. 
 If you run in FIPS 140-2 mode, you will either need to request an exception 
-from your security organization to upgrade to Elasticsearch 8.0, 
-or remain on Elasticsearch 7.x until Java 17 is certified.
-
+from your security organization to upgrade to {es} 8.0, 
+or remain on {es} 7.x until Java 17 is certified.
 ====
 
 .JAVA_HOME is no longer supported.


### PR DESCRIPTION
Portions of the change reference Java 11 while other portions reference
Java 17. This updates the docs to consistently use Java 17.

### Preview
https://elasticsearch_79018.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_packaging_changes