### PR TITLE
Add upgrade preparation and completion callbacks to `SystemIndexPlugin` (#78542)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -576,6 +576,8 @@ public class SystemIndices {
         private final Collection<SystemDataStreamDescriptor> dataStreamDescriptors;
         private final Collection<AssociatedIndexDescriptor> associatedIndexDescriptors;
         private final TriConsumer<ClusterService, Client, ActionListener<ResetFeatureStateStatus>> cleanUpFunction;
+        private final MigrationPreparationHandler preMigrationFunction;
+        private final MigrationCompletionHandler postMigrationFunction;
 
         /**
          * Construct a Feature with a custom cleanup function
@@ -584,18 +586,25 @@ public class SystemIndices {
          * @param dataStreamDescriptors Collection of objects describing system data streams for this feature
          * @param associatedIndexDescriptors Collection of objects describing associated indices for this feature
          * @param cleanUpFunction A function that will clean up the feature's state
+         * @param preMigrationFunction A function that will be called prior to upgrading any of this plugin's system indices
+         * @param postMigrationFunction A function that will be called after upgrading all of this plugin's system indices
          */
         public Feature(
             String description,
             Collection<SystemIndexDescriptor> indexDescriptors,
             Collection<SystemDataStreamDescriptor> dataStreamDescriptors,
             Collection<AssociatedIndexDescriptor> associatedIndexDescriptors,
-            TriConsumer<ClusterService, Client, ActionListener<ResetFeatureStateStatus>> cleanUpFunction) {
+            TriConsumer<ClusterService, Client, ActionListener<ResetFeatureStateStatus>> cleanUpFunction,
+            MigrationPreparationHandler preMigrationFunction,
+            MigrationCompletionHandler postMigrationFunction
+        ) {
             this.description = description;
             this.indexDescriptors = indexDescriptors;
             this.dataStreamDescriptors = dataStreamDescriptors;
             this.associatedIndexDescriptors = associatedIndexDescriptors;
             this.cleanUpFunction = cleanUpFunction;
+            this.preMigrationFunction = preMigrationFunction;
+            this.postMigrationFunction = postMigrationFunction;
         }
 
         /**
@@ -605,11 +614,24 @@ public class SystemIndices {
          * @param indexDescriptors Patterns describing system indices for this feature
          */
         public Feature(String name, String description, Collection<SystemIndexDescriptor> indexDescriptors) {
-            this(description, indexDescriptors, Collections.emptyList(), Collections.emptyList(),
-                (clusterService, client, listener) ->
-                    cleanUpFeature(indexDescriptors, Collections.emptyList(), name, clusterService, client, listener)
+            this(
+                description,
+                indexDescriptors,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                (clusterService, client, listener) -> cleanUpFeature(
+                    indexDescriptors,
+                    Collections.emptyList(),
+                    name,
+                    clusterService,
+                    client,
+                    listener
+                ),
+                Feature::noopPreMigrationFunction,
+                Feature::noopPostMigrationFunction
             );
         }
+
         /**
          * Construct a Feature using the default clean-up function
          * @param name Name of the feature, used in logging
@@ -617,11 +639,45 @@ public class SystemIndices {
          * @param indexDescriptors Patterns describing system indices for this feature
          * @param dataStreamDescriptors Collection of objects describing system data streams for this feature
          */
-        public Feature(String name, String description, Collection<SystemIndexDescriptor> indexDescriptors,
-                       Collection<SystemDataStreamDescriptor> dataStreamDescriptors) {
-            this(description, indexDescriptors, dataStreamDescriptors, Collections.emptyList(),
-                (clusterService, client, listener) ->
-                    cleanUpFeature(indexDescriptors, Collections.emptyList(), name, clusterService, client, listener)
+        public Feature(
+            String name,
+            String description,
+            Collection<SystemIndexDescriptor> indexDescriptors,
+            Collection<SystemDataStreamDescriptor> dataStreamDescriptors
+        ) {
+            this(
+                description,
+                indexDescriptors,
+                dataStreamDescriptors,
+                Collections.emptyList(),
+                (clusterService, client, listener) -> cleanUpFeature(
+                    indexDescriptors,
+                    Collections.emptyList(),
+                    name,
+                    clusterService,
+                    client,
+                    listener
+                ),
+                Feature::noopPreMigrationFunction,
+                Feature::noopPostMigrationFunction
+            );
+        }
+
+        /**
+         * Creates a {@link Feature} from a {@link SystemIndexPlugin}.
+         * @param plugin The {@link SystemIndexPlugin} that adds this feature.
+         * @param settings Node-level settings, as this may impact the descriptors returned by the plugin.
+         * @return A {@link Feature} which represents the feature added by the given plugin.
+         */
+        public static Feature fromSystemIndexPlugin(SystemIndexPlugin plugin, Settings settings) {
+            return new Feature(
+                plugin.getFeatureDescription(),
+                plugin.getSystemIndexDescriptors(settings),
+                plugin.getSystemDataStreamDescriptors(),
+                plugin.getAssociatedIndexDescriptors(),
+                plugin::cleanUpFeature,
+                plugin::prepareForIndicesMigration,
+                plugin::indicesMigrationComplete
             );
         }
 
@@ -645,6 +701,14 @@ public class SystemIndices {
             return cleanUpFunction;
         }
 
+        public MigrationPreparationHandler getPreMigrationFunction() {
+            return preMigrationFunction;
+        }
+
+        public MigrationCompletionHandler getPostMigrationFunction() {
+            return postMigrationFunction;
+        }
+
         /**
          * Clean up the state of a feature
          * @param indexDescriptors List of descriptors of a feature's system indices
@@ -660,7 +724,8 @@ public class SystemIndices {
             String name,
             ClusterService clusterService,
             Client client,
-            ActionListener<ResetFeatureStateStatus> listener) {
+            ActionListener<ResetFeatureStateStatus> listener
+        ) {
             Metadata metadata = clusterService.state().getMetadata();
 
             List<String> allIndices = Stream.concat(indexDescriptors.stream(), associatedIndexDescriptors.stream())
@@ -688,14 +753,40 @@ public class SystemIndices {
                 }
             });
         }
-    }
 
-    public static Feature pluginToFeature(SystemIndexPlugin plugin, Settings settings) {
-        return new Feature(plugin.getFeatureDescription(),
-            plugin.getSystemIndexDescriptors(settings),
-            plugin.getSystemDataStreamDescriptors(),
-            plugin.getAssociatedIndexDescriptors(),
-            plugin::cleanUpFeature);
+        // No-op pre-migration function to be used as the default in case none are provided.
+        private static void noopPreMigrationFunction(
+            ClusterService clusterService,
+            Client client,
+            ActionListener<Map<String, Object>> listener
+        ) {
+            listener.onResponse(Collections.emptyMap());
+        }
+
+        // No-op pre-migration function to be used as the default in case none are provided.
+        private static void noopPostMigrationFunction(
+            Map<String, Object> preUpgradeMetadata,
+            ClusterService clusterService,
+            Client client,
+            ActionListener<Boolean> listener
+        ) {
+            listener.onResponse(true);
+        }
+
+        @FunctionalInterface
+        interface MigrationPreparationHandler {
+            void prepareForIndicesMigration(ClusterService clusterService, Client client, ActionListener<Map<String, Object>> listener);
+        }
+
+        @FunctionalInterface
+        interface MigrationCompletionHandler {
+            void indicesMigrationComplete(
+                Map<String, Object> preUpgradeMetadata,
+                ClusterService clusterService,
+                Client client,
+                ActionListener<Boolean> listener
+            );
+        }
     }
 
     public ExecutorSelector getExecutorSelector() {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -496,7 +496,7 @@ public class Node implements Closeable {
                 .peek(plugin -> SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName()))
                 .collect(Collectors.toMap(
                     SystemIndexPlugin::getFeatureName,
-                    plugin -> SystemIndices.pluginToFeature(plugin, settings)
+                    plugin -> SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings)
                 ));
             final SystemIndices systemIndices = new SystemIndices(featuresMap);
             final ExecutorSelector executorSelector = systemIndices.getExecutorSelector();

--- a/server/src/main/java/org/elasticsearch/plugins/SystemIndexPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/SystemIndexPlugin.java
@@ -20,6 +20,7 @@ import org.elasticsearch.indices.SystemIndices;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * Plugin for defining system indices. Extends {@link ActionPlugin} because system indices must be accessed via APIs
@@ -81,5 +82,59 @@ public interface SystemIndexPlugin extends ActionPlugin {
             client,
             listener
         );
+    }
+
+    /**
+     * A method used to signal that the system indices owned by this plugin are about to be upgraded.
+     *
+     * This method will typically be called once, before any changes are made to the system indices owned by this plugin. However, if there
+     * is a master failover at exactly the wrong time during the upgrade process, this may be called more than once, though this should be
+     * very rare.
+     *
+     * This method can also store metadata to be passed to
+     * {@link SystemIndexPlugin#indicesMigrationComplete(Map, ClusterService, Client, ActionListener)} when it is called; see the
+     * {@code listener} parameter for details.
+     *
+     * @param clusterService The cluster service.
+     * @param client A {@link org.elasticsearch.client.ParentTaskAssigningClient} with the parent task set to the upgrade task. Does not set
+     *               the origin header, so implementors of this method will likely want to wrap it in an
+     *               {@link org.elasticsearch.client.OriginSettingClient}.
+     * @param listener A listener that should have {@link ActionListener#onResponse(Object)} called once all necessary preparations for the
+     *                 upgrade of indices owned by this plugin have been completed. The {@link Map} passed to the listener will be stored
+     *                 and passed to {@link #indicesMigrationComplete(Map, ClusterService, Client, ActionListener)}. Note the contents of
+     *                 the map *must* be writeable using {@link org.elasticsearch.common.io.stream.StreamOutput#writeGenericValue(Object)}.
+     */
+    default void prepareForIndicesMigration(ClusterService clusterService, Client client, ActionListener<Map<String, Object>> listener) {
+        listener.onResponse(Collections.emptyMap());
+    }
+
+    /**
+     * A method used to signal that the system indices owned by this plugin have been upgraded and all restrictions (i.e. write blocks)
+     * necessary for the upgrade have been lifted from the indices owned by this plugin.
+     *
+     * This method will be called once, after all system indices owned by this plugin have been upgraded. Note that the upgrade may not have
+     * completed successfully, but if not, all write blocks/etc. will have been removed from the indices in question anyway as the upgrade
+     * process tries not to leave anything in an unusable state.
+     *
+     * Note: This method may need additional parameters when we support breaking mapping changes, as in that case we can't assume that
+     * any indices which were not upgraded can still be used (whereas we can assume that while the upgrade process is limited to reindexing,
+     * with no data format changes allowed).
+     *
+     * @param preUpgradeMetadata The metadata that was given to the listener by
+     *                           {@link #prepareForIndicesMigration(ClusterService, Client, ActionListener)}.
+     * @param clusterService The cluster service.
+     * @param client A {@link org.elasticsearch.client.ParentTaskAssigningClient} with the parent task set to the upgrade task. Does not set
+     *               the origin header, so implementors of this method will likely want to wrap it in an
+     *               {@link org.elasticsearch.client.OriginSettingClient}.
+     * @param listener A listener that should have {@code ActionListener.onResponse(true)} called once all actions following the upgrade
+     *                 of this plugin's system indices have been completed.
+     */
+    default void indicesMigrationComplete(
+        Map<String, Object> preUpgradeMetadata,
+        ClusterService clusterService,
+        Client client,
+        ActionListener<Boolean> listener
+    ) {
+        listener.onResponse(true);
     }
 }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -52,7 +52,7 @@ public class FleetTests extends ESTestCase {
 
     public void testFleetFeature() {
         Fleet module = new Fleet();
-        Feature fleet = SystemIndices.pluginToFeature(module, Settings.EMPTY);
+        Feature fleet = Feature.fromSystemIndexPlugin(module, Settings.EMPTY);
         SystemIndices systemIndices = new SystemIndices(Collections.singletonMap(module.getFeatureName(), fleet));
         assertNotNull(systemIndices);
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.watcher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -64,6 +65,7 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.core.watcher.WatcherField;
+import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
 import org.elasticsearch.xpack.core.watcher.actions.ActionFactory;
 import org.elasticsearch.xpack.core.watcher.actions.ActionRegistry;
 import org.elasticsearch.xpack.core.watcher.condition.ConditionFactory;
@@ -84,6 +86,7 @@ import org.elasticsearch.xpack.core.watcher.transport.actions.execute.ExecuteWat
 import org.elasticsearch.xpack.core.watcher.transport.actions.get.GetWatchAction;
 import org.elasticsearch.xpack.core.watcher.transport.actions.put.PutWatchAction;
 import org.elasticsearch.xpack.core.watcher.transport.actions.service.WatcherServiceAction;
+import org.elasticsearch.xpack.core.watcher.transport.actions.service.WatcherServiceRequest;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsAction;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
@@ -195,6 +198,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -682,6 +686,53 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     @Override
     public String getFeatureName() {
         return "watcher";
+    }
+
+    @Override
+    public void prepareForIndicesMigration(ClusterService clusterService, Client client, ActionListener<Map<String, Object>> listener) {
+        Client originClient = new OriginSettingClient(client, WATCHER_ORIGIN);
+        boolean manuallyStopped = Optional.ofNullable(clusterService.state().metadata().<WatcherMetadata>custom(WatcherMetadata.TYPE))
+            .map(WatcherMetadata::manuallyStopped)
+            .orElse(false);
+
+        if (manuallyStopped == false) {
+            WatcherServiceRequest serviceRequest = new WatcherServiceRequest();
+            serviceRequest.stop();
+            originClient.execute(
+                WatcherServiceAction.INSTANCE,
+                serviceRequest,
+                ActionListener.wrap(
+                    (response) -> { listener.onResponse(Collections.singletonMap("manually_stopped", manuallyStopped)); },
+                    listener::onFailure
+                )
+            );
+        } else {
+            // If Watcher is manually stopped, we don't want to stop it AGAIN, so just call the listener.
+            listener.onResponse(Collections.singletonMap("manually_stopped", manuallyStopped));
+        }
+    }
+
+    @Override
+    public void indicesMigrationComplete(
+        Map<String, Object> preUpgradeMetadata,
+        ClusterService clusterService,
+        Client client,
+        ActionListener<Boolean> listener
+    ) {
+        Client originClient = new OriginSettingClient(client, WATCHER_ORIGIN);
+        boolean manuallyStopped = (boolean) preUpgradeMetadata.getOrDefault("manually_stopped", false);
+        if (manuallyStopped == false) {
+            WatcherServiceRequest serviceRequest = new WatcherServiceRequest();
+            serviceRequest.start();
+            originClient.execute(
+                WatcherServiceAction.INSTANCE,
+                serviceRequest,
+                ActionListener.wrap((response) -> { listener.onResponse(response.isAcknowledged()); }, listener::onFailure)
+            );
+        } else {
+            // Watcher was manually stopped before we got there, don't start it.
+            listener.onResponse(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/78542

---

This PR introduces two new methods to `SystemIndexPlugin`: One which will be called before upgrading any of the plugin's system indices, and one which will
be called after they have all been completed (or the upgrade has
failed).

This PR also implements these methods for `Watcher`, to demonstrate
their usage.

Currently, these callbacks are not actually called anywhere. Shortly,
they will be called by the actual upgrade mechanism.