### PR TITLE
[7.15] [ML] add bucket ks test results reader (#79063)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregationBuilder.java
@@ -127,7 +127,7 @@ public class BucketCountKSTestAggregationBuilder extends BucketMetricsPipelineAg
             NAME,
             BucketCountKSTestAggregationBuilder::new,
             BucketCountKSTestAggregationBuilder.PARSER
-        );
+        ).addResultReader(InternalKSTestAggregation::new);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.aggs.kstest;
 
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -26,6 +27,11 @@ public class InternalKSTestAggregation extends InternalAggregation {
         this.modeValues = modeValues;
     }
 
+    public InternalKSTestAggregation(StreamInput in) throws IOException {
+        super(in);
+        this.modeValues = in.readMap(StreamInput::readString, StreamInput::readDouble);
+    }
+
     @Override
     public String getWriteableName() {
         return BucketCountKSTestAggregationBuilder.NAME.getPreferredName();
@@ -34,6 +40,10 @@ public class InternalKSTestAggregation extends InternalAggregation {
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeMap(modeValues, StreamOutput::writeString, StreamOutput::writeDouble);
+    }
+
+    Map<String, Double> getModeValues() {
+        return modeValues;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.kstest;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.test.InternalAggregationTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class InternalKSTestAggregationTests extends InternalAggregationTestCase<InternalKSTestAggregation> {
+
+    @Override
+    protected SearchPlugin registerPlugin() {
+        return new MachineLearning(Settings.EMPTY, null);
+    }
+
+    @Override
+    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
+        return CollectionUtils.appendToCopy(
+            super.getNamedXContents(),
+            new NamedXContentRegistry.Entry(
+                Aggregation.class,
+                BucketCountKSTestAggregationBuilder.NAME, (p, c) -> ParsedKSTest.fromXContent(p, (String) c)
+            )
+        );
+    }
+
+    @Override
+    protected InternalKSTestAggregation createTestInstance(String name, Map<String, Object> metadata) {
+        List<String> modes = randomSubsetOf(Arrays.stream(Alternative.values()).map(Alternative::toString).collect(Collectors.toList()));
+        return new InternalKSTestAggregation(
+            name, metadata, modes.stream().collect(Collectors.toMap(Function.identity(), a -> randomDouble()))
+        );
+    }
+
+    @Override
+    protected void assertReduced(InternalKSTestAggregation reduced, List<InternalKSTestAggregation> inputs) {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    public void testReduceRandom() {
+        expectThrows(UnsupportedOperationException.class, () -> createTestInstance("name", null).reduce(null, null));
+    }
+
+    @Override
+    protected void assertFromXContent(InternalKSTestAggregation aggregation, ParsedAggregation parsedAggregation) {
+        ParsedKSTest ks = (ParsedKSTest) parsedAggregation;
+        assertThat(ks.getModes(), equalTo(aggregation.getModeValues()));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
@@ -9,11 +9,11 @@ package org.elasticsearch.xpack.ml.aggs.kstest;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.util.Arrays;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.kstest;
+
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ParsedKSTest extends ParsedAggregation {
+
+    @SuppressWarnings("unchecked")
+    public static ParsedKSTest fromXContent(XContentParser parser, final String name) throws IOException {
+        Map<String, Object> values = parser.map();
+        Map<String, Double> doubleValues = new HashMap<>(values.size(), 1.0f);
+        for (Alternative alternative : Alternative.values()) {
+            Double value = (Double)values.get(alternative.toString());
+            if (value != null) {
+                doubleValues.put(alternative.toString(), value);
+            }
+        }
+        ParsedKSTest parsed = new ParsedKSTest(
+            doubleValues,
+            (Map<String, Object>)values.get(InternalAggregation.CommonFields.META.getPreferredName())
+        );
+        parsed.setName(name);
+        return parsed;
+    }
+
+    private final Map<String, Double> modes;
+
+    ParsedKSTest(Map<String, Double> modes, Map<String, Object> metadata) {
+        this.modes = modes;
+        this.metadata = metadata;
+    }
+
+    Map<String, Double> getModes() {
+        return modes;
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        for (Map.Entry<String, Double> kv : modes.entrySet()) {
+            builder.field(kv.getKey(), kv.getValue());
+        }
+        return builder;
+    }
+
+    @Override
+    public String getType() {
+        return BucketCountKSTestAggregationBuilder.NAME.getPreferredName();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.ml.aggs.kstest;
 
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.HashMap;


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [ML] add bucket ks test results reader (#79063)