### PR TITLE
Allow for debugging of rest test clusters during test execution

### DIFF
--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -4,10 +4,10 @@
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
-    <option name="PORT" value="5005" />
+    <option name="PORT" value="5006" />
     <option name="AUTO_RESTART" value="true" />
     <RunnerSettings RunnerId="Debug">
-      <option name="DEBUG_PORT" value="5005" />
+      <option name="DEBUG_PORT" value="5006" />
       <option name="LOCAL" value="false" />
     </RunnerSettings>
     <method v="2" />

--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -4,7 +4,7 @@
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
-    <option name="PORT" value="5006" />
+    <option name="PORT" value="5007" />
     <option name="AUTO_RESTART" value="true" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="5006" />

--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -7,7 +7,7 @@
     <option name="PORT" value="5007" />
     <option name="AUTO_RESTART" value="true" />
     <RunnerSettings RunnerId="Debug">
-      <option name="DEBUG_PORT" value="5006" />
+      <option name="DEBUG_PORT" value="5007" />
       <option name="LOCAL" value="false" />
     </RunnerSettings>
     <method v="2" />

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -283,6 +283,36 @@ memory or some of the containers will fail to start. You can tell that you
 are short of memory if containers are exiting quickly after starting with
 code 137 (128 + 9, where 9 means SIGKILL).
 
+== Debugging tests
+
+If you would like to debug your tests themselves, simply pass the `--debug-jvm`
+flag to the testing task and connect a debugger on the default port of `5005`.
+
+---------------------------------------------------------------------------
+./gradlew :server:test --debug-jvm
+---------------------------------------------------------------------------
+
+For REST tests, if you'd like to debug the Elasticsearch server itself, and
+not your test code, use the `--debug-server-jvm` flag and use the
+"Debug Elasticsearch" run configuration in IntelliJ to listen on the default
+port of `5007`.
+
+---------------------------------------------------------------------------
+./gradlew :rest-api-spec:yamlRestTest --debug-server-jvm
+---------------------------------------------------------------------------
+
+NOTE: In the case of test clusters using multiple nodes, multiple debuggers
+will need to be attached on incrementing ports. For example, for a 3 node
+cluster ports `5007`, `5008`, and `5009` will attempt to attach to a listening
+debugger.
+
+You can also use a combination of both flags to debug both tests and server.
+This is only applicable to Java REST tests.
+
+---------------------------------------------------------------------------
+./gradlew :modules:kibana:javaRestTest --debug-jvm --debug-server-jvm
+---------------------------------------------------------------------------
+
 == Testing the REST layer
 
 The REST layer is tested through specific tests that are executed against

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -88,7 +88,6 @@ public class RunTask extends DefaultTestClustersTask {
 
     @Override
     public void beforeStart() {
-        int debugPort = 5005;
         int httpPort = 9200;
         int transportPort = 9300;
         Map<String, String> additionalSettings = System.getProperties()
@@ -120,15 +119,14 @@ public class RunTask extends DefaultTestClustersTask {
                 if (dataDir != null) {
                     node.setDataPath(getDataPath.apply(node));
                 }
-                if (debug) {
-                    logger.lifecycle("Running elasticsearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
-                    node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
-                    debugPort += 1;
-                }
                 if (keystorePassword.length() > 0) {
                     node.keystorePassword(keystorePassword);
                 }
             }
+        }
+
+        if (debug) {
+            enableDebug();
         }
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.SharedResource;
@@ -36,6 +37,7 @@ import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.THROTTLE_
 public class StandaloneRestIntegTestTask extends Test implements TestClustersAware, FileSystemOperationsAware {
 
     private Collection<ElasticsearchCluster> clusters = new HashSet<>();
+    private boolean debugServer = false;
 
     public StandaloneRestIntegTestTask() {
         this.getOutputs()
@@ -60,6 +62,11 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
                 // Don't cache the output of this task if it's not running from a clean data directory.
                 t -> getClusters().stream().anyMatch(cluster -> cluster.isPreserveDataDir())
             );
+    }
+
+    @Option(option = "debug-server-jvm", description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch.")
+    public void setDebugServer(boolean enabled) {
+        this.debugServer = enabled;
     }
 
     @Override
@@ -90,5 +97,12 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
 
     public WorkResult delete(Object... objects) {
         return getFileSystemOperations().delete(d -> d.delete(objects));
+    }
+
+    @Override
+    public void beforeStart() {
+        if (debugServer) {
+            enableDebug();
+        }
     }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.gradle.testclusters;
 
-import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Provider;
@@ -37,4 +36,15 @@ public interface TestClustersAware extends Task {
     }
 
     default void beforeStart() {}
+
+    default void enableDebug() {
+        int debugPort = 5006;
+        for (ElasticsearchCluster cluster : getClusters()) {
+            for (ElasticsearchNode node : cluster.getNodes()) {
+                getLogger().lifecycle("Running elasticsearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
+                node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
+                debugPort += 1;
+            }
+        }
+    }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -38,7 +38,7 @@ public interface TestClustersAware extends Task {
     default void beforeStart() {}
 
     default void enableDebug() {
-        int debugPort = 5006;
+        int debugPort = 5007;
         for (ElasticsearchCluster cluster : getClusters()) {
             for (ElasticsearchNode node : cluster.getNodes()) {
                 getLogger().lifecycle("Running elasticsearch in debug mode, {} expecting running debug server on port {}", node, debugPort);


### PR DESCRIPTION
Add a `--debug-server-jvm` command line option to rest test tasks to allow for debugging the Elasticsearch server as well as tests.

Closes #48672