### PR TITLE
Separate minimum compiler and runtime Java version properties

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
@@ -15,13 +15,11 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutFactory;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import javax.inject.Inject;
 
 abstract class VersionPropertiesBuildService implements BuildService<VersionPropertiesBuildService.Params>, AutoCloseable {
 
@@ -33,15 +31,24 @@ abstract class VersionPropertiesBuildService implements BuildService<VersionProp
         try {
             File propertiesInputFile = new File(infoPath, "version.properties");
             properties = VersionPropertiesLoader.loadBuildSrcVersion(propertiesInputFile, providerFactory);
-            properties.computeIfAbsent("minimumJava", s -> resolveMinimumJavaVersion(infoPath));
+            properties.computeIfAbsent("minimumRuntimeJava", s -> resolveMinimumRuntimeJavaVersion(infoPath));
+            properties.computeIfAbsent("minimumCompilerJava", s -> resolveMinimumCompilerJavaVersion(infoPath));
         } catch (IOException e) {
             throw new GradleException("Cannot load VersionPropertiesBuildService", e);
         }
     }
 
-    private JavaVersion resolveMinimumJavaVersion(File infoPath) {
+    private JavaVersion resolveMinimumRuntimeJavaVersion(File infoPath) {
+        return resolveJavaVersion(infoPath, "src/main/resources/minimumRuntimeVersion");
+    }
+
+    private JavaVersion resolveMinimumCompilerJavaVersion(File infoPath) {
+        return resolveJavaVersion(infoPath, "src/main/resources/minimumCompilerVersion");
+    }
+
+    private JavaVersion resolveJavaVersion(File infoPath, String path) {
         final JavaVersion minimumJavaVersion;
-        File minimumJavaInfoSource = new File(infoPath, "src/main/resources/minimumRuntimeVersion");
+        File minimumJavaInfoSource = new File(infoPath, path);
         try {
             String versionString = FileUtils.readFileToString(minimumJavaInfoSource);
             minimumJavaVersion = JavaVersion.toVersion(versionString);

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -6,13 +6,6 @@
  * Side Public License, v 1.
  */
 
-
-import org.elasticsearch.gradle.internal.conventions.VersionPropertiesLoader
-import org.apache.tools.ant.taskdefs.condition.Os
-import org.gradle.plugins.ide.eclipse.model.AccessRule
-import org.gradle.plugins.ide.eclipse.model.SourceFolder
-import org.gradle.plugins.ide.eclipse.model.ProjectDependency
-
 plugins {
   id 'java-gradle-plugin'
   id 'groovy-gradle-plugin'
@@ -169,7 +162,7 @@ gradlePlugin {
  *         Java version                                                      *
  *****************************************************************************/
 
-def minCompilerJava = versions.get("minimumJava")
+def minCompilerJava = versions.get("minimumCompilerJava")
 targetCompatibility = minCompilerJava
 sourceCompatibility = minCompilerJava
 

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import org.elasticsearch.gradle.internal.conventions.VersionPropertiesLoader
 
 plugins {
     id 'java-gradle-plugin'
@@ -21,8 +20,8 @@ description = "The elasticsearch build tools"
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumJava")
-sourceCompatibility = versions.get("minimumJava")
+targetCompatibility = versions.get("minimumRuntimeJava")
+sourceCompatibility = versions.get("minimumRuntimeJava")
 
 gradlePlugin {
     // We already configure publication and we don't need or want the one that comes

--- a/build-tools/reaper/build.gradle
+++ b/build-tools/reaper/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumJava")
-sourceCompatibility = versions.get("minimumJava")
+targetCompatibility = versions.get("minimumRuntimeJava")
+sourceCompatibility = versions.get("minimumRuntimeJava")
 
 tasks.named("jar").configure {
   archiveFileName = "${project.name}.jar"


### PR DESCRIPTION
This is a follow up to #78704 to additionally distinguish between minimum _compiler_ version and minimum _runtime_ versions of Java for the Elasticsearch project. The former is what we require you to run the build with. The latter is what we require you to run Elasticsearch with. These are also different for different build logic projects.

`build-tools` is public, and used by folks to build plugins for Elasticsearch. Therefore, it should support the same minimum Java version as Elasticsearch does at runtime. That is, if you can run Elasticsearch 8.0 with Java 11, you should be able to build plugins using Java 11 across the board. In this case we want to target the minimum _runtime_ version.

`build-tools-internal` is, obviously, internal. Since we generally force a higher minimum compiler version, this project can (and does) use newer Java APIs. In this case we want to target the minimum _compiler_ version.

This was actually causing compile errors in the IDE since we configure IntelliJ to compile with the `-release` flag but Gradle doesn't apply this to the build-tools projects. The alleviates the problem so we don't have a discrepancy between compile time and runtime Java requirements for the `build-tools-internal` project.