### PR TITLE
[7.15] [DOCS] EQL: Consistently use 'statement' (#79020)

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -228,8 +228,8 @@ sequences.
 // TESTRESPONSE[s/"_id": "OQmfCaduce8zoHT93o4H"/"_id": $body.hits.sequences.0.events.0._id/]
 // TESTRESPONSE[s/"_id": "yDwnGIJouOYGBzP0ZE9n"/"_id": $body.hits.sequences.0.events.1._id/]
 
-Use the <<eql-with-maxspan-keywords,`with maxspan` keywords>> to constrain
-matching sequences to a timespan:
+Use <<eql-with-maxspan-keywords,`with maxspan`>> to constrain matching sequences
+to a timespan:
 
 [source,console]
 ----

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -517,13 +517,13 @@ sequence
 
 [discrete]
 [[eql-with-maxspan-keywords]]
-=== `with maxspan` keywords
+=== `with maxspan` statement
 
-You can use the `with maxspan` keywords to constrain a sequence to a specified
-timespan. All events in a matching sequence must occur within this duration,
-starting at the first event's timestamp.
+You can use `with maxspan` to constrain a sequence to a specified timespan. All
+events in a matching sequence must occur within this duration, starting at the
+first event's timestamp.
 
-The `maxspan` keyword accepts <<time-units,time value>> arguments.
+`maxspan` accepts <<time-units,time value>> arguments.
 
 [source,eql]
 ----
@@ -587,8 +587,8 @@ sequence by user.name
   [ process where true ] by process.executable
 ----
 
-You can combine the `sequence by` and `with maxspan` keywords to constrain a
-sequence by both field values and a timespan.
+You can combine `sequence by` and `with maxspan` to constrain a sequence by both
+field values and a timespan.
 
 [source,eql]
 ----
@@ -599,8 +599,8 @@ sequence by field_foo with maxspan=30s
 ----
 
 *Example* +
-The following sequence query uses the `sequence by` keyword and `with maxspan`
-keywords to match only a sequence of events that:
+The following sequence query uses `sequence by` and `with maxspan` to only match
+a sequence of events that:
 
 * Share the same `user.name` field values
 * Occur within `15m` (15 minutes) of the first matching event


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] EQL: Consistently use 'statement' (#79020)