### PR TITLE
BWC change following backport of PR 78697 to 7.x

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -379,7 +379,7 @@ won't be included in the response because `include_unmapped` isn't set to
 [discrete]
 [[Ignored-field values]]
 ==== Ignored field values
-The `fields` option only returns values that were valid when indexed.
+The `fields` section of the response only returns values that were valid when indexed.
 If your search request asks for values from a field that ignored certain
 because they were malformed or too large these values are returned
 separately in an `ignored_field_values` section.

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -43,7 +43,7 @@ public class DocumentField implements Writeable, Iterable<Object> {
     public DocumentField(StreamInput in) throws IOException {
         name = in.readString();
         values = in.readList(StreamInput::readGenericValue);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             ignoredValues = in.readList(StreamInput::readGenericValue);
         } else {
             ignoredValues = Collections.emptyList();
@@ -102,7 +102,7 @@ public class DocumentField implements Writeable, Iterable<Object> {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeCollection(values, StreamOutput::writeGenericValue);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeCollection(ignoredValues, StreamOutput::writeGenericValue);
         }
         


### PR DESCRIPTION
Ignored_Field_value support is now backported in https://github.com/elastic/elasticsearch/pull/79048