### PR TITLE
Reduce memory usage and wire size of field caps internal responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -71,7 +71,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
         super(in);
         indices = in.readStringArray();
         this.responseMap = in.readMap(StreamInput::readString, FieldCapabilitiesResponse::readField);
-        indexResponses = in.readList(FieldCapabilitiesIndexResponse::new);
+        indexResponses = FieldCapabilitiesIndexResponse.readResponses(in);
         this.failures = in.readList(FieldCapabilitiesFailure::new);
     }
 
@@ -137,7 +137,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
         out.writeMap(responseMap, StreamOutput::writeString, FieldCapabilitiesResponse::writeField);
-        out.writeList(indexResponses);
+        FieldCapabilitiesIndexResponse.writeResponses(out, indexResponses);
         out.writeList(failures);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamOutput.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.io.IOException;
+
+public abstract class FilterStreamOutput extends StreamOutput {
+    private final StreamOutput out;
+
+    public FilterStreamOutput(StreamOutput out) {
+        this.out = out;
+    }
+
+    @Override
+    public void writeByte(byte b) throws IOException {
+        out.writeByte(b);
+    }
+
+    @Override
+    public void writeBytes(byte[] b, int offset, int length) throws IOException {
+        out.writeBytes(b, offset, length);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        out.reset();
+    }
+}


### PR DESCRIPTION
As the merging logic is too complex to introduce in 7x, I'd like to introduce a simpler and contained optimization that reduces the wire size and the memory usage of internal field cap responses (i.e., FieldCapabilitiesResponse between clusters and FieldCapabilitiesNodeResponse between nodes).