### PR TITLE
[Backport 7.x] Use a licensed feature per realm-type (+custom)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -351,13 +351,25 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
     public static final LicensedFeature.Momentary AUDITING_FEATURE =
         LicensedFeature.momentaryLenient(null, "security_auditing", License.OperationMode.GOLD);
 
+    private static final String REALMS_FEATURE_FAMILY = "security-realms";
     // Builtin realms (file/native) realms are Basic licensed, so don't need to be checked or tracked
-    // Standard realms (LDAP, AD, PKI, etc) are Gold+
+    // Some realms (LDAP, AD, PKI) are Gold+
+    public static final LicensedFeature.Persistent LDAP_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "ldap", License.OperationMode.GOLD);
+    public static final LicensedFeature.Persistent AD_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "active-directory", License.OperationMode.GOLD);
+    public static final LicensedFeature.Persistent PKI_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "pki", License.OperationMode.GOLD);
     // SSO realms are Platinum+
-    public static final LicensedFeature.Persistent STANDARD_REALMS_FEATURE =
-        LicensedFeature.persistentLenient(null, "security_standard_realms", License.OperationMode.GOLD);
-    public static final LicensedFeature.Persistent ALL_REALMS_FEATURE =
-        LicensedFeature.persistentLenient(null, "security_all_realms", License.OperationMode.PLATINUM);
+    public static final LicensedFeature.Persistent SAML_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "saml", License.OperationMode.PLATINUM);
+    public static final LicensedFeature.Persistent OIDC_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "oidc", License.OperationMode.PLATINUM);
+    public static final LicensedFeature.Persistent KERBEROS_REALM_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "kerberos", License.OperationMode.PLATINUM);
+    // Custom realms are Platinum+
+    public static final LicensedFeature.Persistent CUSTOM_REALMS_FEATURE =
+        LicensedFeature.persistentLenient(REALMS_FEATURE_FAMILY, "custom", License.OperationMode.PLATINUM);
 
     private static final Logger logger = LogManager.getLogger(Security.class);
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
@@ -7,9 +7,12 @@
 package org.elasticsearch.xpack.security.authc;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.authc.Realm;
@@ -23,6 +26,7 @@ import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettin
 import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.authc.esnative.NativeRealm;
 import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
@@ -53,36 +57,64 @@ import java.util.stream.Collectors;
  */
 public final class InternalRealms {
 
-    /**
-     * The list of all <em>internal</em> realm types, excluding {@link ReservedRealm#TYPE}.
-     */
-    private static final Set<String> XPACK_TYPES = Collections
-        .unmodifiableSet(Sets.newHashSet(NativeRealmSettings.TYPE, FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE,
-            LdapRealmSettings.LDAP_TYPE, PkiRealmSettings.TYPE, SamlRealmSettings.TYPE, KerberosRealmSettings.TYPE,
-            OpenIdConnectRealmSettings.TYPE));
+    static final String RESERVED_TYPE = ReservedRealm.TYPE;
+    static final String NATIVE_TYPE = NativeRealmSettings.TYPE;
+    static final String FILE_TYPE = FileRealmSettings.TYPE;
+    static final String LDAP_TYPE = LdapRealmSettings.LDAP_TYPE;
+    static final String AD_TYPE = LdapRealmSettings.AD_TYPE;
+    static final String PKI_TYPE = PkiRealmSettings.TYPE;
+    static final String SAML_TYPE = SamlRealmSettings.TYPE;
+    static final String OIDC_TYPE = OpenIdConnectRealmSettings.TYPE;
+    static final String KERBEROS_TYPE = KerberosRealmSettings.TYPE;
+
+    private static final Set<String> BUILTIN_TYPES = Sets.newHashSet(NATIVE_TYPE, FILE_TYPE);
 
     /**
-     * The list of all standard realm types, which are those provided by x-pack and do not have extensive
-     * interaction with third party sources
+     * The map of all <em>licensed</em> internal realm types to their licensed feature
      */
-    private static final Set<String> STANDARD_TYPES = Collections.unmodifiableSet(Sets.newHashSet(NativeRealmSettings.TYPE,
-        FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE, LdapRealmSettings.LDAP_TYPE, PkiRealmSettings.TYPE));
+    private static final Map<String, LicensedFeature.Persistent> LICENSED_REALMS = org.elasticsearch.core.Map.ofEntries(
+        org.elasticsearch.core.Map.entry(AD_TYPE, Security.AD_REALM_FEATURE),
+        org.elasticsearch.core.Map.entry(LDAP_TYPE, Security.LDAP_REALM_FEATURE),
+        org.elasticsearch.core.Map.entry(PKI_TYPE, Security.PKI_REALM_FEATURE),
+        org.elasticsearch.core.Map.entry(SAML_TYPE, Security.SAML_REALM_FEATURE),
+        org.elasticsearch.core.Map.entry(KERBEROS_TYPE, Security.KERBEROS_REALM_FEATURE),
+        org.elasticsearch.core.Map.entry(OIDC_TYPE, Security.OIDC_REALM_FEATURE)
+    );
 
+    /**
+     * The set of all <em>internal</em> realm types, excluding {@link ReservedRealm#TYPE}
+     * @deprecated Use of this method (other than in tests) is discouraged.
+     */
+    @Deprecated
     public static Collection<String> getConfigurableRealmsTypes() {
-        return Collections.unmodifiableSet(XPACK_TYPES);
+        return org.elasticsearch.core.Set.copyOf(Sets.union(BUILTIN_TYPES, LICENSED_REALMS.keySet()));
     }
 
-    /**
-     * Determines whether <code>type</code> is an internal realm-type that is provided by x-pack,
-     * excluding the {@link ReservedRealm} and realms that have extensive interaction with
-     * third party sources
-     */
-    static boolean isStandardRealm(String type) {
-        return STANDARD_TYPES.contains(type);
+    static boolean isInternalRealm(String type) {
+        return RESERVED_TYPE.equals(type) || BUILTIN_TYPES.contains(type) || LICENSED_REALMS.containsKey(type);
     }
 
     static boolean isBuiltinRealm(String type) {
-        return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);
+        return BUILTIN_TYPES.contains(type);
+    }
+
+    /**
+     * @return The licensed feature for the given realm type, or {@code null} if the realm does not require a specific license type
+     * @throws IllegalArgumentException if the provided type is not an {@link #isInternalRealm(String) internal realm}
+     */
+    @Nullable
+    static LicensedFeature.Persistent getLicensedFeature(String type) {
+        if (Strings.isNullOrEmpty(type)) {
+            throw new IllegalArgumentException("Empty realm type [" + type + "]");
+        }
+        if (type.equals(RESERVED_TYPE) || isBuiltinRealm(type)) {
+            return null;
+        }
+        final LicensedFeature.Persistent feature = LICENSED_REALMS.get(type);
+        if (feature == null) {
+            throw new IllegalArgumentException("Unsupported realm type [" + type + "]");
+        }
+        return feature;
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
@@ -56,7 +56,7 @@ public final class RestDelegatePkiAuthenticationAction extends SecurityBaseRestH
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (Security.STANDARD_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
+        } else if (Security.PKI_REALM_FEATURE.checkWithoutTracking(licenseState)) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", PkiRealmSettings.TYPE);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
@@ -216,9 +217,14 @@ public class AuthenticationServiceTests extends ESTestCase {
             .put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true)
             .build();
         MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(true);
+        for (String realmType : InternalRealms.getConfigurableRealmsTypes()) {
+            final LicensedFeature.Persistent feature = InternalRealms.getLicensedFeature(realmType);
+            if (feature != null) {
+                when(licenseState.isAllowed(feature)).thenReturn(true);
+            }
+        }
+        when(licenseState.isAllowed(Security.CUSTOM_REALMS_FEATURE)).thenReturn(true);
         when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
@@ -227,9 +233,10 @@ public class AuthenticationServiceTests extends ESTestCase {
         ReservedRealm reservedRealm = mock(ReservedRealm.class);
         when(reservedRealm.type()).thenReturn("reserved");
         when(reservedRealm.name()).thenReturn("reserved_realm");
-        realms = spy(new TestRealms(Settings.EMPTY, TestEnvironment.newEnvironment(settings), Collections.<String, Realm.Factory>emptyMap(),
-                licenseState, threadContext, reservedRealm, Arrays.asList(firstRealm, secondRealm),
-                Collections.singletonList(firstRealm)));
+        realms = spy(new TestRealms(Settings.EMPTY, TestEnvironment.newEnvironment(settings),
+            Collections.<String, Realm.Factory>emptyMap(),
+            licenseState, threadContext, reservedRealm, Arrays.asList(firstRealm, secondRealm),
+            Arrays.asList(firstRealm)));
 
         // Needed because this is calculated in the constructor, which means the override doesn't get called correctly
         realms.recomputeActiveRealms();
@@ -396,6 +403,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(realms, atLeastOnce()).recomputeActiveRealms();
         verify(realms, atLeastOnce()).calculateLicensedRealms(any(XPackLicenseState.class));
         verify(realms, atLeastOnce()).getActiveRealms();
+        verify(realms, atLeastOnce()).stopTrackingInactiveRealms(any(XPackLicenseState.class), any());
         // ^^ We don't care how many times these methods are called, we just check it here so that we can verify no more interactions below.
         verifyNoMoreInteractions(realms);
     }
@@ -2130,7 +2138,9 @@ public class AuthenticationServiceTests extends ESTestCase {
                 // This can happen because the realms are recalculated during construction
                 return super.calculateLicensedRealms(licenseState);
             }
-            if (Security.STANDARD_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
+
+            // Use custom as a placeholder for all non-internal realm
+            if (Security.CUSTOM_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
                 return allRealms;
             } else {
                 return internalRealms;
@@ -2140,6 +2150,11 @@ public class AuthenticationServiceTests extends ESTestCase {
         // Make public for testing
         public void recomputeActiveRealms() {
             super.recomputeActiveRealms();
+        }
+
+        @Override
+        protected void stopTrackingInactiveRealms(XPackLicenseState licenseStateSnapshot, List<Realm> licensedRealms) {
+            // Ignore
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
@@ -10,18 +10,16 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
@@ -31,9 +29,11 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import static org.elasticsearch.mock.orig.Mockito.times;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,8 +44,14 @@ public class InternalRealmsTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void testNativeRealmRegistersIndexHealthChangeListener() throws Exception {
         SecurityIndexManager securityIndex = mock(SecurityIndexManager.class);
-        Map<String, Realm.Factory> factories = InternalRealms.getFactories(mock(ThreadPool.class), mock(ResourceWatcherService.class),
-                mock(SSLService.class), mock(NativeUsersStore.class), mock(NativeRoleMappingStore.class), securityIndex);
+        Map<String, Realm.Factory> factories = InternalRealms.getFactories(
+            mock(ThreadPool.class),
+            mock(ResourceWatcherService.class),
+            mock(SSLService.class),
+            mock(NativeUsersStore.class),
+            mock(NativeRoleMappingStore.class),
+            securityIndex
+        );
         assertThat(factories, hasEntry(is(NativeRealmSettings.TYPE), any(Realm.Factory.class)));
         verifyZeroInteractions(securityIndex);
 
@@ -60,11 +66,31 @@ public class InternalRealmsTests extends ESTestCase {
         verify(securityIndex, times(2)).addStateListener(isA(BiConsumer.class));
     }
 
-    public void testIsStandardType() {
-        String type = randomFrom(NativeRealmSettings.TYPE, FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE, LdapRealmSettings.LDAP_TYPE,
-                PkiRealmSettings.TYPE);
-        assertThat(InternalRealms.isStandardRealm(type), is(true));
-        type = randomFrom(SamlRealmSettings.TYPE, KerberosRealmSettings.TYPE, OpenIdConnectRealmSettings.TYPE);
-        assertThat(InternalRealms.isStandardRealm(type), is(false));
+    public void testLicenseLevels() {
+        for (String type : InternalRealms.getConfigurableRealmsTypes()) {
+            final LicensedFeature.Persistent feature = InternalRealms.getLicensedFeature(type);
+            if (InternalRealms.isBuiltinRealm(type)) {
+                assertThat(feature, nullValue());
+            } else if (isStandardRealm(type)) {
+                assertThat(feature, notNullValue());
+                // In theory a "standard" realm could actually be OperationMode.STANDARD, but we don't have any of those at the moment
+                assertThat(feature.getMinimumOperationMode(), is(License.OperationMode.GOLD));
+            } else {
+                assertThat(feature, notNullValue());
+                // In theory a (not-builtin & not-standard) realm could actually be OperationMode.ENTERPRISE, but we don't have any
+                assertThat(feature.getMinimumOperationMode(), is(License.OperationMode.PLATINUM));
+            }
+        }
+    }
+
+    private boolean isStandardRealm(String type) {
+        switch (type) {
+            case LdapRealmSettings.LDAP_TYPE:
+            case LdapRealmSettings.AD_TYPE:
+            case PkiRealmSettings.TYPE:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseStateListener;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.Security;
@@ -46,6 +48,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -80,13 +83,13 @@ public class RealmsTests extends ESTestCase {
     @Before
     public void init() throws Exception {
         factories = new HashMap<>();
-        factories.put(FileRealmSettings.TYPE, config -> new DummyRealm(FileRealmSettings.TYPE, config));
-        factories.put(NativeRealmSettings.TYPE, config -> new DummyRealm(NativeRealmSettings.TYPE, config));
-        factories.put(KerberosRealmSettings.TYPE, config -> new DummyRealm(KerberosRealmSettings.TYPE, config));
+        factories.put(FileRealmSettings.TYPE, config -> new DummyRealm(config));
+        factories.put(NativeRealmSettings.TYPE, config -> new DummyRealm(config));
+        factories.put(KerberosRealmSettings.TYPE, config -> new DummyRealm(config));
         randomRealmTypesCount = randomIntBetween(2, 5);
         for (int i = 0; i < randomRealmTypesCount; i++) {
             String name = "type_" + i;
-            factories.put(name, config -> new DummyRealm(name, config));
+            factories.put(name, config -> new DummyRealm(config));
         }
         licenseState = mock(MockLicenseState.class);
         licenseStateListeners = new ArrayList<>();
@@ -109,20 +112,25 @@ public class RealmsTests extends ESTestCase {
     }
 
     private void allowAllRealms() {
-        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(true);
-        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(true);
-        licenseStateListeners.forEach(LicenseStateListener::licenseStateChanged);
+        setRealmAvailability(type -> true);
     }
 
     private void allowOnlyStandardRealms() {
-        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(false);
-        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(true);
-        licenseStateListeners.forEach(LicenseStateListener::licenseStateChanged);
+        setRealmAvailability(f -> f.getMinimumOperationMode() != License.OperationMode.PLATINUM);
     }
 
     private void allowOnlyNativeRealms() {
-        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(false);
-        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(false);
+        setRealmAvailability(type -> false);
+    }
+
+    private void setRealmAvailability(Function<LicensedFeature.Persistent, Boolean> body) {
+        InternalRealms.getConfigurableRealmsTypes().forEach(type -> {
+            final LicensedFeature.Persistent feature = InternalRealms.getLicensedFeature(type);
+            if (feature != null) {
+                when(licenseState.isAllowed(feature)).thenReturn(body.apply(feature));
+            }
+        });
+        when(licenseState.isAllowed(Security.CUSTOM_REALMS_FEATURE)).thenReturn(body.apply(Security.CUSTOM_REALMS_FEATURE));
         licenseStateListeners.forEach(LicenseStateListener::licenseStateChanged);
     }
 
@@ -155,8 +163,7 @@ public class RealmsTests extends ESTestCase {
     }
 
     public void testWithSettings() throws Exception {
-        Settings.Builder builder = Settings.builder()
-                .put("path.home", createTempDir());
+        Settings.Builder builder = Settings.builder().put("path.home", createTempDir());
         List<Integer> orders = new ArrayList<>(randomRealmTypesCount);
         for (int i = 0; i < randomRealmTypesCount; i++) {
             orders.add(i);
@@ -177,9 +184,9 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState, times(1)).getOperationMode();
 
         // Verify that we recorded licensed-feature use for each realm (this is trigger on license load during node startup)
-        verify(licenseState, Mockito.atLeast(randomRealmTypesCount)).isAllowed(Security.ALL_REALMS_FEATURE);
+        verify(licenseState, Mockito.atLeast(randomRealmTypesCount)).isAllowed(Security.CUSTOM_REALMS_FEATURE);
         for (int i = 0; i < randomRealmTypesCount; i++) {
-            verify(licenseState, atLeastOnce()).enableUsageTracking(Security.ALL_REALMS_FEATURE, "realm_" + i);
+            verify(licenseState, atLeastOnce()).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "realm_" + i);
         }
         verifyNoMoreInteractions(licenseState);
 
@@ -203,8 +210,7 @@ public class RealmsTests extends ESTestCase {
     }
 
     public void testWithSettingsWhereDifferentRealmsHaveSameOrder() throws Exception {
-        Settings.Builder builder = Settings.builder()
-                .put("path.home", createTempDir());
+        Settings.Builder builder = Settings.builder().put("path.home", createTempDir());
         List<Integer> randomSeq = new ArrayList<>(randomRealmTypesCount);
         for (int i = 0; i < randomRealmTypesCount; i++) {
             randomSeq.add(i);
@@ -253,10 +259,10 @@ public class RealmsTests extends ESTestCase {
 
     public void testWithSettingsWithMultipleInternalRealmsOfSameType() throws Exception {
         Settings settings = Settings.builder()
-                .put("xpack.security.authc.realms.file.realm_1.order", 0)
-                .put("xpack.security.authc.realms.file.realm_2.order", 1)
-                .put("path.home", createTempDir())
-                .build();
+            .put("xpack.security.authc.realms.file.realm_1.order", 0)
+            .put("xpack.security.authc.realms.file.realm_2.order", 1)
+            .put("path.home", createTempDir())
+            .build();
         Environment env = TestEnvironment.newEnvironment(settings);
         try {
             new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
@@ -274,15 +280,22 @@ public class RealmsTests extends ESTestCase {
             .put("path.home", createTempDir())
             .build();
         Environment env = TestEnvironment.newEnvironment(settings);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->{
-            new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
-        });
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> { new Realms(settings, env, factories, licenseState, threadContext, reservedRealm); }
+        );
         assertThat(e.getMessage(), containsString("Found multiple realms configured with the same name"));
     }
 
     public void testWithEmptySettings() throws Exception {
-        Realms realms = new Realms(Settings.EMPTY, TestEnvironment.newEnvironment(Settings.builder().put("path.home",
-                createTempDir()).build()), factories, licenseState, threadContext, reservedRealm);
+        Realms realms = new Realms(
+            Settings.EMPTY,
+            TestEnvironment.newEnvironment(Settings.builder().put("path.home", createTempDir()).build()),
+            factories,
+            licenseState,
+            threadContext,
+            reservedRealm
+        );
         Iterator<Realm> iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         Realm realm = iter.next();
@@ -301,9 +314,37 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
     }
 
+    public void testFeatureTrackingWithMultipleRealms() throws Exception {
+        factories.put(LdapRealmSettings.LDAP_TYPE, DummyRealm::new);
+        factories.put(PkiRealmSettings.TYPE, DummyRealm::new);
+
+        Settings settings = Settings.builder()
+            .put("xpack.security.authc.realms.file.file_realm.order", 0)
+            .put("xpack.security.authc.realms.native.native_realm.order", 1)
+            .put("xpack.security.authc.realms.kerberos.kerberos_realm.order", 2)
+            .put("xpack.security.authc.realms.ldap.ldap_realm_1.order", 3)
+            .put("xpack.security.authc.realms.ldap.ldap_realm_2.order", 4)
+            .put("xpack.security.authc.realms.pki.pki_realm.order", 5)
+            .put("xpack.security.authc.realms.type_0.custom_realm_1.order", 6)
+            .put("xpack.security.authc.realms.type_1.custom_realm_2.order", 7)
+            .put("path.home", createTempDir())
+            .build();
+        Environment env = TestEnvironment.newEnvironment(settings);
+
+        Realms realms = new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
+        assertThat(realms.getUnlicensedRealms(), empty());
+        assertThat(realms.getActiveRealms(), hasSize(9)); // 0..7 configured + reserved
+
+        verify(licenseState).enableUsageTracking(Security.KERBEROS_REALM_FEATURE, "kerberos_realm");
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, "ldap_realm_1");
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, "ldap_realm_2");
+        verify(licenseState).enableUsageTracking(Security.PKI_REALM_FEATURE, "pki_realm");
+        verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_1");
+        verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_2");
+    }
+
     public void testUnlicensedWithOnlyCustomRealms() throws Exception {
-        Settings.Builder builder = Settings.builder()
-                .put("path.home", createTempDir());
+        Settings.Builder builder = Settings.builder().put("path.home", createTempDir());
         List<Integer> orders = new ArrayList<>(randomRealmTypesCount);
         for (int i = 0; i < randomRealmTypesCount; i++) {
             orders.add(i);
@@ -337,7 +378,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
         for (i = 0; i < randomRealmTypesCount; i++) {
-            verify(licenseState).enableUsageTracking(Security.ALL_REALMS_FEATURE, "realm_" + i);
+            verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "realm_" + i);
         }
 
         allowOnlyNativeRealms();
@@ -398,7 +439,7 @@ public class RealmsTests extends ESTestCase {
     }
 
     public void testUnlicensedWithInternalRealms() throws Exception {
-        factories.put(LdapRealmSettings.LDAP_TYPE, config -> new DummyRealm(LdapRealmSettings.LDAP_TYPE, config));
+        factories.put(LdapRealmSettings.LDAP_TYPE, config -> new DummyRealm(config));
         assertThat(factories.get("type_0"), notNullValue());
         String ldapRealmName = randomAlphaOfLengthBetween(3, 8);
         Settings.Builder builder = Settings.builder()
@@ -425,7 +466,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(types, contains("ldap", "type_0"));
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
-        verify(licenseState).enableUsageTracking(Security.STANDARD_REALMS_FEATURE, ldapRealmName);
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, ldapRealmName);
 
         allowOnlyStandardRealms();
         iter = realms.iterator();
@@ -470,7 +511,7 @@ public class RealmsTests extends ESTestCase {
     }
 
     public void testUnlicensedWithNativeRealmSettings() throws Exception {
-        factories.put(LdapRealmSettings.LDAP_TYPE, config -> new DummyRealm(LdapRealmSettings.LDAP_TYPE, config));
+        factories.put(LdapRealmSettings.LDAP_TYPE, config -> new DummyRealm(config));
         final String type = randomFrom(FileRealmSettings.TYPE, NativeRealmSettings.TYPE);
         Settings.Builder builder = Settings.builder()
                 .put("path.home", createTempDir())
@@ -501,8 +542,8 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState, times(1)).getOperationMode();
 
         // Verify that we recorded licensed-feature use for each licensed realm (this is trigger on license load/change)
-        verify(licenseState, times(1)).isAllowed(Security.STANDARD_REALMS_FEATURE);
-        verify(licenseState).enableUsageTracking(Security.STANDARD_REALMS_FEATURE, "foo");
+        verify(licenseState, times(1)).isAllowed(Security.LDAP_REALM_FEATURE);
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, "foo");
         verifyNoMoreInteractions(licenseState);
 
         allowOnlyNativeRealms();
@@ -521,9 +562,9 @@ public class RealmsTests extends ESTestCase {
         assertThat(iter.hasNext(), is(false));
 
         // Verify that we checked (a 2nd time) the license for the non-basic realm
-        verify(licenseState, times(2)).isAllowed(Security.STANDARD_REALMS_FEATURE);
-        // Verify that we stopped tracking  use for realms which are no longer licensed
-        verify(licenseState).disableUsageTracking(Security.STANDARD_REALMS_FEATURE, "foo");
+        verify(licenseState, times(2)).isAllowed(Security.LDAP_REALM_FEATURE);
+        // Verify that we stopped tracking use for realms which are no longer licensed
+        verify(licenseState).disableUsageTracking(Security.LDAP_REALM_FEATURE, "foo");
         verifyNoMoreInteractions(licenseState);
 
         assertThat(realms.getUnlicensedRealms(), iterableWithSize(1));
@@ -534,7 +575,8 @@ public class RealmsTests extends ESTestCase {
 
     public void testUnlicensedWithNonStandardRealms() throws Exception {
         final String selectedRealmType = randomFrom(SamlRealmSettings.TYPE, KerberosRealmSettings.TYPE, OpenIdConnectRealmSettings.TYPE);
-        factories.put(selectedRealmType, config -> new DummyRealm(selectedRealmType, config));
+        factories.put(selectedRealmType, config -> new DummyRealm(config));
+        final LicensedFeature.Persistent feature = InternalRealms.getLicensedFeature(selectedRealmType);
         String realmName = randomAlphaOfLengthBetween(3, 8);
         Settings.Builder builder = Settings.builder()
                 .put("path.home", createTempDir())
@@ -552,8 +594,8 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), is(selectedRealmType));
         assertThat(iter.hasNext(), is(false));
         assertThat(realms.getUnlicensedRealms(), empty());
-        verify(licenseState, times(1)).isAllowed(Security.ALL_REALMS_FEATURE);
-        verify(licenseState, times(1)).enableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
+        verify(licenseState, times(1)).isAllowed(feature);
+        verify(licenseState, times(1)).enableUsageTracking(feature, realmName);
 
         allowOnlyStandardRealms();
         iter = realms.iterator();
@@ -573,10 +615,10 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), equalTo(selectedRealmType));
         assertThat(realm.name(), equalTo(realmName));
 
-        verify(licenseState, times(2)).isAllowed(Security.ALL_REALMS_FEATURE);
-        verify(licenseState, times(1)).disableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
+        verify(licenseState, times(2)).isAllowed(feature);
+        verify(licenseState, times(1)).disableUsageTracking(feature, realmName);
         // this happened when the realm was allowed. Check it's still only 1 call
-        verify(licenseState, times(1)).enableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
+        verify(licenseState, times(1)).enableUsageTracking(feature, realmName);
 
         allowOnlyNativeRealms();
         iter = realms.iterator();
@@ -596,11 +638,11 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), equalTo(selectedRealmType));
         assertThat(realm.name(), equalTo(realmName));
 
-        verify(licenseState, times(3)).isAllowed(Security.ALL_REALMS_FEATURE);
+        verify(licenseState, times(3)).isAllowed(feature);
         // this doesn't get called a second time because it didn't change
-        verify(licenseState, times(1)).disableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
+        verify(licenseState, times(1)).disableUsageTracking(feature, realmName);
         // this happened when the realm was allowed. Check it's still only 1 call
-        verify(licenseState, times(1)).enableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
+        verify(licenseState, times(1)).enableUsageTracking(feature, realmName);
     }
 
     public void testDisabledRealmsAreNotAdded() throws Exception {
@@ -864,8 +906,7 @@ public class RealmsTests extends ESTestCase {
     }
 
     public void testWarningsForReservedPrefixedRealmNames() throws Exception {
-        Settings.Builder builder = Settings.builder()
-            .put("path.home", createTempDir());
+        Settings.Builder builder = Settings.builder().put("path.home", createTempDir());
         final boolean invalidFileRealmName = randomBoolean();
         final boolean invalidNativeRealmName = randomBoolean();
         // Ensure at least one realm has invalid name
@@ -902,10 +943,14 @@ public class RealmsTests extends ESTestCase {
         Environment env = TestEnvironment.newEnvironment(settings);
         new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
 
-        assertWarnings("Found realm " + (invalidRealmNames.size() == 1 ? "name" : "names")
-            + " with reserved prefix [_]: ["
-            + Strings.collectionToDelimitedString(invalidRealmNames.stream().sorted().collect(Collectors.toList()), "; ") + "]. "
-            + "In a future major release, node will fail to start if any realm names start with reserved prefix.");
+        assertWarnings(
+            "Found realm "
+                + (invalidRealmNames.size() == 1 ? "name" : "names")
+                + " with reserved prefix [_]: ["
+                + Strings.collectionToDelimitedString(invalidRealmNames.stream().sorted().collect(Collectors.toList()), "; ")
+                + "]. "
+                + "In a future major release, node will fail to start if any realm names start with reserved prefix."
+        );
     }
 
     private void disableFileAndNativeRealms(Settings.Builder builder) {
@@ -915,7 +960,7 @@ public class RealmsTests extends ESTestCase {
 
     static class DummyRealm extends Realm {
 
-        DummyRealm(String type, RealmConfig config) {
+        DummyRealm(RealmConfig config) {
             super(config);
         }
 


### PR DESCRIPTION
This commit changes the licensed feature usage tracking for realms to
record each realm type as its own separate feature.
Custom realms continue to fall under a single catch-all feature.

Backport of: #78810
