### PR TITLE
Update transform destination index privilege for kibana_system

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -452,7 +452,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .privileges("read", "view_index_metadata")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("metrics-endpoint.metadata_current_default", "metrics-endpoint.metadata_united_default")
+                    .indices("metrics-endpoint.metadata_current_default", ".metrics-endpoint.metadata_united_default")
                     .privileges("create_index", "delete_index", "read", "index")
                     .build(),
             },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -452,7 +452,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .privileges("read", "view_index_metadata")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("metrics-endpoint.metadata_current_default", ".metrics-endpoint.metadata_united_default")
+                    .indices("metrics-endpoint.metadata_current_default", ".metrics-endpoint.metadata_current_default",
+                        ".metrics-endpoint.metadata_united_default")
                     .privileges("create_index", "delete_index", "read", "index")
                     .build(),
             },

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -717,6 +717,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         Arrays.asList(
             "metrics-endpoint.metadata_current_default",
+            ".metrics-endpoint.metadata_current_default",
             ".metrics-endpoint.metadata_united_default"
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -717,7 +717,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         Arrays.asList(
             "metrics-endpoint.metadata_current_default",
-            "metrics-endpoint.metadata_united_default"
+            ".metrics-endpoint.metadata_united_default"
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/78049

Changes the privilege required for installing the endpoint package's transform to the correct name (a hidden index instead of a regular one).

I've tested this against https://github.com/elastic/kibana/pull/112808 and verified it meets all of our requirements.