### PR TITLE
Improve GeoIpDownloaderIT test suite and improve geoip failure tagging.

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -107,6 +108,18 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             if (task != null) {
                 GeoIpTaskState state = (GeoIpTaskState) task.getState();
                 assertThat(state.getDatabases(), anEmptyMap());
+            }
+        });
+        assertBusy(() -> {
+            GeoIpDownloaderStatsAction.Response  response =
+                client().execute(GeoIpDownloaderStatsAction.INSTANCE, new GeoIpDownloaderStatsAction.Request()).actionGet();
+            assertThat(response.getStats().getDatabasesCount(), equalTo(0));
+            assertThat(response.getNodes(), not(empty()));
+            for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
+                assertThat(nodeResponse.getConfigDatabases(), empty());
+                assertThat(nodeResponse.getDatabases(), empty());
+                assertThat(nodeResponse.getFilesInTemp().stream().filter(s -> s.endsWith(".txt") == false).collect(Collectors.toList()),
+                    empty());
             }
         });
         assertBusy(() -> {
@@ -263,7 +276,6 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79074")
     @TestLogging(value = "org.elasticsearch.ingest.geoip:TRACE", reason = "https://github.com/elastic/elasticsearch/issues/69972")
     public void testUseGeoIpProcessorWithDownloadedDBs() throws Exception {
         assumeTrue("only test with fixture to have stable results", ENDPOINT != null);
@@ -310,9 +322,9 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
                 }
             }
         });
+        deleteDatabasesInConfigDirectory();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79074")
     public void testStartWithNoDatabases() throws Exception {
         assumeTrue("only test with fixture to have stable results", ENDPOINT != null);
         putPipeline();
@@ -330,31 +342,24 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         // Enable downloader:
         Settings.Builder settings = Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), true);
         assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings));
-        {
-            assertBusy(() -> {
-                SimulateDocumentBaseResult result = simulatePipeline();
-                assertThat(result.getFailure(), nullValue());
-                assertThat(result.getIngestDocument(), notNullValue());
-                Map<?, ?> source = result.getIngestDocument().getSourceAndMetadata();
-                assertThat(source, not(hasKey("tags")));
-                assertThat(source, hasKey("ip-city"));
-                assertThat(source, hasKey("ip-asn"));
-                assertThat(source, hasKey("ip-country"));
-
-                assertThat(((Map<?, ?>) source.get("ip-city")).get("city_name"), equalTo("Linköping"));
-                assertThat(((Map<?, ?>) source.get("ip-asn")).get("organization_name"), equalTo("Bredband2 AB"));
-                assertThat(((Map<?, ?>) source.get("ip-country")).get("country_name"), equalTo("Sweden"));
-            });
-        }
+        verifyUpdatedDatabase();
     }
 
     private void verifyUpdatedDatabase() throws Exception {
         assertBusy(() -> {
             SimulateDocumentBaseResult result = simulatePipeline();
             assertThat(result.getFailure(), nullValue());
-            assertThat(result.getIngestDocument().getFieldValue("ip-city.city_name", String.class), equalTo("Linköping"));
-            assertThat(result.getIngestDocument().getFieldValue("ip-asn.organization_name", String.class), equalTo("Bredband2 AB"));
-            assertThat(result.getIngestDocument().getFieldValue("ip-country.country_name", String.class), equalTo("Sweden"));
+            assertThat(result.getIngestDocument(), notNullValue());
+
+            Map<?, ?> source = result.getIngestDocument().getSourceAndMetadata();
+            assertThat(source, not(hasKey("tags")));
+            assertThat(source, hasKey("ip-city"));
+            assertThat(source, hasKey("ip-asn"));
+            assertThat(source, hasKey("ip-country"));
+
+            assertThat(((Map<?, ?>) source.get("ip-city")).get("city_name"), equalTo("Linköping"));
+            assertThat(((Map<?, ?>) source.get("ip-asn")).get("organization_name"), equalTo("Bredband2 AB"));
+            assertThat(((Map<?, ?>) source.get("ip-country")).get("country_name"), equalTo("Sweden"));
         });
     }
 
@@ -483,6 +488,29 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
                 assertThat(nodeResponse.getConfigDatabases(),
                     containsInAnyOrder("GeoLite2-Country.mmdb", "GeoLite2-City.mmdb", "GeoLite2-ASN.mmdb"));
+            }
+        });
+    }
+
+    private void deleteDatabasesInConfigDirectory() throws Exception {
+        StreamSupport.stream(internalCluster().getInstances(Environment.class).spliterator(), false)
+            .map(Environment::configFile)
+            .map(path -> path.resolve("ingest-geoip"))
+            .distinct()
+            .forEach(path -> {
+                try {
+                    IOUtils.rm(path);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+
+        assertBusy(() -> {
+            GeoIpDownloaderStatsAction.Response  response =
+                client().execute(GeoIpDownloaderStatsAction.INSTANCE, new GeoIpDownloaderStatsAction.Request()).actionGet();
+            assertThat(response.getNodes(), not(empty()));
+            for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
+                assertThat(nodeResponse.getConfigDatabases(), empty());
             }
         });
     }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -36,8 +36,8 @@ import static org.hamcrest.Matchers.nullValue;
 public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCity() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "8.8.8.8");
@@ -60,8 +60,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testNullValueWithIgnoreMissing() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true, false, "filename");
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -70,8 +70,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testNonExistentWithIgnoreMissing() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true, false, "filename");
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         processor.execute(ingestDocument);
@@ -79,8 +79,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testNullWithoutIgnoreMissing() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -89,8 +89,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testNonExistentWithoutIgnoreMissing() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         Exception exception = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
@@ -98,8 +98,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testCity_withIpV6() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         String address = "2602:306:33d3:8000::3257:9652";
         Map<String, Object> document = new HashMap<>();
@@ -126,8 +126,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testCityWithMissingLocation() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "80.231.5.0");
@@ -142,8 +142,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testCountry() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-Country.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-Country.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "82.170.213.79");
@@ -161,8 +161,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testCountryWithMissingLocation() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-Country.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-Country.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "80.231.5.0");
@@ -178,8 +178,8 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testAsn() throws Exception {
         String ip = "82.171.64.0";
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-ASN.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-ASN.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", ip);
@@ -197,8 +197,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testAddressIsNotInTheDatabase() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "127.0.0.1");
@@ -211,8 +211,8 @@ public class GeoIpProcessorTests extends ESTestCase {
      * Don't silently do DNS lookups or anything trappy on bogus data
      */
     public void testInvalid() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "www.google.com");
@@ -222,8 +222,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testListAllValid() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("8.8.8.8", "82.171.64.0"));
@@ -242,8 +242,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testListPartiallyValid() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("8.8.8.8", "127.0.0.1"));
@@ -262,8 +262,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testListNoMatches() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("127.0.0.1", "127.0.0.1"));
@@ -274,8 +274,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testListFirstOnly() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("8.8.8.8", "127.0.0.1"));
@@ -292,8 +292,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testListFirstOnlyNoMatches() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("127.0.0.1", "127.0.0.2"));
@@ -304,8 +304,8 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testInvalidDatabase() throws Exception {
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field",
-            loader("/GeoLite2-City.mmdb"), () -> false, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true);
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", loader("/GeoLite2-City.mmdb"),
+            () -> false, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, true, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", Arrays.asList("127.0.0.1", "127.0.0.2"));


### PR DESCRIPTION
In the case a database couldn't be loaded, the geoip processor factory
checks whether any databases are available and then returns a processor
implementation that tags documents with the fact that required database
wasn't available. The GeoIpProcessor itself also loads the database, but
in case a database can't be loaded then it always fails with resource
missing exception. The GeoIpProcessor is modified in this change to
also check whether any database is available and in that case tag
documents instead of failing.

GeoIpDownloaderIT improvements:
* The `testUseGeoIpProcessorWithDownloadedDBs()` was adding databases to config dirs,
  but not cleaning it up. Which broke assumptions in others in this suite, because
  the test cluster is reused.
* Use the geoip stats api after each test to wait for a clean state, which means
  wait for database downloader to be disabled and all database files to be removed
  on all ingest nodes.
* Don't use `IngestDocument#getFieldValue(...)` in test code surrounded by `assertBusy(...)`.
  If a field isn't there an illegal state exception is thrown, which isn't caught by
  `assertBusy(...)`. Only assertion errors are handled.

Closes #79074