### PR TITLE
[7.x] [DOCS] Add `has-passwd` parameter (#77594)

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -14,6 +14,7 @@ bin/elasticsearch-keystore
 ( [add <settings>] [-f] [--stdin]
 | [add-file (<setting> <path>)+]
 | [create] [-p]
+| [has-passwd]
 | [list]
 | [passwd]
 | [remove <setting>]
@@ -67,6 +68,10 @@ created a keystore yet, it creates a keystore that is obfuscated but not
 password protected.
 
 `-h, --help`:: Returns all of the command parameters.
+
+`has-passwd`:: Returns a success message if the keystore exists and is
+password-protected. Otherwise, the command fails with exit code 1 and returns an
+error message.
 
 `list`:: Lists the settings in the keystore. If the keystore is password
 protected, you are prompted to enter the password.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add `has-passwd` parameter (#77594)