### PR TITLE
More accurate error message for datastream and alias

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -158,7 +158,7 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                 if (indexAbstraction.getParentDataStream() != null) {
                     throw new IllegalArgumentException("The provided expressions [" + String.join(",", action.indices())
                         + "] match a backing index belonging to data stream [" + indexAbstraction.getParentDataStream().getName()
-                        + "]. Data streams and their backing indices don't support aliases.");
+                        + "]. Data stream backing indices don't support aliases.");
                 }
             }
             final Optional<Exception> maybeException = requestValidators.validateRequest(request, state, concreteIndices);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -222,7 +222,7 @@ public class MetadataIndexAliasesService {
         if (indexAbstraction.getParentDataStream() != null) {
             throw new IllegalArgumentException("The provided index [" + action.getIndex()
                 + "] is a backing index belonging to data stream [" + indexAbstraction.getParentDataStream().getName()
-                + "]. Data streams and their backing indices don't support alias operations.");
+                + "]. Data stream backing indices don't support alias operations.");
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -499,7 +499,7 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> service.applyAliasActions(state,
             singletonList(new AliasAction.Add(backingIndexName, "test", null, null, null, null, null))));
         assertThat(exception.getMessage(), is("The provided index [" + backingIndexName + "] is a backing index belonging to data " +
-            "stream [foo-stream]. Data streams and their backing indices don't support alias operations."));
+            "stream [foo-stream]. Data stream backing indices don't support alias operations."));
     }
 
     public void testDataStreamAliases() {

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -846,7 +846,7 @@ public class DataStreamIT extends ESIntegTestCase {
                     + backingIndex
                     + "] match a backing index belonging to data stream ["
                     + dataStreamName
-                    + "]. Data streams and their backing indices don't "
+                    + "]. Data stream backing indices don't "
                     + "support aliases."
             )
         );


### PR DESCRIPTION
Alias for datastream is supported since #66163. Currently alias for the
backing indices are still not allowed. As a result, the error messages
are updated to reflect the latest status.

Relates: #58327