### PR TITLE
Make some CS Applier NOOPs Cheaper (#79098)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -280,8 +280,11 @@ public class IndexLifecycleService
     public void applyClusterState(ClusterChangedEvent event) {
         if (event.localNodeMaster()) { // only act if we are master, otherwise
             // keep idle until elected
-            if (event.state().metadata().custom(IndexLifecycleMetadata.TYPE) != null) {
-                policyRegistry.update(event.state());
+            final IndexLifecycleMetadata ilmMetadata = event.state().metadata().custom(IndexLifecycleMetadata.TYPE);
+            // only update the policy registry if we just became the master node or if the ilm metadata changed
+            if (ilmMetadata != null && (event.previousState().nodes().isLocalNodeElectedMaster() == false
+                    || ilmMetadata != event.previousState().metadata().custom(IndexLifecycleMetadata.TYPE))) {
+                policyRegistry.update(ilmMetadata);
             }
         }
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -91,8 +91,7 @@ public class PolicyStepsRegistry {
         return stepMap;
     }
 
-    public void update(ClusterState clusterState) {
-        final IndexLifecycleMetadata meta = clusterState.metadata().custom(IndexLifecycleMetadata.TYPE);
+    public void update(IndexLifecycleMetadata meta) {
         assert meta != null : "IndexLifecycleMetadata cannot be null when updating the policy steps registry";
 
         DiffableUtils.MapDiff<String, LifecyclePolicyMetadata, Map<String, LifecyclePolicyMetadata>> mapDiff =

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -139,7 +139,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .build();
-        policyStepsRegistry.update(clusterState);
+        policyStepsRegistry.update(clusterState.metadata().custom(IndexLifecycleMetadata.TYPE));
         return indexMetadata;
     }
 
@@ -197,7 +197,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
                 .put(IndexMetadata.builder(clusterState.getMetadata().index(index))
                     .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap()))).build();
 
-        policyStepsRegistry.update(clusterState);
+        policyStepsRegistry.update(clusterState.metadata().custom(IndexLifecycleMetadata.TYPE));
 
         Step invalidStep = new MockClusterStateActionStep(firstStepKey, secondStepKey);
         long now = randomNonNegativeLong();
@@ -301,6 +301,6 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
             .metadata(Metadata.builder(clusterState.getMetadata())
                 .put(IndexMetadata.builder(clusterState.getMetadata().index(index))
                     .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap()))).build();
-        policyStepsRegistry.update(clusterState);
+        policyStepsRegistry.update(clusterState.metadata().custom(IndexLifecycleMetadata.TYPE));
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -232,7 +232,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         PolicyStepsRegistry registry = new PolicyStepsRegistry(NamedXContentRegistry.EMPTY, client, null);
 
         // add new policy
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
 
         assertThat(registry.getFirstStep(newPolicy.getName()), equalTo(policySteps.get(0)));
         assertThat(registry.getLifecyclePolicyMap().size(), equalTo(1));
@@ -252,7 +252,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
                         .putCustom(ILM_CUSTOM_METADATA_KEY, newIndexState.build().asMap())))
                 .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
                 .build();
-            registry.update(currentState);
+            registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
             assertThat(registeredStepsForPolicy.get(step.getKey()), equalTo(step));
             assertThat(registry.getStep(metadata.index(index), step.getKey()), equalTo(step));
         }
@@ -260,7 +260,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         Map<String, LifecyclePolicyMetadata> registryPolicyMap = registry.getLifecyclePolicyMap();
         Map<String, Step> registryFirstStepMap = registry.getFirstStepMap();
         Map<String, Map<Step.StepKey, Step>> registryStepMap = registry.getStepMap();
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
         assertThat(registry.getLifecyclePolicyMap(), equalTo(registryPolicyMap));
         assertThat(registry.getFirstStepMap(), equalTo(registryFirstStepMap));
         assertThat(registry.getStepMap(), equalTo(registryStepMap));
@@ -271,7 +271,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             .metadata(
                 Metadata.builder(metadata)
                     .putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata)).build();
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
         assertTrue(registry.getLifecyclePolicyMap().isEmpty());
         assertTrue(registry.getFirstStepMap().isEmpty());
         assertTrue(registry.getStepMap().isEmpty());
@@ -305,7 +305,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             .build();
         PolicyStepsRegistry registry = new PolicyStepsRegistry(NamedXContentRegistry.EMPTY, client, null);
         // add new policy
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
 
         // swap out policy
         newPolicy = LifecyclePolicyTests.randomTestLifecyclePolicy(policyName);
@@ -314,7 +314,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
                 randomNonNegativeLong(), randomNonNegativeLong())), OperationMode.RUNNING);
         currentState = ClusterState.builder(currentState)
             .metadata(Metadata.builder(metadata).putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata)).build();
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
         // TODO(talevy): assert changes... right now we do not support updates to policies. will require internal cleanup
     }
 
@@ -383,7 +383,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         PolicyStepsRegistry registry = new PolicyStepsRegistry(REGISTRY, client, null);
 
         // add new policy
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
 
         Map<Step.StepKey, Step> registeredStepsForPolicy = registry.getStepMap().get(newPolicy.getName());
         Step shrinkStep = registeredStepsForPolicy.entrySet().stream()
@@ -409,7 +409,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         currentState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
 
         // Update the policies
-        registry.update(currentState);
+        registry.update(currentState.metadata().custom(IndexLifecycleMetadata.TYPE));
 
         registeredStepsForPolicy = registry.getStepMap().get(newPolicy.getName());
         shrinkStep = registeredStepsForPolicy.entrySet().stream()


### PR DESCRIPTION
Short-circuiting a few spots where we needlessly diff maps or iterate over all indices.

backport of #79098 