### PR TITLE
[Backport 7.x] Add warning log message on realm disable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -457,6 +457,10 @@ public class XPackLicenseState {
         return checkAgainstStatus(status -> status.active);
     }
 
+    public String statusDescription() {
+        return executeAgainstStatus(status -> (status.active ? "active" : "expired") + ' ' + status.mode.description() + " license");
+    }
+
     @Deprecated
     public boolean checkFeature(Feature feature) {
         return feature.feature.check(this);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -41,9 +41,14 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     /** Creates a license state with the given license type and active state, and checks the given method returns expected. */
     void assertAllowed(OperationMode mode, boolean active, Predicate<XPackLicenseState> predicate, boolean expected) {
+        XPackLicenseState licenseState = buildLicenseState(mode, active);
+        assertEquals(expected, predicate.test(licenseState));
+    }
+
+    XPackLicenseState buildLicenseState(OperationMode mode, boolean active) {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(mode, active, null);
-        assertEquals(expected, predicate.test(licenseState));
+        return licenseState;
     }
 
     /**
@@ -321,6 +326,15 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertAllowed(PLATINUM, true, s -> s.isAllowed(feature), false);
         assertAllowed(ENTERPRISE, true, s -> s.isAllowed(feature), true);
         assertAllowed(TRIAL, true, s -> s.isAllowed(feature), true);
+    }
+
+    public void testStatusDescription() {
+        assertThat(buildLicenseState(BASIC, true).statusDescription(), is("active basic license"));
+        assertThat(buildLicenseState(STANDARD, true).statusDescription(), is("active standard license"));
+        assertThat(buildLicenseState(GOLD, false).statusDescription(), is("expired gold license"));
+        assertThat(buildLicenseState(PLATINUM, false).statusDescription(), is("expired platinum license"));
+        assertThat(buildLicenseState(ENTERPRISE, true).statusDescription(), is("active enterprise license"));
+        assertThat(buildLicenseState(TRIAL, false).statusDescription(), is("expired trial license"));
     }
 
     public void testLastUsedMomentaryFeature() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -129,25 +129,31 @@ public class Realms implements Iterable<Realm> {
             Strings.collectionToCommaDelimitedString(licensedRealms)
         );
 
-        stopTrackingInactiveRealms(licenseStateSnapshot, licensedRealms);
+        // Stop license-tracking for any previously-active realms that are no longer allowed
+        if (activeRealms != null) {
+            activeRealms.stream().filter(r -> licensedRealms.contains(r) == false).forEach(realm -> {
+                handleDisabledRealmDueToLicenseChange(realm, licenseStateSnapshot);
+            });
+        }
 
         activeRealms = licensedRealms;
     }
 
     // Can be overridden in testing
-    protected void stopTrackingInactiveRealms(XPackLicenseState licenseStateSnapshot, List<Realm> licensedRealms) {
-        // Stop license-tracking for any previously-active realms that are no longer allowed
-        if (activeRealms != null) {
-            activeRealms.stream().filter(r -> licensedRealms.contains(r) == false).forEach(realm -> {
-                final LicensedFeature.Persistent feature = getLicensedFeatureForRealm(realm.type());
-                assert feature != null : "Realm ["
-                    + realm
-                    + "] with no licensed feature became inactive due to change to license mode ["
-                    + licenseStateSnapshot.getOperationMode()
-                    + "]";
-                feature.stopTracking(licenseStateSnapshot, realm.name());
-            });
-        }
+    protected void handleDisabledRealmDueToLicenseChange(Realm realm, XPackLicenseState licenseStateSnapshot) {
+        final LicensedFeature.Persistent feature = getLicensedFeatureForRealm(realm.type());
+        assert feature != null : "Realm ["
+            + realm
+            + "] with no licensed feature became inactive due to change to license mode ["
+            + licenseStateSnapshot.getOperationMode()
+            + "]";
+        feature.stopTracking(licenseStateSnapshot, realm.name());
+        logger.warn(
+            "The [{}.{}] realm has been automatically disabled due to a change in license [{}]",
+            realm.type(),
+            realm.name(),
+            licenseStateSnapshot.statusDescription()
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -435,7 +435,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(realms, atLeastOnce()).recomputeActiveRealms();
         verify(realms, atLeastOnce()).calculateLicensedRealms(any(XPackLicenseState.class));
         verify(realms, atLeastOnce()).getActiveRealms();
-        verify(realms, atLeastOnce()).stopTrackingInactiveRealms(any(XPackLicenseState.class), any());
+        verify(realms, atLeastOnce()).handleDisabledRealmDueToLicenseChange(any(Realm.class), any(XPackLicenseState.class));
         // ^^ We don't care how many times these methods are called, we just check it here so that we can verify no more interactions below.
         verifyNoMoreInteractions(realms);
     }
@@ -2194,7 +2194,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         }
 
         @Override
-        protected void stopTrackingInactiveRealms(XPackLicenseState licenseStateSnapshot, List<Realm> licensedRealms) {
+        protected void handleDisabledRealmDueToLicenseChange(Realm realm, XPackLicenseState licenseStateSnapshot) {
             // Ignore
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -6,9 +6,13 @@
  */
 package org.elasticsearch.xpack.security.authc;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
@@ -19,6 +23,7 @@ import org.elasticsearch.license.LicenseStateListener;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
@@ -38,6 +43,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,6 +60,7 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -343,6 +350,69 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_2");
     }
 
+    public void testRealmsAreDisabledOnLicenseDowngrade() throws Exception {
+        factories.put(LdapRealmSettings.LDAP_TYPE, DummyRealm::new);
+        factories.put(PkiRealmSettings.TYPE, DummyRealm::new);
+
+        Settings settings = Settings.builder()
+            .put("xpack.security.authc.realms.file.file_realm.order", 0)
+            .put("xpack.security.authc.realms.native.native_realm.order", 1)
+            .put("xpack.security.authc.realms.kerberos.kerberos_realm.order", 2)
+            .put("xpack.security.authc.realms.ldap.ldap_realm_1.order", 3)
+            .put("xpack.security.authc.realms.ldap.ldap_realm_2.order", 4)
+            .put("xpack.security.authc.realms.pki.pki_realm.order", 5)
+            .put("xpack.security.authc.realms.type_0.custom_realm_1.order", 6)
+            .put("xpack.security.authc.realms.type_1.custom_realm_2.order", 7)
+            .put("path.home", createTempDir())
+            .build();
+        Environment env = TestEnvironment.newEnvironment(settings);
+
+        allowAllRealms();
+
+        final Realms realms = new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
+        assertThat(realms.getUnlicensedRealms(), empty());
+        assertThat(realms.getActiveRealms(), hasSize(9)); // 0..7 configured + reserved
+
+        verify(licenseState).enableUsageTracking(Security.KERBEROS_REALM_FEATURE, "kerberos_realm");
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, "ldap_realm_1");
+        verify(licenseState).enableUsageTracking(Security.LDAP_REALM_FEATURE, "ldap_realm_2");
+        verify(licenseState).enableUsageTracking(Security.PKI_REALM_FEATURE, "pki_realm");
+        verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_1");
+        verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_2");
+
+        final Logger realmsLogger = LogManager.getLogger(Realms.class);
+        final MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(realmsLogger, appender);
+        appender.start();
+
+        when(licenseState.statusDescription()).thenReturn("mock license");
+        try {
+            for (String realmId : Arrays.asList("kerberos.kerberos_realm", "type_0.custom_realm_1", "type_1.custom_realm_2")) {
+                appender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(
+                        "Realm [" + realmId + "] disabled",
+                        realmsLogger.getName(),
+                        Level.WARN,
+                        "The [" + realmId + "] realm has been automatically disabled due to a change in license [mock license]"
+                    )
+                );
+            }
+            allowOnlyStandardRealms();
+            appender.assertAllExpectationsMatched();
+        } finally {
+            appender.stop();
+            Loggers.removeAppender(realmsLogger, appender);
+        }
+
+        final List<String> unlicensedRealmNames = realms.getUnlicensedRealms().stream().map(r -> r.name()).collect(Collectors.toList());
+        assertThat(unlicensedRealmNames, containsInAnyOrder("kerberos_realm", "custom_realm_1", "custom_realm_2"));
+        assertThat(realms.getActiveRealms(), hasSize(6)); // 9 - 3
+
+        verify(licenseState).disableUsageTracking(Security.KERBEROS_REALM_FEATURE, "kerberos_realm");
+        verify(licenseState).disableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_1");
+        verify(licenseState).disableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_2");
+    }
+
     public void testUnlicensedWithOnlyCustomRealms() throws Exception {
         Settings.Builder builder = Settings.builder().put("path.home", createTempDir());
         List<Integer> orders = new ArrayList<>(randomRealmTypesCount);
@@ -565,6 +635,7 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState, times(2)).isAllowed(Security.LDAP_REALM_FEATURE);
         // Verify that we stopped tracking use for realms which are no longer licensed
         verify(licenseState).disableUsageTracking(Security.LDAP_REALM_FEATURE, "foo");
+        verify(licenseState).statusDescription();
         verifyNoMoreInteractions(licenseState);
 
         assertThat(realms.getUnlicensedRealms(), iterableWithSize(1));


### PR DESCRIPTION
When a license is changed, it may cause a realm to be disabled.
This commit adds an additional log message whenever a realm is
disabled to explicitly warn the cluster administrator that the
realm is no longer in use.

Backport of: #79039
