### PR TITLE
Unify AuthC chain - 1. Authenticator extraction (#77293)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationResult.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationResult.java
@@ -80,7 +80,6 @@ public final class AuthenticationResult {
      * @param user The user that was authenticated. Cannot be {@code null}.
      */
     public static AuthenticationResult success(User user) {
-        Objects.requireNonNull(user);
         return success(user, null);
     }
 
@@ -90,6 +89,7 @@ public final class AuthenticationResult {
      * @see #success(User)
      */
     public static AuthenticationResult success(User user, @Nullable Map<String, Object> metadata) {
+        Objects.requireNonNull(user);
         return new AuthenticationResult(Status.SUCCESS, user, null, null, metadata);
     }
 

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -218,7 +218,8 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         } else {
             ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(401));
-            assertThat(e.getMessage(), containsString("missing authentication credentials for REST request"));
+            assertThat(e.getMessage(), containsString(
+                "unable to authenticate with provided credentials and anonymous access is not allowed for this request"));
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
+import org.elasticsearch.xpack.security.authc.ApiKeyService.ApiKeyCredentials;
+
+class ApiKeyAuthenticator implements Authenticator {
+
+    private static final Logger logger = LogManager.getLogger(ApiKeyAuthenticator.class);
+
+    private final ApiKeyService apiKeyService;
+    private final String nodeName;
+
+    ApiKeyAuthenticator(ApiKeyService apiKeyService, String nodeName) {
+        this.apiKeyService = apiKeyService;
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public String name() {
+        return "API key";
+    }
+
+    @Override
+    public AuthenticationToken extractCredentials(Context context) {
+        return apiKeyService.getCredentialsFromHeader(context.getThreadContext());
+    }
+
+    @Override
+    public void authenticate(Context context, ActionListener<Result> listener) {
+        final AuthenticationToken authenticationToken = context.getMostRecentAuthenticationToken();
+        if (false == authenticationToken instanceof ApiKeyCredentials) {
+            listener.onResponse(Authenticator.Result.notHandled());
+            return;
+        }
+        ApiKeyCredentials apiKeyCredentials = (ApiKeyCredentials) authenticationToken;
+        apiKeyService.tryAuthenticate(context.getThreadContext(), apiKeyCredentials, ActionListener.wrap(authResult -> {
+            if (authResult.isAuthenticated()) {
+                final Authentication authentication = apiKeyService.createApiKeyAuthentication(authResult, nodeName);
+                listener.onResponse(Authenticator.Result.success(authentication));
+            } else if (authResult.getStatus() == AuthenticationResult.Status.TERMINATE) {
+                Exception e = (authResult.getException() != null) ?
+                    authResult.getException() :
+                    Exceptions.authenticationError(authResult.getMessage());
+                logger.debug(new ParameterizedMessage("API key service terminated authentication for request [{}]", context.getRequest()),
+                    e);
+                listener.onFailure(e);
+            } else {
+                if (authResult.getMessage() != null) {
+                    if (authResult.getException() != null) {
+                        logger.warn(new ParameterizedMessage("Authentication using apikey failed - {}", authResult.getMessage()),
+                            authResult.getException());
+                    } else {
+                        logger.warn("Authentication using apikey failed - {}", authResult.getMessage());
+                    }
+                }
+                listener.onResponse(Authenticator.Result.unsuccessful(
+                    authResult.getMessage(),
+                    authResult.getException()));
+            }
+        }, e -> listener.onFailure(context.getRequest().exceptionProcessingRequest(e, null))));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -90,6 +90,7 @@ import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -408,37 +409,21 @@ public class ApiKeyService {
         return builder;
     }
 
-    /**
-     * Checks for the presence of a {@code Authorization} header with a value that starts with
-     * {@code ApiKey }. If found this will attempt to authenticate the key.
-     */
-    void authenticateWithApiKeyIfPresent(ThreadContext ctx, ActionListener<AuthenticationResult> listener) {
-        if (isEnabled()) {
-            final ApiKeyCredentials credentials;
-            try {
-                credentials = getCredentialsFromHeader(ctx);
-            } catch (IllegalArgumentException iae) {
-                listener.onResponse(AuthenticationResult.unsuccessful(iae.getMessage(), iae));
-                return;
-            }
-
-            if (credentials != null) {
-                loadApiKeyAndValidateCredentials(ctx, credentials, ActionListener.wrap(
-                    response -> {
-                        credentials.close();
-                        listener.onResponse(response);
-                    },
-                    e -> {
-                        credentials.close();
-                        listener.onFailure(e);
-                    }
-                ));
-            } else {
-                listener.onResponse(AuthenticationResult.notHandled());
-            }
-        } else {
+    void tryAuthenticate(ThreadContext ctx, ApiKeyCredentials credentials, ActionListener<AuthenticationResult> listener) {
+        if (false == isEnabled()) {
             listener.onResponse(AuthenticationResult.notHandled());
         }
+        assert credentials != null : "api key credentials must not be null";
+        loadApiKeyAndValidateCredentials(ctx, credentials, ActionListener.wrap(
+            response -> {
+                credentials.close();
+                listener.onResponse(response);
+            },
+            e -> {
+                credentials.close();
+                listener.onFailure(e);
+            }
+        ));
     }
 
     public Authentication createApiKeyAuthentication(AuthenticationResult authResult, String nodeName) {
@@ -769,11 +754,13 @@ public class ApiKeyService {
      * Gets the API Key from the <code>Authorization</code> header if the header begins with
      * <code>ApiKey </code>
      */
-    static ApiKeyCredentials getCredentialsFromHeader(ThreadContext threadContext) {
-        String header = threadContext.getHeader("Authorization");
-        if (Strings.hasText(header) && header.regionMatches(true, 0, "ApiKey ", 0, "ApiKey ".length())
-            && header.length() > "ApiKey ".length()) {
-            final byte[] decodedApiKeyCredBytes = Base64.getDecoder().decode(header.substring("ApiKey ".length()));
+    ApiKeyCredentials getCredentialsFromHeader(ThreadContext threadContext) {
+        if (false == isEnabled()) {
+            return null;
+        }
+        final SecureString apiKeyString = Authenticator.extractCredentialFromAuthorizationHeader(threadContext, "ApiKey");
+        if (apiKeyString != null) {
+            final byte[] decodedApiKeyCredBytes = Base64.getDecoder().decode(CharArrays.toUtf8Bytes(apiKeyString.getChars()));
             char[] apiKeyCredChars = null;
             try {
                 apiKeyCredChars = CharArrays.utf8BytesToChars(decodedApiKeyCredBytes);
@@ -849,7 +836,7 @@ public class ApiKeyService {
     }
 
     // public class for testing
-    public static final class ApiKeyCredentials implements Closeable {
+    public static final class ApiKeyCredentials implements AuthenticationToken, Closeable {
         private final String id;
         private final SecureString key;
 
@@ -869,6 +856,21 @@ public class ApiKeyService {
         @Override
         public void close() {
             key.close();
+        }
+
+        @Override
+        public String principal() {
+            return id;
+        }
+
+        @Override
+        public Object credentials() {
+            return key;
+        }
+
+        @Override
+        public void clearCredentials() {
+            close();
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -8,60 +8,39 @@ package org.elasticsearch.xpack.security.authc;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
-import org.elasticsearch.core.Nullable;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
-import org.elasticsearch.core.Tuple;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.xpack.core.common.IteratingActionListener;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
-import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
-import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationFailureHandler;
-import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.EmptyAuthorizationInfo;
-import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
-import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
-import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
-import org.elasticsearch.xpack.security.authc.support.RealmUserLookup;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isIndexDeleted;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isMoveFromRedToNonRed;
@@ -85,32 +64,19 @@ public class AuthenticationService {
     private final AuditTrailService auditTrailService;
     private final AuthenticationFailureHandler failureHandler;
     private final ThreadContext threadContext;
-    private final String nodeName;
-    private final AnonymousUser anonymousUser;
-    private final TokenService tokenService;
     private final Cache<String, Realm> lastSuccessfulAuthCache;
     private final AtomicLong numInvalidation = new AtomicLong();
-    private final ApiKeyService apiKeyService;
-    private final ServiceAccountService serviceAccountService;
-    private final OperatorPrivilegesService operatorPrivilegesService;
-    private final boolean runAsEnabled;
-    private final boolean isAnonymousUserEnabled;
-    private final AuthenticationContextSerializer authenticationSerializer;
+    private final AuthenticatorChain authenticatorChain;
 
     public AuthenticationService(Settings settings, Realms realms, AuditTrailService auditTrailService,
                                  AuthenticationFailureHandler failureHandler, ThreadPool threadPool,
                                  AnonymousUser anonymousUser, TokenService tokenService, ApiKeyService apiKeyService,
                                  ServiceAccountService serviceAccountService,
                                  OperatorPrivilegesService operatorPrivilegesService) {
-        this.nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.realms = realms;
         this.auditTrailService = auditTrailService;
         this.failureHandler = failureHandler;
         this.threadContext = threadPool.getThreadContext();
-        this.anonymousUser = anonymousUser;
-        this.runAsEnabled = AuthenticationServiceField.RUN_AS_ENABLED.get(settings);
-        this.isAnonymousUserEnabled = AnonymousUser.isAnonymousEnabled(settings);
-        this.tokenService = tokenService;
         if (SUCCESS_AUTH_CACHE_ENABLED.get(settings)) {
             this.lastSuccessfulAuthCache = CacheBuilder.<String, Realm>builder()
                 .setMaximumWeight(Integer.toUnsignedLong(SUCCESS_AUTH_CACHE_MAX_SIZE.get(settings)))
@@ -119,10 +85,18 @@ public class AuthenticationService {
         } else {
             this.lastSuccessfulAuthCache = null;
         }
-        this.apiKeyService = apiKeyService;
-        this.serviceAccountService = serviceAccountService;
-        this.operatorPrivilegesService = operatorPrivilegesService;
-        this.authenticationSerializer = new AuthenticationContextSerializer();
+
+        final String nodeName = Node.NODE_NAME_SETTING.get(settings);
+        this.authenticatorChain = new AuthenticatorChain(
+            settings,
+            operatorPrivilegesService,
+            anonymousUser,
+            new AuthenticationContextSerializer(),
+            new ServiceAccountAuthenticator(serviceAccountService, nodeName),
+            new OAuth2TokenAuthenticator(tokenService),
+            new ApiKeyAuthenticator(apiKeyService, nodeName),
+            new RealmsAuthenticator(nodeName, numInvalidation, lastSuccessfulAuthCache)
+        );
     }
 
     /**
@@ -146,10 +120,16 @@ public class AuthenticationService {
      * @param request The request to be authenticated
      * @param allowAnonymous If {@code false}, then authentication will <em>not</em> fallback to anonymous.
      *                               If {@code true}, then authentication <em>will</em> fallback to anonymous, if this service is
-     *                               configured to allow anonymous access (see {@link #isAnonymousUserEnabled}).
+     *                               configured to allow anonymous access.
      */
     public void authenticate(RestRequest request, boolean allowAnonymous, ActionListener<Authentication> authenticationListener) {
-        createAuthenticator(request, allowAnonymous, authenticationListener).authenticateAsync();
+        final Authenticator.Context context = new Authenticator.Context(
+            threadContext,
+            new AuditableRestRequest(auditTrailService.get(), failureHandler, threadContext, request),
+            null,
+            allowAnonymous,
+            realms);
+        authenticatorChain.authenticateAsync(context, authenticationListener);
     }
 
     /**
@@ -164,7 +144,13 @@ public class AuthenticationService {
      */
     public void authenticate(String action, TransportRequest transportRequest, User fallbackUser, ActionListener<Authentication> listener) {
         Objects.requireNonNull(fallbackUser, "fallback user may not be null");
-        createAuthenticator(action, transportRequest, fallbackUser, listener).authenticateAsync();
+        final Authenticator.Context context = new Authenticator.Context(
+            threadContext,
+            new AuditableTransportRequest(auditTrailService.get(), failureHandler, threadContext, action, transportRequest),
+            fallbackUser,
+            false,
+            realms);
+        authenticatorChain.authenticateAsync(context, listener);
     }
 
     /**
@@ -172,16 +158,22 @@ public class AuthenticationService {
      * a user was indeed associated with the request and the credentials were verified to be valid), the method returns
      * the user and that user is then "attached" to the message's context.
      * If no user or credentials are found to be attached to the given message, and the caller allows anonymous access
-     * ({@code allowAnonymous} parameter), and this service is configured for anonymous access (see {@link #isAnonymousUserEnabled} and
-     * {@link #anonymousUser}), then the anonymous user will be returned instead.
+     * ({@code allowAnonymous} parameter), and this service is configured for anonymous access,
+     * then the anonymous user will be returned instead.
      * @param action       The action of the message
      * @param transportRequest      The request to be authenticated
      * @param allowAnonymous Whether to permit anonymous access for this request (this only relevant if the service is
- *                       {@link #isAnonymousUserEnabled configured for anonymous access}).
+     *                       configured for anonymous access).
      */
     public void authenticate(String action, TransportRequest transportRequest, boolean allowAnonymous,
                              ActionListener<Authentication> listener) {
-        createAuthenticator(action, transportRequest, allowAnonymous, listener).authenticateAsync();
+        final Authenticator.Context context = new Authenticator.Context(
+            threadContext,
+            new AuditableTransportRequest(auditTrailService.get(), failureHandler, threadContext, action, transportRequest),
+            null,
+            allowAnonymous,
+            realms);
+        authenticatorChain.authenticateAsync(context, listener);
     }
 
     /**
@@ -193,7 +185,14 @@ public class AuthenticationService {
      */
     public void authenticate(String action, TransportRequest transportRequest,
                              AuthenticationToken token, ActionListener<Authentication> listener) {
-        new Authenticator(action, transportRequest, shouldFallbackToAnonymous(true), listener).consumeToken(token);
+        final Authenticator.Context context = new Authenticator.Context(
+                threadContext,
+                new AuditableTransportRequest(auditTrailService.get(), failureHandler, threadContext, action, transportRequest),
+                null,
+                true,
+                realms);
+        context.addAuthenticationToken(token);
+        authenticatorChain.authenticateAsyncWithExistingCredentials(context, listener);
     }
 
     public void expire(String principal) {
@@ -221,512 +220,8 @@ public class AuthenticationService {
     }
 
     // pkg private method for testing
-    Authenticator createAuthenticator(RestRequest request, boolean fallbackToAnonymous, ActionListener<Authentication> listener) {
-        return new Authenticator(request, shouldFallbackToAnonymous(fallbackToAnonymous), listener);
-    }
-
-    // pkg private method for testing
-    Authenticator createAuthenticator(String action, TransportRequest transportRequest, boolean fallbackToAnonymous,
-                                      ActionListener<Authentication> listener) {
-        return new Authenticator(action, transportRequest, shouldFallbackToAnonymous(fallbackToAnonymous), listener);
-    }
-
-    // pkg private method for testing
-    Authenticator createAuthenticator(String action, TransportRequest transportRequest, User fallbackUser,
-                                      ActionListener<Authentication> listener) {
-        return new Authenticator(action, transportRequest, fallbackUser, listener);
-    }
-
-    // pkg private method for testing
     long getNumInvalidation() {
         return numInvalidation.get();
-    }
-
-    /**
-     * Determines whether to support anonymous access for the current request. Returns {@code true} if all of the following are true
-     * <ul>
-     *     <li>The service has anonymous authentication enabled (see {@link #isAnonymousUserEnabled})</li>
-     *     <li>Anonymous access is accepted for this request ({@code allowAnonymousOnThisRequest} parameter)
-     *     <li>The {@link ThreadContext} does not provide API Key or Bearer Token credentials. If these are present, we
-     *     treat the request as though it attempted to authenticate (even if that failed), and will not fall back to anonymous.</li>
-     * </ul>
-     */
-    boolean shouldFallbackToAnonymous(boolean allowAnonymousOnThisRequest) {
-        if (isAnonymousUserEnabled == false) {
-            return false;
-        }
-        if (allowAnonymousOnThisRequest == false) {
-            return false;
-        }
-        String header = threadContext.getHeader("Authorization");
-        if (Strings.hasText(header) &&
-            ((header.regionMatches(true, 0, "Bearer ", 0, "Bearer ".length()) && header.length() > "Bearer ".length()) ||
-                (header.regionMatches(true, 0, "ApiKey ", 0, "ApiKey ".length()) && header.length() > "ApiKey ".length()))) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * This class is responsible for taking a request and executing the authentication. The authentication is executed in an asynchronous
-     * fashion in order to avoid blocking calls on a network thread. This class also performs the auditing necessary around authentication
-     */
-    class Authenticator {
-
-        private final AuditableRequest request;
-        private final User fallbackUser;
-        private final boolean fallbackToAnonymous;
-        private final List<Realm> defaultOrderedRealmList;
-        private final ActionListener<Authentication> listener;
-
-        private RealmRef authenticatedBy = null;
-        private RealmRef lookedupBy = null;
-        private AuthenticationToken authenticationToken = null;
-        private AuthenticationResult authenticationResult = null;
-
-        Authenticator(RestRequest request, boolean fallbackToAnonymous, ActionListener<Authentication> listener) {
-            this(new AuditableRestRequest(auditTrailService.get(), failureHandler, threadContext, request),
-                 null, fallbackToAnonymous, listener);
-        }
-
-        Authenticator(String action, TransportRequest transportRequest, boolean fallbackToAnonymous,
-                      ActionListener<Authentication> listener) {
-            this(new AuditableTransportRequest(auditTrailService.get(), failureHandler, threadContext, action, transportRequest),
-                null, fallbackToAnonymous, listener);
-        }
-
-        Authenticator(String action, TransportRequest transportRequest, User fallbackUser, ActionListener<Authentication> listener) {
-            this(new AuditableTransportRequest(auditTrailService.get(), failureHandler, threadContext, action, transportRequest),
-                Objects.requireNonNull(fallbackUser, "Fallback user cannot be null"), false, listener);
-        }
-
-        private Authenticator(AuditableRequest auditableRequest, User fallbackUser, boolean fallbackToAnonymous,
-                              ActionListener<Authentication> listener) {
-            this.request = auditableRequest;
-            this.fallbackUser = fallbackUser;
-            this.fallbackToAnonymous = fallbackToAnonymous;
-            this.defaultOrderedRealmList = realms.getActiveRealms();
-            this.listener = listener;
-        }
-
-        /**
-         * This method starts the authentication process. The authentication process can be broken down into distinct operations. In order,
-         * these operations are:
-         *
-         * <ol>
-         * <li>look for existing authentication {@link #lookForExistingAuthentication()}</li>
-         * <li>look for a user token</li>
-         * <li>token extraction {@link #extractToken()}</li>
-         * <li>token authentication {@link #consumeToken(AuthenticationToken)}</li>
-         * <li>user lookup for run as if necessary {@link #consumeUser(User, Map)} and
-         * {@link #lookupRunAsUser(User, String, Consumer)}</li>
-         * <li>write authentication into the context {@link #finishAuthentication(User)}</li>
-         * </ol>
-         */
-        private void authenticateAsync() {
-            if (defaultOrderedRealmList.isEmpty()) {
-                // this happens when the license state changes between the call to authenticate and the actual invocation
-                // to get the realm list
-                logger.debug("No realms available, failing authentication");
-                listener.onResponse(null);
-            } else {
-                final Authentication authentication;
-                try {
-                    authentication = lookForExistingAuthentication();
-                } catch (Exception e) {
-                    listener.onFailure(e);
-                    return;
-                }
-                if (authentication != null) {
-                    logger.trace("Found existing authentication [{}] in request [{}]", authentication, request);
-                    listener.onResponse(authentication);
-                } else {
-                    checkForBearerToken();
-                }
-            }
-        }
-
-        private void checkForBearerToken() {
-            final SecureString bearerString = tokenService.extractBearerTokenFromHeader(threadContext);
-            final ServiceAccountToken serviceAccountToken = ServiceAccountService.tryParseToken(bearerString);
-            if (serviceAccountToken != null) {
-                serviceAccountService.authenticateToken(serviceAccountToken, nodeName, ActionListener.wrap(authentication -> {
-                    assert authentication != null : "service account authenticate should return either authentication or call onFailure";
-                    this.authenticatedBy = authentication.getAuthenticatedBy();
-                    writeAuthToContext(authentication);
-                }, e -> {
-                    logger.debug(new ParameterizedMessage("Failed to validate service account token for request [{}]", request), e);
-                    listener.onFailure(request.exceptionProcessingRequest(e, serviceAccountToken));
-                }));
-            } else {
-                tokenService.tryAuthenticateToken(bearerString, ActionListener.wrap(userToken -> {
-                    if (userToken != null) {
-                        writeAuthToContext(userToken.getAuthentication());
-                    } else {
-                        checkForApiKey();
-                    }
-                }, e -> {
-                    logger.debug(new ParameterizedMessage("Failed to validate token authentication for request [{}]", request), e);
-                    if (e instanceof ElasticsearchSecurityException
-                        && false == tokenService.isExpiredTokenException((ElasticsearchSecurityException) e)) {
-                        // intentionally ignore the returned exception; we call this primarily
-                        // for the auditing as we already have a purpose built exception
-                        request.tamperedRequest();
-                    }
-                    listener.onFailure(e);
-                }));
-            }
-        }
-
-        private void checkForApiKey() {
-            apiKeyService.authenticateWithApiKeyIfPresent(threadContext, ActionListener.wrap(authResult -> {
-                    if (authResult.isAuthenticated()) {
-                        final Authentication authentication = apiKeyService.createApiKeyAuthentication(authResult, nodeName);
-                        this.authenticatedBy = authentication.getAuthenticatedBy();
-                        writeAuthToContext(authentication);
-                    } else if (authResult.getStatus() == AuthenticationResult.Status.TERMINATE) {
-                        Exception e = (authResult.getException() != null) ? authResult.getException()
-                            : Exceptions.authenticationError(authResult.getMessage());
-                        logger.debug(new ParameterizedMessage("API key service terminated authentication for request [{}]", request), e);
-                        listener.onFailure(e);
-                    } else {
-                        if (authResult.getMessage() != null) {
-                            if (authResult.getException() != null) {
-                                logger.warn(new ParameterizedMessage("Authentication using apikey failed - {}", authResult.getMessage()),
-                                    authResult.getException());
-                            } else {
-                                logger.warn("Authentication using apikey failed - {}", authResult.getMessage());
-                            }
-                        }
-                        final AuthenticationToken token;
-                        try {
-                            token = extractToken();
-                        } catch (Exception e) {
-                            listener.onFailure(e);
-                            return;
-                        }
-                        consumeToken(token);
-                    }
-                },
-                e -> listener.onFailure(request.exceptionProcessingRequest(e, null))));
-        }
-
-        /**
-         * Looks to see if the request contains an existing {@link Authentication} and if so, that authentication will be used. The
-         * consumer is called if no exception was thrown while trying to read the authentication and may be called with a {@code null}
-         * value
-         */
-        private Authentication lookForExistingAuthentication() {
-            final Authentication authentication;
-            try {
-                authentication = authenticationSerializer.readFromContext(threadContext);
-            } catch (Exception e) {
-                logger.error((Supplier<?>)
-                        () -> new ParameterizedMessage("caught exception while trying to read authentication from request [{}]", request),
-                    e);
-                throw request.tamperedRequest();
-            }
-            if (authentication != null && request instanceof AuditableRestRequest) {
-                throw request.tamperedRequest();
-            }
-            return authentication;
-        }
-
-        /**
-         * Attempts to extract an {@link AuthenticationToken} from the request by iterating over the {@link Realms} and calling
-         * {@link Realm#token(ThreadContext)}. The first non-null token that is returned will be used. The consumer is only called if
-         * no exception was caught during the extraction process and may be called with a {@code null} token.
-         */
-        // pkg-private accessor testing token extraction with a consumer
-        AuthenticationToken extractToken() {
-            try {
-                if (authenticationToken != null) {
-                    return authenticationToken;
-                } else {
-                    for (Realm realm : defaultOrderedRealmList) {
-                        final AuthenticationToken token = realm.token(threadContext);
-                        if (token != null) {
-                            logger.trace("Found authentication credentials [{}] for principal [{}] in request [{}]",
-                                token.getClass().getName(), token.principal(), request);
-                            return token;
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                logger.warn("An exception occurred while attempting to find authentication credentials", e);
-                throw request.exceptionProcessingRequest(e, null);
-            }
-
-            return null;
-        }
-
-        /**
-         * Consumes the {@link AuthenticationToken} provided by the caller. In the case of a {@code null} token, {@link #handleNullToken()}
-         * is called. In the case of a {@code non-null} token, the realms are iterated over in the order defined in the configuration
-         * while possibly also taking into consideration the last realm that authenticated this principal. When consulting multiple realms,
-         * the first realm that returns a non-null {@link User} is the authenticating realm and iteration is stopped. This user is then
-         * passed to {@link #consumeUser(User, Map)} if no exception was caught while trying to authenticate the token
-         */
-        private void consumeToken(AuthenticationToken token) {
-            if (token == null) {
-                handleNullToken();
-            } else {
-                authenticationToken = token;
-                final List<Realm> realmsList = getRealmList(authenticationToken.principal());
-                logger.trace("Checking token of type [{}] against [{}] realm(s)", token.getClass().getName(), realmsList.size());
-                final long startInvalidation = numInvalidation.get();
-                final Map<Realm, Tuple<String, Exception>> messages = new LinkedHashMap<>();
-                final BiConsumer<Realm, ActionListener<User>> realmAuthenticatingConsumer = (realm, userListener) -> {
-                    if (realm.supports(authenticationToken)) {
-                        logger.trace("Trying to authenticate [{}] using realm [{}] with token [{}] ",
-                            token.principal(), realm, token.getClass().getName());
-                        realm.authenticate(authenticationToken, ActionListener.wrap((result) -> {
-                            assert result != null : "Realm " + realm + " produced a null authentication result";
-                            logger.debug("Authentication of [{}] using realm [{}] with token [{}] was [{}]",
-                                token.principal(), realm, token.getClass().getSimpleName(), result);
-                            if (result.getStatus() == AuthenticationResult.Status.SUCCESS) {
-                                // user was authenticated, populate the authenticated by information
-                                authenticatedBy = new RealmRef(realm.name(), realm.type(), nodeName);
-                                authenticationResult = result;
-                                if (lastSuccessfulAuthCache != null && startInvalidation == numInvalidation.get()) {
-                                    lastSuccessfulAuthCache.put(authenticationToken.principal(), realm);
-                                }
-                                userListener.onResponse(result.getUser());
-                            } else {
-                                // the user was not authenticated, call this so we can audit the correct event
-                                request.realmAuthenticationFailed(authenticationToken, realm.name());
-                                if (result.getStatus() == AuthenticationResult.Status.TERMINATE) {
-                                    if (result.getException() != null) {
-                                        logger.info(new ParameterizedMessage(
-                                                "Authentication of [{}] was terminated by realm [{}] - {}",
-                                                authenticationToken.principal(), realm.name(), result.getMessage()), result.getException());
-                                    } else {
-                                        logger.info("Authentication of [{}] was terminated by realm [{}] - {}",
-                                                authenticationToken.principal(), realm.name(), result.getMessage());
-                                    }
-                                    userListener.onFailure(result.getException());
-                                } else {
-                                    if (result.getMessage() != null) {
-                                        messages.put(realm, new Tuple<>(result.getMessage(), result.getException()));
-                                    }
-                                    userListener.onResponse(null);
-                                }
-                            }
-                        }, (ex) -> {
-                            logger.warn(new ParameterizedMessage(
-                                "An error occurred while attempting to authenticate [{}] against realm [{}]",
-                                authenticationToken.principal(), realm.name()), ex);
-                            userListener.onFailure(ex);
-                        }));
-                    } else {
-                        userListener.onResponse(null);
-                    }
-                };
-
-                final IteratingActionListener<User, Realm> authenticatingListener =
-                    new IteratingActionListener<>(ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(
-                        (user) -> consumeUser(user, messages),
-                        (e) -> {
-                            if (e != null) {
-                                listener.onFailure(request.exceptionProcessingRequest(e, token));
-                            } else {
-                                listener.onFailure(request.authenticationFailed(token));
-                            }
-                        }), threadContext),
-                        realmAuthenticatingConsumer, realmsList, threadContext);
-                try {
-                    authenticatingListener.run();
-                } catch (Exception e) {
-                    logger.debug(new ParameterizedMessage("Authentication of [{}] with token [{}] failed",
-                        token.principal(), token.getClass().getName()), e);
-                    listener.onFailure(request.exceptionProcessingRequest(e, token));
-                }
-            }
-        }
-
-        /**
-         * Possibly reorders the realm list depending on whether this principal has been recently authenticated by a specific realm
-         *
-         * @param principal The principal of the {@link AuthenticationToken} to be authenticated by a realm
-         * @return a list of realms ordered based on which realm should authenticate the current {@link AuthenticationToken}
-         */
-        private List<Realm> getRealmList(String principal) {
-            final List<Realm> orderedRealmList = this.defaultOrderedRealmList;
-            if (lastSuccessfulAuthCache != null) {
-                final Realm lastSuccess = lastSuccessfulAuthCache.get(principal);
-                if (lastSuccess != null) {
-                    final int index = orderedRealmList.indexOf(lastSuccess);
-                    if (index > 0) {
-                        final List<Realm> smartOrder = new ArrayList<>(orderedRealmList.size());
-                        smartOrder.add(lastSuccess);
-                        for (int i = 0; i < orderedRealmList.size(); i++) {
-                            if (i != index) {
-                                smartOrder.add(orderedRealmList.get(i));
-                            }
-                        }
-                        assert smartOrder.size() == orderedRealmList.size() && smartOrder.containsAll(orderedRealmList)
-                            : "Element mismatch between SmartOrder=" + smartOrder + " and DefaultOrder=" + orderedRealmList;
-                        return Collections.unmodifiableList(smartOrder);
-                    }
-                }
-            }
-            return orderedRealmList;
-        }
-
-        /**
-         * Handles failed extraction of an authentication token. This can happen in a few different scenarios:
-         *
-         * <ul>
-         * <li>this is an initial request from a client without preemptive authentication, so we must return an authentication
-         * challenge</li>
-         * <li>this is a request that contained an Authorization Header that we can't validate </li>
-         * <li>this is a request made internally within a node and there is a fallback user, which is typically the
-         * {@link SystemUser}</li>
-         * <li>anonymous access is enabled and this will be considered an anonymous request</li>
-         * </ul>
-         * <p>
-         * Regardless of the scenario, this method will call the listener with either failure or success.
-         */
-        // pkg-private for tests
-        void handleNullToken() {
-            List<Realm> unlicensedRealms = realms.getUnlicensedRealms();
-            if (unlicensedRealms.isEmpty() == false) {
-                logger.warn("No authentication credential could be extracted using realms [{}]." +
-                                " Realms [{}] were skipped because they are not permitted on the current license",
-                            Strings.collectionToCommaDelimitedString(defaultOrderedRealmList),
-                            Strings.collectionToCommaDelimitedString(unlicensedRealms));
-            }
-            final Authentication authentication;
-            if (fallbackUser != null) {
-                logger.trace("No valid credentials found in request [{}], using fallback [{}]", request, fallbackUser.principal());
-                RealmRef authenticatedBy = new RealmRef("__fallback", "__fallback", nodeName);
-                authentication = new Authentication(fallbackUser, authenticatedBy, null, Version.CURRENT, AuthenticationType.INTERNAL,
-                    Collections.emptyMap());
-            } else if (fallbackToAnonymous) {
-                logger.trace("No valid credentials found in request [{}], using anonymous [{}]", request, anonymousUser.principal());
-                RealmRef authenticatedBy = new RealmRef("__anonymous", "__anonymous", nodeName);
-                authentication = new Authentication(anonymousUser, authenticatedBy, null, Version.CURRENT, AuthenticationType.ANONYMOUS,
-                    Collections.emptyMap());
-            } else {
-                authentication = null;
-            }
-
-            if (authentication != null) {
-                writeAuthToContext(authentication);
-            } else {
-                logger.debug("No valid credentials found in request [{}], rejecting", request);
-                listener.onFailure(request.anonymousAccessDenied());
-            }
-        }
-
-        /**
-         * Consumes the {@link User} that resulted from attempting to authenticate a token against the {@link Realms}. When the user is
-         * {@code null}, authentication fails and does not proceed. When there is a user, the request is inspected to see if the run as
-         * functionality is in use. When run as is not in use, {@link #finishAuthentication(User)} is called, otherwise we try to lookup
-         * the run as user in {@link #lookupRunAsUser(User, String, Consumer)}
-         */
-        private void consumeUser(User user, Map<Realm, Tuple<String, Exception>> messages) {
-            if (user == null) {
-                messages.forEach((realm, tuple) -> {
-                    final String message = tuple.v1();
-                    final String cause = tuple.v2() == null ? "" : " (Caused by " + tuple.v2() + ")";
-                    logger.warn("Authentication to realm {} failed - {}{}", realm.name(), message, cause);
-                });
-                List<Realm> unlicensedRealms = realms.getUnlicensedRealms();
-                if (unlicensedRealms.isEmpty() == false) {
-                    logger.warn("Authentication failed using realms [{}]." +
-                            " Realms [{}] were skipped because they are not permitted on the current license",
-                        Strings.collectionToCommaDelimitedString(defaultOrderedRealmList),
-                        Strings.collectionToCommaDelimitedString(unlicensedRealms));
-                }
-                logger.trace("Failed to authenticate request [{}]", request);
-                listener.onFailure(request.authenticationFailed(authenticationToken));
-            } else {
-                threadContext.putTransient(AuthenticationResult.THREAD_CONTEXT_KEY, authenticationResult);
-                if (runAsEnabled) {
-                    final String runAsUsername = threadContext.getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
-                    if (runAsUsername != null && runAsUsername.isEmpty() == false) {
-                        lookupRunAsUser(user, runAsUsername, this::finishAuthentication);
-                    } else if (runAsUsername == null) {
-                        finishAuthentication(user);
-                    } else {
-                        assert runAsUsername.isEmpty() : "the run as username may not be empty";
-                        logger.debug("user [{}] attempted to runAs with an empty username", user.principal());
-                        listener.onFailure(request.runAsDenied(
-                            new Authentication(new User(runAsUsername, null, user), authenticatedBy, lookedupBy), authenticationToken));
-                    }
-                } else {
-                    finishAuthentication(user);
-                }
-            }
-        }
-
-        /**
-         * Iterates over the realms and attempts to lookup the run as user by the given username. The consumer will be called regardless of
-         * if the user is found or not, with a non-null user. We do not fail requests if the run as user is not found as that can leak the
-         * names of users that exist using a timing attack
-         */
-        private void lookupRunAsUser(final User user, String runAsUsername, Consumer<User> userConsumer) {
-            logger.trace("Looking up run-as user [{}] for authenticated user [{}]", runAsUsername, user.principal());
-            final RealmUserLookup lookup = new RealmUserLookup(getRealmList(runAsUsername), threadContext);
-            final long startInvalidationNum = numInvalidation.get();
-            lookup.lookup(runAsUsername, ActionListener.wrap(tuple -> {
-                if (tuple == null) {
-                    logger.debug("Cannot find run-as user [{}] for authenticated user [{}]", runAsUsername, user.principal());
-                    // the user does not exist, but we still create a User object, which will later be rejected by authz
-                    userConsumer.accept(new User(runAsUsername, null, user));
-                } else {
-                    User foundUser = Objects.requireNonNull(tuple.v1());
-                    Realm realm = Objects.requireNonNull(tuple.v2());
-                    lookedupBy = new RealmRef(realm.name(), realm.type(), nodeName);
-                    if (lastSuccessfulAuthCache != null && startInvalidationNum == numInvalidation.get()) {
-                        // only cache this as last success if it doesn't exist since this really isn't an auth attempt but
-                        // this might provide a valid hint
-                        lastSuccessfulAuthCache.computeIfAbsent(runAsUsername, s -> realm);
-                    }
-                    logger.trace("Using run-as user [{}] with authenticated user [{}]", foundUser, user.principal());
-                    userConsumer.accept(new User(foundUser, user));
-                }
-            }, exception -> listener.onFailure(request.exceptionProcessingRequest(exception, authenticationToken))));
-        }
-
-        /**
-         * Finishes the authentication process by ensuring the returned user is enabled and that the run as user is enabled if there is
-         * one. If authentication is successful, this method also ensures that the authentication is written to the ThreadContext
-         */
-        void finishAuthentication(User finalUser) {
-            if (finalUser.enabled() == false || finalUser.authenticatedUser().enabled() == false) {
-                // TODO: these should be different log messages if the runas vs auth user is disabled?
-                logger.debug("user [{}] is disabled. failing authentication", finalUser);
-                listener.onFailure(request.authenticationFailed(authenticationToken));
-            } else {
-                final Authentication finalAuth = new Authentication(finalUser, authenticatedBy, lookedupBy);
-                writeAuthToContext(finalAuth);
-            }
-        }
-
-        /**
-         * Writes the authentication to the {@link ThreadContext} and then calls the listener if
-         * successful
-         */
-        void writeAuthToContext(Authentication authentication) {
-            try {
-                authenticationSerializer.writeToContext(authentication, threadContext);
-                request.authenticationSuccess(authentication);
-                // Header for operator privileges will only be written if authentication actually happens,
-                // i.e. not read from either header or transient header
-                operatorPrivilegesService.maybeMarkOperatorUser(authentication, threadContext);
-            } catch (Exception e) {
-                logger.debug(
-                        new ParameterizedMessage("Failed to store authentication [{}] for request [{}]", authentication, request), e);
-                listener.onFailure(request.exceptionProcessingRequest(e, authenticationToken));
-                return;
-            }
-
-            logger.trace("Established authentication [{}] for request [{}]", authentication, request);
-            listener.onResponse(authentication);
-        }
-
     }
 
     abstract static class AuditableRequest {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Authenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Authenticator.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.user.User;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The Authenticator interface represents an authentication mechanism or a group of similar authentication mechanisms.
+ */
+public interface Authenticator {
+
+    /**
+     * A descriptive name of the authenticator.
+     */
+    String name();
+
+    /**
+     * Attempt to Extract an {@link AuthenticationToken} from the given {@link Context}.
+     * @param context The context object encapsulating current request and other information relevant for authentication.
+     *
+     * @return An {@link AuthenticationToken} if one can be extracted or null if this Authenticator cannot
+     *         extract one.
+     */
+    @Nullable
+    AuthenticationToken extractCredentials(Context context);
+
+    /**
+     * Whether authentication with anonymous or fallback user is allowed after this authenticator.
+     */
+    default boolean canBeFollowedByNullTokenHandler() {
+        return true;
+    }
+
+    /**
+     * Attempt to authenticate current request encapsulated by the {@link Context} object.
+     * @param context The context object encapsulating current request and other information relevant for authentication.
+     * @param listener The listener accepts a {@link Result} object indicating the outcome of authentication.
+     */
+    void authenticate(Context context, ActionListener<Result> listener);
+
+    static SecureString extractCredentialFromAuthorizationHeader(ThreadContext threadContext, String prefix) {
+        String header = threadContext.getHeader("Authorization");
+        final String prefixWithSpace = prefix + " ";
+        if (Strings.hasText(header)
+            && header.regionMatches(true, 0, prefixWithSpace, 0, prefixWithSpace.length())
+            && header.length() > prefixWithSpace.length()) {
+            char[] chars = new char[header.length() - prefixWithSpace.length()];
+            header.getChars(prefixWithSpace.length(), header.length(), chars, 0);
+            return new SecureString(chars);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the token from the <code>Authorization</code> header if the header begins with
+     * <code>Bearer </code>
+     */
+    static SecureString extractBearerTokenFromHeader(ThreadContext threadContext) {
+        return extractCredentialFromAuthorizationHeader(threadContext, "Bearer");
+    }
+
+    /**
+     * This class is a container to encapsulate the current request and other necessary information (mostly configuration related)
+     * required for authentication.
+     * It is instantiated for every incoming request and passed around to {@link AuthenticatorChain} and subsequently all
+     * {@link Authenticator}.
+     */
+    class Context implements Closeable {
+        private final ThreadContext threadContext;
+        private final AuthenticationService.AuditableRequest request;
+        private final User fallbackUser;
+        private final boolean allowAnonymous;
+        private final Realms realms;
+        private final List<AuthenticationToken> authenticationTokens = new ArrayList<>();
+        private final List<String> unsuccessfulMessages = new ArrayList<>();
+        private boolean handleNullToken = true;
+        private SecureString bearerString = null;
+        private List<Realm> defaultOrderedRealmList = null;
+        private List<Realm> unlicensedRealms = null;
+
+        public Context(
+            ThreadContext threadContext,
+            AuthenticationService.AuditableRequest request,
+            User fallbackUser,
+            boolean allowAnonymous,
+            Realms realms
+        ) {
+            this.threadContext = threadContext;
+            this.request = request;
+            this.fallbackUser = fallbackUser;
+            this.allowAnonymous = allowAnonymous;
+            this.realms = realms;
+        }
+
+        public ThreadContext getThreadContext() {
+            return threadContext;
+        }
+
+        public AuthenticationService.AuditableRequest getRequest() {
+            return request;
+        }
+
+        public User getFallbackUser() {
+            return fallbackUser;
+        }
+
+        public boolean isAllowAnonymous() {
+            return allowAnonymous;
+        }
+
+        public void setHandleNullToken(boolean value) {
+            handleNullToken = value;
+        }
+
+        public boolean shouldHandleNullToken() {
+            return handleNullToken;
+        }
+
+        public List<String> getUnsuccessfulMessages() {
+            return unsuccessfulMessages;
+        }
+
+        public void addAuthenticationToken(AuthenticationToken authenticationToken) {
+            authenticationTokens.add(authenticationToken);
+        }
+
+        @Nullable
+        public AuthenticationToken getMostRecentAuthenticationToken() {
+            return authenticationTokens.isEmpty() ? null : authenticationTokens.get(authenticationTokens.size() - 1);
+        }
+
+        public SecureString getBearerString() {
+            if (bearerString == null) {
+                bearerString = extractBearerTokenFromHeader(threadContext);
+            }
+            return bearerString;
+        }
+
+        public List<Realm> getDefaultOrderedRealmList() {
+            if (defaultOrderedRealmList == null) {
+                defaultOrderedRealmList = realms.getActiveRealms();
+            }
+            return defaultOrderedRealmList;
+        }
+
+        public List<Realm> getUnlicensedRealms() {
+            if (unlicensedRealms == null) {
+                unlicensedRealms = realms.getUnlicensedRealms();
+            }
+            return unlicensedRealms;
+        }
+
+        public void addUnsuccessfulMessage(String message) {
+            unsuccessfulMessages.add(message);
+        }
+
+        @Override
+        public void close() throws IOException {
+            authenticationTokens.forEach(AuthenticationToken::clearCredentials);
+        }
+    }
+
+    enum Status {
+        /**
+         * The authenticator successfully handled the authentication request
+         */
+        SUCCESS,
+        /**
+         * The authenticator tried to handle the authentication request but it was unsuccessful.
+         * Subsequent authenticators (if any) still have chance to attempt authentication.
+         */
+        UNSUCCESSFUL,
+        /**
+         * The authenticator did not handle the authentication request for reasons such as it cannot find necessary credentials
+         */
+        NOT_HANDLED
+    }
+
+    class Result {
+
+        private static final Result NOT_HANDLED =
+            new Result(Status.NOT_HANDLED, null, null, null);
+
+        private final Status status;
+        private final Authentication authentication;
+        private final String message;
+        private final Exception exception;
+
+        public Result(
+            Status status,
+            @Nullable Authentication authentication,
+            @Nullable String message,
+            @Nullable Exception exception) {
+            this.status = status;
+            this.authentication = authentication;
+            this.message = message;
+            this.exception = exception;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public Authentication getAuthentication() {
+            return authentication;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Exception getException() {
+            return exception;
+        }
+
+        public static Result success(Authentication authentication) {
+            Objects.requireNonNull(authentication);
+            return new Result(Status.SUCCESS, authentication, null, null);
+        }
+
+        public static Result notHandled() {
+            return NOT_HANDLED;
+        }
+
+        public static Result unsuccessful(
+            String message,
+            @Nullable Exception cause) {
+            Objects.requireNonNull(message);
+            return new Result(Status.UNSUCCESSFUL, null, message, cause);
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -72,7 +72,13 @@ class AuthenticatorChain {
     }
 
     void authenticateAsync(Authenticator.Context context, ActionListener<Authentication> listener) {
-        assert false == context.getDefaultOrderedRealmList().isEmpty() : "realm list must not be empty";
+        if (context.getDefaultOrderedRealmList().isEmpty()) {
+            // this happens when the license state changes between the call to authenticate and the actual invocation
+            // to get the realm list
+            logger.debug("No realms available, failing authentication");
+            listener.onResponse(null);
+            return;
+        }
         final Authentication authentication;
         try {
             authentication = lookForExistingAuthentication(context);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.xpack.core.common.IteratingActionListener;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
+import org.elasticsearch.xpack.core.security.user.AnonymousUser;
+import org.elasticsearch.xpack.core.security.user.SystemUser;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+class AuthenticatorChain {
+
+    private static final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
+
+    private final String nodeName;
+    private final boolean runAsEnabled;
+    private final OperatorPrivilegesService operatorPrivilegesService;
+    private final AnonymousUser anonymousUser;
+    private final boolean isAnonymousUserEnabled;
+    private final AuthenticationContextSerializer authenticationSerializer;
+    private final RealmsAuthenticator realmsAuthenticator;
+    private final List<Authenticator> allAuthenticators;
+
+    AuthenticatorChain(
+        Settings settings,
+        OperatorPrivilegesService operatorPrivilegesService,
+        AnonymousUser anonymousUser,
+        AuthenticationContextSerializer authenticationSerializer,
+        ServiceAccountAuthenticator serviceAccountAuthenticator,
+        OAuth2TokenAuthenticator oAuth2TokenAuthenticator,
+        ApiKeyAuthenticator apiKeyAuthenticator,
+        RealmsAuthenticator realmsAuthenticator
+    ) {
+        this.nodeName = Node.NODE_NAME_SETTING.get(settings);
+        this.runAsEnabled = AuthenticationServiceField.RUN_AS_ENABLED.get(settings);
+        this.operatorPrivilegesService = operatorPrivilegesService;
+        this.anonymousUser = anonymousUser;
+        this.isAnonymousUserEnabled = AnonymousUser.isAnonymousEnabled(settings);
+        this.authenticationSerializer = authenticationSerializer;
+        this.realmsAuthenticator = realmsAuthenticator;
+        this.allAuthenticators = org.elasticsearch.core.List.of(
+            serviceAccountAuthenticator,
+            oAuth2TokenAuthenticator,
+            apiKeyAuthenticator,
+            realmsAuthenticator
+        );
+    }
+
+    void authenticateAsync(Authenticator.Context context, ActionListener<Authentication> listener) {
+        assert false == context.getDefaultOrderedRealmList().isEmpty() : "realm list must not be empty";
+        final Authentication authentication;
+        try {
+            authentication = lookForExistingAuthentication(context);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        if (authentication != null) {
+            logger.trace("Found existing authentication [{}] in request [{}]", authentication, context.getRequest());
+            listener.onResponse(authentication);
+        } else {
+            doAuthenticate(context, true, ActionListener.runBefore(listener, context::close));
+        }
+    }
+
+    /**
+     * Similar to {@link #authenticateAsync} but without extracting credentials. The credentials should
+     * be prepared by the called and made available in the context before calling this method.
+     * This method currently uses a shorter chain to match existing behaviour. But there is no reason
+     * why this could not use the same chain.
+     */
+    void authenticateAsyncWithExistingCredentials(
+        Authenticator.Context context,
+        ActionListener<Authentication> listener) {
+        assert context.getMostRecentAuthenticationToken() != null : "existing authentication token must not be null";
+        context.setHandleNullToken(false);  // already has a token, should not try null token
+        doAuthenticate(context, false, listener);
+    }
+
+    private void doAuthenticate(
+        Authenticator.Context context,
+        boolean shouldExtractCredentials,
+        ActionListener<Authentication> listener
+    ) {
+        // The iterating listener walks through the list of Authenticators and attempts to authenticate using
+        // each Authenticator (and optionally asks it to extract the authenticationToken).
+        // Depending on the authentication result from each Authenticator, the iteration may stop earlier
+        // because of either a successful authentication or a not-continuable failure.
+        final IteratingActionListener<Authenticator.Result, Authenticator> iteratingActionListener = new IteratingActionListener<>(
+            ActionListener.wrap(result -> {
+                if (result.getStatus() == Authenticator.Status.SUCCESS) {
+                    maybeLookupRunAsUser(context, result.getAuthentication(), listener);
+                } else {
+                    if (context.shouldHandleNullToken()) {
+                        handleNullToken(context, listener);
+                    } else {
+                        listener.onFailure(Exceptions.authenticationError("failed to authenticate", result.getException()));
+                    }
+                }
+            }, listener::onFailure),
+            getAuthenticatorConsumer(context, shouldExtractCredentials),
+            allAuthenticators,
+            context.getThreadContext(),
+            Function.identity(),
+            result -> result.getStatus() == Authenticator.Status.UNSUCCESSFUL || result.getStatus() == Authenticator.Status.NOT_HANDLED);
+        iteratingActionListener.run();
+    }
+
+    private BiConsumer<Authenticator, ActionListener<Authenticator.Result>> getAuthenticatorConsumer(
+        Authenticator.Context context,
+        boolean shouldExtractCredentials
+    ) {
+        return (authenticator, listener) -> {
+            if (shouldExtractCredentials) {
+                final AuthenticationToken authenticationToken;
+                try {
+                    authenticationToken = authenticator.extractCredentials(context);
+                } catch (Exception e) {
+                    if (e instanceof ElasticsearchSecurityException) {
+                        listener.onFailure(e);
+                    } else { // other exceptions like illegal argument
+                        context.addUnsuccessfulMessage(authenticator.name() + ": " + e.getMessage());
+                        listener.onResponse(Authenticator.Result.unsuccessful(e.getMessage(), e));
+                    }
+                    return;
+                }
+                if (authenticationToken == null) {
+                    listener.onResponse(Authenticator.Result.notHandled());
+                    return;
+                }
+                context.addAuthenticationToken(authenticationToken);
+            }
+            context.setHandleNullToken(context.shouldHandleNullToken() && authenticator.canBeFollowedByNullTokenHandler());
+            authenticator.authenticate(context, ActionListener.wrap(result -> {
+                if (result.getStatus() == Authenticator.Status.UNSUCCESSFUL) {
+                    context.addUnsuccessfulMessage(authenticator.name() + ": " + result.getMessage());
+                }
+                listener.onResponse(result);
+            }, e -> {
+                if (e instanceof ElasticsearchSecurityException) {
+                    final ElasticsearchSecurityException ese = (ElasticsearchSecurityException) e;
+                    if (false == context.getUnsuccessfulMessages().isEmpty()) {
+                        addMetadata(context, ese);
+                    }
+                }
+                // Not adding additional metadata if the exception is not security related, e.g. server busy.
+                // Because (1) unlike security errors which are intentionally obscure, non-security errors are clear
+                // about their nature so that no additional information is needed; (2) Non-security errors may
+                // not inherit ElasticsearchException and thus does not have the addMetadata method.
+                listener.onFailure(e);
+            }));
+        };
+    }
+
+    private void maybeLookupRunAsUser(
+        Authenticator.Context context,
+        Authentication authentication,
+        ActionListener<Authentication> listener
+    ) {
+        // TODO: only allow run as for realm authentication to maintain the existing behaviour
+        if (false == runAsEnabled || authentication.getAuthenticationType() != Authentication.AuthenticationType.REALM) {
+            finishAuthentication(context, authentication, listener);
+            return;
+        }
+
+        final String runAsUsername = context.getThreadContext().getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
+        if (runAsUsername == null) {
+            finishAuthentication(context, authentication, listener);
+            return;
+        }
+
+        final User user = authentication.getUser();
+        if (runAsUsername.isEmpty()) {
+            logger.debug("user [{}] attempted to runAs with an empty username", user.principal());
+            listener.onFailure(context.getRequest()
+                .runAsDenied(new Authentication(new User(runAsUsername, null, user),
+                    authentication.getAuthenticatedBy(),
+                    null), context.getMostRecentAuthenticationToken()));
+            return;
+        }
+
+        // Now we have a valid runAsUsername
+        realmsAuthenticator.lookupRunAsUser(context, authentication, ActionListener.wrap(tuple -> {
+            final Authentication finalAuth;
+            if (tuple == null) {
+                logger.debug("Cannot find run-as user [{}] for authenticated user [{}]", runAsUsername, user.principal());
+                // the user does not exist, but we still create a User object, which will later be rejected by authz
+                finalAuth = new Authentication(new User(runAsUsername, null, user), authentication.getAuthenticatedBy(), null);
+            } else {
+                finalAuth = new Authentication(new User(tuple.v1(), user), authentication.getAuthenticatedBy(), tuple.v2());
+            }
+            finishAuthentication(context, finalAuth, listener);
+        }, listener::onFailure));
+    }
+
+    /**
+     * Looks to see if the request contains an existing {@link Authentication} and if so, that authentication will be used. The
+     * consumer is called if no exception was thrown while trying to read the authentication and may be called with a {@code null}
+     * value
+     */
+    private Authentication lookForExistingAuthentication(Authenticator.Context context) {
+        final Authentication authentication;
+        try {
+            authentication = authenticationSerializer.readFromContext(context.getThreadContext());
+        } catch (Exception e) {
+            logger.error(() -> new ParameterizedMessage(
+                "caught exception while trying to read authentication from request [{}]",
+                context.getRequest()), e);
+            throw context.getRequest().tamperedRequest();
+        }
+        if (authentication != null && context.getRequest() instanceof AuthenticationService.AuditableRestRequest) {
+            throw context.getRequest().tamperedRequest();
+        }
+        return authentication;
+    }
+
+    /**
+     * Handles failed extraction of an authentication token. This can happen in a few different scenarios:
+     *
+     * <ul>
+     * <li>this is an initial request from a client without preemptive authentication, so we must return an authentication
+     * challenge</li>
+     * <li>this is a request that contained an Authorization Header that we can't validate </li>
+     * <li>this is a request made internally within a node and there is a fallback user, which is typically the
+     * {@link SystemUser}</li>
+     * <li>anonymous access is enabled and this will be considered an anonymous request</li>
+     * </ul>
+     * <p>
+     * Regardless of the scenario, this method will call the listener with either failure or success.
+     */
+    // TODO: In theory, handleNullToken should not be called at all if any credentials is extracted
+    // pkg-private for tests
+    void handleNullToken(Authenticator.Context context, ActionListener<Authentication> listener) {
+        final Authentication authentication;
+        if (context.getFallbackUser() != null) {
+            // TODO: assert we really haven't extract any token
+            logger.trace(
+                "No valid credentials found in request [{}], using fallback [{}]",
+                context.getRequest(),
+                context.getFallbackUser().principal());
+            Authentication.RealmRef authenticatedBy = new Authentication.RealmRef("__fallback", "__fallback", nodeName);
+            authentication = new Authentication(context.getFallbackUser(),
+                authenticatedBy,
+                null,
+                Version.CURRENT,
+                Authentication.AuthenticationType.INTERNAL,
+                Collections.emptyMap());
+        } else if (shouldFallbackToAnonymous(context)) {
+            logger.trace(
+                "No valid credentials found in request [{}], using anonymous [{}]",
+                context.getRequest(),
+                anonymousUser.principal());
+            Authentication.RealmRef authenticatedBy = new Authentication.RealmRef("__anonymous", "__anonymous", nodeName);
+            authentication = new Authentication(anonymousUser,
+                authenticatedBy,
+                null,
+                Version.CURRENT,
+                Authentication.AuthenticationType.ANONYMOUS,
+                Collections.emptyMap());
+        } else {
+            authentication = null;
+        }
+
+        if (authentication != null) {
+            // TODO: we can also support run-as for fallback users if needed
+            // TODO: the authentication for fallback user is now serialised in the inner threadContext
+            //       instead of at the AuthenticationService level
+            writeAuthToContext(context, authentication, listener);
+        } else {
+            final ElasticsearchSecurityException ese = context.getRequest().anonymousAccessDenied();
+            if (false == context.getUnsuccessfulMessages().isEmpty()) {
+                logger.debug("Authenticating with null credentials is unsuccessful in request [{}]" +
+                    " after unsuccessful attempts of other credentials", context.getRequest());
+                final ElasticsearchSecurityException eseWithPreviousCredentials = new ElasticsearchSecurityException(
+                    "unable to authenticate with provided credentials and anonymous access is not allowed for this request",
+                    ese.status(), ese.getCause());
+                ese.getHeaderKeys().forEach(k -> eseWithPreviousCredentials.addHeader(k, ese.getHeader(k)));
+                addMetadata(context, eseWithPreviousCredentials);
+                listener.onFailure(eseWithPreviousCredentials);
+            } else {
+                logger.debug("No valid credentials found in request [{}], rejecting", context.getRequest());
+                listener.onFailure(ese);
+            }
+        }
+    }
+
+    /**
+     * Finishes the authentication process by ensuring the returned user is enabled and that the run as user is enabled if there is
+     * one. If authentication is successful, this method also ensures that the authentication is written to the ThreadContext
+     */
+    void finishAuthentication(Authenticator.Context context, Authentication authentication, ActionListener<Authentication> listener) {
+        if (authentication.getUser().enabled() == false || authentication.getUser().authenticatedUser().enabled() == false) {
+            // TODO: these should be different log messages if the runas vs auth user is disabled?
+            logger.debug("user [{}] is disabled. failing authentication", authentication.getUser());
+            listener.onFailure(context.getRequest().authenticationFailed(context.getMostRecentAuthenticationToken()));
+        } else {
+            writeAuthToContext(context, authentication, listener);
+        }
+    }
+
+    /**
+     * Writes the authentication to the {@link ThreadContext} and then calls the listener if
+     * successful
+     */
+    void writeAuthToContext(Authenticator.Context context, Authentication authentication, ActionListener<Authentication> listener) {
+        try {
+            authenticationSerializer.writeToContext(authentication, context.getThreadContext());
+            context.getRequest().authenticationSuccess(authentication);
+            // Header for operator privileges will only be written if authentication actually happens,
+            // i.e. not read from either header or transient header
+            operatorPrivilegesService.maybeMarkOperatorUser(authentication, context.getThreadContext());
+        } catch (Exception e) {
+            logger.debug(new ParameterizedMessage("Failed to store authentication [{}] for request [{}]",
+                authentication,
+                context.getRequest()), e);
+            final ElasticsearchSecurityException ese = context.getRequest().exceptionProcessingRequest(
+                e, context.getMostRecentAuthenticationToken());
+            addMetadata(context, ese);
+            listener.onFailure(ese);
+            return;
+        }
+        logger.trace("Established authentication [{}] for request [{}]", authentication, context.getRequest());
+        listener.onResponse(authentication);
+    }
+
+    private void addMetadata(Authenticator.Context context, ElasticsearchSecurityException ese) {
+        if (false == context.getUnsuccessfulMessages().isEmpty()) {
+            ese.addMetadata("es.additional_unsuccessful_credentials", context.getUnsuccessfulMessages());
+        }
+    }
+
+    /**
+     * Determines whether to support anonymous access for the current request. Returns {@code true} if all of the following are true
+     * <ul>
+     *     <li>The service has anonymous authentication enabled (see {@link #isAnonymousUserEnabled})</li>
+     *     <li>Anonymous access is accepted for this request ({@code allowAnonymousOnThisRequest} parameter)
+     *     <li>The {@link ThreadContext} does not provide API Key or Bearer Token credentials. If these are present, we
+     *     treat the request as though it attempted to authenticate (even if that failed), and will not fall back to anonymous.</li>
+     * </ul>
+     */
+    private boolean shouldFallbackToAnonymous(Authenticator.Context context) {
+        if (isAnonymousUserEnabled == false) {
+            return false;
+        }
+        if (context.isAllowAnonymous() == false) {
+            return false;
+        }
+        String header = context.getThreadContext().getHeader("Authorization");
+        if (Strings.hasText(header) &&
+            ((header.regionMatches(true, 0, "Bearer ", 0, "Bearer ".length()) && header.length() > "Bearer ".length()) ||
+                (header.regionMatches(true, 0, "ApiKey ", 0, "ApiKey ".length()) && header.length() > "ApiKey ".length()))) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/BearerToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/BearerToken.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+
+public class BearerToken implements AuthenticationToken {
+
+    private final SecureString bearerString;
+
+    public BearerToken(SecureString bearerString) {
+        this.bearerString = bearerString;
+    }
+
+    @Override
+    public String principal() {
+        return "_bearer_token";
+    }
+
+    @Override
+    public SecureString credentials() {
+        return bearerString;
+    }
+
+    @Override
+    public void clearCredentials() {
+        bearerString.close();
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/OAuth2TokenAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/OAuth2TokenAuthenticator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+
+class OAuth2TokenAuthenticator implements Authenticator {
+
+    private static final Logger logger = LogManager.getLogger(OAuth2TokenAuthenticator.class);
+    private final TokenService tokenService;
+
+    OAuth2TokenAuthenticator(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public String name() {
+        return "oauth2 token";
+    }
+
+    @Override
+    public AuthenticationToken extractCredentials(Context context) {
+        final SecureString bearerString = context.getBearerString();
+        return bearerString == null ? null : new BearerToken(bearerString);
+    }
+
+    @Override
+    public void authenticate(Context context, ActionListener<Authenticator.Result> listener) {
+        final AuthenticationToken authenticationToken = context.getMostRecentAuthenticationToken();
+        if (false == authenticationToken instanceof BearerToken) {
+            listener.onResponse(Authenticator.Result.notHandled());
+            return;
+        }
+        final BearerToken bearerToken = (BearerToken) authenticationToken;
+        tokenService.tryAuthenticateToken(bearerToken.credentials(), ActionListener.wrap(userToken -> {
+            if (userToken != null) {
+                listener.onResponse(Authenticator.Result.success(userToken.getAuthentication()));
+            } else {
+                listener.onResponse(Authenticator.Result.unsuccessful("invalid token", null));
+            }
+        }, e -> {
+            logger.debug(new ParameterizedMessage("Failed to validate token authentication for request [{}]", context.getRequest()), e);
+            if (e instanceof ElasticsearchSecurityException
+                && false == tokenService.isExpiredTokenException((ElasticsearchSecurityException) e)) {
+                // intentionally ignore the returned exception; we call this primarily
+                // for the auditing as we already have a purpose built exception
+                context.getRequest().tamperedRequest();
+            }
+            listener.onFailure(e);
+        }));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.common.IteratingActionListener;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.support.RealmUserLookup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+class RealmsAuthenticator implements Authenticator {
+
+    private static final Logger logger = LogManager.getLogger(RealmsAuthenticator.class);
+
+    private final String nodeName;
+    private final AtomicLong numInvalidation;
+    private final Cache<String, Realm> lastSuccessfulAuthCache;
+    private boolean authenticationTokenExtracted = false;
+
+    RealmsAuthenticator(
+        String nodeName, AtomicLong numInvalidation, Cache<String, Realm> lastSuccessfulAuthCache) {
+        this.nodeName = nodeName;
+        this.numInvalidation = numInvalidation;
+        this.lastSuccessfulAuthCache = lastSuccessfulAuthCache;
+    }
+
+    @Override
+    public String name() {
+        return "realms";
+    }
+
+    @Override
+    public AuthenticationToken extractCredentials(Context context) {
+        final AuthenticationToken authenticationToken = extractToken(context);
+        if (authenticationToken != null) {
+            authenticationTokenExtracted = true;
+        }
+        return authenticationToken;
+    }
+
+    @Override
+    public boolean canBeFollowedByNullTokenHandler() {
+        // TODO: once a token is extracted by realms, we should no longer handle null token if no realm can authenticate the token
+        return false == authenticationTokenExtracted;
+    }
+
+    @Override
+    public void authenticate(Context context, ActionListener<Result> listener) {
+        if (context.getMostRecentAuthenticationToken() == null) {
+            listener.onFailure(new ElasticsearchSecurityException(
+                "authentication token must present for realms authentication", RestStatus.UNAUTHORIZED));
+            return;
+        }
+        assert context.getMostRecentAuthenticationToken() != null : "null token should be handled by fallback authenticator";
+        consumeToken(context, listener);
+    }
+
+    /**
+     * Attempts to extract an {@link AuthenticationToken} from the request by iterating over the {@link Realms} and calling
+     * {@link Realm#token(ThreadContext)}. The first non-null token that is returned will be used. The consumer is only called if
+     * no exception was caught during the extraction process and may be called with a {@code null} token.
+     */
+    // pkg-private accessor testing token extraction with a consumer
+    AuthenticationToken extractToken(Context context) {
+        try {
+            for (Realm realm : context.getDefaultOrderedRealmList()) {
+                final AuthenticationToken token = realm.token(context.getThreadContext());
+                if (token != null) {
+                    logger.trace("Found authentication credentials [{}] for principal [{}] in request [{}]",
+                        token.getClass().getName(),
+                        token.principal(),
+                        context.getRequest());
+                    return token;
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("An exception occurred while attempting to find authentication credentials", e);
+            throw context.getRequest().exceptionProcessingRequest(e, null);
+        }
+        if (context.getUnlicensedRealms().isEmpty() == false) {
+            logger.warn(
+                "No authentication credential could be extracted using realms [{}]." +
+                    " Realms [{}] were skipped because they are not permitted on the current license",
+                Strings.collectionToCommaDelimitedString(context.getDefaultOrderedRealmList()),
+                Strings.collectionToCommaDelimitedString(context.getUnlicensedRealms()));
+        }
+        return null;
+    }
+
+    /**
+     * Consumes the {@link AuthenticationToken} provided by the caller.
+     * The realms are iterated over in the order defined in the configuration
+     * while possibly also taking into consideration the last realm that authenticated this principal. When consulting multiple realms,
+     * the first realm that returns a non-null {@link User} is the authenticating realm and iteration is stopped. This user is then
+     * is used to create authentication if no exception was caught while trying to authenticate the token
+     */
+    private void consumeToken(Context context, ActionListener<Result> listener) {
+        final AuthenticationToken authenticationToken = context.getMostRecentAuthenticationToken();
+        final List<Realm> realmsList = getRealmList(context, authenticationToken.principal());
+        logger.trace("Checking token of type [{}] against [{}] realm(s)",
+            authenticationToken.getClass().getName(), realmsList.size());
+
+        final long startInvalidation = numInvalidation.get();
+        final Map<Realm, Tuple<String, Exception>> messages = new LinkedHashMap<>();
+
+        final AtomicReference<Authentication.RealmRef> authenticatedByRef = new AtomicReference<>();
+        final AtomicReference<AuthenticationResult> authenticationResultRef = new AtomicReference<>();
+
+        final BiConsumer<Realm, ActionListener<User>> realmAuthenticatingConsumer = (realm, userListener) -> {
+            if (realm.supports(authenticationToken)) {
+                logger.trace("Trying to authenticate [{}] using realm [{}] with token [{}] ",
+                    authenticationToken.principal(),
+                    realm,
+                    authenticationToken.getClass().getName());
+                realm.authenticate(authenticationToken, ActionListener.wrap(result -> {
+                    assert result != null : "Realm " + realm + " produced a null authentication result";
+                    logger.debug("Authentication of [{}] using realm [{}] with token [{}] was [{}]",
+                        authenticationToken.principal(),
+                        realm,
+                        authenticationToken.getClass().getSimpleName(),
+                        result);
+                    if (result.getStatus() == AuthenticationResult.Status.SUCCESS) {
+                        // user was authenticated, populate the authenticated by information
+                        authenticatedByRef.set(new Authentication.RealmRef(realm.name(), realm.type(), nodeName));
+                        authenticationResultRef.set(result);
+                        if (lastSuccessfulAuthCache != null && startInvalidation == numInvalidation.get()) {
+                            lastSuccessfulAuthCache.put(authenticationToken.principal(), realm);
+                        }
+                        userListener.onResponse(result.getUser());
+                    } else {
+                        // the user was not authenticated, call this so we can audit the correct event
+                        context.getRequest().realmAuthenticationFailed(authenticationToken, realm.name());
+                        if (result.getStatus() == AuthenticationResult.Status.TERMINATE) {
+                            if (result.getException() != null) {
+                                logger.info(new ParameterizedMessage("Authentication of [{}] was terminated by realm [{}] - {}",
+                                    authenticationToken.principal(),
+                                    realm.name(),
+                                    result.getMessage()), result.getException());
+                            } else {
+                                logger.info("Authentication of [{}] was terminated by realm [{}] - {}",
+                                    authenticationToken.principal(),
+                                    realm.name(),
+                                    result.getMessage());
+                            }
+                            userListener.onFailure(result.getException());
+                        } else {
+                            if (result.getMessage() != null) {
+                                messages.put(realm, new Tuple<>(result.getMessage(), result.getException()));
+                            }
+                            userListener.onResponse(null);
+                        }
+                    }
+                }, (ex) -> {
+                    logger.warn(new ParameterizedMessage("An error occurred while attempting to authenticate [{}] against realm [{}]",
+                        authenticationToken.principal(),
+                        realm.name()), ex);
+                    userListener.onFailure(ex);
+                }));
+            } else {
+                userListener.onResponse(null);
+            }
+        };
+
+        final IteratingActionListener<User, Realm> authenticatingListener = new IteratingActionListener<>(
+            ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(
+                user -> {
+                    if (user == null) {
+                        consumeNullUser(context, messages, listener);
+                    } else {
+                        final AuthenticationResult result = authenticationResultRef.get();
+                        assert result != null : "authentication result must not be null when user is not null";
+                        context.getThreadContext().putTransient(AuthenticationResult.THREAD_CONTEXT_KEY, result);
+                        listener.onResponse(Authenticator.Result.success(
+                            new Authentication(user, authenticatedByRef.get(), null)));
+                    }
+                },
+                e -> {
+                    if (e != null) {
+                        listener.onFailure(context.getRequest().exceptionProcessingRequest(e, authenticationToken));
+                    } else {
+                        listener.onFailure(context.getRequest().authenticationFailed(authenticationToken));
+                    }
+                }), context.getThreadContext()),
+            realmAuthenticatingConsumer, realmsList, context.getThreadContext()
+        );
+        try {
+            authenticatingListener.run();
+        } catch (Exception e) {
+            logger.debug(
+                new ParameterizedMessage("Authentication of [{}] with token [{}] failed",
+                    authenticationToken.principal(),
+                    authenticationToken.getClass().getName()),
+                e);
+            listener.onFailure(context.getRequest().exceptionProcessingRequest(e, authenticationToken));
+        }
+    }
+
+    // This method assumes the RealmsAuthenticator is the last one in the chain and the whole chain fails if
+    // the request cannot be authenticated with the realms. If this is not true in the future, the method
+    // needs to be updated as well.
+    private void consumeNullUser(
+        Context context,
+        Map<Realm, Tuple<String, Exception>> messages,
+        ActionListener<Result> listener
+    ) {
+        messages.forEach((realm, tuple) -> {
+            final String message = tuple.v1();
+            final String cause = tuple.v2() == null ? "" : " (Caused by " + tuple.v2() + ")";
+            logger.warn("Authentication to realm {} failed - {}{}", realm.name(), message, cause);
+        });
+        if (context.getUnlicensedRealms().isEmpty() == false) {
+            logger.warn("Authentication failed using realms [{}]."
+                    + " Realms [{}] were skipped because they are not permitted on the current license",
+                Strings.collectionToCommaDelimitedString(context.getDefaultOrderedRealmList()),
+                Strings.collectionToCommaDelimitedString(context.getUnlicensedRealms()));
+        }
+        logger.trace("Failed to authenticate request [{}]", context.getRequest());
+        listener.onFailure(context.getRequest().authenticationFailed(context.getMostRecentAuthenticationToken()));
+    }
+
+    /**
+     * Iterates over the realms and attempts to lookup the run as user by the given username. The consumer will be called regardless of
+     * if the user is found or not, with a non-null user. We do not fail requests if the run as user is not found as that can leak the
+     * names of users that exist using a timing attack
+     */
+    public void lookupRunAsUser(
+        Context context,
+        Authentication authentication,
+        ActionListener<Tuple<User, Authentication.RealmRef>> listener
+    ) {
+        assert authentication.getLookedUpBy() == null : "authentication already has a lookup realm";
+        final String runAsUsername = context.getThreadContext().getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
+        if (runAsUsername != null && runAsUsername.isEmpty() == false) {
+            logger.trace("Looking up run-as user [{}] for authenticated user [{}]", runAsUsername, authentication.getUser().principal());
+            final RealmUserLookup lookup = new RealmUserLookup(getRealmList(context, runAsUsername), context.getThreadContext());
+            final long startInvalidationNum = numInvalidation.get();
+            lookup.lookup(runAsUsername, ActionListener.wrap(tuple -> {
+                if (tuple == null) {
+                    logger.debug("Cannot find run-as user [{}] for authenticated user [{}]",
+                        runAsUsername, authentication.getUser().principal());
+                    listener.onResponse(null);
+                } else {
+                    User foundUser = Objects.requireNonNull(tuple.v1());
+                    Realm realm = Objects.requireNonNull(tuple.v2());
+                    if (lastSuccessfulAuthCache != null && startInvalidationNum == numInvalidation.get()) {
+                        // only cache this as last success if it doesn't exist since this really isn't an auth attempt but
+                        // this might provide a valid hint
+                        lastSuccessfulAuthCache.computeIfAbsent(runAsUsername, s -> realm);
+                    }
+                    logger.trace("Using run-as user [{}] with authenticated user [{}]", foundUser, authentication.getUser().principal());
+                    listener.onResponse(
+                        new Tuple<>(tuple.v1(), new Authentication.RealmRef(tuple.v2().name(), tuple.v2().type(), nodeName)));
+                }
+            }, e -> listener.onFailure(context.getRequest().exceptionProcessingRequest(e, context.getMostRecentAuthenticationToken()))));
+        } else if (runAsUsername == null) {
+            listener.onResponse(null);
+        } else {
+            logger.debug("user [{}] attempted to runAs with an empty username", authentication.getUser().principal());
+            listener.onFailure(context.getRequest().runAsDenied(
+                new Authentication(new User(runAsUsername, null, authentication.getUser()), authentication.getAuthenticatedBy(), null),
+                context.getMostRecentAuthenticationToken()));
+        }
+    }
+
+    /**
+     * Possibly reorders the realm list depending on whether this principal has been recently authenticated by a specific realm
+     *
+     * @param principal The principal of the {@link AuthenticationToken} to be authenticated by a realm
+     * @return a list of realms ordered based on which realm should authenticate the current {@link AuthenticationToken}
+     */
+    private List<Realm> getRealmList(Context context, String principal) {
+        final List<Realm> orderedRealmList = context.getDefaultOrderedRealmList();
+        if (lastSuccessfulAuthCache != null) {
+            final Realm lastSuccess = lastSuccessfulAuthCache.get(principal);
+            if (lastSuccess != null) {
+                final int index = orderedRealmList.indexOf(lastSuccess);
+                if (index > 0) {
+                    final List<Realm> smartOrder = new ArrayList<>(orderedRealmList.size());
+                    smartOrder.add(lastSuccess);
+                    for (int i = 0; i < orderedRealmList.size(); i++) {
+                        if (i != index) {
+                            smartOrder.add(orderedRealmList.get(i));
+                        }
+                    }
+                    assert smartOrder.size() == orderedRealmList.size() && smartOrder.containsAll(orderedRealmList)
+                        : "Element mismatch between SmartOrder=" + smartOrder + " and DefaultOrder=" + orderedRealmList;
+                    return Collections.unmodifiableList(smartOrder);
+                }
+            }
+        }
+        return orderedRealmList;
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ServiceAccountAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ServiceAccountAuthenticator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
+
+class ServiceAccountAuthenticator implements Authenticator {
+
+    private static final Logger logger = LogManager.getLogger(ServiceAccountAuthenticator.class);
+    private final ServiceAccountService serviceAccountService;
+    private final String nodeName;
+
+    ServiceAccountAuthenticator(ServiceAccountService serviceAccountService, String nodeName) {
+        this.serviceAccountService = serviceAccountService;
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public String name() {
+        return "service account";
+    }
+
+    @Override
+    public AuthenticationToken extractCredentials(Context context) {
+        final SecureString bearerString = context.getBearerString();
+        if (bearerString == null) {
+            return null;
+        }
+        return ServiceAccountService.tryParseToken(bearerString);
+    }
+
+    @Override
+    public void authenticate(Context context, ActionListener<Authenticator.Result> listener) {
+        final AuthenticationToken authenticationToken = context.getMostRecentAuthenticationToken();
+        if (false == authenticationToken instanceof ServiceAccountToken) {
+            listener.onResponse(Authenticator.Result.notHandled());
+            return;
+        }
+        final ServiceAccountToken serviceAccountToken = (ServiceAccountToken) authenticationToken;
+        serviceAccountService.authenticateToken(serviceAccountToken, nodeName, ActionListener.wrap(authentication -> {
+            assert authentication != null : "service account authenticate should return either authentication or call onFailure";
+            listener.onResponse(Authenticator.Result.success(authentication));
+        }, e -> {
+            logger.debug(new ParameterizedMessage("Failed to validate service account token for request [{}]", context.getRequest()), e);
+            listener.onFailure(context.getRequest().exceptionProcessingRequest(e, serviceAccountToken));
+        }));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1703,21 +1703,6 @@ public final class TokenService {
         }
     }
 
-    /**
-     * Gets the token from the <code>Authorization</code> header if the header begins with
-     * <code>Bearer </code>
-     */
-    public SecureString extractBearerTokenFromHeader(ThreadContext threadContext) {
-        String header = threadContext.getHeader("Authorization");
-        if (Strings.hasText(header) && header.regionMatches(true, 0, "Bearer ", 0, "Bearer ".length())
-            && header.length() > "Bearer ".length()) {
-            char[] chars = new char[header.length() - "Bearer ".length()];
-            header.getChars("Bearer ".length(), header.length(), chars, 0);
-            return new SecureString(chars);
-        }
-        return null;
-    }
-
     String prependVersionAndEncodeAccessToken(Version version, String accessToken) throws IOException, GeneralSecurityException {
         if (version.onOrAfter(VERSION_ACCESS_TOKENS_AS_UUIDS)) {
             try (BytesStreamOutput out = new BytesStreamOutput(MINIMUM_BASE64_BYTES)) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -73,8 +73,7 @@ public class ServiceAccountService {
 
     /**
      * Parses a token object from the content of a {@link ServiceAccountToken#asBearerString()} bearer string}.
-     * This bearer string would typically be
-     * {@link org.elasticsearch.xpack.security.authc.TokenService#extractBearerTokenFromHeader extracted} from an HTTP authorization header.
+     * This bearer string would typically be extracted from an HTTP authorization header.
      *
      * <p>
      * <strong>This method does not validate the credential, it simply parses it.</strong>

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -232,8 +232,9 @@ public class ApiKeyServiceTests extends ESTestCase {
     }
 
     public void testGetCredentialsFromThreadContext() {
+        final ApiKeyService apiKeyService = createApiKeyService();
         ThreadContext threadContext = threadPool.getThreadContext();
-        assertNull(ApiKeyService.getCredentialsFromHeader(threadContext));
+        assertNull(apiKeyService.getCredentialsFromHeader(threadContext));
 
         final String apiKeyAuthScheme = randomFrom("apikey", "apiKey", "ApiKey", "APikey", "APIKEY");
         final String id = randomAlphaOfLength(12);
@@ -242,7 +243,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", headerValue);
-            ApiKeyService.ApiKeyCredentials creds = ApiKeyService.getCredentialsFromHeader(threadContext);
+            ApiKeyService.ApiKeyCredentials creds = apiKeyService.getCredentialsFromHeader(threadContext);
             assertNotNull(creds);
             assertEquals(id, creds.getId());
             assertEquals(key, creds.getKey().toString());
@@ -252,7 +253,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         headerValue = apiKeyAuthScheme + Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8));
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", headerValue);
-            ApiKeyService.ApiKeyCredentials creds = ApiKeyService.getCredentialsFromHeader(threadContext);
+            ApiKeyService.ApiKeyCredentials creds = apiKeyService.getCredentialsFromHeader(threadContext);
             assertNull(creds);
         }
 
@@ -261,7 +262,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", headerValue);
             IllegalArgumentException e =
-                expectThrows(IllegalArgumentException.class, () -> ApiKeyService.getCredentialsFromHeader(threadContext));
+                expectThrows(IllegalArgumentException.class, () -> apiKeyService.getCredentialsFromHeader(threadContext));
             assertEquals("invalid ApiKey value", e.getMessage());
         }
     }
@@ -439,7 +440,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             threadContext.putHeader("Authorization", header);
 
             final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-            service.authenticateWithApiKeyIfPresent(threadContext, future);
+            service.tryAuthenticate(threadContext, new ApiKeyCredentials(id, new SecureString(key.toCharArray())), future);
 
             final AuthenticationResult auth = future.get();
             assertThat(auth, notNullValue());
@@ -448,6 +449,7 @@ public class ApiKeyServiceTests extends ESTestCase {
     }
 
     public void testValidateApiKey() throws Exception {
+        final String apiKeyId = randomAlphaOfLength(12);
         final String apiKey = randomAlphaOfLength(16);
         Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
@@ -455,10 +457,9 @@ public class ApiKeyServiceTests extends ESTestCase {
         ApiKeyDoc apiKeyDoc = buildApiKeyDoc(hash, -1, false);
 
         ApiKeyService service = createApiKeyService(Settings.EMPTY);
-        ApiKeyService.ApiKeyCredentials creds =
-            new ApiKeyService.ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
+        service.validateApiKeyCredentials(apiKeyId, apiKeyDoc,
+            new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray())), Clock.systemUTC(), future);
         AuthenticationResult result = future.get();
         assertNotNull(result);
         assertTrue(result.isAuthenticated());
@@ -474,7 +475,8 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         apiKeyDoc = buildApiKeyDoc(hash, Clock.systemUTC().instant().plus(1L, ChronoUnit.HOURS).toEpochMilli(), false);
         future = new PlainActionFuture<>();
-        service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
+        service.validateApiKeyCredentials(apiKeyId, apiKeyDoc,
+            new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray())), Clock.systemUTC(), future);
         result = future.get();
         assertNotNull(result);
         assertTrue(result.isAuthenticated());
@@ -490,21 +492,25 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         apiKeyDoc = buildApiKeyDoc(hash, Clock.systemUTC().instant().minus(1L, ChronoUnit.HOURS).toEpochMilli(), false);
         future = new PlainActionFuture<>();
-        service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
+        service.validateApiKeyCredentials(apiKeyId, apiKeyDoc,
+            new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray())), Clock.systemUTC(), future);
         result = future.get();
         assertNotNull(result);
         assertFalse(result.isAuthenticated());
 
+        // key is invalidated
         apiKeyDoc = buildApiKeyDoc(hash, -1, true);
-        creds = new ApiKeyService.ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(randomAlphaOfLength(15).toCharArray()));
-        service.getApiKeyAuthCache().put(creds.getId(), new ListenableFuture<>());
-        assertNotNull(service.getApiKeyAuthCache().get(creds.getId()));
+        service.getApiKeyAuthCache().put(apiKeyId, new ListenableFuture<>());
+        assertNotNull(service.getApiKeyAuthCache().get(apiKeyId));
         future = new PlainActionFuture<>();
-        service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
+        service.validateApiKeyCredentials(apiKeyId, apiKeyDoc,
+            new ApiKeyCredentials(apiKeyId, new SecureString(randomAlphaOfLength(15).toCharArray())),
+            Clock.systemUTC(), future);
         result = future.get();
         assertNotNull(result);
         assertFalse(result.isAuthenticated());
-        assertNull(service.getApiKeyAuthCache().get(creds.getId()));
+        // make sure the cache is cleared
+        assertNull(service.getApiKeyAuthCache().get(apiKeyId));
     }
 
     public void testGetRolesForApiKeyNotInContext() throws Exception {
@@ -661,6 +667,7 @@ public class ApiKeyServiceTests extends ESTestCase {
     }
 
     public void testApiKeyCache() throws IOException {
+        final String apiKeyId = randomAlphaOfLength(12);
         final String apiKey = randomAlphaOfLength(16);
         Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
@@ -668,7 +675,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         ApiKeyDoc apiKeyDoc = buildApiKeyDoc(hash, -1, false);
 
         ApiKeyService service = createApiKeyService(Settings.EMPTY);
-        ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
+        ApiKeyCredentials creds = new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray()));
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         AuthenticationResult result = future.actionGet();
@@ -876,15 +883,15 @@ public class ApiKeyServiceTests extends ESTestCase {
             return invocationOnMock.callRealMethod();
         }).when(service).verifyKeyAgainstHash(any(String.class), any(ApiKeyCredentials.class), anyActionListener());
 
-        final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
+        final String apiKeyId = randomAlphaOfLength(12);
         final PlainActionFuture<AuthenticationResult> future1 = new PlainActionFuture<>();
 
         // Call the top level authenticate... method because it has been known to be buggy in async situations
-        writeCredentialsToThreadContext(creds);
-        mockSourceDocument(creds.getId(), sourceMap);
+        mockSourceDocument(apiKeyId, sourceMap);
 
         // This needs to be done in another thread, because we need it to not complete until we say so, but it should not block this test
-        this.threadPool.generic().execute(() -> service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future1));
+        this.threadPool.generic().execute(() -> service.tryAuthenticate(threadPool.getThreadContext(),
+            new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray())), future1));
 
         // Wait for the first credential validation to get to the blocked state
         assertBusy(() -> assertThat(hashCounter.get(), equalTo(1)));
@@ -896,7 +903,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         // The second authentication should pass (but not immediately, but will not block)
         PlainActionFuture<AuthenticationResult> future2 = new PlainActionFuture<>();
 
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future2);
+        service.tryAuthenticate(threadPool.getThreadContext(),
+            new ApiKeyCredentials(apiKeyId, new SecureString(apiKey.toCharArray())), future2);
 
         assertThat(hashCounter.get(), equalTo(1));
         if (future2.isDone()) {
@@ -914,7 +922,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(authResult2.isAuthenticated(), is(true));
         checkAuthApiKeyMetadata(metadata, authResult2);
 
-        CachedApiKeyHashResult cachedApiKeyHashResult = service.getFromCache(creds.getId());
+        CachedApiKeyHashResult cachedApiKeyHashResult = service.getFromCache(apiKeyId);
         assertNotNull(cachedApiKeyHashResult);
         assertThat(cachedApiKeyHashResult.success, is(true));
     }
@@ -1054,7 +1062,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Map<String, Object> metadata4 =
             mockKeyDocument(service, docId, apiKey, new User("hulk", "superuser"), false, Duration.ofSeconds(3600));
         PlainActionFuture<AuthenticationResult> future4 = new PlainActionFuture<>();
-        service.loadApiKeyAndValidateCredentials(threadContext, apiKeyCredentials, future4);
+        service.loadApiKeyAndValidateCredentials(threadContext,
+            new ApiKeyCredentials(docId, new SecureString(apiKey.toCharArray())), future4);
         verify(client, times(4)).get(any(GetRequest.class), anyActionListener());
         assertEquals(2, service.getRoleDescriptorsBytesCache().count());
         final AuthenticationResult authResult4 = future4.get();
@@ -1064,7 +1073,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         // 5. Cached entries will be used for the same API key doc
         SecurityMocks.mockGetRequestException(client, new EsRejectedExecutionException("rejected"));
         PlainActionFuture<AuthenticationResult> future5 = new PlainActionFuture<>();
-        service.loadApiKeyAndValidateCredentials(threadContext, apiKeyCredentials, future5);
+        service.loadApiKeyAndValidateCredentials(threadContext,
+            new ApiKeyCredentials(docId, new SecureString(apiKey.toCharArray())), future5);
         final AuthenticationResult authResult5 = future5.get();
         assertSame(AuthenticationResult.Status.SUCCESS, authResult5.getStatus());
         checkAuthApiKeyMetadata(metadata4, authResult5);
@@ -1105,11 +1115,10 @@ public class ApiKeyServiceTests extends ESTestCase {
     public void testAuthWillTerminateIfGetThreadPoolIsSaturated() throws ExecutionException, InterruptedException {
         final String apiKey = randomAlphaOfLength(16);
         final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
-        writeCredentialsToThreadContext(creds);
         SecurityMocks.mockGetRequestException(client, new EsRejectedExecutionException("rejected"));
         ApiKeyService service = createApiKeyService(Settings.EMPTY);
         final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future);
+        service.tryAuthenticate(threadPool.getThreadContext(), creds, future);
         final AuthenticationResult authenticationResult = future.get();
         assertEquals(AuthenticationResult.Status.TERMINATE, authenticationResult.getStatus());
         assertThat(authenticationResult.getMessage(), containsString("server is too busy to respond"));
@@ -1118,7 +1127,6 @@ public class ApiKeyServiceTests extends ESTestCase {
     public void testAuthWillTerminateIfHashingThreadPoolIsSaturated() throws IOException, ExecutionException, InterruptedException {
         final String apiKey = randomAlphaOfLength(16);
         final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
-        writeCredentialsToThreadContext(creds);
 
         Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
@@ -1134,7 +1142,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         ApiKeyService service = createApiKeyService(Settings.EMPTY);
         final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future);
+        service.tryAuthenticate(threadPool.getThreadContext(), creds, future);
         final AuthenticationResult authenticationResult = future.get();
         assertEquals(AuthenticationResult.Status.TERMINATE, authenticationResult.getStatus());
         assertThat(authenticationResult.getMessage(), containsString("server is too busy to respond"));
@@ -1160,20 +1168,20 @@ public class ApiKeyServiceTests extends ESTestCase {
     }
 
     public void testCachedApiKeyValidationWillNotBeBlockedByUnCachedApiKey() throws IOException, ExecutionException, InterruptedException {
+        final String apiKeyId1 = randomAlphaOfLength(12);
         final String apiKey1 = randomAlphaOfLength(16);
-        final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey1.toCharArray()));
-        writeCredentialsToThreadContext(creds);
+        final ApiKeyCredentials creds = new ApiKeyCredentials(apiKeyId1, new SecureString(apiKey1.toCharArray()));
 
         Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey1.toCharArray()));
         Map<String, Object> sourceMap = buildApiKeySourceDoc(hash);
         final Object metadata = sourceMap.get("metadata_flattened");
-        mockSourceDocument(creds.getId(), sourceMap);
+        mockSourceDocument(apiKeyId1, sourceMap);
 
         // Authenticate the key once to cache it
         ApiKeyService service = createApiKeyService(Settings.EMPTY);
         final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future);
+        service.tryAuthenticate(threadPool.getThreadContext(), creds, future);
         final AuthenticationResult authenticationResult = future.get();
         assertEquals(AuthenticationResult.Status.SUCCESS, authenticationResult.getStatus());
         checkAuthApiKeyMetadata(metadata,authenticationResult);
@@ -1188,22 +1196,21 @@ public class ApiKeyServiceTests extends ESTestCase {
         }).when(mockExecutorService).execute(any(Runnable.class));
 
         // A new API key trying to connect that must go through full hash computation
+        final String apiKeyId2 = randomAlphaOfLength(12);
         final String apiKey2 = randomAlphaOfLength(16);
-        final ApiKeyCredentials creds2 = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey2.toCharArray()));
-        mockSourceDocument(creds2.getId(), buildApiKeySourceDoc(hasher.hash(new SecureString(apiKey2.toCharArray()))));
+        final ApiKeyCredentials creds2 = new ApiKeyCredentials(apiKeyId2, new SecureString(apiKey2.toCharArray()));
+        mockSourceDocument(apiKeyId2, buildApiKeySourceDoc(hasher.hash(new SecureString(apiKey2.toCharArray()))));
         final PlainActionFuture<AuthenticationResult> future2 = new PlainActionFuture<>();
-        final ThreadContext.StoredContext storedContext = threadPool.getThreadContext().stashContext();
-        writeCredentialsToThreadContext(creds2);
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future2);
+        service.tryAuthenticate(threadPool.getThreadContext(), creds2, future2);
         final AuthenticationResult authenticationResult2 = future2.get();
         assertEquals(AuthenticationResult.Status.TERMINATE, authenticationResult2.getStatus());
         assertThat(authenticationResult2.getMessage(), containsString("server is too busy to respond"));
 
         // The cached API key should not be affected
-        mockSourceDocument(creds.getId(), sourceMap);
+        mockSourceDocument(apiKeyId1, sourceMap);
         final PlainActionFuture<AuthenticationResult> future3 = new PlainActionFuture<>();
-        storedContext.restore();
-        service.authenticateWithApiKeyIfPresent(threadPool.getThreadContext(), future3);
+        service.tryAuthenticate(threadPool.getThreadContext(),
+            new ApiKeyCredentials(apiKeyId1, new SecureString(apiKey1.toCharArray())), future3);
         final AuthenticationResult authenticationResult3 = future3.get();
         assertEquals(AuthenticationResult.Status.SUCCESS, authenticationResult3.getStatus());
         checkAuthApiKeyMetadata(metadata, authenticationResult3);
@@ -1373,6 +1380,11 @@ public class ApiKeyServiceTests extends ESTestCase {
                     Collections.singleton(new RoleDescriptor("user_role_" + randomAlphaOfLength(4), new String[]{"manage"}, null, null)),
                     null, Version.CURRENT);
         }
+    }
+
+    private ApiKeyService createApiKeyService() {
+        final Settings settings = Settings.builder().put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true).build();
+        return createApiKeyService(settings);
     }
 
     private ApiKeyService createApiKeyService(Settings baseSettings) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -92,7 +92,6 @@ import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
-import org.elasticsearch.xpack.security.authc.AuthenticationService.Authenticator;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
@@ -101,6 +100,7 @@ import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -136,12 +136,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.atLeastOnce;
@@ -307,51 +309,81 @@ public class AuthenticationServiceTests extends ESTestCase {
     public void testTokenFirstMissingSecondFound() throws Exception {
         when(firstRealm.token(threadContext)).thenReturn(null);
         when(secondRealm.token(threadContext)).thenReturn(token);
+        when(firstRealm.supports(token)).thenReturn(false);
+        when(secondRealm.supports(token)).thenReturn(true);
+        final User user = new User(randomAlphaOfLength(8));
+        final AuthenticationResult authenticationResult = AuthenticationResult.success(user);
+        doAnswer(invocationOnMock -> {
+            final Object[] arguments = invocationOnMock.getArguments();
+            assertThat(arguments[0], is(token));
+            @SuppressWarnings("unchecked") final ActionListener<AuthenticationResult> listener =
+                (ActionListener<AuthenticationResult>) arguments[1];
+            listener.onResponse(authenticationResult);
+            return null;
+        }).when(secondRealm).authenticate(eq(token), anyActionListener());
 
-        PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-        Authenticator authenticator = service.createAuthenticator("_action", transportRequest, true, future);
-        AuthenticationToken result = authenticator.extractToken();
-        assertThat(result, notNullValue());
-        assertThat(result, is(token));
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        service.authenticate("action", transportRequest, true, ActionListener.wrap(authentication -> {
+            assertThat(threadContext.getTransient(AuthenticationResult.THREAD_CONTEXT_KEY), is(authenticationResult));
+            assertThat(threadContext.getTransient(AuthenticationField.AUTHENTICATION_KEY), is(authentication));
+            verify(auditTrail).authenticationSuccess(anyString(), eq(authentication), eq("action"), eq(transportRequest));
+            setCompletedToTrue(completed);
+        }, this::logAndFail));
+        assertThat(completed.get(), is(true));
         verifyZeroInteractions(auditTrail);
     }
 
     public void testTokenMissing() throws Exception {
-        final Logger unlicensedRealmsLogger = LogManager.getLogger(AuthenticationService.class);
+        final Logger unlicensedRealmsLogger = LogManager.getLogger(RealmsAuthenticator.class);
         final MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
         try {
             Loggers.addAppender(unlicensedRealmsLogger, mockAppender);
             mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation(
                 "unlicensed realms",
-                AuthenticationService.class.getName(), Level.WARN,
+                RealmsAuthenticator.class.getName(), Level.WARN,
                 "No authentication credential could be extracted using realms [file_realm/file]. " +
                     "Realms [second_realm/second] were skipped because they are not permitted on the current license"
             ));
 
-            Mockito.doReturn(Arrays.asList(secondRealm)).when(realms).getUnlicensedRealms();
-            Mockito.doReturn(Arrays.asList(firstRealm)).when(realms).getActiveRealms();
-            boolean requestIdAlreadyPresent = randomBoolean();
+            Mockito.doReturn(org.elasticsearch.core.List.of(secondRealm)).when(realms).getUnlicensedRealms();
+            Mockito.doReturn(org.elasticsearch.core.List.of(firstRealm)).when(realms).getActiveRealms();
             SetOnce<String> reqId = new SetOnce<>();
+
+            final boolean requestIdAlreadyPresent = randomBoolean();
             if (requestIdAlreadyPresent) {
                 reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
             }
-            PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-            Authenticator authenticator = service.createAuthenticator("_action", transportRequest, true, future);
-            AuthenticationToken token = authenticator.extractToken();
-            assertThat(token, nullValue());
-            if (requestIdAlreadyPresent) {
-                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-            } else {
-                reqId.set(expectAuditRequestId(threadContext));
-            }
-            authenticator.handleNullToken();
+            // requestId is always generated for rest request and should not already have it
+            final boolean isRestRequest = randomBoolean() && false == requestIdAlreadyPresent;
 
-            ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> future.actionGet());
-            assertThat(e.getMessage(), containsString("missing authentication credentials"));
-            verify(auditTrail).anonymousAccessDenied(reqId.get(), "_action", transportRequest);
-            verifyNoMoreInteractions(auditTrail);
-            mockAppender.assertAllExpectationsMatched();
+            final AtomicBoolean completed = new AtomicBoolean(false);
+            final ActionListener<Authentication> listener = ActionListener.wrap(authentication -> {
+                fail("should not reach here");
+            }, e -> {
+                if (requestIdAlreadyPresent) {
+                    assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+                } else {
+                    reqId.set(expectAuditRequestId(threadContext));
+                }
+                assertThat(e, isA(ElasticsearchSecurityException.class));
+                assertThat(e.getMessage(), containsString("missing authentication credentials"));
+                if (isRestRequest) {
+                    verify(auditTrail).anonymousAccessDenied(reqId.get(), restRequest);
+                } else {
+                    verify(auditTrail).anonymousAccessDenied(reqId.get(), "_action", transportRequest);
+                }
+                verifyNoMoreInteractions(auditTrail);
+                mockAppender.assertAllExpectationsMatched();
+                setCompletedToTrue(completed);
+            });
+
+            if (isRestRequest) {
+                service.authenticate(restRequest, true, listener);
+            } else {
+                service.authenticate("_action", transportRequest, true, listener);
+            }
+            assertThat(completed.get(), is(true));
         } finally {
             Loggers.removeAppender(unlicensedRealmsLogger, mockAppender);
             mockAppender.stop();
@@ -634,42 +666,31 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
 
-        Tuple<Authentication, String> result = authenticateBlocking("_action", transportRequest, null);
-
-        if (requestIdAlreadyPresent) {
-            assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        }
-        assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-        assertThat(result, notNullValue());
-        assertThat(result.v1(), is(authentication));
-        assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.REALM));
-        verifyZeroInteractions(auditTrail);
-        verifyZeroInteractions(firstRealm, secondRealm);
-        verifyZeroInteractions(operatorPrivilegesService);
+        authenticateBlocking("_action", transportRequest, null, result -> {
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            }
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            assertThat(result, notNullValue());
+            assertThat(result.v1(), is(authentication));
+            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.REALM));
+            verifyZeroInteractions(auditTrail);
+            verifyZeroInteractions(firstRealm, secondRealm);
+            verifyZeroInteractions(operatorPrivilegesService);
+        });
     }
 
     public void testAuthenticateNonExistentRestRequestUserThrowsAuthenticationException() throws Exception {
         when(firstRealm.token(threadContext)).thenReturn(new UsernamePasswordToken("idonotexist",
                 new SecureString("passwd".toCharArray())));
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("Authentication was successful but should not");
         } catch (ElasticsearchSecurityException e) {
             expectAuditRequestId(threadContext);
             assertAuthenticationException(e, containsString("unable to authenticate user [idonotexist] for REST request [/]"));
             verifyZeroInteractions(operatorPrivilegesService);
         }
-    }
-
-    public void testTokenRestMissing() throws Exception {
-        when(firstRealm.token(threadContext)).thenReturn(null);
-        when(secondRealm.token(threadContext)).thenReturn(null);
-
-        @SuppressWarnings("unchecked")
-        Authenticator authenticator = service.createAuthenticator(restRequest, true, mock(ActionListener.class));
-        AuthenticationToken token = authenticator.extractToken();
-        expectAuditRequestId(threadContext);
-        assertThat(token, nullValue());
     }
 
     public void testAuthenticationInContextAndHeader() throws Exception {
@@ -708,7 +729,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("expected an authentication exception when trying to authenticate an anonymous message");
         } catch (ElasticsearchSecurityException e) {
             // expected
@@ -727,7 +748,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(firstRealm.token(threadContext)).thenReturn(null);
         when(secondRealm.token(threadContext)).thenReturn(null);
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("expected an authentication exception when trying to authenticate an anonymous message");
         } catch (ElasticsearchSecurityException e) {
             // expected
@@ -747,18 +768,17 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
 
-        Tuple<Authentication, String> result = authenticateBlocking("_action", transportRequest, user1);
-        if (requestIdAlreadyPresent) {
-            assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        } else {
-            reqId.set(expectAuditRequestId(threadContext));
-        }
-        assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-        assertThat(result, notNullValue());
-        assertThat(result.v1().getUser(), sameInstance(user1));
-        assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.INTERNAL));
-        assertThreadContextContainsAuthentication(result.v1());
-        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        authenticateBlocking("_action", transportRequest, user1, result -> {
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            }
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            assertThat(result, notNullValue());
+            assertThat(result.v1().getUser(), sameInstance(user1));
+            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.INTERNAL));
+            assertThreadContextContainsAuthentication(result.v1());
+            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        });
     }
 
     public void testAuthenticateTransportDisabledUser() throws Exception {
@@ -774,7 +794,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(firstRealm, token, user);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback, null));
         if (requestIdAlreadyPresent) {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
         } else {
@@ -793,7 +813,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(firstRealm, token, user);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking(restRequest));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking(restRequest, null));
         String reqId = expectAuditRequestId(threadContext);
         verify(auditTrail).authenticationFailed(reqId, token, restRequest);
         verifyNoMoreInteractions(auditTrail);
@@ -986,7 +1006,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
         try {
-            authenticateBlocking("_action", message, randomBoolean() ? SystemUser.INSTANCE : null);
+            authenticateBlocking("_action", message, randomBoolean() ? SystemUser.INSTANCE : null, null);
         } catch (Exception e) {
             //expected
             if (requestIdAlreadyPresent) {
@@ -1021,7 +1041,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             threadContext.putHeader("Authorization", "Bearer thisisaninvalidtoken");
             ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             } else {
@@ -1063,7 +1083,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             threadContext.putHeader("Authorization", "ApiKey dGhpc2lzYW5pbnZhbGlkaWQ6dGhpc2lzYW5pbnZhbGlkc2VjcmV0");
             ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             } else {
@@ -1090,16 +1110,16 @@ public class AuthenticationServiceTests extends ESTestCase {
             threadPool, anonymousUser, tokenService, apiKeyService, serviceAccountService, operatorPrivilegesService);
         RestRequest request = new FakeRestRequest();
 
-        Tuple<Authentication, String> result = authenticateBlocking(request);
-
-        assertThat(result, notNullValue());
-        assertThat(result.v1().getUser(), sameInstance((Object) anonymousUser));
-        assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.ANONYMOUS));
-        assertThreadContextContainsAuthentication(result.v1());
-        assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-        verify(auditTrail).authenticationSuccess(result.v2(), result.v1(), request);
-        verifyNoMoreInteractions(auditTrail);
-        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        authenticateBlocking(request, result -> {
+            assertThat(result, notNullValue());
+            assertThat(result.v1().getUser(), sameInstance((Object) anonymousUser));
+            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.ANONYMOUS));
+            assertThreadContextContainsAuthentication(result.v1());
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            verify(auditTrail).authenticationSuccess(result.v2(), result.v1(), request);
+            verifyNoMoreInteractions(auditTrail);
+            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        });
     }
 
     public void testAuthenticateRestRequestDisallowAnonymous() throws Exception {
@@ -1146,18 +1166,16 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
 
-        Tuple<Authentication, String> result = authenticateBlocking("_action", message, null);
-        if (requestIdAlreadyPresent) {
-            assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        } else {
-            reqId.set(expectAuditRequestId(threadContext));
-        }
-        assertThat(result, notNullValue());
-        assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-        assertThat(result.v1().getUser(), sameInstance(anonymousUser));
-        assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.ANONYMOUS));
-        assertThreadContextContainsAuthentication(result.v1());
-        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        authenticateBlocking("_action", message, null, result -> {
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            }
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            assertThat(result.v1().getUser(), sameInstance(anonymousUser));
+            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.ANONYMOUS));
+            assertThreadContextContainsAuthentication(result.v1());
+            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        });
     }
 
     public void testAnonymousUserTransportWithDefaultUser() throws Exception {
@@ -1176,18 +1194,17 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
 
-        Tuple<Authentication, String> result = authenticateBlocking("_action", message, SystemUser.INSTANCE);
-        if (requestIdAlreadyPresent) {
-            assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        } else {
-            reqId.set(expectAuditRequestId(threadContext));
-        }
-        assertThat(result, notNullValue());
-        assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-        assertThat(result.v1().getUser(), sameInstance(SystemUser.INSTANCE));
-        assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.INTERNAL));
-        assertThreadContextContainsAuthentication(result.v1());
-        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        authenticateBlocking("_action", message, SystemUser.INSTANCE, result -> {
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            }
+            assertThat(result, notNullValue());
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            assertThat(result.v1().getUser(), sameInstance(SystemUser.INSTANCE));
+            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.INTERNAL));
+            assertThreadContextContainsAuthentication(result.v1());
+            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+        });
     }
 
     public void testRealmTokenThrowingException() throws Exception {
@@ -1198,7 +1215,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         }
         when(firstRealm.token(threadContext)).thenThrow(authenticationError("realm doesn't like tokens"));
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like tokens"));
@@ -1215,7 +1232,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     public void testRealmTokenThrowingExceptionRest() throws Exception {
         when(firstRealm.token(threadContext)).thenThrow(authenticationError("realm doesn't like tokens"));
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like tokens"));
@@ -1232,7 +1249,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.supports(token)).thenThrow(authenticationError("realm doesn't like supports"));
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like supports"));
@@ -1247,7 +1264,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.token(threadContext)).thenReturn(token);
         when(secondRealm.supports(token)).thenThrow(authenticationError("realm doesn't like supports"));
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like supports"));
@@ -1282,7 +1299,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(secondRealm, token, throwE, true);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null, null));
         if (throwElasticsearchSecurityException) {
             assertThat(e.getMessage(), is("authentication error"));
             if (withAuthenticateHeader) {
@@ -1320,7 +1337,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(firstRealm, token, null, true);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null, null));
             assertThat(e.getMessage(), is("unable to authenticate user [" + principal + "] for action [_action]"));
             assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
         if (requestIdAlreadyPresent) {
@@ -1347,7 +1364,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like authenticate"));
@@ -1369,7 +1386,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         doThrow(authenticationError("realm doesn't like authenticate"))
                 .when(secondRealm).authenticate(eq(token), anyActionListener());
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchSecurityException e) {
             assertThat(e.getMessage(), is("realm doesn't like authenticate"));
@@ -1395,7 +1412,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
         }
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't want to lookup"));
@@ -1420,7 +1437,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         doThrow(authenticationError("realm doesn't want to lookup"))
                 .when(secondRealm).lookupUser(eq("run_as"), anyActionListener());
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't want to lookup"));
@@ -1551,7 +1568,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(secondRealm, token, user);
 
         try {
-            authenticateBlocking(restRequest);
+            authenticateBlocking(restRequest, null);
             fail("exception should be thrown");
         } catch (ElasticsearchException e) {
             String reqId = expectAuditRequestId(threadContext);
@@ -1576,7 +1593,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(secondRealm, token, user);
 
         try {
-            authenticateBlocking("_action", transportRequest, null);
+            authenticateBlocking("_action", transportRequest, null, null);
             fail("exception should be thrown");
         } catch (ElasticsearchException e) {
             if (requestIdAlreadyPresent) {
@@ -1612,7 +1629,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         }).when(secondRealm).lookupUser(eq("run_as"), anyActionListener());
         User fallback = randomBoolean() ? SystemUser.INSTANCE : null;
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback, null));
         if (requestIdAlreadyPresent) {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
         } else {
@@ -1640,7 +1657,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         }).when(secondRealm).lookupUser(eq("run_as"), anyActionListener());
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking(restRequest));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking(restRequest, null));
         String reqId = expectAuditRequestId(threadContext);
         verify(auditTrail).authenticationFailed(reqId, token, restRequest);
         verifyNoMoreInteractions(auditTrail);
@@ -1790,7 +1807,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             threadContext.putHeader("Authorization", "Bearer " + token);
             ElasticsearchSecurityException e =
-                    expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+                    expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             }
@@ -1810,12 +1827,17 @@ public class AuthenticationServiceTests extends ESTestCase {
             final String invalidHeader = randomFrom("apikey", "apikey ", "apikey foo");
             threadContext.putHeader("Authorization", invalidHeader);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
-                () -> authenticateBlocking("_action", transportRequest, null));
+                () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             }
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
-            assertThat(e.getMessage(), containsString("missing authentication credentials"));
+            if (invalidHeader.equals("apikey foo")) {
+                assertThat(e.getMessage(), containsString(
+                    "unable to authenticate with provided credentials and anonymous access is not allowed for this request"));
+            } else {
+                assertThat(e.getMessage(), containsString("missing authentication credentials"));
+            }
             verifyZeroInteractions(operatorPrivilegesService);
         }
     }
@@ -1865,16 +1887,17 @@ public class AuthenticationServiceTests extends ESTestCase {
                 reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
             }
             threadContext.putHeader("Authorization", headerValue);
-            Tuple <Authentication, String> result = authenticateBlocking("_action", transportRequest, null);
-            if (requestIdAlreadyPresent) {
-                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-            }
-            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-            assertThat(result.v1().getUser().principal(), is("johndoe"));
-            assertThat(result.v1().getUser().fullName(), is("john doe"));
-            assertThat(result.v1().getUser().email(), is("john@doe.com"));
-            assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.API_KEY));
-            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+            authenticateBlocking("_action", transportRequest, null, result -> {
+                if (requestIdAlreadyPresent) {
+                    assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+                }
+                assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+                assertThat(result.v1().getUser().principal(), is("johndoe"));
+                assertThat(result.v1().getUser().fullName(), is("john doe"));
+                assertThat(result.v1().getUser().email(), is("john@doe.com"));
+                assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.API_KEY));
+                verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+            });
         }
     }
 
@@ -1919,7 +1942,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             threadContext.putHeader("Authorization", headerValue);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
-                () -> authenticateBlocking("_action", transportRequest, null));
+                () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             }
@@ -1950,15 +1973,16 @@ public class AuthenticationServiceTests extends ESTestCase {
                 listener.onResponse(authentication);
                 return null;
             }).when(serviceAccountService).authenticateToken(any(), any(), any());
-            final Tuple<Authentication, String> result = authenticateBlocking("_action", transportRequest, null);
-            if (requestIdAlreadyPresent) {
-                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-            }
-            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
-            assertThat(result.v1(), is(authentication));
-            verify(auditTrail).authenticationSuccess(eq(result.v2()), same(authentication), eq("_action"), same(transportRequest));
-            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
-            verifyNoMoreInteractions(auditTrail);
+            authenticateBlocking("_action", transportRequest, null, result -> {
+                if (requestIdAlreadyPresent) {
+                    assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+                }
+                assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+                assertThat(result.v1(), is(authentication));
+                verify(auditTrail).authenticationSuccess(eq(result.v2()), same(authentication), eq("_action"), same(transportRequest));
+                verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+                verifyNoMoreInteractions(auditTrail);
+            });
         }
     }
 
@@ -1980,7 +2004,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 return null;
             }).when(serviceAccountService).authenticateToken(any(), any(), any());
             final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
-                () -> authenticateBlocking("_action", transportRequest, null));
+                () -> authenticateBlocking("_action", transportRequest, null, null));
             if (requestIdAlreadyPresent) {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             } else {
@@ -1989,20 +2013,31 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(e, sameInstance(bailOut));
             verifyZeroInteractions(operatorPrivilegesService);
             final ServiceAccountToken serviceToken = ServiceAccountToken.fromBearerString(new SecureString(bearerString.toCharArray()));
-            verify(auditTrail).authenticationFailed(eq(reqId.get()), eq(serviceToken), eq("_action"), eq(transportRequest));
+            verify(auditTrail).authenticationFailed(eq(reqId.get()),
+                argThat(new ArgumentMatcher<AuthenticationToken>() {
+                    @Override
+                    public boolean matches(Object o) {
+                        return ((ServiceAccountToken) o).getTokenId().equals(serviceToken.getTokenId());
+                    }
+                }),
+                eq("_action"), eq(transportRequest));
         }
     }
 
-    private static class InternalRequest extends TransportRequest {
+    static class InternalRequest extends TransportRequest {
         @Override
         public void writeTo(StreamOutput out) {}
     }
 
-    void assertThreadContextContainsAuthentication(Authentication authentication) throws IOException {
+    void assertThreadContextContainsAuthentication(Authentication authentication) {
         Authentication contextAuth = threadContext.getTransient(AuthenticationField.AUTHENTICATION_KEY);
         assertThat(contextAuth, notNullValue());
         assertThat(contextAuth, is(authentication));
-        assertThat(threadContext.getHeader(AuthenticationField.AUTHENTICATION_KEY), equalTo((Object) authentication.encode()));
+        try {
+            assertThat(threadContext.getHeader(AuthenticationField.AUTHENTICATION_KEY), equalTo((Object) authentication.encode()));
+        } catch (IOException e) {
+            fail("should not error");
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -2041,13 +2076,17 @@ public class AuthenticationServiceTests extends ESTestCase {
         }).when(realm).authenticate(eq(token), anyActionListener());
     }
 
-    private Tuple<Authentication, String> authenticateBlocking(RestRequest restRequest) {
+    private void authenticateBlocking(RestRequest restRequest,
+                                      Consumer<Tuple<Authentication, String>> verifier) {
         SetOnce<String> reqId = new SetOnce<>();
         PlainActionFuture<Authentication> future = new PlainActionFuture<Authentication>() {
             @Override
             public void onResponse(Authentication result) {
                 reqId.set(expectAuditRequestId(threadContext));
                 assertThat(new AuthenticationContextSerializer().getAuthentication(threadContext), is(result));
+                if (verifier != null) {
+                    verifier.accept(new Tuple<>(result, reqId.get()));
+                }
                 super.onResponse(result);
             }
 
@@ -2058,18 +2097,21 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
         };
         service.authenticate(restRequest, future);
-        Authentication authentication = future.actionGet();
+        future.actionGet();
         assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        return new Tuple<>(authentication, reqId.get());
     }
 
-    private Tuple<Authentication, String> authenticateBlocking(String action, TransportRequest transportRequest, User fallbackUser) {
+    private void authenticateBlocking(String action, TransportRequest transportRequest, User fallbackUser,
+                                      Consumer<Tuple<Authentication, String>> verifier) {
         SetOnce<String> reqId = new SetOnce<>();
         PlainActionFuture<Authentication> future = new PlainActionFuture<Authentication>() {
             @Override
             public void onResponse(Authentication result) {
                 reqId.set(expectAuditRequestId(threadContext));
                 assertThat(new AuthenticationContextSerializer().getAuthentication(threadContext), is(result));
+                if (verifier != null) {
+                    verifier.accept(new Tuple<>(result, reqId.get()));
+                }
                 super.onResponse(result);
             }
 
@@ -2084,9 +2126,8 @@ public class AuthenticationServiceTests extends ESTestCase {
         } else {
             service.authenticate(action, transportRequest, fallbackUser, future);
         }
-        Authentication authentication = future.actionGet();
+        future.actionGet();
         assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
-        return new Tuple<>(authentication, reqId.get());
     }
 
     private static String expectAuditRequestId(ThreadContext threadContext) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.user.AnonymousUser;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.ApiKeyService.ApiKeyCredentials;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
+import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class AuthenticatorChainTests extends ESTestCase {
+
+    private ThreadContext threadContext;
+    private Realms realms;
+    private OperatorPrivilegesService operatorPrivilegesService;
+    private AnonymousUser anonymousUser;
+    private AuthenticationContextSerializer authenticationContextSerializer;
+    private ServiceAccountAuthenticator serviceAccountAuthenticator;
+    private OAuth2TokenAuthenticator oAuth2TokenAuthenticator;
+    private ApiKeyAuthenticator apiKeyAuthenticator;
+    private RealmsAuthenticator realmsAuthenticator;
+    private Authentication authentication;
+    private User fallbackUser;
+    private AuthenticatorChain authenticatorChain;
+
+    @Before
+    public void init() {
+        final Settings settings = Settings.builder()
+            .put(Node.NODE_NAME_SETTING.getKey(), randomAlphaOfLength(8))
+            .put(AuthenticationServiceField.RUN_AS_ENABLED.getKey(), "true")
+            .put(AnonymousUser.USERNAME_SETTING.getKey(), "anonymous")
+            .put(AnonymousUser.ROLES_SETTING.getKey(), "anonymous_role")
+            .build();
+        threadContext = new ThreadContext(settings);
+        realms = mock(Realms.class);
+        operatorPrivilegesService = mock(OperatorPrivilegesService.class);
+        anonymousUser = mock(AnonymousUser.class);
+
+        authenticationContextSerializer = mock(AuthenticationContextSerializer.class);
+        serviceAccountAuthenticator = mock(ServiceAccountAuthenticator.class);
+        oAuth2TokenAuthenticator = mock(OAuth2TokenAuthenticator.class);
+        apiKeyAuthenticator = mock(ApiKeyAuthenticator.class);
+        realmsAuthenticator = mock(RealmsAuthenticator.class);
+        when(serviceAccountAuthenticator.canBeFollowedByNullTokenHandler()).thenReturn(true);
+        when(oAuth2TokenAuthenticator.canBeFollowedByNullTokenHandler()).thenReturn(true);
+        when(apiKeyAuthenticator.canBeFollowedByNullTokenHandler()).thenReturn(true);
+        when(realmsAuthenticator.canBeFollowedByNullTokenHandler()).thenCallRealMethod();
+        when(realms.getActiveRealms()).thenReturn(List.of(mock(Realm.class)));
+        when(realms.getUnlicensedRealms()).thenReturn(List.of());
+        final User user = new User(randomAlphaOfLength(8));
+        authentication = mock(Authentication.class);
+        when(authentication.getUser()).thenReturn(user);
+        fallbackUser = mock(User.class);
+        authenticatorChain = new AuthenticatorChain(settings,
+            operatorPrivilegesService,
+            anonymousUser,
+            authenticationContextSerializer,
+            serviceAccountAuthenticator,
+            oAuth2TokenAuthenticator,
+            apiKeyAuthenticator,
+            realmsAuthenticator);
+    }
+
+    public void testAuthenticateWillLookForExistingAuthenticationFirst() throws IOException {
+        final Authenticator.Context context = createAuthenticatorContext(mock(AuthenticationService.AuditableTransportRequest.class));
+        when(authenticationContextSerializer.readFromContext(any())).thenReturn(authentication);
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(future.actionGet(), is(authentication));
+        verifyZeroInteractions(serviceAccountAuthenticator);
+        verifyZeroInteractions(oAuth2TokenAuthenticator);
+        verifyZeroInteractions(apiKeyAuthenticator);
+        verifyZeroInteractions(realmsAuthenticator);
+        verify(authenticationContextSerializer, never()).writeToContext(any(), any());
+        verifyZeroInteractions(operatorPrivilegesService);
+    }
+
+    public void testAuthenticateFailsIfExistingAuthenticationFoundForRestRequest() throws IOException {
+        final AuthenticationService.AuditableRestRequest auditableRestRequest = mock(AuthenticationService.AuditableRestRequest.class);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(auditableRestRequest.tamperedRequest()).thenReturn(e);
+        final Authenticator.Context context = createAuthenticatorContext(auditableRestRequest);
+        when(authenticationContextSerializer.readFromContext(any())).thenReturn(mock(Authentication.class));
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(expectThrows(ElasticsearchSecurityException.class, future::actionGet), is(e));
+    }
+
+    public void testAuthenticateWithServiceAccount() throws IOException {
+        final Authenticator.Context context = createAuthenticatorContext();
+        when(serviceAccountAuthenticator.extractCredentials(context)).thenReturn(mock(ServiceAccountToken.class));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Authenticator.Result> listener = (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+            listener.onResponse(Authenticator.Result.success(authentication));
+            return null;
+        }).when(serviceAccountAuthenticator).authenticate(eq(context), any());
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(future.actionGet(), is(authentication));
+        verifyZeroInteractions(oAuth2TokenAuthenticator);
+        verifyZeroInteractions(apiKeyAuthenticator);
+        verifyZeroInteractions(realmsAuthenticator);
+        verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
+        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
+    }
+
+    public void testAuthenticateWithOAuth2Token() throws IOException {
+        final Authenticator.Context context = createAuthenticatorContext();
+        when(oAuth2TokenAuthenticator.extractCredentials(context)).thenReturn(mock(BearerToken.class));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Authenticator.Result> listener = (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+            listener.onResponse(Authenticator.Result.success(authentication));
+            return null;
+        }).when(oAuth2TokenAuthenticator).authenticate(eq(context), any());
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(future.actionGet(), is(authentication));
+        verify(serviceAccountAuthenticator).extractCredentials(eq(context));
+        verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
+        verifyZeroInteractions(apiKeyAuthenticator);
+        verifyZeroInteractions(realmsAuthenticator);
+        verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
+        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
+    }
+
+    public void testAuthenticateWithApiKey() throws IOException {
+        final Authenticator.Context context = createAuthenticatorContext();
+        when(apiKeyAuthenticator.extractCredentials(context)).thenReturn(
+            new ApiKeyCredentials(randomAlphaOfLength(20), new SecureString(randomAlphaOfLength(22).toCharArray())));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Authenticator.Result> listener = (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+            listener.onResponse(Authenticator.Result.success(authentication));
+            return null;
+        }).when(apiKeyAuthenticator).authenticate(eq(context), any());
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(future.actionGet(), is(authentication));
+        verify(serviceAccountAuthenticator).extractCredentials(eq(context));
+        verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
+        verify(oAuth2TokenAuthenticator).extractCredentials(eq(context));
+        verify(oAuth2TokenAuthenticator, never()).authenticate(eq(context), any());
+        verifyZeroInteractions(realmsAuthenticator);
+        verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
+        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
+    }
+
+    public void testAuthenticateWithRealms() throws IOException {
+        final Authenticator.Context context = createAuthenticatorContext();
+        when(realmsAuthenticator.extractCredentials(context)).thenReturn(mock(AuthenticationToken.class));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Authenticator.Result> listener = (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+            listener.onResponse(Authenticator.Result.success(authentication));
+            return null;
+        }).when(realmsAuthenticator).authenticate(eq(context), any());
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        assertThat(future.actionGet(), is(authentication));
+        verify(serviceAccountAuthenticator).extractCredentials(eq(context));
+        verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
+        verify(oAuth2TokenAuthenticator).extractCredentials(eq(context));
+        verify(oAuth2TokenAuthenticator, never()).authenticate(eq(context), any());
+        verify(apiKeyAuthenticator).extractCredentials(eq(context));
+        verify(apiKeyAuthenticator, never()).authenticate(eq(context), any());
+        verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
+        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
+    }
+
+    public void testAuthenticateFallbackAndAnonymous() throws IOException {
+        final boolean hasFallbackUser = randomBoolean();
+        final Authenticator.Context context;
+        if (hasFallbackUser) {
+            context = createAuthenticatorContext(fallbackUser);
+        } else {
+            context = createAuthenticatorContext();
+        }
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+
+        authenticatorChain.authenticateAsync(context, future);
+        final Authentication authentication = future.actionGet();
+        assertThat(authentication.getUser(), is(hasFallbackUser ? fallbackUser : anonymousUser));
+        verify(serviceAccountAuthenticator).extractCredentials(eq(context));
+        verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
+        verify(oAuth2TokenAuthenticator).extractCredentials(eq(context));
+        verify(oAuth2TokenAuthenticator, never()).authenticate(eq(context), any());
+        verify(apiKeyAuthenticator).extractCredentials(eq(context));
+        verify(apiKeyAuthenticator, never()).authenticate(eq(context), any());
+        verify(realmsAuthenticator).extractCredentials(eq(context));
+        verify(realmsAuthenticator, never()).authenticate(eq(context), any());
+        verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
+        verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
+    }
+
+    public void testUnsuccessfulOAuth2TokenOrApiKeyWillNotFallToAnonymousOrReportMissingCredentials() {
+        final boolean unsuccessfulApiKey = randomBoolean();
+        final AuthenticationService.AuditableRequest auditableRequest = mock(AuthenticationService.AuditableRequest.class);
+        when(auditableRequest.anonymousAccessDenied()).thenReturn(new ElasticsearchSecurityException("fail"));
+        final Authenticator.Context context = new Authenticator.Context(threadContext, auditableRequest, null, true, realms);
+        threadContext.putHeader("Authorization", unsuccessfulApiKey ? "ApiKey key_id:key_secret" : "Bearer some_token_value");
+        if (unsuccessfulApiKey) {
+            when(apiKeyAuthenticator.extractCredentials(context)).thenReturn(
+                new ApiKeyCredentials(randomAlphaOfLength(20), new SecureString(randomAlphaOfLength(22).toCharArray())));
+            doAnswer(invocationOnMock -> {
+                @SuppressWarnings("unchecked") final ActionListener<Authenticator.Result> listener =
+                    (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+                listener.onResponse(Authenticator.Result.unsuccessful("unsuccessful api key", null));
+                return null;
+            }).when(apiKeyAuthenticator).authenticate(eq(context), any());
+        } else {
+            when(oAuth2TokenAuthenticator.extractCredentials(context)).thenReturn(mock(BearerToken.class));
+            doAnswer(invocationOnMock -> {
+                @SuppressWarnings("unchecked") final ActionListener<Authenticator.Result> listener =
+                    (ActionListener<Authenticator.Result>) invocationOnMock.getArguments()[1];
+                listener.onResponse(Authenticator.Result.unsuccessful("unsuccessful bearer token", null));
+                return null;
+            }).when(oAuth2TokenAuthenticator).authenticate(eq(context), any());
+        }
+
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.authenticateAsync(context, future);
+        final ElasticsearchSecurityException e =
+            expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        assertThat(e.getMessage(), containsString("" +
+            "unable to authenticate with provided credentials and anonymous access is not allowed for this request"));
+        assertThat(e.getMetadata("es.additional_unsuccessful_credentials"),
+            hasItem(containsString(unsuccessfulApiKey ? "unsuccessful api key" : "unsuccessful bearer token")));
+    }
+
+    private Authenticator.Context createAuthenticatorContext() {
+        return createAuthenticatorContext(mock(AuthenticationService.AuditableRequest.class));
+    }
+
+    private Authenticator.Context createAuthenticatorContext(AuthenticationService.AuditableRequest request) {
+        return createAuthenticatorContext(request, null);
+    }
+
+    private Authenticator.Context createAuthenticatorContext(User fallbackUser) {
+        return new Authenticator.Context(threadContext, mock(AuthenticationService.AuditableRequest.class), fallbackUser, true, realms);
+    }
+
+    private Authenticator.Context createAuthenticatorContext(AuthenticationService.AuditableRequest request, User fallbackUser) {
+        return new Authenticator.Context(threadContext, request, fallbackUser, true, realms);
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPriv
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
@@ -79,8 +78,8 @@ public class AuthenticatorChainTests extends ESTestCase {
         when(oAuth2TokenAuthenticator.canBeFollowedByNullTokenHandler()).thenReturn(true);
         when(apiKeyAuthenticator.canBeFollowedByNullTokenHandler()).thenReturn(true);
         when(realmsAuthenticator.canBeFollowedByNullTokenHandler()).thenCallRealMethod();
-        when(realms.getActiveRealms()).thenReturn(List.of(mock(Realm.class)));
-        when(realms.getUnlicensedRealms()).thenReturn(List.of());
+        when(realms.getActiveRealms()).thenReturn(org.elasticsearch.core.List.of(mock(Realm.class)));
+        when(realms.getUnlicensedRealms()).thenReturn(org.elasticsearch.core.List.of());
         final User user = new User(randomAlphaOfLength(8));
         authentication = mock(Authentication.class);
         when(authentication.getUser()).thenReturn(user);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RealmsAuthenticatorTests extends ESTestCase {
+
+    private ThreadContext threadContext;
+    private Realms realms;
+    private Realm realm1;
+    private Realm realm2;
+    private Realm realm3;
+    private AuthenticationService.AuditableRequest request;
+    private AuthenticationToken authenticationToken;
+    private String username;
+    private User user;
+    private AtomicLong numInvalidation;
+    private Cache<String, Realm> lastSuccessfulAuthCache;
+    private String nodeName;
+    private RealmsAuthenticator realmsAuthenticator;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void init() throws Exception {
+        threadContext = new ThreadContext(Settings.EMPTY);
+
+        realms = mock(Realms.class);
+        realm1 = mock(Realm.class);
+        when(realm1.name()).thenReturn("realm1");
+        when(realm1.type()).thenReturn("realm1");
+        when(realm1.toString()).thenReturn("realm1/realm1");
+        realm2 = mock(Realm.class);
+        when(realm2.name()).thenReturn("realm2");
+        when(realm2.type()).thenReturn("realm2");
+        when(realm2.toString()).thenReturn("realm2/realm2");
+        realm3 = mock(Realm.class);
+        when(realm3.toString()).thenReturn("realm3/realm3");
+        when(realms.getActiveRealms()).thenReturn(List.of(realm1, realm2));
+        when(realms.getUnlicensedRealms()).thenReturn(List.of(realm3));
+
+        request = randomBoolean() ?
+            mock(AuthenticationService.AuditableRestRequest.class) :
+            mock(AuthenticationService.AuditableTransportRequest.class);
+        authenticationToken = mock(AuthenticationToken.class);
+        username = randomAlphaOfLength(5);
+        when(authenticationToken.principal()).thenReturn(username);
+        user = new User(username);
+
+        nodeName = randomAlphaOfLength(8);
+        numInvalidation = new AtomicLong();
+        lastSuccessfulAuthCache = mock(Cache.class);
+        realmsAuthenticator = new RealmsAuthenticator(nodeName, numInvalidation, lastSuccessfulAuthCache);
+    }
+
+    public void testExtractCredentials() {
+        if (randomBoolean()) {
+            when(realm1.token(threadContext)).thenReturn(authenticationToken);
+        } else {
+            when(realm2.token(threadContext)).thenReturn(authenticationToken);
+        }
+        assertThat(realmsAuthenticator.extractCredentials(createAuthenticatorContext()), is(authenticationToken));
+    }
+
+    public void testWillAuditOnCredentialsExtractionFailure() {
+        final RuntimeException cause = new RuntimeException("fail");
+        final ElasticsearchSecurityException wrapped = new ElasticsearchSecurityException("wrapped");
+        when(request.exceptionProcessingRequest(cause, null)).thenReturn(wrapped);
+        doThrow(cause).when(randomBoolean() ? realm1 : realm2).token(threadContext);
+        assertThat(expectThrows(ElasticsearchSecurityException.class,
+            () -> realmsAuthenticator.extractCredentials(createAuthenticatorContext())), is(wrapped));
+    }
+
+    public void testAuthenticate() {
+        when(lastSuccessfulAuthCache.get(username)).thenReturn(randomFrom(realm1, realm2, null));
+
+        final Realm successfulRealm, unsuccessfulRealm;
+        if (randomBoolean()) {
+            successfulRealm = realm1;
+            unsuccessfulRealm = realm2;
+        } else {
+            successfulRealm = realm2;
+            unsuccessfulRealm = realm1;
+        }
+
+        when(successfulRealm.supports(authenticationToken)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked") final ActionListener<AuthenticationResult> listener =
+                (ActionListener<AuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(AuthenticationResult.success(user));
+            return null;
+        }).when(successfulRealm).authenticate(eq(authenticationToken), any());
+
+        when(unsuccessfulRealm.supports(authenticationToken)).thenReturn(randomBoolean());
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked") final ActionListener<AuthenticationResult> listener =
+                (ActionListener<AuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(AuthenticationResult.unsuccessful("unsuccessful", null));
+            return null;
+        }).when(unsuccessfulRealm).authenticate(eq(authenticationToken), any());
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(authenticationToken);
+        final PlainActionFuture<Authenticator.Result> future = new PlainActionFuture<>();
+        realmsAuthenticator.authenticate(context, future);
+        final Authenticator.Result result = future.actionGet();
+        assertThat(result.getStatus(), is(Authenticator.Status.SUCCESS));
+        final Authentication authentication = result.getAuthentication();
+        assertThat(authentication.getUser(), is(user));
+        assertThat(authentication.getAuthenticatedBy(),
+            equalTo(new Authentication.RealmRef(successfulRealm.name(), successfulRealm.type(), nodeName)));
+    }
+
+    public void testNullUser() throws IllegalAccessException {
+        if (randomBoolean()) {
+            when(realm1.supports(authenticationToken)).thenReturn(true);
+            configureRealmAuthResponse(realm1, AuthenticationResult.unsuccessful("unsuccessful", null));
+        } else {
+            when(realm1.supports(authenticationToken)).thenReturn(false);
+        }
+
+        if (randomBoolean()) {
+            when(realm2.supports(authenticationToken)).thenReturn(true);
+            configureRealmAuthResponse(realm2, AuthenticationResult.unsuccessful("unsuccessful", null));
+        } else {
+            when(realm2.supports(authenticationToken)).thenReturn(false);
+        }
+
+        final Authenticator.Context context = createAuthenticatorContext();
+        context.addAuthenticationToken(authenticationToken);
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.authenticationFailed(authenticationToken)).thenReturn(e);
+
+        final Logger unlicensedRealmsLogger = LogManager.getLogger(RealmsAuthenticator.class);
+        final MockLogAppender mockAppender = new MockLogAppender();
+        mockAppender.start();
+        try {
+            mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                "unlicensed realms",
+                RealmsAuthenticator.class.getName(), Level.WARN,
+                "Authentication failed using realms [realm1/realm1,realm2/reaml2]."
+                + " Realms [realm3/realm3] were skipped because they are not permitted on the current license"
+            ));
+            final PlainActionFuture<Authenticator.Result> future = new PlainActionFuture<>();
+            realmsAuthenticator.authenticate(context, future);
+            assertThat(expectThrows(ElasticsearchSecurityException.class, future::actionGet), is(e));
+        } finally {
+            Loggers.removeAppender(unlicensedRealmsLogger, mockAppender);
+            mockAppender.stop();
+        }
+    }
+
+    public void testLookupRunAsUser() {
+        when(lastSuccessfulAuthCache.get(username)).thenReturn(randomFrom(realm1, realm2, null));
+        final String runAsUsername = randomAlphaOfLength(10);
+        threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, runAsUsername);
+        final boolean lookupByRealm1 = randomBoolean();
+        if (lookupByRealm1) {
+            configureRealmUserResponse(realm1, runAsUsername);
+            configureRealmUserResponse(realm2, null);
+        } else {
+            configureRealmUserResponse(realm1, null);
+            configureRealmUserResponse(realm2, runAsUsername);
+        }
+
+        final Realm authRealm = randomFrom(realm1, realm2);
+        final Authentication authentication =
+            new Authentication(user, new Authentication.RealmRef(authRealm.name(), authRealm.type(), nodeName), null);
+        final PlainActionFuture<Tuple<User, Authentication.RealmRef>> future = new PlainActionFuture<>();
+        realmsAuthenticator.lookupRunAsUser(createAuthenticatorContext(), authentication, future);
+        final Tuple<User, Authentication.RealmRef> tuple = future.actionGet();
+        assertThat(tuple.v1(), equalTo(new User(runAsUsername)));
+        assertThat(tuple.v2().getName(), is(lookupByRealm1 ? realm1.name() : realm2.name()));
+    }
+
+    public void testNullRunAsUser() {
+        final PlainActionFuture<Tuple<User, Authentication.RealmRef>> future = new PlainActionFuture<>();
+        realmsAuthenticator.lookupRunAsUser(createAuthenticatorContext(), mock(Authentication.class), future);
+        assertThat(future.actionGet(), nullValue());
+    }
+
+    public void testEmptyRunAsUsernameWillFail() {
+        threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, "");
+        final Realm authRealm = randomFrom(realm1, realm2);
+        final Authentication authentication =
+            new Authentication(user, new Authentication.RealmRef(authRealm.name(), authRealm.type(), nodeName), null);
+        final PlainActionFuture<Tuple<User, Authentication.RealmRef>> future = new PlainActionFuture<>();
+        final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
+        when(request.runAsDenied(any(), any())).thenReturn(e);
+        realmsAuthenticator.lookupRunAsUser(createAuthenticatorContext(), authentication, future);
+        assertThat(expectThrows(ElasticsearchSecurityException.class, future::actionGet), is(e));
+    }
+
+    private void configureRealmAuthResponse(Realm realm, AuthenticationResult authenticationResult) {
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked") final ActionListener<AuthenticationResult> listener =
+                (ActionListener<AuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(authenticationResult);
+            return null;
+        }).when(realm).authenticate(eq(authenticationToken), any());
+    }
+
+    private void configureRealmUserResponse(Realm realm, String runAsUsername) {
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked") final ActionListener<User> listener =
+                (ActionListener<User>) invocationOnMock.getArguments()[1];
+            listener.onResponse(runAsUsername == null ? null : new User(runAsUsername));
+            return null;
+        }).when(realm).lookupUser(runAsUsername == null ? anyString() : eq(runAsUsername), any());
+    }
+
+    private Authenticator.Context createAuthenticatorContext() {
+        return new Authenticator.Context(threadContext, request, null, true, realms);
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.junit.Before;
 
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -74,8 +73,8 @@ public class RealmsAuthenticatorTests extends ESTestCase {
         when(realm2.toString()).thenReturn("realm2/realm2");
         realm3 = mock(Realm.class);
         when(realm3.toString()).thenReturn("realm3/realm3");
-        when(realms.getActiveRealms()).thenReturn(List.of(realm1, realm2));
-        when(realms.getUnlicensedRealms()).thenReturn(List.of(realm3));
+        when(realms.getActiveRealms()).thenReturn(org.elasticsearch.core.List.of(realm1, realm2));
+        when(realms.getUnlicensedRealms()).thenReturn(org.elasticsearch.core.List.of(realm3));
 
         request = randomBoolean() ?
             mock(AuthenticationService.AuditableRestRequest.class) :

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -246,7 +246,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -257,7 +257,7 @@ public class TokenServiceTests extends ESTestCase {
             TokenService anotherService = createTokenService(tokenServiceEnabledSettings, systemUTC());
             anotherService.refreshMetadata(tokenService.getTokenMetadata());
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = anotherService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             anotherService.tryAuthenticateToken(bearerToken, future);
             UserToken fromOtherService = future.get();
             assertAuthentication(authentication, fromOtherService.getAuthentication());
@@ -273,7 +273,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertThat(serialized, nullValue());
@@ -300,7 +300,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -309,7 +309,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -330,7 +330,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -370,7 +370,7 @@ public class TokenServiceTests extends ESTestCase {
         storeTokenHeader(requestContext, accessToken);
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = otherTokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             otherTokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(serialized.getAuthentication(), authentication);
@@ -382,7 +382,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = otherTokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             otherTokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(serialized.getAuthentication(), authentication);
@@ -409,7 +409,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -424,7 +424,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -444,7 +444,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertNull(serialized);
@@ -455,7 +455,7 @@ public class TokenServiceTests extends ESTestCase {
         mockGetTokenFromId(tokenService, newUserTokenId, authentication, false);
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -483,7 +483,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             UserToken serialized = future.get();
             assertAuthentication(authentication, serialized.getAuthentication());
@@ -493,7 +493,7 @@ public class TokenServiceTests extends ESTestCase {
             // verify a second separate token service with its own passphrase cannot verify
             TokenService anotherService = createTokenService(tokenServiceEnabledSettings, systemUTC());
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = anotherService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             anotherService.tryAuthenticateToken(bearerToken, future);
             assertNull(future.get());
         }
@@ -538,7 +538,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
             final String headerValue = e.getHeader("WWW-Authenticate").get(0);
@@ -655,7 +655,7 @@ public class TokenServiceTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             // the clock is still frozen, so the cookie should be valid
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertAuthentication(authentication, future.get().getAuthentication());
         }
@@ -666,7 +666,7 @@ public class TokenServiceTests extends ESTestCase {
             // move the clock forward but don't go to expiry
             clock.fastForwardSeconds(fastForwardAmount);
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertAuthentication(authentication, future.get().getAuthentication());
         }
@@ -675,7 +675,7 @@ public class TokenServiceTests extends ESTestCase {
             // move to expiry, stripping nanoseconds, as we don't store them in the security-tokens index
             clock.setTime(userToken.getExpirationTime().truncatedTo(ChronoUnit.MILLIS).atZone(clock.getZone()));
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertAuthentication(authentication, future.get().getAuthentication());
         }
@@ -684,7 +684,7 @@ public class TokenServiceTests extends ESTestCase {
             // move one second past expiry
             clock.fastForwardSeconds(1);
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
             final String headerValue = e.getHeader("WWW-Authenticate").get(0);
@@ -752,7 +752,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertNull(future.get());
         }
@@ -768,7 +768,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertNull(future.get());
         }
@@ -784,7 +784,7 @@ public class TokenServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertNull(future.get());
         }
@@ -824,7 +824,7 @@ public class TokenServiceTests extends ESTestCase {
         }
         try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
-            final SecureString bearerToken3 = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken3 = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken3, future);
             assertNull(future.get());
 
@@ -832,13 +832,13 @@ public class TokenServiceTests extends ESTestCase {
             when(tokensIndex.getUnavailableReason()).thenReturn(new UnavailableShardsException(null, "unavailable"));
             when(tokensIndex.indexExists()).thenReturn(true);
             future = new PlainActionFuture<>();
-            final SecureString bearerToken2 = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken2 = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken2, future);
             assertNull(future.get());
 
             when(tokensIndex.indexExists()).thenReturn(false);
             future = new PlainActionFuture<>();
-            final SecureString bearerToken1 = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken1 = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken1, future);
             assertNull(future.get());
 
@@ -846,7 +846,7 @@ public class TokenServiceTests extends ESTestCase {
             when(tokensIndex.indexExists()).thenReturn(true);
             mockGetTokenFromId(tokenService, userTokenId, authentication, false);
             future = new PlainActionFuture<>();
-            final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(requestContext);
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             assertAuthentication(future.get().getAuthentication(), authentication);
         }
@@ -910,7 +910,7 @@ public class TokenServiceTests extends ESTestCase {
 
         PlainActionFuture<UserToken> authFuture = new PlainActionFuture<>();
         when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(false);
-        final SecureString bearerToken = tokenService.extractBearerTokenFromHeader(threadContext);
+        final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(threadContext);
         tokenService.tryAuthenticateToken(bearerToken, authFuture);
         UserToken authToken = authFuture.actionGet();
         assertThat(authToken, Matchers.nullValue());

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
@@ -40,7 +40,7 @@
   - do:
       headers:
         Authorization: Bearer boom
-      catch: /missing authentication credentials/
+      catch: /unable to authenticate with provided credentials and anonymous access is not allowed for this request/
       search:
         rest_total_hits_as_int: true
         index: token_index


### PR DESCRIPTION
This PR is a first step to refactor and unify the authentication chain. An
Authenticator interface is extracted for following concrete Authenticators
(listed in decreasing priority):

* Service token
* OAuth2 token
* API key
* Realms

Before runnning the above authenticators, existing authentication from
ThreadContext is always checked first. After running the authenticators,
fallback, anonymous and lookup users are checked more consistently. Failed
authentication with either OAuth2 token or API key now reports the attempted
and failed credentials instead of "missing credentials".

In above authenticators, the RealmsAuthenticator has its own sub-chain.
Technically, this sub-chain can also be flattend and be part of the main chain.
But it's impractical to do so without also changing the existing behaviour.
Though the change makes sense imo, it adds a lot complexities of the PR. So it
is better to be left as future work.

Relates: #75607

Co-authored-by: Tim Vernum <tim@adjective.org>

