### PR TITLE
Add warning log message on realm disable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -442,6 +442,10 @@ public class XPackLicenseState {
         return checkAgainstStatus(status -> status.active);
     }
 
+    public String statusDescription() {
+        return executeAgainstStatus(status -> (status.active ? "active" : "expired") + ' ' + status.mode.description() + " license");
+    }
+
     @Deprecated
     public boolean checkFeature(Feature feature) {
         return feature.feature.check(this);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -39,9 +39,14 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     /** Creates a license state with the given license type and active state, and checks the given method returns expected. */
     void assertAllowed(OperationMode mode, boolean active, Predicate<XPackLicenseState> predicate, boolean expected) {
+        XPackLicenseState licenseState = buildLicenseState(mode, active);
+        assertEquals(expected, predicate.test(licenseState));
+    }
+
+    XPackLicenseState buildLicenseState(OperationMode mode, boolean active) {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(mode, active, null);
-        assertEquals(expected, predicate.test(licenseState));
+        return licenseState;
     }
 
     /**
@@ -117,8 +122,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
     }
-
-
 
     public void testSecurityGold() {
         XPackLicenseState licenseState = new XPackLicenseState(() -> 0);
@@ -264,6 +267,15 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertAllowed(PLATINUM, true, s -> s.isAllowed(feature), false);
         assertAllowed(ENTERPRISE, true, s -> s.isAllowed(feature), true);
         assertAllowed(TRIAL, true, s -> s.isAllowed(feature), true);
+    }
+
+    public void testStatusDescription() {
+        assertThat(buildLicenseState(BASIC, true).statusDescription(), is("active basic license"));
+        assertThat(buildLicenseState(STANDARD, true).statusDescription(), is("active standard license"));
+        assertThat(buildLicenseState(GOLD, false).statusDescription(), is("expired gold license"));
+        assertThat(buildLicenseState(PLATINUM, false).statusDescription(), is("expired platinum license"));
+        assertThat(buildLicenseState(ENTERPRISE, true).statusDescription(), is("active enterprise license"));
+        assertThat(buildLicenseState(TRIAL, false).statusDescription(), is("expired trial license"));
     }
 
     public void testLastUsedMomentaryFeature() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -425,7 +425,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(realms, atLeastOnce()).recomputeActiveRealms();
         verify(realms, atLeastOnce()).calculateLicensedRealms(any(XPackLicenseState.class));
         verify(realms, atLeastOnce()).getActiveRealms();
-        verify(realms, atLeastOnce()).stopTrackingInactiveRealms(any(XPackLicenseState.class), any());
+        verify(realms, atLeastOnce()).handleDisabledRealmDueToLicenseChange(any(Realm.class), any(XPackLicenseState.class));
         // ^^ We don't care how many times these methods are called, we just check it here so that we can verify no more interactions below.
         verifyNoMoreInteractions(realms);
     }
@@ -2174,7 +2174,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         }
 
         @Override
-        protected void stopTrackingInactiveRealms(XPackLicenseState licenseStateSnapshot, List<Realm> licensedRealms) {
+        protected void handleDisabledRealmDueToLicenseChange(Realm realm, XPackLicenseState licenseStateSnapshot) {
             // Ignore
         }
     }


### PR DESCRIPTION
When a license is changed, it may cause a realm to be disabled.
This commit adds an additional log message whenever a realm is
disabled to explicitly warn the cluster administrator that it the
realm is no longer in use.
