### PR TITLE
Revert "Convert path.data to String setting instead of List (#72282)"

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
@@ -44,12 +44,13 @@ public class AvailableIndexFoldersBenchmark {
     @Setup
     public void setup() throws IOException {
         Path path = Files.createTempDirectory("test");
+        String[] paths = new String[] { path.toString() };
         nodePath = new NodeEnvironment.NodePath(path);
 
         LogConfigurator.setNodeName("test");
         Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), path)
-            .put(Environment.PATH_DATA_SETTING.getKey(), path.resolve("data"))
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths)
             .build();
         nodeEnv = new NodeEnvironment(settings, new Environment(settings, null));
 

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
@@ -30,7 +30,7 @@ public class AzureRepositorySettingsTests extends ESTestCase {
     private AzureRepository azureRepository(Settings settings) {
         Settings internalSettings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
-            .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
             .put(settings)
             .build();
         final AzureRepository azureRepository = new AzureRepository(new RepositoryMetadata("foo", "azure", internalSettings),

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
@@ -24,6 +24,9 @@ import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
+
 @SuppressForbidden(reason = "modifies system properties and attempts to create symbolic links intentionally")
 public class EvilSecurityTests extends ESTestCase {
 
@@ -67,7 +70,8 @@ public class EvilSecurityTests extends ESTestCase {
 
         Settings.Builder settingsBuilder = Settings.builder();
         settingsBuilder.put(Environment.PATH_HOME_SETTING.getKey(), esHome.resolve("home").toString());
-        settingsBuilder.put(Environment.PATH_DATA_SETTING.getKey(), esHome.resolve("data1").toString());
+        settingsBuilder.putList(Environment.PATH_DATA_SETTING.getKey(), esHome.resolve("data1").toString(),
+                esHome.resolve("data2").toString());
         settingsBuilder.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), esHome.resolve("custom").toString());
         settingsBuilder.put(Environment.PATH_LOGS_SETTING.getKey(), esHome.resolve("logs").toString());
         settingsBuilder.put(Environment.NODE_PIDFILE_SETTING.getKey(), esHome.resolve("test.pid").toString());
@@ -118,6 +122,31 @@ public class EvilSecurityTests extends ESTestCase {
         assertExactPermissions(new FilePermission(fakeTmpDir.toString(), "read,readlink,write,delete"), permissions);
         // PID file: delete only (for the shutdown hook)
         assertExactPermissions(new FilePermission(environment.pidFile().toString(), "delete"), permissions);
+    }
+
+    public void testDuplicateDataPaths() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44558", Constants.WINDOWS);
+        final Path path = createTempDir();
+        final Path home = path.resolve("home");
+        final Path data = path.resolve("data");
+        final Path duplicate;
+        if (randomBoolean()) {
+            duplicate = data;
+        } else {
+            duplicate = createTempDir().toAbsolutePath().resolve("link");
+            Files.createSymbolicLink(duplicate, data);
+        }
+
+        final Settings settings =
+                Settings
+                        .builder()
+                        .put(Environment.PATH_HOME_SETTING.getKey(), home.toString())
+                        .putList(Environment.PATH_DATA_SETTING.getKey(), data.toString(), duplicate.toString())
+                        .build();
+
+        final Environment environment = TestEnvironment.newEnvironment(settings);
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> Security.createPermissions(environment));
+        assertThat(e, hasToString(containsString("path [" + duplicate.toRealPath() + "] is duplicated by [" + duplicate + "]")));
     }
 
     public void testEnsureSymlink() throws IOException {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/env/NodeEnvironmentEvilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/env/NodeEnvironmentEvilTests.java
@@ -7,8 +7,8 @@
  */
 package org.elasticsearch.env;
 
-import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PosixPermissionsResetter;
 import org.junit.BeforeClass;

--- a/qa/evil-tests/src/test/java/org/elasticsearch/env/NodeEnvironmentEvilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/env/NodeEnvironmentEvilTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.env;
 
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PosixPermissionsResetter;
@@ -31,13 +32,14 @@ public class NodeEnvironmentEvilTests extends ESTestCase {
 
     public void testMissingWritePermission() throws IOException {
         assumeTrue("posix filesystem", isPosix);
-        Path path = createTempDir();
+        final String[] tempPaths = tmpPaths();
+        Path path = PathUtils.get(randomFrom(tempPaths));
         try (PosixPermissionsResetter attr = new PosixPermissionsResetter(path)) {
             attr.setPermissions(new HashSet<>(Arrays.asList(PosixFilePermission.OTHERS_READ, PosixFilePermission.GROUP_READ,
                 PosixFilePermission.OWNER_READ)));
             Settings build = Settings.builder()
                     .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-                    .put(Environment.PATH_DATA_SETTING.getKey(), path).build();
+                    .putList(Environment.PATH_DATA_SETTING.getKey(), tempPaths).build();
             IllegalStateException exception = expectThrows(IllegalStateException.class, () -> {
                 new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
             });
@@ -48,7 +50,8 @@ public class NodeEnvironmentEvilTests extends ESTestCase {
 
     public void testMissingWritePermissionOnIndex() throws IOException {
         assumeTrue("posix filesystem", isPosix);
-        Path path = createTempDir();
+        final String[] tempPaths = tmpPaths();
+        Path path = PathUtils.get(randomFrom(tempPaths));
         Path fooIndex = path.resolve(NodeEnvironment.INDICES_FOLDER)
             .resolve("foo");
         Files.createDirectories(fooIndex);
@@ -57,7 +60,7 @@ public class NodeEnvironmentEvilTests extends ESTestCase {
                 PosixFilePermission.OWNER_READ)));
             Settings build = Settings.builder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-                .put(Environment.PATH_DATA_SETTING.getKey(), path).build();
+                .putList(Environment.PATH_DATA_SETTING.getKey(), tempPaths).build();
             IOException ioException = expectThrows(IOException.class, () -> {
                 new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
             });
@@ -67,7 +70,8 @@ public class NodeEnvironmentEvilTests extends ESTestCase {
 
     public void testMissingWritePermissionOnShard() throws IOException {
         assumeTrue("posix filesystem", isPosix);
-        Path path = createTempDir();
+        final String[] tempPaths = tmpPaths();
+        Path path = PathUtils.get(randomFrom(tempPaths));
         Path fooIndex = path.resolve(NodeEnvironment.INDICES_FOLDER)
             .resolve("foo");
         Path fooShard = fooIndex.resolve("0");
@@ -81,7 +85,7 @@ public class NodeEnvironmentEvilTests extends ESTestCase {
                 PosixFilePermission.OWNER_READ)));
             Settings build = Settings.builder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-                .put(Environment.PATH_DATA_SETTING.getKey(), path).build();
+                .putList(Environment.PATH_DATA_SETTING.getKey(), tempPaths).build();
             IOException ioException = expectThrows(IOException.class, () -> {
                 new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
             });

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
@@ -136,7 +137,8 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
 
         // simulate older data path layout by moving data under "nodes/0" folder
-        final List<Path> dataPaths = List.of(PathUtils.get(Environment.PATH_DATA_SETTING.get(dataPathSettings)));
+        final List<Path> dataPaths = Environment.PATH_DATA_SETTING.get(dataPathSettings)
+            .stream().map(PathUtils::get).collect(Collectors.toList());
         dataPaths.forEach(path -> {
                 final Path targetPath = path.resolve("nodes").resolve("0");
                 try {

--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -235,7 +235,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
         final Path dataDirWithLeftOverShards = createTempDir();
         String dataNode = internalCluster().startDataOnlyNode(
             Settings.builder()
-                .put(Environment.PATH_DATA_SETTING.getKey(), dataDirWithLeftOverShards.toAbsolutePath().toString())
+                .putList(Environment.PATH_DATA_SETTING.getKey(), List.of(dataDirWithLeftOverShards.toAbsolutePath().toString()))
                 .putNull(Environment.PATH_SHARED_DATA_SETTING.getKey())
                 .build()
         );

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -150,7 +150,7 @@ public class JoinHelper {
             TransportRequest.Empty::new,
             (request, channel, task) -> channel.sendResponse(Empty.INSTANCE));
 
-        final String dataPath = Environment.PATH_DATA_SETTING.get(settings);
+        final List<String> dataPaths = Environment.PATH_DATA_SETTING.get(settings);
         transportService.registerRequestHandler(JOIN_VALIDATE_ACTION_NAME,
             ThreadPool.Names.GENERIC, ValidateJoinRequest::new,
             (request, channel, task) -> {
@@ -161,8 +161,9 @@ public class JoinHelper {
                             localState.metadata().clusterUUID() + "] and is now trying to join a different cluster with UUID [" +
                             request.getState().metadata().clusterUUID() + "]. This is forbidden and usually indicates an incorrect " +
                             "discovery or cluster bootstrapping configuration. Note that the cluster UUID persists across restarts and " +
-                            "can only be changed by deleting the contents of the node's data path [" + dataPath +
-                            "] which will also remove any data held by this node.");
+                            "can only be changed by deleting the contents of the node's data " +
+                            (dataPaths.size() == 1 ? "path " : "paths ") + dataPaths +
+                            " which will also remove any data held by this node.");
                 }
                 joinValidators.forEach(action -> action.accept(transportService.getLocalNode(), request.getState()));
                 channel.sendResponse(Empty.INSTANCE);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -327,7 +327,9 @@ public class Node implements Closeable {
                 );
             }
 
-            if (Environment.dataPathUsesList(tmpSettings)) {
+            if (initialEnvironment.dataFiles().length > 1) {
+                throw new IllegalArgumentException("Multiple [path.data] values found. Specify a single data path.");
+            } else if (Environment.dataPathUsesList(tmpSettings)) {
                 throw new IllegalArgumentException("[path.data] is a list. Specify as a string value.");
             }
 

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -140,8 +140,9 @@ public class EnvironmentTests extends ESTestCase {
 
         final Path home = PathUtils.get(homePath);
 
-        final String dataPath = Environment.PATH_DATA_SETTING.get(environment.settings());
-        assertPath(dataPath, home.resolve("data"));
+        final List<String> dataPaths = Environment.PATH_DATA_SETTING.get(environment.settings());
+        assertThat(dataPaths, hasSize(1));
+        assertPath(dataPaths.get(0), home.resolve("data"));
 
         final String logPath = Environment.PATH_LOGS_SETTING.get(environment.settings());
         assertPath(logPath, home.resolve("logs"));

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.startsWith;
@@ -52,7 +53,7 @@ public class NodeEnvironmentTests extends ESTestCase {
     public void testNodeLock() throws IOException {
         final Settings settings = buildEnvSettings(Settings.EMPTY);
         NodeEnvironment env = newNodeEnvironment(settings);
-        String dataPath = Environment.PATH_DATA_SETTING.get(settings);
+        List<String> dataPaths = Environment.PATH_DATA_SETTING.get(settings);
 
         // Reuse the same location and attempt to lock again
         IllegalStateException ex = expectThrows(IllegalStateException.class, () ->
@@ -62,8 +63,11 @@ public class NodeEnvironmentTests extends ESTestCase {
         // Close the environment that holds the lock and make sure we can get the lock after release
         env.close();
         env = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
-        assertThat(env.nodeDataPaths()[0], equalTo(PathUtils.get(dataPath)));
+        assertThat(env.nodeDataPaths(), arrayWithSize(dataPaths.size()));
 
+        for (int i = 0; i < dataPaths.size(); i++) {
+            assertTrue(env.nodeDataPaths()[i].startsWith(PathUtils.get(dataPaths.get(i))));
+        }
         env.close();
         assertThat(env.lockedShards(), empty());
     }
@@ -346,8 +350,8 @@ public class NodeEnvironmentTests extends ESTestCase {
     }
 
     public void testCustomDataPaths() throws Exception {
-        Path dataPath = createTempDir();
-        NodeEnvironment env = newNodeEnvironment(dataPath.toAbsolutePath().toString(), "/tmp", Settings.EMPTY);
+        String[] dataPaths = tmpPaths();
+        NodeEnvironment env = newNodeEnvironment(dataPaths, "/tmp", Settings.EMPTY);
 
         Index index = new Index("myindex", "myindexUUID");
         ShardId sid = new ShardId(index, 0);
@@ -357,47 +361,53 @@ public class NodeEnvironmentTests extends ESTestCase {
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
-            env.availableShardPaths(sid)[0],
-            equalTo(dataPath.resolve("indices/" + index.getUUID() + "/0")));
+            env.availableShardPaths(sid),
+            equalTo(stringsToPaths(dataPaths, "indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",
-            env.indexPaths(index)[0], equalTo(dataPath.resolve("indices/" + index.getUUID())));
+            env.indexPaths(index), equalTo(stringsToPaths(dataPaths, "indices/" + index.getUUID())));
 
         assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
         assertThat(env.resolveCustomLocation("/tmp/foo", sid).toAbsolutePath(),
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
-            env.availableShardPaths(sid)[0],
-            equalTo(dataPath.resolve("indices/" + index.getUUID() + "/0")));
+            env.availableShardPaths(sid),
+            equalTo(stringsToPaths(dataPaths, "indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",
-            env.indexPaths(index)[0], equalTo(dataPath.resolve("indices/" + index.getUUID())));
+            env.indexPaths(index), equalTo(stringsToPaths(dataPaths, "indices/" + index.getUUID())));
 
         env.close();
     }
 
     public void testExistingTempFiles() throws IOException {
-        Path nodePath = createTempDir();
+        String[] paths = tmpPaths();
         // simulate some previous left over temp files
-        Files.createDirectories(nodePath);
-        Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME));
-        if (randomBoolean()) {
-            Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".tmp"));
+        for (String path : randomSubsetOf(randomIntBetween(1, paths.length), paths)) {
+            final Path nodePath = PathUtils.get(path);
+            Files.createDirectories(nodePath);
+            Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME));
+            if (randomBoolean()) {
+                Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".tmp"));
+            }
+            if (randomBoolean()) {
+                Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".final"));
+            }
         }
-        if (randomBoolean()) {
-            Files.createFile(nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".final"));
-        }
-        NodeEnvironment env = newNodeEnvironment(nodePath.toAbsolutePath().toString(), Settings.EMPTY);
+        NodeEnvironment env = newNodeEnvironment(paths, Settings.EMPTY);
         env.close();
 
         // check we clean up
-        final Path tempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME);
-        assertFalse(tempFile + " should have been cleaned", Files.exists(tempFile));
-        final Path srcTempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".src");
-        assertFalse(srcTempFile + " should have been cleaned", Files.exists(srcTempFile));
-        final Path targetTempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".target");
-        assertFalse(targetTempFile + " should have been cleaned", Files.exists(targetTempFile));
+        for (String path : paths) {
+            final Path nodePath = PathUtils.get(path);
+            final Path tempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME);
+            assertFalse(tempFile + " should have been cleaned", Files.exists(tempFile));
+            final Path srcTempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".src");
+            assertFalse(srcTempFile + " should have been cleaned", Files.exists(srcTempFile));
+            final Path targetTempFile = nodePath.resolve(NodeEnvironment.TEMP_FILE_NAME + ".target");
+            assertFalse(targetTempFile + " should have been cleaned", Files.exists(targetTempFile));
+        }
     }
 
     public void testEnsureNoShardDataOrIndexMetadata() throws IOException {
@@ -490,6 +500,16 @@ public class NodeEnvironmentTests extends ESTestCase {
     }
 
     @Override
+    public String[] tmpPaths() {
+        final int numPaths = randomIntBetween(1, 3);
+        final String[] absPaths = new String[numPaths];
+        for (int i = 0; i < numPaths; i++) {
+            absPaths[i] = createTempDir().toAbsolutePath().toString();
+        }
+        return absPaths;
+    }
+
+    @Override
     public NodeEnvironment newNodeEnvironment() throws IOException {
         return newNodeEnvironment(Settings.EMPTY);
     }
@@ -503,24 +523,24 @@ public class NodeEnvironmentTests extends ESTestCase {
     public Settings buildEnvSettings(Settings settings) {
         return Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-            .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
             .put(settings).build();
     }
 
-    public NodeEnvironment newNodeEnvironment(String dataPath, Settings settings) throws IOException {
+    public NodeEnvironment newNodeEnvironment(String[] dataPaths, Settings settings) throws IOException {
         Settings build = Settings.builder()
             .put(settings)
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-            .put(Environment.PATH_DATA_SETTING.getKey(), dataPath).build();
+            .putList(Environment.PATH_DATA_SETTING.getKey(), dataPaths).build();
         return new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
     }
 
-    public NodeEnvironment newNodeEnvironment(String dataPath, String sharedDataPath, Settings settings) throws IOException {
+    public NodeEnvironment newNodeEnvironment(String[] dataPaths, String sharedDataPath, Settings settings) throws IOException {
         Settings build = Settings.builder()
             .put(settings)
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataPath)
-            .put(Environment.PATH_DATA_SETTING.getKey(), dataPath).build();
+            .putList(Environment.PATH_DATA_SETTING.getKey(), dataPaths).build();
         return new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -33,8 +33,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.NodeMetadata;
 import org.elasticsearch.gateway.PersistedClusterStateService.Writer;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -49,11 +51,14 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.apache.lucene.index.IndexWriter.WRITE_LOCK_NAME;
@@ -74,7 +79,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testPersistsAndReloadsTerm() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
             final long newTerm = randomNonNegativeLong();
 
@@ -89,7 +94,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testPersistsAndReloadsGlobalMetadata() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
             final String clusterUUID = UUIDs.randomBase64UUID(random());
             final long version = randomLongBetween(1L, Long.MAX_VALUE);
@@ -133,10 +138,216 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         }
     }
 
+    public void testLoadsFreshestState() throws IOException {
+        final Path[] dataPaths = createDataPaths();
+        final long freshTerm = randomLongBetween(1L, Long.MAX_VALUE);
+        final long staleTerm = randomBoolean() ? freshTerm : randomLongBetween(1L, freshTerm);
+        final long freshVersion = randomLongBetween(2L, Long.MAX_VALUE);
+        final long staleVersion = staleTerm == freshTerm ? randomLongBetween(1L, freshVersion - 1) : randomLongBetween(1L, Long.MAX_VALUE);
+
+        final HashSet<Path> unimportantPaths = Arrays.stream(dataPaths).collect(Collectors.toCollection(HashSet::new));
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths)) {
+            final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                writeState(writer, staleTerm,
+                    ClusterState.builder(clusterState).version(staleVersion)
+                        .metadata(Metadata.builder(clusterState.metadata()).coordinationMetadata(
+                            CoordinationMetadata.builder(clusterState.coordinationMetadata()).term(staleTerm).build())).build(),
+                    clusterState);
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(new Path[]{randomFrom(dataPaths)})) {
+            unimportantPaths.remove(nodeEnvironment.nodeDataPaths()[0]);
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writeState(writer, freshTerm,
+                    ClusterState.builder(clusterState).version(freshVersion)
+                        .metadata(Metadata.builder(clusterState.metadata()).coordinationMetadata(
+                            CoordinationMetadata.builder(clusterState.coordinationMetadata()).term(freshTerm).build())).build(),
+                    clusterState);
+            }
+        }
+
+        if (randomBoolean() && unimportantPaths.isEmpty() == false) {
+            IOUtils.rm(randomFrom(unimportantPaths));
+        }
+
+        // verify that the freshest state is chosen
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths)) {
+            final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService(nodeEnvironment)
+                .loadBestOnDiskState();
+            final ClusterState clusterState = clusterStateFromMetadata(onDiskState.lastAcceptedVersion, onDiskState.metadata);
+            assertThat(clusterState.term(), equalTo(freshTerm));
+            assertThat(clusterState.version(), equalTo(freshVersion));
+        }
+    }
+
+    public void testFailsOnMismatchedNodeIds() throws IOException {
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+
+        final String[] nodeIds = new String[2];
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths1)) {
+            nodeIds[0] = nodeEnvironment.nodeId();
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writer.writeFullStateAndCommit(0L,
+                    ClusterState.builder(clusterState).version(randomLongBetween(1L, Long.MAX_VALUE)).build());
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths2)) {
+            nodeIds[1] = nodeEnvironment.nodeId();
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writer.writeFullStateAndCommit(0L,
+                    ClusterState.builder(clusterState).version(randomLongBetween(1L, Long.MAX_VALUE)).build());
+            }
+        }
+
+        NodeMetadata.FORMAT.cleanupOldFiles(Long.MAX_VALUE, dataPaths2);
+
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
+
+        final String failure = expectThrows(IllegalStateException.class, () -> newNodeEnvironment(combinedPaths)).getMessage();
+        assertThat(failure,
+            allOf(containsString("unexpected node ID in metadata"), containsString(nodeIds[0]), containsString(nodeIds[1])));
+        assertTrue("[" + failure + "] should match " + Arrays.toString(dataPaths2),
+            Arrays.stream(dataPaths2).anyMatch(p -> failure.contains(p.toString())));
+
+        // verify that loadBestOnDiskState has same check
+        final String message = expectThrows(IllegalStateException.class,
+            () -> new PersistedClusterStateService(combinedPaths, nodeIds[0], xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                () -> 0L).loadBestOnDiskState()).getMessage();
+        assertThat(message,
+            allOf(containsString("unexpected node ID in metadata"), containsString(nodeIds[0]), containsString(nodeIds[1])));
+        assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths2),
+            Arrays.stream(dataPaths2).anyMatch(p -> message.contains(p.toString())));
+    }
+
+    public void testFailsOnMismatchedCommittedClusterUUIDs() throws IOException {
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
+
+        final String clusterUUID1 = UUIDs.randomBase64UUID(random());
+        final String clusterUUID2 = UUIDs.randomBase64UUID(random());
+
+        // first establish consistent node IDs and write initial metadata
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                assertFalse(clusterState.metadata().clusterUUIDCommitted());
+                writer.writeFullStateAndCommit(0L, clusterState);
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths1)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                assertFalse(clusterState.metadata().clusterUUIDCommitted());
+                writer.writeFullStateAndCommit(0L, ClusterState.builder(clusterState)
+                    .metadata(Metadata.builder(clusterState.metadata())
+                        .clusterUUID(clusterUUID1)
+                        .clusterUUIDCommitted(true)
+                        .version(1))
+                    .incrementVersion().build());
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths2)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                assertFalse(clusterState.metadata().clusterUUIDCommitted());
+                writer.writeFullStateAndCommit(0L, ClusterState.builder(clusterState)
+                    .metadata(Metadata.builder(clusterState.metadata())
+                        .clusterUUID(clusterUUID2)
+                        .clusterUUIDCommitted(true)
+                        .version(1))
+                    .incrementVersion().build());
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            final String message = expectThrows(IllegalStateException.class,
+                () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
+            assertThat(message,
+                allOf(containsString("mismatched cluster UUIDs in metadata"), containsString(clusterUUID1), containsString(clusterUUID2)));
+            assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths1),
+                Arrays.stream(dataPaths1).anyMatch(p -> message.contains(p.toString())));
+            assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths2),
+                Arrays.stream(dataPaths2).anyMatch(p -> message.contains(p.toString())));
+        }
+    }
+
+    public void testFailsIfFreshestStateIsInStaleTerm() throws IOException {
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
+
+        final long staleCurrentTerm = randomLongBetween(1L, Long.MAX_VALUE - 1);
+        final long freshCurrentTerm = randomLongBetween(staleCurrentTerm + 1, Long.MAX_VALUE);
+
+        final long freshTerm = randomLongBetween(1L, Long.MAX_VALUE);
+        final long staleTerm = randomBoolean() ? freshTerm : randomLongBetween(1L, freshTerm);
+        final long freshVersion = randomLongBetween(2L, Long.MAX_VALUE);
+        final long staleVersion = staleTerm == freshTerm ? randomLongBetween(1L, freshVersion - 1) : randomLongBetween(1L, Long.MAX_VALUE);
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                assertFalse(clusterState.metadata().clusterUUIDCommitted());
+                writeState(writer, staleCurrentTerm, ClusterState.builder(clusterState)
+                    .metadata(Metadata.builder(clusterState.metadata()).version(1)
+                        .coordinationMetadata(CoordinationMetadata.builder(clusterState.coordinationMetadata()).term(staleTerm).build()))
+                    .version(staleVersion)
+                    .build(),
+                    clusterState);
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths1)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writeState(writer, freshCurrentTerm, clusterState, clusterState);
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths2)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService(nodeEnvironment)
+                    .loadBestOnDiskState();
+                final ClusterState clusterState = clusterStateFromMetadata(onDiskState.lastAcceptedVersion, onDiskState.metadata);
+                writeState(writer, onDiskState.currentTerm, ClusterState.builder(clusterState)
+                    .metadata(Metadata.builder(clusterState.metadata()).version(2)
+                        .coordinationMetadata(CoordinationMetadata.builder(clusterState.coordinationMetadata()).term(freshTerm).build()))
+                    .version(freshVersion)
+                    .build(), clusterState);
+            }
+        }
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            final String message = expectThrows(IllegalStateException.class,
+                () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
+            assertThat(message, allOf(
+                    containsString("inconsistent terms found"),
+                    containsString(Long.toString(staleCurrentTerm)),
+                    containsString(Long.toString(freshCurrentTerm))));
+            assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths1),
+                Arrays.stream(dataPaths1).anyMatch(p -> message.contains(p.toString())));
+            assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths2),
+                Arrays.stream(dataPaths2).anyMatch(p -> message.contains(p.toString())));
+        }
+    }
+
     public void testFailsGracefullyOnExceptionDuringFlush() throws IOException {
         final AtomicBoolean throwException = new AtomicBoolean();
 
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
                 = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
@@ -174,7 +385,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     public void testClosesWriterOnFatalError() throws IOException {
         final AtomicBoolean throwException = new AtomicBoolean();
 
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
                 = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
@@ -220,7 +431,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     public void testCrashesWithIOErrorOnCommitFailure() throws IOException {
         final AtomicBoolean throwException = new AtomicBoolean();
 
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
                 = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
@@ -269,7 +480,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         // if someone attempted surgery on the metadata index by hand, e.g. deleting broken segments, then maybe the global metadata
         // isn't there any more
 
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
                 final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
                 writeState(writer, 0L, ClusterState.builder(clusterState).version(randomLongBetween(1L, Long.MAX_VALUE)).build(),
@@ -295,20 +506,19 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         // if someone attempted surgery on the metadata index by hand, e.g. deleting broken segments, then maybe the global metadata
         // is duplicated
 
-        final Path brokenPath = createTempDir();
-        final Path dupPath = createTempDir(); // this exists only to create a duplicate structure that can be copied
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
 
-        try (NodeEnvironment nodeEnvironment1 = newNodeEnvironment(brokenPath);
-             NodeEnvironment nodeEnvironment2 = newNodeEnvironment(dupPath)) {
-            try (Writer writer1 = newPersistedClusterStateService(nodeEnvironment1).createWriter();
-                 Writer writer2 = newPersistedClusterStateService(nodeEnvironment2).createWriter()) {
-                final ClusterState oldClusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment1));
-                final long newVersion = randomLongBetween(1L, Long.MAX_VALUE);
-                final ClusterState newClusterState = ClusterState.builder(oldClusterState).version(newVersion).build();
-                writeState(writer1, 0L, newClusterState, oldClusterState);
-                writeState(writer2, 0L, newClusterState, oldClusterState);
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writeState(writer, 0L, ClusterState.builder(clusterState).version(randomLongBetween(1L, Long.MAX_VALUE)).build(),
+                    clusterState);
             }
 
+            final Path brokenPath = randomFrom(nodeEnvironment.nodeDataPaths());
+            final Path dupPath = randomValueOtherThan(brokenPath, () -> randomFrom(nodeEnvironment.nodeDataPaths()));
             try (Directory directory = newFSDirectory(brokenPath.resolve(PersistedClusterStateService.METADATA_DIRECTORY_NAME));
                  Directory dupDirectory = newFSDirectory(dupPath.resolve(PersistedClusterStateService.METADATA_DIRECTORY_NAME))) {
                 try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
@@ -318,7 +528,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
             }
 
             final String message = expectThrows(IllegalStateException.class,
-                () -> newPersistedClusterStateService(nodeEnvironment1).loadBestOnDiskState()).getMessage();
+                () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(containsString("duplicate global metadata found"), containsString(brokenPath.toString())));
         }
     }
@@ -327,33 +537,33 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         // if someone attempted surgery on the metadata index by hand, e.g. deleting broken segments, then maybe some index metadata
         // is duplicated
 
-        final Path brokenPath = createTempDir();
-        final Path dupPath = createTempDir(); // this exists only to create a duplicate structure that can be copied
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
 
-        try (NodeEnvironment nodeEnvironment1 = newNodeEnvironment(brokenPath);
-             NodeEnvironment nodeEnvironment2 = newNodeEnvironment(dupPath)) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
             final String indexUUID = UUIDs.randomBase64UUID(random());
             final String indexName = randomAlphaOfLength(10);
 
-            try (Writer writer1 = newPersistedClusterStateService(nodeEnvironment1).createWriter();
-                 Writer writer2 = newPersistedClusterStateService(nodeEnvironment2).createWriter()) {
-                final ClusterState oldClusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment1));
-                final ClusterState newClusterState = ClusterState.builder(oldClusterState)
-                    .metadata(Metadata.builder(oldClusterState.metadata())
-                        .version(1L)
-                        .coordinationMetadata(CoordinationMetadata.builder(oldClusterState.coordinationMetadata()).term(1L).build())
-                        .put(IndexMetadata.builder(indexName)
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writeState(writer, 0L, ClusterState.builder(clusterState)
+                        .metadata(Metadata.builder(clusterState.metadata())
                             .version(1L)
-                            .settings(Settings.builder()
-                                .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                                .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                                .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))))
-                    .incrementVersion().build();
-                writeState(writer1, 0L, newClusterState, oldClusterState);
-                writeState(writer2, 0L, newClusterState, oldClusterState);
+                            .coordinationMetadata(CoordinationMetadata.builder(clusterState.coordinationMetadata()).term(1L).build())
+                            .put(IndexMetadata.builder(indexName)
+                                .version(1L)
+                                .settings(Settings.builder()
+                                    .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                                    .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                                    .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))))
+                        .incrementVersion().build(),
+                    clusterState);
             }
 
+            final Path brokenPath = randomFrom(nodeEnvironment.nodeDataPaths());
+            final Path dupPath = randomValueOtherThan(brokenPath, () -> randomFrom(nodeEnvironment.nodeDataPaths()));
             try (Directory directory = newFSDirectory(brokenPath.resolve(PersistedClusterStateService.METADATA_DIRECTORY_NAME));
                  Directory dupDirectory = newFSDirectory(dupPath.resolve(PersistedClusterStateService.METADATA_DIRECTORY_NAME))) {
                 try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
@@ -364,7 +574,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
             }
 
             final String message = expectThrows(IllegalStateException.class,
-                () -> newPersistedClusterStateService(nodeEnvironment1).loadBestOnDiskState()).getMessage();
+                () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(
                 containsString("duplicate metadata found"),
                 containsString(brokenPath.toString()),
@@ -374,7 +584,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testPersistsAndReloadsIndexMetadataIffVersionOrTermChanges() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
             final long globalVersion = randomLongBetween(1L, Long.MAX_VALUE);
             final String indexUUID = UUIDs.randomBase64UUID(random());
@@ -451,7 +661,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testPersistsAndReloadsIndexMetadataForMultipleIndices() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
 
             final long term = randomLongBetween(1L, Long.MAX_VALUE);
@@ -523,7 +733,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testReloadsMetadataAcrossMultipleSegments() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
 
             final int writes = between(5, 20);
@@ -579,7 +789,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         final AtomicLong writeDurationMillis = new AtomicLong(slowWriteLoggingThresholdMillis);
 
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             PersistedClusterStateService persistedClusterStateService = new PersistedClusterStateService(nodeEnvironment,
                     xContentRegistry(), getBigArrays(), clusterSettings, () -> currentTime.getAndAdd(writeDurationMillis.get()));
 
@@ -647,7 +857,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
     }
 
     public void testFailsIfCorrupt() throws IOException {
-        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createTempDir())) {
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService = newPersistedClusterStateService(nodeEnvironment);
 
             try (Writer writer = persistedClusterStateService.createWriter()) {
@@ -701,9 +911,17 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath()).build();
     }
 
-    private NodeEnvironment newNodeEnvironment(Path dataPath) throws IOException {
+    public static Path[] createDataPaths() {
+        final Path[] dataPaths = new Path[randomIntBetween(1, 4)];
+        for (int i = 0; i < dataPaths.length; i++) {
+            dataPaths[i] = createTempDir();
+        }
+        return dataPaths;
+    }
+
+    private NodeEnvironment newNodeEnvironment(Path[] dataPaths) throws IOException {
         return newNodeEnvironment(Settings.builder()
-            .put(Environment.PATH_DATA_SETTING.getKey(), dataPath.toString())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), Arrays.stream(dataPaths).map(Path::toString).collect(Collectors.toList()))
             .build());
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -224,7 +224,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 () -> 0L).loadBestOnDiskState()).getMessage();
         assertThat(message,
-            allOf(containsString("unexpected node ID in metadata"), containsString(nodeIds[0]), containsString(nodeIds[1])));
+            allOf(containsString("belongs to a node with ID"), containsString(nodeIds[0]), containsString(nodeIds[1])));
         assertTrue("[" + message + "] should match " + Arrays.toString(dataPaths2),
             Arrays.stream(dataPaths2).anyMatch(p -> message.contains(p.toString())));
     }
@@ -320,7 +320,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(dataPaths2)) {
             try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
                 final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService(nodeEnvironment)
-                    .loadBestOnDiskState();
+                    .loadBestOnDiskState(false);
                 final ClusterState clusterState = clusterStateFromMetadata(onDiskState.lastAcceptedVersion, onDiskState.metadata);
                 writeState(writer, onDiskState.currentTerm, ClusterState.builder(clusterState)
                     .metadata(Metadata.builder(clusterState.metadata()).version(2)

--- a/server/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.index.shard;
+
+
+import org.apache.lucene.mockfile.FilterFileSystemProvider;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.core.PathUtilsForTesting;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.NodeEnvironment.NodePath;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/** Separate test class from ShardPathTests because we need static (BeforeClass) setup to install mock filesystems... */
+public class NewPathForShardTests extends ESTestCase {
+
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
+
+    // Sneakiness to install mock file stores so we can pretend how much free space we have on each path.data:
+    private static MockFileStore aFileStore = new MockFileStore("mocka");
+    private static MockFileStore bFileStore = new MockFileStore("mockb");
+    private static String aPathPart;
+    private static String bPathPart;
+
+    @BeforeClass
+    public static void installMockUsableSpaceFS() throws Exception {
+        FileSystem current = PathUtils.getDefaultFileSystem();
+        aPathPart = current.getSeparator() + 'a' + current.getSeparator();
+        bPathPart = current.getSeparator() + 'b' + current.getSeparator();
+        FileSystemProvider mock = new MockUsableSpaceFileSystemProvider(current);
+        PathUtilsForTesting.installMock(mock.getFileSystem(null));
+    }
+
+    @AfterClass
+    public static void removeMockUsableSpaceFS() throws Exception {
+        PathUtilsForTesting.teardown();
+        aFileStore = null;
+        bFileStore = null;
+    }
+
+    /** Mock file system that fakes usable space for each FileStore */
+    static class MockUsableSpaceFileSystemProvider extends FilterFileSystemProvider {
+
+        MockUsableSpaceFileSystemProvider(FileSystem inner) {
+            super("mockusablespace://", inner);
+            final List<FileStore> fileStores = new ArrayList<>();
+            fileStores.add(aFileStore);
+            fileStores.add(bFileStore);
+        }
+
+        @Override
+        public FileStore getFileStore(Path path) throws IOException {
+            if (path.toString().contains(aPathPart) || (path.toString() + path.getFileSystem().getSeparator()).contains(aPathPart)) {
+                return aFileStore;
+            } else {
+                return bFileStore;
+            }
+        }
+    }
+
+    static class MockFileStore extends FileStore {
+
+        public long usableSpace;
+
+        private final String desc;
+
+        MockFileStore(String desc) {
+            this.desc = desc;
+        }
+
+        @Override
+        public String type() {
+            return "mock";
+        }
+
+        @Override
+        public String name() {
+            return desc;
+        }
+
+        @Override
+        public String toString() {
+            return desc;
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public long getTotalSpace() throws IOException {
+            return usableSpace*3;
+        }
+
+        @Override
+        public long getUsableSpace() throws IOException {
+            return usableSpace;
+        }
+
+        @Override
+        public long getUnallocatedSpace() throws IOException {
+            return usableSpace*2;
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(String name) {
+            return false;
+        }
+
+        @Override
+        public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+            return null;
+        }
+
+        @Override
+        public Object getAttribute(String attribute) throws IOException {
+            return null;
+        }
+    }
+
+    static void createFakeShard(ShardPath path) throws IOException {
+        Files.createDirectories(path.resolveIndex().getParent());
+    }
+
+    public void testSelectNewPathForShard() throws Exception {
+        Path path = PathUtils.get(createTempDir().toString());
+
+        // Use 2 data paths:
+        String[] paths = new String[] {path.resolve("a").toString(),
+                                       path.resolve("b").toString()};
+
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), path)
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+        NodeEnvironment nodeEnv = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+
+        // Make sure all our mocking above actually worked:
+        NodePath[] nodePaths = nodeEnv.nodePaths();
+        assertEquals(2, nodePaths.length);
+
+        assertEquals("mocka", nodePaths[0].fileStore.name());
+        assertEquals("mockb", nodePaths[1].fileStore.name());
+
+        // Path a has lots of free space, but b has little, so new shard should go to a:
+        aFileStore.usableSpace = 100000;
+        bFileStore.usableSpace = 1000;
+
+        ShardId shardId = new ShardId("index", "_na_", 0);
+        ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        assertTrue(result.getDataPath().toString().contains(aPathPart));
+
+        // Test the reverse: b has lots of free space, but a has little, so new shard should go to b:
+        aFileStore.usableSpace = 1000;
+        bFileStore.usableSpace = 100000;
+
+        shardId = new ShardId("index", "_na_", 0);
+        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        assertTrue(result.getDataPath().toString().contains(bPathPart));
+
+        // Now a and be have equal usable space; we allocate two shards to the node, and each should go to different paths:
+        aFileStore.usableSpace = 100000;
+        bFileStore.usableSpace = 100000;
+
+        Map<Path,Integer> dataPathToShardCount = new HashMap<>();
+        ShardPath result1 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        createFakeShard(result1);
+        dataPathToShardCount.put(NodeEnvironment.shardStatePathToDataPath(result1.getDataPath()), 1);
+        ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        createFakeShard(result2);
+
+        // #11122: this was the original failure: on a node with 2 disks that have nearly equal
+        // free space, we would always allocate all N incoming shards to the one path that
+        // had the most free space, never using the other drive unless new shards arrive
+        // after the first shards started using storage:
+        assertNotEquals(result1.getDataPath(), result2.getDataPath());
+
+        nodeEnv.close();
+    }
+
+    public void testSelectNewPathForShardEvenly() throws Exception {
+        Path path = PathUtils.get(createTempDir().toString());
+
+        // Use 2 data paths:
+        String[] paths = new String[] {path.resolve("a").toString(),
+                                       path.resolve("b").toString()};
+
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), path)
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+        NodeEnvironment nodeEnv = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+
+        // Make sure all our mocking above actually worked:
+        NodePath[] nodePaths = nodeEnv.nodePaths();
+        assertEquals(2, nodePaths.length);
+
+        assertEquals("mocka", nodePaths[0].fileStore.name());
+        assertEquals("mockb", nodePaths[1].fileStore.name());
+
+        // Path a has lots of free space, but b has little, so new shard should go to a:
+        aFileStore.usableSpace = 100000;
+        bFileStore.usableSpace = 10000;
+
+        ShardId shardId = new ShardId("index", "uid1", 0);
+        ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        createFakeShard(result);
+        // First shard should go to a
+        assertThat(result.getDataPath().toString(), containsString(aPathPart));
+
+        shardId = new ShardId("index", "uid1", 1);
+        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        createFakeShard(result);
+        // Second shard should go to b
+        assertThat(result.getDataPath().toString(), containsString(bPathPart));
+
+        Map<Path,Integer> dataPathToShardCount = new HashMap<>();
+        shardId = new ShardId("index2", "uid2", 0);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index2",
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3).build());
+        ShardPath result1 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result1);
+        dataPathToShardCount.put(NodeEnvironment.shardStatePathToDataPath(result1.getDataPath()), 1);
+        shardId = new ShardId("index2", "uid2", 1);
+        ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result2);
+        dataPathToShardCount.put(NodeEnvironment.shardStatePathToDataPath(result2.getDataPath()), 1);
+        shardId = new ShardId("index2", "uid2", 2);
+        ShardPath result3 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result3);
+        // 2 shards go to 'a' and 1 to 'b'
+        assertThat(result1.getDataPath().toString(), containsString(aPathPart));
+        assertThat(result2.getDataPath().toString(), containsString(bPathPart));
+        assertThat(result3.getDataPath().toString(), containsString(aPathPart));
+
+        nodeEnv.close();
+    }
+
+    public void testGettingPathWithMostFreeSpace() throws Exception {
+        Path path = PathUtils.get(createTempDir().toString());
+
+        // Use 2 data paths:
+        String[] paths = new String[] {path.resolve("a").toString(),
+                                       path.resolve("b").toString()};
+
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), path)
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+        NodeEnvironment nodeEnv = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+
+        aFileStore.usableSpace = 100000;
+        bFileStore.usableSpace = 1000;
+
+        assertThat(ShardPath.getPathWithMostFreeSpace(nodeEnv), equalTo(nodeEnv.nodePaths()[0]));
+
+        aFileStore.usableSpace = 10000;
+        bFileStore.usableSpace = 20000;
+
+        assertThat(ShardPath.getPathWithMostFreeSpace(nodeEnv), equalTo(nodeEnv.nodePaths()[1]));
+
+        nodeEnv.close();
+    }
+
+    public void testTieBreakWithMostShards() throws Exception {
+        Path path = PathUtils.get(createTempDir().toString());
+
+        // Use 2 data paths:
+        String[] paths = new String[] {path.resolve("a").toString(),
+                                       path.resolve("b").toString()};
+
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), path)
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+        NodeEnvironment nodeEnv = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+
+        // Make sure all our mocking above actually worked:
+        NodePath[] nodePaths = nodeEnv.nodePaths();
+        assertEquals(2, nodePaths.length);
+
+        assertEquals("mocka", nodePaths[0].fileStore.name());
+        assertEquals("mockb", nodePaths[1].fileStore.name());
+
+        // Path a has lots of free space, but b has little, so new shard should go to a:
+        aFileStore.usableSpace = 100000;
+        bFileStore.usableSpace = 10000;
+
+        Map<Path, Integer> dataPathToShardCount = new HashMap<>();
+
+        ShardId shardId = new ShardId("index", "uid1", 0);
+        ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        createFakeShard(result);
+        // First shard should go to a
+        assertThat(result.getDataPath().toString(), containsString(aPathPart));
+        dataPathToShardCount.compute(NodeEnvironment.shardStatePathToDataPath(result.getDataPath()), (k, v) -> v == null ? 1 : v + 1);
+
+        shardId = new ShardId("index", "uid1", 1);
+        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        createFakeShard(result);
+        // Second shard should go to b
+        assertThat(result.getDataPath().toString(), containsString(bPathPart));
+        dataPathToShardCount.compute(NodeEnvironment.shardStatePathToDataPath(result.getDataPath()), (k, v) -> v == null ? 1 : v + 1);
+
+        shardId = new ShardId("index2", "uid3", 0);
+        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        createFakeShard(result);
+        // Shard for new index should go to a
+        assertThat(result.getDataPath().toString(), containsString(aPathPart));
+        dataPathToShardCount.compute(NodeEnvironment.shardStatePathToDataPath(result.getDataPath()), (k, v) -> v == null ? 1 : v + 1);
+
+        shardId = new ShardId("index2", "uid2", 0);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index2",
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3).build());
+        ShardPath result1 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result1);
+        dataPathToShardCount.compute(NodeEnvironment.shardStatePathToDataPath(result1.getDataPath()), (k, v) -> v == null ? 1 : v + 1);
+        shardId = new ShardId("index2", "uid2", 1);
+        ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result2);
+        dataPathToShardCount.compute(NodeEnvironment.shardStatePathToDataPath(result2.getDataPath()), (k, v) -> v == null ? 1 : v + 1);
+        shardId = new ShardId("index2", "uid2", 2);
+        ShardPath result3 = ShardPath.selectNewPathForShard(nodeEnv, shardId, idxSettings, 100, dataPathToShardCount);
+        createFakeShard(result3);
+        // 2 shards go to 'b' and 1 to 'a'
+        assertThat(result1.getDataPath().toString(), containsString(bPathPart));
+        assertThat(result2.getDataPath().toString(), containsString(aPathPart));
+        assertThat(result3.getDataPath().toString(), containsString(bPathPart));
+
+        nodeEnv.close();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -99,7 +99,7 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         environment =
             TestEnvironment.newEnvironment(Settings.builder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), dataDir)
-                .put(Environment.PATH_DATA_SETTING.getKey(), dataDir.toAbsolutePath().toString()).build());
+                .putList(Environment.PATH_DATA_SETTING.getKey(), dataDir.toAbsolutePath().toString()).build());
 
         // create same directory structure as prod does
         Files.createDirectories(dataDir);

--- a/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
@@ -80,7 +80,7 @@ public class FsRepositoryTests extends ESTestCase {
             Settings settings = Settings.builder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
                 .put(Environment.PATH_REPO_SETTING.getKey(), repo.toAbsolutePath())
-                .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath())
+                .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
                 .put("location", repo)
                 .put("compress", randomBoolean())
                 .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1048,6 +1048,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
     }
 
+    /** Returns a random number of temporary paths. */
+    public String[] tmpPaths() {
+        return new String[] { createTempDir().toAbsolutePath().toString() };
+    }
+
     public NodeEnvironment newNodeEnvironment() throws IOException {
         return newNodeEnvironment(Settings.EMPTY);
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -136,6 +136,17 @@ public class FrozenCacheService implements Releasable {
                             roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.joining(","))
                         );
                     }
+
+                    @SuppressWarnings("unchecked")
+                    final List<String> dataPaths = (List<String>) settings.get(Environment.PATH_DATA_SETTING);
+                    if (dataPaths.size() > 1) {
+                        throw new SettingsException(
+                            "setting [{}={}] is not permitted on nodes with multiple data paths [{}]",
+                            SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
+                            value.getStringRep(),
+                            String.join(",", dataPaths)
+                        );
+                    }
                 }
             }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -192,7 +192,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     private NodeEnvironment newSinglePathNodeEnvironment() throws IOException {
         Settings build = Settings.builder()
             .put(buildEnvSettings(Settings.EMPTY))
-            .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
             .build();
         return new NodeEnvironment(build, TestEnvironment.newEnvironment(build));
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCacheTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCacheTests.java
@@ -210,7 +210,7 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
             nodeEnvironment = newNodeEnvironment(
                 Settings.builder()
                     .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
-                    .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath())
+                    .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
                     .build()
             );
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
@@ -11,11 +11,11 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.common.unit.RatioValue;
 import org.elasticsearch.common.unit.RelativeByteSizeValue;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.ShardId;
@@ -27,8 +27,8 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService.CacheFileRegion;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.common.unit.RatioValue;
 import org.elasticsearch.common.unit.RelativeByteSizeValue;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -26,6 +27,7 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService.CacheFileRegion;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -226,6 +228,30 @@ public class FrozenCacheServiceTests extends ESTestCase {
                     + "] to be positive ["
                     + cacheSize
                     + "] is only permitted on nodes with the data_frozen role, roles are [data_hot]"
+            )
+        );
+    }
+
+    public void testMultipleDataPathsRejectedOnFrozenNodes() {
+        final Settings settings = Settings.builder()
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
+            .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), List.of("a", "b"))
+            .build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(settings)
+        );
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause(), instanceOf(SettingsException.class));
+        assertThat(
+            e.getCause().getMessage(),
+            is(
+                "setting ["
+                    + FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey()
+                    + "="
+                    + new ByteSizeValue(size(500)).getStringRep()
+                    + "] is not permitted on nodes with multiple data paths [a,b]"
             )
         );
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -584,7 +584,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                         Settings.builder()
                             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
                             .put(Environment.PATH_REPO_SETTING.getKey(), repositoryPath.toAbsolutePath())
-                            .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath())
+                            .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
                             .build(),
                         null
                     ),


### PR DESCRIPTION
This reverts commit d933ecd26cc443b1160e3fa7cab0fc4382893585.

The revert had two conflicts. The first was very minor in JoinHelper.
The second was several tests in PersistedClusterStateServiceTests.

relates #78525
relates #71205