### PR TITLE
[7.15] [DOCS] Add `has-passwd` parameter (#77594)

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -13,7 +13,7 @@ in the {es} keystore.
 bin/elasticsearch-keystore
 ([add <settings>] [-f] [--stdin] |
 [add-file (<setting> <path>)+] | [create] [-p] |
-[list] | [passwd] | [remove <setting>] | [upgrade])
+[has-passwd] | [list] | [passwd] | [remove <setting>] | [upgrade])
 [-h, --help] ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
@@ -58,6 +58,10 @@ created a keystore yet, it creates a keystore that is obfuscated but not
 password protected.
 
 `-h, --help`:: Returns all of the command parameters.
+
+`has-passwd`:: Returns a success message if the keystore exists and is
+password-protected. Otherwise, the command fails with exit code 1 and returns an
+error message.
 
 `list`:: Lists the settings in the keystore. If the keystore is password
 protected, you are prompted to enter the password.


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add `has-passwd` parameter (#77594)