### PR TITLE
[DOCS] Add 8.0 breaking change for adjacency matrix setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -6,6 +6,29 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[index-max-adjacency-matrix-filters-removed]]
+.The `index.max_adjacency_matrix_filters` index setting has been removed.
+[%collapsible]
+====
+*Details* +
+The `index.max_adjacency_matrix_filters` index setting has been removed.
+Previously, you could use this setting to configure the maximum number of
+filters for the
+{ref}/search-aggregations-bucket-adjacency-matrix-aggregation.html[adjacency
+matrix aggregation]. The `indices.query.bool.max_clause_count` index setting now
+determines the maximum number of filters for the aggregation.
+
+*Impact* +
+Discontinue use of the `index.max_adjacency_matrix_filters` index setting.
+
+Requests that include the index setting will return an error. If you upgrade a
+cluster with a 7.x index that already contains the setting, {es} will
+{ref}/archived-settings.html#archived-index-settings[archive the setting].
+
+Remove the index setting from index and component templates. Attempts to use a
+template that contains the setting will fail and return an error. This includes
+automated operations, such the {ilm-init} rollover action.
+====
 
 [[remove-term-order-key]]
 .The `terms` aggregation no longer supports the `_term` order key.


### PR DESCRIPTION
Adds an 8.0 breaking change for the removal of the
`index.max_adjacency_matrix_filters` index setting.

Relates to #77803.

### Preview
https://elasticsearch_79023.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_aggregations_changes