### PR TITLE
Don't Set up IndicesClusterStateService on non-Data Nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -170,15 +170,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
     @Override
     protected void doStart() {
-        // Doesn't make sense to manage shards on non-master and non-data nodes
-        if (DiscoveryNode.canContainData(settings) || DiscoveryNode.isMasterNode(settings)) {
+        // Doesn't make sense to manage shards on non-data nodes
+        if (DiscoveryNode.canContainData(settings)) {
             clusterService.addHighPriorityApplier(this);
         }
     }
 
     @Override
     protected void doStop() {
-        if (DiscoveryNode.canContainData(settings) || DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.canContainData(settings)) {
             clusterService.removeApplier(this);
         }
     }


### PR DESCRIPTION
No point in setting up this service as a CS applier on non-data nodes, it doesn't do
anything specific to the master role as far as I can tell.