### PR TITLE
Small clean-ups in dense vector plugin

### DIFF
--- a/x-pack/plugin/vectors/build.gradle
+++ b/x-pack/plugin/vectors/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.internal-es-plugin'
 esplugin {
   name 'vectors'
   description 'A plugin for working with vectors'
-  classname 'org.elasticsearch.xpack.vectors.Vectors'
+  classname 'org.elasticsearch.xpack.vectors.DenseVectorPlugin'
   extendedPlugins = ['x-pack-core', 'lang-painless']
 }
 archivesBaseName = 'x-pack-vectors'

--- a/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
-import org.elasticsearch.xpack.vectors.Vectors;
+import org.elasticsearch.xpack.vectors.DenseVectorPlugin;
 
 import java.util.Collection;
 
@@ -36,7 +36,7 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(Vectors.class, LocalStateCompositeXPackPlugin.class);
+        return pluginList(DenseVectorPlugin.class, LocalStateCompositeXPackPlugin.class);
     }
 
     // this allows to set indexVersion as it is a private setting

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/DenseVectorPlugin.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/DenseVectorPlugin.java
@@ -19,11 +19,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class Vectors extends Plugin implements MapperPlugin {
+public class DenseVectorPlugin extends Plugin implements MapperPlugin {
 
-    public static final String NAME = "vectors";
-
-    public Vectors() { }
+    public DenseVectorPlugin() { }
 
     public Collection<Module> createGuiceModules() {
         return Collections.emptyList();

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xpack.vectors.Vectors;
+import org.elasticsearch.xpack.vectors.DenseVectorPlugin;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -34,7 +34,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return Collections.singletonList(new Vectors());
+        return Collections.singletonList(new DenseVectorPlugin());
     }
 
     @Override

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xpack.vectors.Vectors;
+import org.elasticsearch.xpack.vectors.DenseVectorPlugin;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -68,7 +68,7 @@ public class SparseVectorFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Collection<Plugin> getPlugins() {
-        return Collections.singletonList(new Vectors());
+        return Collections.singletonList(new DenseVectorPlugin());
     }
 
     public void testDefaults() throws Exception {


### PR DESCRIPTION
Backport of #78535. It omits the part "Remove outdated skips in REST tests"
since this doesn't apply to the 7.x branch.