### PR TITLE
[DOCS] Overhaul snapshot and restore overview

### DIFF
--- a/docs/reference/settings/snapshot-settings.asciidoc
+++ b/docs/reference/settings/snapshot-settings.asciidoc
@@ -1,15 +1,21 @@
-[role="xpack"]
-[[slm-settings]]
-=== {slm-cap} settings in {es}
+[[snapshot-settings]]
+=== Snapshot and restore settings
 [subs="attributes"]
-++++
-<titleabbrev>{slm-cap} settings</titleabbrev>
-++++
 
-These are the settings available for configuring
-<<snapshot-lifecycle-management, {slm}>> ({slm-init}).
+The following cluster settings configure <<snapshot-restore,snapshot and
+restore>>.
 
-==== Cluster-level settings
+[[snapshot-max-concurrent-ops]]
+`snapshot.max_concurrent_operations`::
+(<<dynamic-cluster-setting,Dynamic>>, integer) Maximum number of concurrent
+snapshot operations. Defaults to `1000`. This limit applies in total to all
+ongoing snapshot creation, cloning, and deletion operations. {es} will reject
+any operations that would exceed this limit.
+
+==== {slm-init} settings
+
+The following cluster settings configure <<snapshot-lifecycle-management,{slm}
+({slm-init})>>.
 
 [[slm-history-index-enabled]]
 `slm.history_index_enabled`::

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -94,7 +94,7 @@ include::settings/security-settings.asciidoc[]
 
 include::modules/indices/request_cache.asciidoc[]
 
-include::settings/slm-settings.asciidoc[]
+include::settings/snapshot-settings.asciidoc[]
 
 include::settings/transform-settings.asciidoc[]
 

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -141,12 +141,15 @@ If `true`, the current global state is included in the restore operation.
 
 The global state includes:
 
-* Persistent cluster settings
-* Index templates
-* Legacy index templates
-* Ingest pipelines
-* {ilm-init} lifecycle policies
-* For snapshots taken after 7.12.0, data stored in system indices, such as Watches and task records, replacing any existing configuration (configurable via `feature_states`)
+// tag::cluster-state-contents[]
+* <<cluster-setting-types,Persistent cluster settings>>
+* <<index-templates,Index templates>>
+* <<indices-templates-v1,Legacy index templates>>
+* <<ingest,Ingest pipelines>>
+* <<index-lifecycle-management,{ilm-init} policies>>
+* For snapshots taken after 7.12.0, data stored in system indices, such as
+  Watches and task records.
+// end::cluster-state-contents[]
 
 If `include_global_state` is `true` then the restore operation merges the
 legacy index templates in your cluster with the templates contained in the
@@ -154,6 +157,9 @@ snapshot, replacing any existing ones whose name matches one in the snapshot.
 It completely removes all persistent settings, non-legacy index templates,
 ingest pipelines and {ilm-init} lifecycle policies that exist in your cluster
 and replaces them with the corresponding items from the snapshot.
+
+You can use the `feature_states` parameter to configure how system indices
+are restored from the cluster state.
 --
 
 [[restore-snapshot-api-feature-states]]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -1,77 +1,111 @@
 [[snapshot-restore]]
 = Snapshot and restore
 
-[partintro]
---
-
 // tag::snapshot-intro[]
-A _snapshot_ is a backup taken from a running {es} cluster.
-You can take snapshots of an entire cluster, including all its data streams and
-indices. You can also take snapshots of only specific data streams or indices in
-the cluster.
+A snapshot is a backup of a running {es} cluster. You can use snapshots to:
 
-You must
-<<snapshots-register-repository, register a snapshot repository>>
-before you can <<snapshots-take-snapshot, create snapshots>>.
-
-Snapshots can be stored in either local or remote repositories.
-Remote repositories can reside on Amazon S3, HDFS, Microsoft Azure,
-Google Cloud Storage,
-and other platforms supported by a {plugins}/repository.html[repository plugin].
-// end::snapshot-intro[]
-
-{es} takes snapshots incrementally: the snapshotting process only copies data
-to the repository that was not already copied there by an earlier snapshot,
-avoiding unnecessary duplication of work or storage space. This means you can
-safely take snapshots very frequently with minimal overhead. This
-incrementality only applies within a single repository because no data is
-shared between repositories. Snapshots are also logically independent from each
-other, even within a single repository: deleting a snapshot does not affect the
-integrity of any other snapshot.
-
-// tag::restore-intro[]
-You can <<snapshots-restore-snapshot,restore snapshots>> to a running cluster, which includes all data streams and indices in the snapshot
-by default.
-However, you can choose to restore only the cluster state or specific data
-streams or indices from a snapshot.
-// end::restore-intro[]
-
-You can use
-<<getting-started-snapshot-lifecycle-management, {slm}>>
-to automatically take and manage snapshots.
+* Regularly back up a cluster without downtime
+* Recover data after deletion or a hardware failure
+* Transfer data between clusters
+* Reduce your storage costs by using <<searchable-snapshots,searchable
+  snapshots>> in the cold and frozen data tiers
 
 // tag::backup-warning[]
-WARNING: **The only reliable and supported way to back up a cluster is by
-taking a snapshot**. You cannot back up an {es} cluster by making copies of the
-data directories of its nodes. There are no supported methods to restore any
-data from a filesystem-level backup. If you try to restore a cluster from such
-a backup, it may fail with reports of corruption or missing files or other data
-inconsistencies, or it may appear to have succeeded having silently lost some
-of your data.
+**A snapshot is the only supported way to back up a cluster.** Other backup
+methods may result in data loss, even if they initially appear to succeed.
 // end::backup-warning[]
+// end::snapshot-intro[]
 
-A copy of the data directories of a cluster's nodes does not work as a backup
-because it is not a consistent representation of their contents at a single
-point in time. You cannot fix this by shutting down nodes while making the
-copies, nor by taking atomic filesystem-level snapshots, because {es} has
-consistency requirements that span the whole cluster. You must use the built-in
-snapshot functionality for cluster backups.
+[discrete]
+[[snapshot-operations]]
+== Snapshot operations
+
+{es} stores snapshots in an off-cluster storage location called a snapshot
+repository. Before you can take or restore snapshots, you must
+<<snapshots-register-repository,register a snapshot repository>> on the cluster.
+{es} supports several repository types with cloud storage options, including:
+
+* Amazon S3
+* Google Cloud Storage (GCS)
+* Microsoft Azure Storage
+
+After you register a snapshot repository, you can use
+<<snapshot-lifecycle-management,{slm} ({slm-init})>> to automatically take and
+manage snapshots. You can also <<snapshots-restore-snapshot,restore snapshots>>
+to recover or transfer data.
+
+You can start multiple snapshot-related operations at the same time. The
+<<snapshot-max-concurrent-ops,`snapshot.max_concurrent_operations`>> cluster
+setting limits the maximum number of concurrent snapshot operations.
+
+[discrete]
+[[snapshot-contents]]
+=== Snapshot contents
+
+By default, a snapshot of a cluster contains the cluster state, all data
+streams, and all indices, including system indices. The cluster state includes:
+
+include::apis/restore-snapshot-api.asciidoc[tag=cluster-state-contents]
+
+You can also take snapshots of only specific data streams or indices in the
+cluster.
+
+Snapshots don't contain or back up:
+
+* Transient cluster settings
+* Registered snapshot repositories
+* Node configuration files
+
+[discrete]
+[[how-snapshots-work]]
+== How snapshots work
+
+Snapshots are incremental. You can take snapshots frequently with little impact
+to your storage overhead.
+
+To back up an index, a snapshot makes a copy of the index's
+<<near-real-time,segment files>> and stores them in the snapshot repository.
+Since segments are immutable, the snapshot only needs to copy any new segments
+created since the last snapshot.
+
+When you delete a snapshot, {es} only deletes segments used exclusively by that
+snapshot. {es} doesn't delete segments used by other snapshots in the
+repository.
+
+[discrete]
+[[snapshots-shard-allocation]]
+=== Snapshots and shard allocation
+
+A snapshot copies segments from an index's primary shards. These shards must be
+available to successfully take a snapshot. If a primary shard is initializing or
+relocating when a snapshot starts, the snapshot will attempt to wait for the
+shard to become available. If the shard doesn't become available, the snapshot
+attempt fails.
+
+Once a snapshot begins copying a shard's segments, {es} won't move the shard to
+another node, even if rebalancing or shard allocation settings would typically
+trigger reallocation. {es} will only move the shard after the snapshot finishes
+copying the shard's data.
+
+[discrete]
+[[snapshot-start-stop-times]]
+=== Snapshot start and stop times
+
+A snapshot doesn't represent a cluster at a precise point in time. Some primary
+shards may be available when others aren't. Instead, each snapshot includes a
+start and end time. The snapshot represents a view of the cluster's data between
+these two times.
+
+Taking a snapshot doesn't block indexing or other requests. However, a snapshot
+isn't likely to include any changes made after the snapshot process starts.
 
 [discrete]
 [[snapshot-restore-version-compatibility]]
-=== Version compatibility
+== Snapshot compatibility
 
-IMPORTANT: Version compatibility refers to the underlying Lucene index
-compatibility. Follow the <<setup-upgrade,Upgrade documentation>>
-when migrating between versions.
+To restore a snapshot to a cluster, the snapshot and cluster versions must be
+compatible.
 
-A snapshot contains a copy of the on-disk data structures that comprise an
-index or a data stream's backing indices. This means that snapshots can only be restored to versions of
-{es} that can read the indices.
-
-The following table indicates snapshot compatibility between versions. The first column denotes the base version that you can restore snapshots from.
-
-// tag::snapshot-compatibility-matrix[]
 [cols="6"]
 |===
 | 5+^h| Cluster version
@@ -82,17 +116,9 @@ The following table indicates snapshot compatibility between versions. The first
 ^| *6.x* -> ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon} ^|{no-icon}
 ^| *7.x* -> ^|{no-icon}  ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon}
 |===
-// end::snapshot-compatibility-matrix[]
 
-The following conditions apply for restoring snapshots and indices across versions:
-
-* *Snapshots*: You cannot restore snapshots from later {es} versions into a cluster running an earlier {es} version. For example, you cannot restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
-* *Indices*: You cannot restore indices into a cluster running a version of {es} that is more than _one major version_ newer than the version of {es} used to snapshot the indices. For example, you cannot restore indices from a snapshot taken in 5.0 to a cluster running 7.0.
-+
-[NOTE]
-====
-The one caveat is that snapshots taken by {es} 2.0 can be restored in clusters running {es} 5.0.
-====
+You can't restore a snapshot to an earlier version of {es}. For example, you
+can't restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
 
 ifeval::["{release-state}"!="released"]
 [[snapshot-prerelease-build-compatibility]]
@@ -111,27 +137,32 @@ succeed having silently lost some data. You should discard your repository
 before using a different build.
 endif::[]
 
-Each snapshot can contain indices created in various versions of {es}. This
-includes backing indices created for data streams. When restoring a snapshot, it
-must be possible to restore all of these indices into the target cluster. If any
-indices in a snapshot were created in an incompatible version, you will not be
-able restore the snapshot.
+[discrete]
+[[snapshot-index-compatibility]]
+=== Index compatibility
 
-IMPORTANT: When backing up your data prior to an upgrade, keep in mind that you
-won't be able to restore snapshots after you upgrade if they contain indices
-created in a version that's incompatible with the upgrade version.
+A snapshot can contain indices created in a previous major version. For example,
+a snapshot of a 7.x cluster can contain an index created in 6.x.
 
-If you end up in a situation where you need to restore a snapshot of a data stream or index
-that is incompatible with the version of the cluster you are currently running,
-you can restore it on the latest compatible version and use
-<<reindex-from-remote,reindex-from-remote>> to rebuild the data stream or index on the current
-version. Reindexing from remote is only possible if the original data stream or index has
-source enabled. Retrieving and reindexing the data can take significantly
-longer than simply restoring a snapshot. If you have a large amount of data, we
-recommend testing the reindex from remote process with a subset of your data to
-understand the time requirements before proceeding.
+A cluster is only compatible with indices created in the previous major version.
+Any data stream or index you restore from a snapshot must also be compatible
+with the current cluster's version. If you try to restore an index created in an
+incompatible version, the restore attempt will fail. Keep this in mind if you
+create a snapshot before upgrading a cluster.
 
---
+For example, a snapshot of a 6.x cluster can contain an index created in 5.x. If
+you try to restore the 5.x index to a 7.x cluster, the attempt will fail.
+
+As a workaround, you can first restore the data stream or index to another
+cluster running the latest version of {es} that's compatible with both the index
+and your current cluster. You can then use
+<<reindex-from-remote,reindex-from-remote>> to rebuild the data stream or index
+on your current cluster. Reindex from remote is only possible if the index's
+<<mapping-source-field,`_source`>> is enabled.
+
+Reindexing from remote can take significantly longer than restoring a snapshot.
+Before you start, test the reindex from remote process with a subset of data to
+estimate your time requirements.
 
 include::register-repository.asciidoc[]
 include::take-snapshot.asciidoc[]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -69,55 +69,6 @@ When you restore the data stream, it will contain only backing indices present
 in the snapshot. If the stream's original write index is not in the snapshot,
 the most recent backing index from the snapshot becomes the stream's write index.
 
-[discrete]
-[[create-snapshot-process-details]]
-=== Snapshot process details
-
-The snapshot process works by taking a byte-for-byte copy of the files that
-make up each index or data stream and placing these copies in the repository.
-These files are mostly written by Lucene and contain a compact representation
-of all the data in each index or data stream in a form that is designed to be
-searched efficiently. This means that when you restore an index or data stream
-from a snapshot there is no need to rebuild these search-focused data
-structures. It also means that you can use <<searchable-snapshots>> to directly
-search the data in the repository.
-
-The snapshot process is incremental: {es} compares the files that make up the
-index or data stream against the files that already exist in the repository
-and only copies files that were created or changed
-since the last snapshot. Snapshots are very space-efficient since they reuse
-any files copied to the repository by earlier snapshots.
-
-Snapshotting does not interfere with ongoing indexing or searching operations.
-A snapshot captures a view of each shard at some point in time between the
-start and end of the snapshotting process. The snapshot may not include
-documents added to a data stream or index after the snapshot process starts.
-
-You can start multiple snapshot operations at the same time. Concurrent snapshot
-operations are limited by the `snapshot.max_concurrent_operations` cluster
-setting, which defaults to `1000`. This limit applies in total to all ongoing snapshot
-creation, cloning, and deletion operations. {es} will reject any operations
-that would exceed this limit.
-
-The snapshot process starts immediately for the primary shards that have been
-started and are not relocating at the moment. {es} waits for relocation or
-initialization of shards to complete before snapshotting them.
-
-Besides creating a copy of each data stream and index, the snapshot process can
-also store global cluster metadata, which includes persistent cluster settings,
-templates, and data stored in system indices, such as Watches and task records,
-regardless of whether those system indices are named in the `indices` section
-of the request. You can also use the create snapshot
-API's <<create-snapshot-api-feature-states,`feature_states`>> parameter to
-include only a subset of system indices in the snapshot. Snapshots do not
-store transient settings or registered snapshot repositories.
-
-While a snapshot of a particular shard is being created, the shard cannot be
-moved to another node, which can interfere with rebalancing and allocation
-filtering. {es} can only move the shard to another node (according to the current
-allocation filtering settings and rebalancing algorithm) after the snapshot
-process is finished.
-
 You can use the <<get-snapshot-api,Get snapshot API>> to retrieve information
 about ongoing and completed snapshots. See
 <<snapshots-monitor-snapshot-restore,Monitor snapshot and restore progress>>.


### PR DESCRIPTION
Adds additional structure to the snapshot and restore overview.

Highlights:

* Creates a new snapshot and restore settings page
* Reuses cluster state contents from the restore API
* Deduplicates and streamlines the description of the snapshot process
* Clarifies content related to index compatibility