### PR TITLE
[DOCS] Remove tag 7.15.1

### DIFF
--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
 
-coming::[7.15.1]
-
 [[enhancement-7.15.1]]
 [float]
 === Enhancements


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

Also merge backport to `7.x`: https://github.com/elastic/elasticsearch/pull/79115