### PR TITLE
[7.x] Add support for peer recoveries using snapshots after primary failovers

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.indices.recovery.plan;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
@@ -53,6 +54,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class ShardSnapshotsServiceIT extends ESIntegTestCase {
     @Override
@@ -184,6 +186,12 @@ public class ShardSnapshotsServiceIT extends ESIntegTestCase {
             assertThat(nonEnabledRepos.contains(shardSnapshotInfo.getRepository()), is(equalTo(false)));
 
             assertThat(shardSnapshotData.getMetadataSnapshot().size(), is(greaterThan(0)));
+            Version commitVersion = shardSnapshotData.getCommitVersion();
+            assertThat(commitVersion, is(notNullValue()));
+            assertThat(commitVersion, is(equalTo(Version.CURRENT)));
+            final org.apache.lucene.util.Version commitLuceneVersion = shardSnapshotData.getCommitLuceneVersion();
+            assertThat(commitLuceneVersion, is(notNullValue()));
+            assertThat(commitLuceneVersion, is(equalTo(Version.CURRENT.luceneVersion)));
 
             assertThat(shardSnapshotInfo.getShardId(), is(equalTo(shardId)));
             assertThat(shardSnapshotInfo.getSnapshot().getSnapshotId().getName(), is(equalTo(snapshotName)));

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -100,6 +100,9 @@ public abstract class Engine implements Closeable {
     public static final String FORCE_MERGE_UUID_KEY = "force_merge_uuid";
     public static final String MIN_RETAINED_SEQNO = "min_retained_seq_no";
     public static final String MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID = "max_unsafe_auto_id_timestamp";
+    // Field name that stores the Elasticsearch version in Lucene commit user data, representing
+    // the version that was used to write the commit (and thus a max version for the underlying segments).
+    public static final String ES_VERSION = "es_version";
     public static final String SEARCH_SOURCE = "search"; // TODO: Make source of search enum?
     public static final String CAN_MATCH_SEARCH_SOURCE = "can_match";
     protected static final String DOC_STATS_SOURCE = "doc_stats";

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -44,6 +44,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
@@ -2525,7 +2526,7 @@ public class InternalEngine extends Engine {
                  * {@link IndexWriter#commit()} call flushes all documents, we defer computation of the maximum sequence number to the time
                  * of invocation of the commit data iterator (which occurs after all documents have been flushed to Lucene).
                  */
-                final Map<String, String> commitData = new HashMap<>(7);
+                final Map<String, String> commitData = new HashMap<>(8);
                 commitData.put(Translog.TRANSLOG_UUID_KEY, translog.getTranslogUUID());
                 commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(localCheckpoint));
                 if (syncId != null) {
@@ -2541,6 +2542,7 @@ public class InternalEngine extends Engine {
                 if (currentForceMergeUUID != null) {
                     commitData.put(FORCE_MERGE_UUID_KEY, currentForceMergeUUID);
                 }
+                commitData.put(ES_VERSION, Version.CURRENT.toString());
                 logger.trace("committing writer with commit data [{}]", commitData);
                 return commitData.entrySet().iterator();
             });

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -142,6 +142,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
+import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.plugins.IndexStorePlugin;
@@ -1786,7 +1787,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     private boolean assertSequenceNumbersInCommit() throws IOException {
-        final Map<String, String> userData = SegmentInfos.readLatestCommit(store.directory()).getUserData();
+        final SegmentInfos segmentCommitInfos = SegmentInfos.readLatestCommit(store.directory());
+        final Map<String, String> userData = segmentCommitInfos.getUserData();
         assert userData.containsKey(SequenceNumbers.LOCAL_CHECKPOINT_KEY) : "commit point doesn't contains a local checkpoint";
         assert userData.containsKey(SequenceNumbers.MAX_SEQ_NO) : "commit point doesn't contains a maximum sequence number";
         assert userData.containsKey(Engine.HISTORY_UUID_KEY) : "commit point doesn't contains a history uuid";
@@ -1795,6 +1797,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert userData.containsKey(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID) :
             "opening index which was created post 5.5.0 but " + Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID
                 + " is not found in commit";
+        final org.apache.lucene.util.Version commitLuceneVersion = segmentCommitInfos.getCommitLuceneVersion();
+        // This relies in the previous minor having another lucene version 
+        assert commitLuceneVersion.onOrAfter(RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion) == false ||
+            userData.containsKey(Engine.ES_VERSION) && Version.fromString(userData.get(Engine.ES_VERSION)).onOrBefore(Version.CURRENT) :
+            "commit point has an invalid ES_VERSION value. commit point lucene version [" + commitLuceneVersion + "]," +
+                " ES_VERSION [" + userData.get(Engine.ES_VERSION) + "]";
         return true;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -20,6 +20,7 @@ import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.store.NativeFSLockFactory;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ElasticsearchNodeCommand;
@@ -403,6 +404,10 @@ public class RemoveCorruptedShardDataCommand extends ElasticsearchNodeCommand {
 
             // commit the new history id
             userData.put(Engine.HISTORY_UUID_KEY, historyUUID);
+            final String commitESVersion = userData.get(Engine.ES_VERSION);
+            if (commitESVersion == null || Version.fromString(commitESVersion).onOrBefore(Version.CURRENT)) {
+                userData.put(Engine.ES_VERSION, Version.CURRENT.toString());
+            }
 
             indexWriter.setLiveCommitData(userData.entrySet());
             indexWriter.commit();

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -174,6 +174,7 @@ final class StoreRecovery {
                 liveCommitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNo));
                 liveCommitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(maxSeqNo));
                 liveCommitData.put(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp));
+                liveCommitData.put(Engine.ES_VERSION, Version.CURRENT.toString());
                 return liveCommitData.entrySet().iterator();
             });
             writer.commit();

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -53,6 +53,7 @@ import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -97,6 +98,7 @@ import java.util.zip.Checksum;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.common.lucene.Lucene.indexWriterConfigWithNoMerging;
+import static org.elasticsearch.index.engine.Engine.ES_VERSION;
 
 /**
  * A Store provides plain access to files written by an elasticsearch index shard. Each shard
@@ -818,6 +820,12 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
          */
         public long getNumDocs() {
             return numDocs;
+        }
+
+        @Nullable
+        public org.elasticsearch.Version getCommitVersion() {
+            String version = commitUserData.get(ES_VERSION);
+            return version == null ? null : org.elasticsearch.Version.fromString(version);
         }
 
         static class LoadedMetadata {
@@ -1592,7 +1600,12 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
                     // The new commit will use segment files from the starting commit but userData from the last commit by default.
                     // Thus, we need to manually set the userData from the starting commit to the new commit.
-                    writer.setLiveCommitData(startingIndexCommit.getUserData().entrySet());
+                    final Map<String, String> userData = startingIndexCommit.getUserData();
+                    writer.setLiveCommitData(() -> {
+                        Map<String, String> updatedUserData = new HashMap<>(userData);
+                        updatedUserData.put(ES_VERSION, org.elasticsearch.Version.CURRENT.toString());
+                        return updatedUserData.entrySet().iterator();
+                    });
                     writer.commit();
                 }
             }
@@ -1619,6 +1632,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     private static void updateCommitData(IndexWriter writer, Map<String, String> keysToUpdate) throws IOException {
         final Map<String, String> userData = getUserData(writer);
+        userData.put(Engine.ES_VERSION, org.elasticsearch.Version.CURRENT.toString());
         userData.putAll(keysToUpdate);
         writer.setLiveCommitData(userData.entrySet());
         writer.commit();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -112,6 +112,18 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
         }
     }
 
+    public void deleteTempFiles() {
+        incRef();
+        try {
+            for (String tempFileName : tempFileNames.keySet()) {
+                store.deleteQuiet(tempFileName);
+            }
+            tempFileNames.clear();
+        } finally {
+            decRef();
+        }
+    }
+
     /** Get a temporary name for the provided file name. */
     String getTempNameForFile(String origFile) {
         return tempFilePrefix + origFile;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -496,6 +496,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         }
     }
 
+
     private ActionListener<Void> createOrFinishListener(final RecoveryRef recoveryRef, final TransportChannel channel,
                                                         final String action, final RecoveryTransportRequest request) {
         return createOrFinishListener(recoveryRef, channel, action, request, nullVal -> TransportResponse.Empty.INSTANCE);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 public class RecoverySettings {
     public static final Version SNAPSHOT_RECOVERIES_SUPPORTED_VERSION = Version.V_7_15_0;
+    public static final Version SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION = Version.V_7_16_0;
 
     private static final Logger logger = LogManager.getLogger(RecoverySettings.class);
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -44,6 +44,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.RecoveryEngineException;
@@ -62,6 +63,7 @@ import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.ShardRecoveryPlan;
+import org.elasticsearch.snapshots.SnapshotShardsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.Transports;
@@ -473,8 +475,10 @@ public class RecoverySourceHandler {
         try {
             StopWatch stopWatch = new StopWatch().start();
             final Store.MetadataSnapshot recoverySourceMetadata;
+            final String shardStateIdentifier;
             try {
                 recoverySourceMetadata = store.getMetadata(snapshot);
+                shardStateIdentifier = SnapshotShardsService.getShardStateId(shard, snapshot);
             } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
                 shard.failShard("recovery", ex);
                 throw ex;
@@ -490,6 +494,7 @@ public class RecoverySourceHandler {
             if (canSkipPhase1(recoverySourceMetadata, request.metadataSnapshot()) == false) {
                 cancellableThreads.checkForCancel();
                 recoveryPlannerService.computeRecoveryPlan(shard.shardId(),
+                    shardStateIdentifier,
                     recoverySourceMetadata,
                     request.metadataSnapshot(),
                     startingSeqNo,
@@ -561,11 +566,15 @@ public class RecoverySourceHandler {
                 phase1ExistingFileNames.size(), new ByteSizeValue(existingTotalSize));
         }
 
+        // We need to pass the ShardRecovery plan between steps instead of capturing it in the closures
+        // since the plan can change after a failure recovering files from the snapshots that cannot be
+        // recovered from the source node, in that case we have to start from scratch using the fallback
+        // recovery plan that would be used in subsequent steps.
         final StepListener<Void> sendFileInfoStep = new StepListener<>();
-        final StepListener<List<StoreFileMetadata>> recoverSnapshotFilesStep = new StepListener<>();
-        final StepListener<Void> sendFilesStep = new StepListener<>();
-        final StepListener<RetentionLease> createRetentionLeaseStep = new StepListener<>();
-        final StepListener<Void> cleanFilesStep = new StepListener<>();
+        final StepListener<Tuple<ShardRecoveryPlan, List<StoreFileMetadata>>> recoverSnapshotFilesStep = new StepListener<>();
+        final StepListener<ShardRecoveryPlan> sendFilesStep = new StepListener<>();
+        final StepListener<Tuple<ShardRecoveryPlan, RetentionLease>> createRetentionLeaseStep = new StepListener<>();
+        final StepListener<ShardRecoveryPlan> cleanFilesStep = new StepListener<>();
 
         final int translogOps = shardRecoveryPlan.getTranslogOps();
         recoveryTarget.receiveFileInfo(filesToRecoverNames,
@@ -576,43 +585,86 @@ public class RecoverySourceHandler {
             sendFileInfoStep
         );
 
-        sendFileInfoStep.whenComplete(r -> recoverSnapshotFiles(shardRecoveryPlan, recoverSnapshotFilesStep), listener::onFailure);
+        sendFileInfoStep.whenComplete(unused -> {
+            recoverSnapshotFiles(shardRecoveryPlan, new ActionListener<List<StoreFileMetadata>>() {
+                @Override
+                public void onResponse(List<StoreFileMetadata> filesFailedToRecoverFromSnapshot) {
+                    recoverSnapshotFilesStep.onResponse(Tuple.tuple(shardRecoveryPlan, filesFailedToRecoverFromSnapshot));
+                }
 
-        recoverSnapshotFilesStep.whenComplete(filesFailedToRecoverFromSnapshot -> {
+                @Override
+                public void onFailure(Exception e) {
+                    if (shardRecoveryPlan.canRecoverSnapshotFilesFromSourceNode() == false &&
+                        e instanceof CancellableThreads.ExecutionCancelledException == false) {
+                        ShardRecoveryPlan fallbackPlan = shardRecoveryPlan.getFallbackPlan();
+                        recoveryTarget.receiveFileInfo(fallbackPlan.getFilesToRecoverNames(),
+                            fallbackPlan.getFilesToRecoverSizes(),
+                            fallbackPlan.getFilesPresentInTargetNames(),
+                            fallbackPlan.getFilesPresentInTargetSizes(),
+                            fallbackPlan.getTranslogOps(),
+                            recoverSnapshotFilesStep.map(r -> Tuple.tuple(fallbackPlan, Collections.emptyList()))
+                        );
+                    } else {
+                        recoverSnapshotFilesStep.onFailure(e);
+                    }
+                }
+            });
+        }, listener::onFailure);
+
+        recoverSnapshotFilesStep.whenComplete(planAndFilesFailedToRecoverFromSnapshot -> {
+            ShardRecoveryPlan recoveryPlan = planAndFilesFailedToRecoverFromSnapshot.v1();
+            List<StoreFileMetadata> filesFailedToRecoverFromSnapshot = planAndFilesFailedToRecoverFromSnapshot.v2();
             final List<StoreFileMetadata> filesToRecoverFromSource;
             if (filesFailedToRecoverFromSnapshot.isEmpty()) {
-                filesToRecoverFromSource = shardRecoveryPlan.getSourceFilesToRecover();
+                filesToRecoverFromSource = recoveryPlan.getSourceFilesToRecover();
             } else {
-                filesToRecoverFromSource = concatLists(shardRecoveryPlan.getSourceFilesToRecover(), filesFailedToRecoverFromSnapshot);
+                filesToRecoverFromSource = concatLists(recoveryPlan.getSourceFilesToRecover(), filesFailedToRecoverFromSnapshot);
             }
 
             sendFiles(store,
-                filesToRecoverFromSource.toArray(new StoreFileMetadata[0]), shardRecoveryPlan::getTranslogOps, sendFilesStep);
+                filesToRecoverFromSource.toArray(new StoreFileMetadata[0]),
+                recoveryPlan::getTranslogOps,
+                sendFilesStep.map(unused -> recoveryPlan)
+            );
         }, listener::onFailure);
 
-        final long startingSeqNo = shardRecoveryPlan.getStartingSeqNo();
-        sendFilesStep.whenComplete(r -> createRetentionLease(startingSeqNo, createRetentionLeaseStep), listener::onFailure);
+        sendFilesStep.whenComplete(recoveryPlan -> {
+            createRetentionLease(recoveryPlan.getStartingSeqNo(),
+                createRetentionLeaseStep.map(retentionLease -> Tuple.tuple(recoveryPlan, retentionLease))
+            );
+        }, listener::onFailure);
 
-        final Store.MetadataSnapshot recoverySourceMetadata = shardRecoveryPlan.getSourceMetadataSnapshot();
-        createRetentionLeaseStep.whenComplete(retentionLease ->
-            {
-                final long lastKnownGlobalCheckpoint = shard.getLastKnownGlobalCheckpoint();
-                assert retentionLease == null || retentionLease.retainingSequenceNumber() - 1 <= lastKnownGlobalCheckpoint
-                    : retentionLease + " vs " + lastKnownGlobalCheckpoint;
-                // Establishes new empty translog on the replica with global checkpoint set to lastKnownGlobalCheckpoint. We want
-                // the commit we just copied to be a safe commit on the replica, so why not set the global checkpoint on the replica
-                // to the max seqno of this commit? Because (in rare corner cases) this commit might not be a safe commit here on
-                // the primary, and in these cases the max seqno would be too high to be valid as a global checkpoint.
-                cleanFiles(store, recoverySourceMetadata, () -> translogOps, lastKnownGlobalCheckpoint, cleanFilesStep);
-            },
-            listener::onFailure);
+        createRetentionLeaseStep.whenComplete(recoveryPlanAndRetentionLease -> {
+            final ShardRecoveryPlan recoveryPlan = recoveryPlanAndRetentionLease.v1();
+            final RetentionLease retentionLease = recoveryPlanAndRetentionLease.v2();
+            final Store.MetadataSnapshot recoverySourceMetadata = recoveryPlan.getSourceMetadataSnapshot();
+            final long lastKnownGlobalCheckpoint = shard.getLastKnownGlobalCheckpoint();
+            assert retentionLease == null || retentionLease.retainingSequenceNumber() - 1 <= lastKnownGlobalCheckpoint
+                : retentionLease + " vs " + lastKnownGlobalCheckpoint;
+            // Establishes new empty translog on the replica with global checkpoint set to lastKnownGlobalCheckpoint. We want
+            // the commit we just copied to be a safe commit on the replica, so why not set the global checkpoint on the replica
+            // to the max seqno of this commit? Because (in rare corner cases) this commit might not be a safe commit here on
+            // the primary, and in these cases the max seqno would be too high to be valid as a global checkpoint.
+            cleanFiles(store,
+                recoverySourceMetadata,
+                () -> translogOps,
+                lastKnownGlobalCheckpoint,
+                cleanFilesStep.map(unused -> recoveryPlan)
+            );
+        }, listener::onFailure);
 
-        cleanFilesStep.whenComplete(r -> {
+        cleanFilesStep.whenComplete(recoveryPlan -> {
             final TimeValue took = stopWatch.totalTime();
             logger.trace("recovery [phase1]: took [{}]", took);
             listener.onResponse(
-                new SendFileResult(filesToRecoverNames, filesToRecoverSizes, totalSize,
-                    phase1ExistingFileNames, phase1ExistingFileSizes, existingTotalSize, took)
+                new SendFileResult(recoveryPlan.getFilesToRecoverNames(),
+                    recoveryPlan.getFilesToRecoverSizes(),
+                    recoveryPlan.getTotalSize(),
+                    recoveryPlan.getFilesPresentInTargetNames(),
+                    recoveryPlan.getFilesPresentInTargetSizes(),
+                    recoveryPlan.getExistingSize(),
+                    took
+                )
             );
         }, listener::onFailure);
     }
@@ -634,6 +686,7 @@ public class RecoverySourceHandler {
     }
 
     private class SnapshotRecoverFileRequestsSender {
+        private final ShardRecoveryPlan shardRecoveryPlan;
         private final ShardRecoveryPlan.SnapshotFilesToRecover snapshotFilesToRecover;
         private final ActionListener<List<StoreFileMetadata>> listener;
         private final CountDown countDown;
@@ -643,6 +696,7 @@ public class RecoverySourceHandler {
         private List<StoreFileMetadata> filesFailedToDownloadFromSnapshot;
 
         SnapshotRecoverFileRequestsSender(ShardRecoveryPlan shardRecoveryPlan, ActionListener<List<StoreFileMetadata>> listener) {
+            this.shardRecoveryPlan = shardRecoveryPlan;
             this.snapshotFilesToRecover = shardRecoveryPlan.getSnapshotFilesToRecover();
             this.listener = listener;
             this.countDown = new CountDown(shardRecoveryPlan.getSnapshotFilesToRecover().size());
@@ -676,7 +730,11 @@ public class RecoverySourceHandler {
                     public void onFailure(Exception e) {
                         logger.warn(new ParameterizedMessage("failed to recover file [{}] from snapshot, " +
                             "will recover from primary instead", snapshotFileToRecover.metadata()), e);
-                        onRequestCompletion(snapshotFileToRecover.metadata(), e);
+                        if (shardRecoveryPlan.canRecoverSnapshotFilesFromSourceNode()) {
+                            onRequestCompletion(snapshotFileToRecover.metadata(), e);
+                        } else {
+                            cancel(e);
+                        }
                     }
                 };
                 requestFuture.addListener(sendRequestListener);
@@ -689,14 +747,14 @@ public class RecoverySourceHandler {
                     ActionListener.runBefore(requestFuture, () -> unTrackOutstandingRequest(requestFuture))
                 );
             } catch (CancellableThreads.ExecutionCancelledException e) {
-                onCancellation(e);
+                cancel(e);
             } catch (Exception e) {
                 unTrackOutstandingRequest(requestFuture);
                 onRequestCompletion(snapshotFileToRecover.metadata(), e);
             }
         }
 
-        void onCancellation(Exception e) {
+        void cancel(Exception e) {
             if (cancelled.compareAndSet(false, true)) {
                 pendingSnapshotFilesToRecover.clear();
                 notifyFailureOnceAllOutstandingRequestAreDone(e);
@@ -737,13 +795,20 @@ public class RecoverySourceHandler {
         private void trackOutstandingRequest(ListenableFuture<Void> future) {
             boolean cancelled;
             synchronized (outstandingRequests) {
-                cancelled = cancellableThreads.isCancelled();
+                cancelled = cancellableThreads.isCancelled() || this.cancelled.get();
                 if (cancelled == false) {
                     outstandingRequests.add(future);
                 }
             }
             if (cancelled) {
                 cancellableThreads.checkForCancel();
+                // If the recover snapshot files operation is cancelled but the recovery is still
+                // valid, it means that some of the snapshot files download failed and the snapshot files
+                // differ from the source index files. In that case we have to cancel all pending operations
+                // and wait until all the in-flight operations are done to reset the recovery and start from
+                // scratch using the source node index files.
+                assert this.cancelled.get();
+                throw new CancellableThreads.ExecutionCancelledException("Recover snapshot files cancelled");
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -419,6 +419,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                                 int totalTranslogOps,
                                 ActionListener<Void> listener) {
         ActionListener.completeWith(listener, () -> {
+            multiFileWriter.deleteTempFiles();
             indexShard.resetRecoveryStage();
             indexShard.prepareForIndexRecovery();
             final RecoveryState.Index index = state().getIndex();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -23,10 +23,10 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.shard.ShardId;
@@ -150,8 +150,12 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     }
 
     @Override
-    public void receiveFileInfo(List<String> phase1FileNames, List<Long> phase1FileSizes, List<String> phase1ExistingFileNames,
-                                List<Long> phase1ExistingFileSizes, int totalTranslogOps, ActionListener<Void> listener) {
+    public void receiveFileInfo(List<String> phase1FileNames,
+                                List<Long> phase1FileSizes,
+                                List<String> phase1ExistingFileNames,
+                                List<Long> phase1ExistingFileSizes,
+                                int totalTranslogOps,
+                                ActionListener<Void> listener) {
         final String action = PeerRecoveryTargetService.Actions.FILES_INFO;
         final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
         RecoveryFilesInfoRequest request = new RecoveryFilesInfoRequest(recoveryId, requestSeqNo, shardId, phase1FileNames, phase1FileSizes,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/RecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/RecoveryPlannerService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.store.Store;
 
 public interface RecoveryPlannerService {
     void computeRecoveryPlan(ShardId shardId,
+                             String shardStateIdentifier,
                              Store.MetadataSnapshot sourceMetadata,
                              Store.MetadataSnapshot targetMetadata,
                              long startingSeqNo,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshot.java
@@ -8,67 +8,96 @@
 
 package org.elasticsearch.indices.recovery.plan;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.ShardSnapshotInfo;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-class ShardSnapshot {
+public class ShardSnapshot {
     private final ShardSnapshotInfo shardSnapshotInfo;
     // Segment file name -> file info
     private final Map<String, BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles;
     private final Store.MetadataSnapshot metadataSnapshot;
+    private final org.apache.lucene.util.Version commitLuceneVersion;
 
-    ShardSnapshot(ShardSnapshotInfo shardSnapshotInfo, List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles) {
+    ShardSnapshot(ShardSnapshotInfo shardSnapshotInfo,
+                  List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles,
+                  Map<String, String> luceneCommitUserData,
+                  org.apache.lucene.util.Version commitLuceneVersion) {
         this.shardSnapshotInfo = shardSnapshotInfo;
         this.snapshotFiles = snapshotFiles.stream()
             .collect(Collectors.toMap(snapshotFile -> snapshotFile.metadata().name(), Function.identity()));
-        this.metadataSnapshot = convertToMetadataSnapshot(snapshotFiles);
+        this.metadataSnapshot = convertToMetadataSnapshot(snapshotFiles, luceneCommitUserData);
+        this.commitLuceneVersion = commitLuceneVersion;
     }
 
-    String getShardStateIdentifier() {
+    public String getShardStateIdentifier() {
         return shardSnapshotInfo.getShardStateIdentifier();
     }
 
-    String getRepository() {
+    public boolean isLogicallyEquivalent(@Nullable String shardStateIdentifier) {
+        return shardStateIdentifier != null && shardStateIdentifier.equals(shardSnapshotInfo.getShardStateIdentifier());
+    }
+
+    public boolean hasDifferentPhysicalFiles(Store.MetadataSnapshot sourceSnapshot) {
+        Store.RecoveryDiff recoveryDiff = metadataSnapshot.recoveryDiff(sourceSnapshot);
+        return recoveryDiff.different.isEmpty() == false || recoveryDiff.missing.isEmpty() == false;
+    }
+
+    public String getRepository() {
         return shardSnapshotInfo.getRepository();
     }
 
-    Store.MetadataSnapshot getMetadataSnapshot() {
+    public Store.MetadataSnapshot getMetadataSnapshot() {
         return metadataSnapshot;
     }
 
-    IndexId getIndexId() {
+    public IndexId getIndexId() {
         return shardSnapshotInfo.getIndexId();
     }
 
-    long getStartedAt() {
+    public long getStartedAt() {
         return shardSnapshotInfo.getStartedAt();
     }
 
-    ShardSnapshotInfo getShardSnapshotInfo() {
+    public ShardSnapshotInfo getShardSnapshotInfo() {
         return shardSnapshotInfo;
     }
 
-    List<BlobStoreIndexShardSnapshot.FileInfo> getSnapshotFiles(List<StoreFileMetadata> segmentFiles) {
+    @Nullable
+    public Version getCommitVersion() {
+        return metadataSnapshot.getCommitVersion();
+    }
+
+    public org.apache.lucene.util.Version getCommitLuceneVersion() {
+        return commitLuceneVersion;
+    }
+
+    public List<BlobStoreIndexShardSnapshot.FileInfo> getSnapshotFilesMatching(List<StoreFileMetadata> segmentFiles) {
         return segmentFiles.stream()
             .map(storeFileMetadata -> snapshotFiles.get(storeFileMetadata.name()))
             .collect(Collectors.toList());
     }
 
-    static Store.MetadataSnapshot convertToMetadataSnapshot(List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles) {
+    public List<BlobStoreIndexShardSnapshot.FileInfo> getSnapshotFiles() {
+        return org.elasticsearch.core.List.copyOf(snapshotFiles.values());
+    }
+
+    static Store.MetadataSnapshot convertToMetadataSnapshot(List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles,
+                                                            Map<String, String> luceneCommitUserData) {
         return new Store.MetadataSnapshot(
             snapshotFiles.stream()
                 .map(BlobStoreIndexShardSnapshot.FileInfo::metadata)
                 .collect(Collectors.toMap(StoreFileMetadata::name, Function.identity())),
-            Collections.emptyMap(),
+            luceneCommitUserData,
             0
         );
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/SnapshotsRecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/SnapshotsRecoveryPlannerService.java
@@ -13,11 +13,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -26,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.util.CollectionUtils.concatLists;
+import static org.elasticsearch.indices.recovery.RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION;
 
 public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
     private final Logger logger = LogManager.getLogger(SnapshotsRecoveryPlannerService.class);
@@ -37,6 +40,7 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
     }
 
     public void computeRecoveryPlan(ShardId shardId,
+                                    @Nullable String shardStateIdentifier,
                                     Store.MetadataSnapshot sourceMetadata,
                                     Store.MetadataSnapshot targetMetadata,
                                     long startingSeqNo,
@@ -50,6 +54,7 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
         fetchLatestSnapshotsIgnoringErrors(shardId, canUseSnapshots, latestSnapshotOpt ->
             ActionListener.completeWith(listener, () ->
                 computeRecoveryPlanWithSnapshots(
+                    shardStateIdentifier,
                     sourceMetadata,
                     targetMetadata,
                     startingSeqNo,
@@ -60,7 +65,8 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
         );
     }
 
-    private ShardRecoveryPlan computeRecoveryPlanWithSnapshots(Store.MetadataSnapshot sourceMetadata,
+    private ShardRecoveryPlan computeRecoveryPlanWithSnapshots(@Nullable String shardStateIdentifier,
+                                                               Store.MetadataSnapshot sourceMetadata,
                                                                Store.MetadataSnapshot targetMetadata,
                                                                long startingSeqNo,
                                                                int translogOps,
@@ -70,16 +76,35 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
 
         if (latestSnapshotOpt.isPresent() == false) {
             // If we couldn't find any valid  snapshots, fallback to the source
-            return new ShardRecoveryPlan(ShardRecoveryPlan.SnapshotFilesToRecover.EMPTY,
-                filesMissingInTarget,
-                sourceTargetDiff.identical,
-                startingSeqNo,
-                translogOps,
-                sourceMetadata
-            );
+            return getRecoveryPlanUsingSourceNode(sourceMetadata, sourceTargetDiff, filesMissingInTarget, startingSeqNo, translogOps);
         }
 
         ShardSnapshot latestSnapshot = latestSnapshotOpt.get();
+
+        // Primary failed over after the snapshot was taken
+        if (latestSnapshot.isLogicallyEquivalent(shardStateIdentifier) &&
+            latestSnapshot.hasDifferentPhysicalFiles(sourceMetadata) &&
+            isSnapshotVersionCompatible(latestSnapshot) &&
+            sourceTargetDiff.identical.isEmpty()) {
+            // Use the current primary as a fallback if the download fails half-way
+            ShardRecoveryPlan fallbackPlan =
+                getRecoveryPlanUsingSourceNode(sourceMetadata, sourceTargetDiff, filesMissingInTarget, startingSeqNo, translogOps);
+
+            ShardRecoveryPlan.SnapshotFilesToRecover snapshotFilesToRecover = new ShardRecoveryPlan.SnapshotFilesToRecover(
+                latestSnapshot.getIndexId(),
+                latestSnapshot.getRepository(),
+                latestSnapshot.getSnapshotFiles()
+            );
+
+            return new ShardRecoveryPlan(snapshotFilesToRecover,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                startingSeqNo,
+                translogOps,
+                latestSnapshot.getMetadataSnapshot(),
+                fallbackPlan
+            );
+        }
 
         Store.MetadataSnapshot filesToRecoverFromSourceSnapshot = toMetadataSnapshot(filesMissingInTarget);
         Store.RecoveryDiff snapshotDiff = filesToRecoverFromSourceSnapshot.recoveryDiff(latestSnapshot.getMetadataSnapshot());
@@ -89,11 +114,38 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
         } else {
             snapshotFilesToRecover = new ShardRecoveryPlan.SnapshotFilesToRecover(latestSnapshot.getIndexId(),
                 latestSnapshot.getRepository(),
-                latestSnapshot.getSnapshotFiles(snapshotDiff.identical));
+                latestSnapshot.getSnapshotFilesMatching(snapshotDiff.identical));
         }
 
         return new ShardRecoveryPlan(snapshotFilesToRecover,
             concatLists(snapshotDiff.missing, snapshotDiff.different),
+            sourceTargetDiff.identical,
+            startingSeqNo,
+            translogOps,
+            sourceMetadata
+        );
+    }
+
+    private boolean isSnapshotVersionCompatible(ShardSnapshot snapshot) {
+        Version commitVersion = snapshot.getCommitVersion();
+        // if the snapshotVersion == null that means that the snapshot was taken in a version <= 7.15,
+        // therefore we can safely use that snapshot. Since this runs on the shard primary and
+        // NodeVersionAllocationDecider ensures that we only recover to a node that has newer or
+        // same version.
+        if (commitVersion == null) {
+            assert SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion.onOrAfter(snapshot.getCommitLuceneVersion());
+            return Version.CURRENT.luceneVersion.onOrAfter(snapshot.getCommitLuceneVersion());
+        }
+        return commitVersion.onOrBefore(Version.CURRENT);
+    }
+
+    private ShardRecoveryPlan getRecoveryPlanUsingSourceNode(Store.MetadataSnapshot sourceMetadata,
+                                                             Store.RecoveryDiff sourceTargetDiff,
+                                                             List<StoreFileMetadata> filesMissingInTarget,
+                                                             long startingSeqNo,
+                                                             int translogOps) {
+        return new ShardRecoveryPlan(ShardRecoveryPlan.SnapshotFilesToRecover.EMPTY,
+            filesMissingInTarget,
             sourceTargetDiff.identical,
             startingSeqNo,
             translogOps,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/SourceOnlyRecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/SourceOnlyRecoveryPlannerService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.indices.recovery.plan;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
@@ -22,6 +23,7 @@ public class SourceOnlyRecoveryPlannerService implements RecoveryPlannerService 
     public static final RecoveryPlannerService INSTANCE = new SourceOnlyRecoveryPlannerService();
     @Override
     public void computeRecoveryPlan(ShardId shardId,
+                                    @Nullable String shardStateIdentifier,
                                     Store.MetadataSnapshot sourceMetadata,
                                     Store.MetadataSnapshot targetMetadata,
                                     long startingSeqNo,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -396,7 +396,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * @return shard state id or {@code null} if none can be used
      */
     @Nullable
-    private static String getShardStateId(IndexShard indexShard, IndexCommit snapshotIndexCommit) throws IOException {
+    public static String getShardStateId(IndexShard indexShard, IndexCommit snapshotIndexCommit) throws IOException {
         final Map<String, String> userCommitData = snapshotIndexCommit.getUserData();
         final SequenceNumbers.CommitInfo seqNumInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userCommitData.entrySet());
         final long maxSeqNo = seqNumInfo.maxSeqNo;

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.NoDeletionPolicy;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PointValues;
@@ -176,6 +177,8 @@ import java.util.stream.LongStream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.shuffle;
+import static org.elasticsearch.common.lucene.Lucene.indexWriterConfigWithNoMerging;
+import static org.elasticsearch.index.engine.Engine.ES_VERSION;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.LOCAL_RESET;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PEER_RECOVERY;
@@ -6521,6 +6524,93 @@ public class InternalEngineTests extends EngineTestCase {
             assertTrue(engine.isClosed.get());
         } finally {
             IndexWriterMaxDocsChanger.restoreMaxDocs();
+        }
+    }
+
+    public void testCurrentVersionIsCommitted() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            EngineConfig config =
+                config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            store.createEmpty();
+            final String translogUUID = Translog.createEmptyTranslog(
+                config.getTranslogConfig().getTranslogPath(),
+                SequenceNumbers.NO_OPS_PERFORMED,
+                shardId,
+                primaryTerm.get()
+            );
+            store.associateIndexWithNewTranslog(translogUUID);
+
+            try (InternalEngine engine = createEngine(config)) {
+                engine.flush(true, true);
+                Map<String, String> userData = engine.getLastCommittedSegmentInfos().getUserData();
+                assertThat(userData, hasKey(ES_VERSION));
+                assertThat(userData.get(ES_VERSION), is(equalTo(Version.CURRENT.toString())));
+            }
+        }
+    }
+
+    public void testTrimUnsafeCommitHasESVersionInUserData() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        final int maxSeqNo = 40;
+        final List<Long> seqNos = LongStream.rangeClosed(1, maxSeqNo).boxed().collect(Collectors.toList());
+        Collections.shuffle(seqNos, random());
+        try (Store store = createStore()) {
+            EngineConfig config =
+                config(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+
+            try (InternalEngine engine = createEngine(config)) {
+                for (Long seqNo : seqNos) {
+                    ParsedDocument doc = testParsedDocument(Long.toString(seqNo),
+                        null,
+                        testDocument(),
+                        new BytesArray("{}"),
+                        null
+                    );
+                    Engine.Index index = new Engine.Index(newUid(doc),
+                        doc,
+                        seqNo,
+                        0,
+                        1,
+                        null,
+                        REPLICA,
+                        System.nanoTime(),
+                        -1,
+                        false,
+                        UNASSIGNED_SEQ_NO,
+                        0
+                    );
+                    engine.index(index);
+                    engine.flush();
+                }
+                globalCheckpoint.set(1);
+                engine.syncTranslog();
+            }
+
+            // Create a new commit with an old ES_VERSION value to ensure that this gets
+            // overwritten in store.trimUnsafeCommits
+            SegmentInfos committedSegmentsInfo = store.readLastCommittedSegmentsInfo();
+            IndexWriterConfig indexWriterConfig = indexWriterConfigWithNoMerging(null)
+                .setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
+                .setCommitOnClose(false)
+                .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE);
+            try(IndexWriter indexWriter = new IndexWriter(store.directory(), indexWriterConfig)) {
+                Map<String, String> commitUserDataWithOlderVersion = new HashMap<>(committedSegmentsInfo.userData);
+                commitUserDataWithOlderVersion.put(ES_VERSION, Version.V_7_0_0.toString());
+                indexWriter.setLiveCommitData(commitUserDataWithOlderVersion.entrySet());
+                indexWriter.commit();
+            }
+
+            Map<String, String> userDataBeforeTrimUnsafeCommits = store.readLastCommittedSegmentsInfo().getUserData();
+            assertThat(userDataBeforeTrimUnsafeCommits, hasKey(ES_VERSION));
+            assertThat(userDataBeforeTrimUnsafeCommits.get(ES_VERSION), is(equalTo(Version.V_7_0_0.toString())));
+
+            store.trimUnsafeCommits(globalCheckpoint.get(), 1, Version.CURRENT);
+
+            Map<String, String> userDataAfterTrimUnsafeCommits = store.readLastCommittedSegmentsInfo().getUserData();
+            assertThat(userDataAfterTrimUnsafeCommits, hasKey(ES_VERSION));
+            assertThat(userDataAfterTrimUnsafeCommits.get(ES_VERSION), is(equalTo(Version.CURRENT.toString())));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
@@ -108,6 +108,7 @@ public class StoreRecoveryTests extends ESTestCase {
         assertThat(userData.get(SequenceNumbers.MAX_SEQ_NO), equalTo(Long.toString(maxSeqNo)));
         assertThat(userData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY), equalTo(Long.toString(maxSeqNo)));
         assertThat(userData.get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID), equalTo(Long.toString(maxUnsafeAutoIdTimestamp)));
+        assertThat(userData.get(Engine.ES_VERSION), equalTo(Version.CURRENT.toString()));
         for (SegmentCommitInfo info : segmentCommitInfos) { // check that we didn't merge
             assertEquals("all sources must be flush",
                 info.info.getDiagnostics().get("source"), "flush");

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -1111,4 +1111,16 @@ public class StoreTests extends ESTestCase {
             }
         }
     }
+
+    public void testVersionIsIncludedInBootstrapCommit() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        try (Store store = new Store(shardId, INDEX_SETTINGS, StoreTests.newDirectory(random()), new DummyShardLock(shardId))) {
+
+            store.createEmpty();
+
+            SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+            assertThat(segmentInfos.getUserData(), hasKey(Engine.ES_VERSION));
+            assertThat(segmentInfos.getUserData().get(Engine.ES_VERSION), is(equalTo(org.elasticsearch.Version.CURRENT.toString())));
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -56,7 +56,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -66,11 +68,13 @@ import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static java.util.Collections.emptyList;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 
@@ -98,7 +102,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         recoveryTarget.receiveFileInfo(
             mdFiles.stream().map(StoreFileMetadata::name).collect(Collectors.toList()),
             mdFiles.stream().map(StoreFileMetadata::length).collect(Collectors.toList()),
-            Collections.emptyList(), Collections.emptyList(), 0, receiveFileInfoFuture
+            emptyList(), emptyList(), 0, receiveFileInfoFuture
         );
         receiveFileInfoFuture.actionGet();
         List<RecoveryFileChunkRequest> requests = new ArrayList<>();
@@ -442,32 +446,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
                                                              ShardId requestedShardId,
                                                              BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo,
                                                              LongConsumer rateLimiterListener) {
-                switch (downloadFileErrorType) {
-                    case CORRUPTED_FILE:
-                        byte[] fileDataCopy = new byte[fileData.length];
-                        System.arraycopy(fileData, 0, fileDataCopy, 0, fileData.length);
-                        // Corrupt the file
-                        for (int i = 0; i < randomIntBetween(1, fileDataCopy.length); i++) {
-                            fileDataCopy[i] ^= 0xFF;
-                        }
-                        return new ByteArrayInputStream(fileDataCopy);
-                    case TRUNCATED_FILE:
-                        final int truncatedFileLength = fileData.length / 2;
-                        byte[] truncatedCopy = new byte[truncatedFileLength];
-                        System.arraycopy(fileData, 0, truncatedCopy, 0, truncatedFileLength);
-                        return new ByteArrayInputStream(truncatedCopy);
-                    case LARGER_THAN_EXPECTED_FILE:
-                        byte[] largerData = new byte[fileData.length + randomIntBetween(1, 250)];
-                        System.arraycopy(fileData, 0, largerData, 0, fileData.length);
-                        for (int i = fileData.length; i < largerData.length; i++) {
-                            largerData[i] = randomByte();
-                        }
-                        return new ByteArrayInputStream(largerData);
-                    case FETCH_ERROR:
-                        throw new RuntimeException("Unexpected error");
-                    default:
-                        throw new IllegalStateException("Unexpected value: " + downloadFileErrorType);
-                }
+                return getFaultyInputStream(downloadFileErrorType, fileData);
             }
 
             @Override
@@ -519,6 +498,96 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         writeChunkFuture.get();
 
         assertThat(fileDetails.recovered(), equalTo(storeFileMetadata.length()));
+
+        recoveryTarget.decRef();
+        closeShards(shard);
+    }
+
+    public void testReceiveFileInfoDeletesRecoveredFiles() throws Exception {
+        DiscoveryNode pNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(),
+            Collections.emptyMap(), Collections.emptySet(), Version.CURRENT);
+        DiscoveryNode rNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(),
+            Collections.emptyMap(), Collections.emptySet(), Version.CURRENT);
+
+        IndexShard shard = newShard(false);
+        shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
+        shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
+        shard.prepareForIndexRecovery();
+
+        RecoveryState.Index recoveryStateIndex = shard.recoveryState().getIndex();
+
+        Directory directory = shard.store().directory();
+
+        String repositoryName = "repo";
+        IndexId indexId = new IndexId("index", "uuid");
+        ShardId shardId = shard.shardId();
+
+        Map<BlobStoreIndexShardSnapshot.FileInfo, byte[]> snapshotFiles = new IdentityHashMap<>();
+        for (int i = 0; i < randomIntBetween(5, 10); i++) {
+            String fileName = randomAlphaOfLength(10);
+            Tuple<StoreFileMetadata, byte[]> storeFileMetadataAndData = createStoreFileMetadataWithRandomContent(fileName);
+            StoreFileMetadata storeFileMetadata = storeFileMetadataAndData.v1();
+            byte[] fileData = storeFileMetadataAndData.v2();
+
+            recoveryStateIndex.addFileDetail(storeFileMetadata.name(), storeFileMetadata.length(), false);
+
+            BlobStoreIndexShardSnapshot.FileInfo fileInfo =
+                new BlobStoreIndexShardSnapshot.FileInfo("name", storeFileMetadata, SNAPSHOT_FILE_PART_SIZE);
+            snapshotFiles.put(fileInfo, fileData);
+        }
+        recoveryStateIndex.setFileDetailsComplete();
+
+        BlobStoreIndexShardSnapshot.FileInfo failingDownloadFile = randomFrom(snapshotFiles.keySet());
+
+        SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(mock(RepositoriesService.class)) {
+            @Override
+            public InputStream getInputStreamForSnapshotFile(String requestedRepositoryName,
+                                                             IndexId requestedIndexId,
+                                                             ShardId requestedShardId,
+                                                             BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo,
+                                                             LongConsumer rateLimiterListener) {
+                assertThat(requestedRepositoryName, equalTo(repositoryName));
+                assertThat(requestedIndexId, equalTo(indexId));
+                assertThat(requestedShardId, equalTo(shardId));
+
+                byte[] fileData = snapshotFiles.get(snapshotFileInfo);
+                assertThat(fileData, is(notNullValue()));
+
+                if (snapshotFileInfo.isSame(failingDownloadFile)) {
+                    return getFaultyInputStream(randomFrom(DownloadFileErrorType.values()), fileData);
+                }
+
+                return new ByteArrayInputStream(fileData);
+            }
+
+            @Override
+            public int getReadSnapshotFileBufferSizeForRepo(String repository) {
+                return (int) new ByteSizeValue(128, ByteSizeUnit.KB).getBytes();
+            }
+        };
+
+        RecoveryTarget recoveryTarget = new RecoveryTarget(shard, null, snapshotFilesProvider, null);
+
+        String[] fileNamesBeforeRecoveringSnapshotFiles = directory.listAll();
+
+        for (Map.Entry<BlobStoreIndexShardSnapshot.FileInfo, byte[]> fileInfoEntry : snapshotFiles.entrySet()) {
+            BlobStoreIndexShardSnapshot.FileInfo fileInfo = fileInfoEntry.getKey();
+            PlainActionFuture<Void> writeSnapshotFileFuture = PlainActionFuture.newFuture();
+            recoveryTarget.restoreFileFromSnapshot(repositoryName, indexId, fileInfo, writeSnapshotFileFuture);
+
+            // Simulate error, that stops downloading snapshot files
+            if (fileInfo.isSame(failingDownloadFile)) {
+                expectThrows(Exception.class, writeSnapshotFileFuture::get);
+                break;
+            }
+            writeSnapshotFileFuture.get();
+        }
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        recoveryTarget.receiveFileInfo(emptyList(), emptyList(), emptyList(), emptyList(), 0, future);
+        future.get();
+
+        assertThat(fileNamesBeforeRecoveringSnapshotFiles, is(equalTo(directory.listAll())));
 
         recoveryTarget.decRef();
         closeShards(shard);
@@ -613,5 +682,34 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
             new StoreFileMetadata(fileName, luceneEncodedFileBytes.length, encodedChecksum, writtenBy),
             luceneEncodedFileBytes
         );
+    }
+
+    private InputStream getFaultyInputStream(DownloadFileErrorType downloadFileErrorType, byte[] fileData) {
+        switch (downloadFileErrorType) {
+            case CORRUPTED_FILE:
+                byte[] fileDataCopy = new byte[fileData.length];
+                System.arraycopy(fileData, 0, fileDataCopy, 0, fileData.length);
+                // Corrupt the file
+                for (int i = 0; i < randomIntBetween(1, fileDataCopy.length); i++) {
+                    fileDataCopy[i] ^= 0xFF;
+                }
+                return new ByteArrayInputStream(fileDataCopy);
+            case TRUNCATED_FILE:
+                final int truncatedFileLength = fileData.length / 2;
+                byte[] truncatedCopy = new byte[truncatedFileLength];
+                System.arraycopy(fileData, 0, truncatedCopy, 0, truncatedFileLength);
+                return new ByteArrayInputStream(truncatedCopy);
+            case LARGER_THAN_EXPECTED_FILE:
+                byte[] largerData = new byte[fileData.length + randomIntBetween(1, 250)];
+                System.arraycopy(fileData, 0, largerData, 0, fileData.length);
+                for (int i = fileData.length; i < largerData.length; i++) {
+                    largerData[i] = randomByte();
+                }
+                return new ByteArrayInputStream(largerData);
+            case FETCH_ERROR:
+                throw new RuntimeException("Unexpected error");
+            default:
+                throw new IllegalStateException("Unexpected value: " + downloadFileErrorType);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -745,7 +745,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final TestRecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
             @Override
             public void receiveFileInfo(List<String> phase1FileNames, List<Long> phase1FileSizes, List<String> phase1ExistingFileNames,
-                                        List<Long> phase1ExistingFileSizes, int totalTranslogOps, ActionListener<Void> listener) {
+                                        List<Long> phase1ExistingFileSizes, int totalTranslogOps,
+                                        ActionListener<Void> listener) {
                 recoveryExecutor.execute(() -> listener.onResponse(null));
                 if (randomBoolean()) {
                     wasCancelled.set(true);
@@ -1219,9 +1220,184 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
     }
 
+    public void testSeqNoBasedRecoveryRecoversFromFallbackPlanAfterAFailure() throws Exception {
+        try (Store store = newStore(createTempDir("source"), false)) {
+            IndexShard shard = mock(IndexShard.class);
+            when(shard.store()).thenReturn(store);
+            when(shard.state()).thenReturn(IndexShardState.STARTED);
+
+            ShardRecoveryPlan shardRecoveryPlan =
+                createShardRecoveryPlanWithFallback(store, randomIntBetween(10, 20), randomIntBetween(10, 20));
+
+            final ShardRecoveryPlan fallbackPlan = shardRecoveryPlan.getFallbackPlan();
+            List<StoreFileMetadata> sourceFilesToRecover = fallbackPlan.getSourceFilesToRecover();
+            List<StoreFileMetadata> snapshotFilesToRecover = shardRecoveryPlan.getSnapshotFilesToRecover()
+                .getSnapshotFiles()
+                .stream()
+                .map(BlobStoreIndexShardSnapshot.FileInfo::metadata)
+                .collect(Collectors.toList());
+
+            int maxConcurrentSnapshotFileDownloads = randomIntBetween(2, 4);
+            CountDownLatch downloadSnapshotFileReceived = new CountDownLatch(maxConcurrentSnapshotFileDownloads);
+
+            List<RecoverSnapshotFileResponse> inFlightRecoverSnapshotFileRequests = new CopyOnWriteArrayList<>();
+            AtomicBoolean retryingUsingFallbackPlan = new AtomicBoolean();
+            AtomicBoolean snapshotFileRecoveryFailed = new AtomicBoolean();
+
+            AtomicInteger receiveFileInfoFromSnapshotCalls = new AtomicInteger();
+            AtomicInteger receiveFileInfoFromSourceCalls = new AtomicInteger();
+            Set<StoreFileMetadata> filesRecoveredFromSource = ConcurrentCollections.newConcurrentSet();
+            TestRecoveryTargetHandler recoveryTarget = new Phase1RecoveryTargetHandler() {
+                @Override
+                public void receiveFileInfo(List<String> phase1FileNames,
+                                            List<Long> phase1FileSizes,
+                                            List<String> phase1ExistingFileNames,
+                                            List<Long> phase1ExistingFileSizes,
+                                            int totalTranslogOps,
+                                            ActionListener<Void> listener) {
+                    assert retryingUsingFallbackPlan.get() == false;
+
+                    final List<StoreFileMetadata> filesToRecover;
+                    if (snapshotFileRecoveryFailed.get()) {
+                        filesToRecover = fallbackPlan.getSourceFilesToRecover();
+                        retryingUsingFallbackPlan.set(true);
+                        assertThat(receiveFileInfoFromSnapshotCalls.get(), is(equalTo(1)));
+                        assertThat(receiveFileInfoFromSourceCalls.incrementAndGet(), is(equalTo(1)));
+                    } else {
+                        filesToRecover = shardRecoveryPlan.getSnapshotFilesToRecover()
+                            .getSnapshotFiles()
+                            .stream()
+                            .map(BlobStoreIndexShardSnapshot.FileInfo::metadata)
+                            .collect(Collectors.toList());
+                        assertThat(receiveFileInfoFromSnapshotCalls.incrementAndGet(), is(equalTo(1)));
+                        assertThat(receiveFileInfoFromSourceCalls.get(), is(equalTo(0)));
+                    }
+
+                    for (int i = 0; i < phase1FileNames.size(); i++) {
+                        String fileName = phase1FileNames.get(i);
+                        long fileSize = phase1FileSizes.get(i);
+                        assertThat(containsFile(filesToRecover, fileName, fileSize), is(equalTo(true)));
+                    }
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public void restoreFileFromSnapshot(String repository,
+                                                    IndexId indexId,
+                                                    BlobStoreIndexShardSnapshot.FileInfo snapshotFile,
+                                                    ActionListener<Void> listener) {
+                    assert retryingUsingFallbackPlan.get() == false;
+
+                    inFlightRecoverSnapshotFileRequests.add(new RecoverSnapshotFileResponse(snapshotFile, listener));
+                    downloadSnapshotFileReceived.countDown();
+                }
+
+                @Override
+                public void writeFileChunk(StoreFileMetadata fileMetadata,
+                                           long position,
+                                           ReleasableBytesReference content,
+                                           boolean lastChunk,
+                                           int totalTranslogOps,
+                                           ActionListener<Void> listener) {
+                    assert retryingUsingFallbackPlan.get();
+
+                    assertThat(containsFile(sourceFilesToRecover, fileMetadata), is(equalTo(true)));
+                    assertThat(containsFile(snapshotFilesToRecover, fileMetadata), is(equalTo(false)));
+
+                    filesRecoveredFromSource.add(fileMetadata);
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public void cleanFiles(int totalTranslogOps,
+                                       long globalCheckpoint,
+                                       Store.MetadataSnapshot sourceMetadata,
+                                       ActionListener<Void> listener) {
+                    assert retryingUsingFallbackPlan.get();
+
+                    assertThat(sourceMetadata, is(equalTo(fallbackPlan.getSourceMetadataSnapshot())));
+                    listener.onResponse(null);
+                }
+            };
+
+            RecoverySourceHandler handler = new RecoverySourceHandler(
+                shard,
+                new AsyncRecoveryTarget(recoveryTarget, threadPool.generic()),
+                threadPool,
+                getStartRecoveryRequest(),
+                between(1, 16),
+                between(1, 4),
+                between(1, 4),
+                maxConcurrentSnapshotFileDownloads,
+                true,
+                null) {
+                @Override
+                void createRetentionLease(long startingSeqNo, ActionListener<RetentionLease> listener) {
+                    listener.onResponse(new RetentionLease("id", startingSeqNo, 0, "test"));
+                }
+            };
+
+            PlainActionFuture<RecoverySourceHandler.SendFileResult> future = PlainActionFuture.newFuture();
+            handler.recoverFilesFromSourceAndSnapshot(shardRecoveryPlan, store, mock(StopWatch.class), future);
+
+            downloadSnapshotFileReceived.await();
+            assertThat(inFlightRecoverSnapshotFileRequests.size(), is(equalTo(maxConcurrentSnapshotFileDownloads)));
+
+            assertThat(future.isDone(), is(equalTo(false)));
+
+            List<RecoverSnapshotFileResponse> firstRoundOfResponses = new ArrayList<>(inFlightRecoverSnapshotFileRequests);
+            inFlightRecoverSnapshotFileRequests.clear();
+
+            int inFlightResponsesBeforeFailure = 0;
+            // fail at least once
+            RecoverSnapshotFileResponse failingDownloadRequest = randomFrom(firstRoundOfResponses);
+            for (final RecoverSnapshotFileResponse inFlightRequest : firstRoundOfResponses) {
+                if (randomBoolean() || inFlightRequest == failingDownloadRequest) {
+                    inFlightRequest.listener.onFailure(new IOException("i/o failure"));
+                    snapshotFileRecoveryFailed.set(true);
+                } else {
+                    inFlightRequest.listener.onResponse(null);
+                    if (snapshotFileRecoveryFailed.get() == false) {
+                        inFlightResponsesBeforeFailure++;
+                    }
+                }
+            }
+
+            // wait until all the expected outgoing request have been received
+            int expectedInFlightResponsesBeforeFailure = inFlightResponsesBeforeFailure;
+            assertBusy(() -> assertThat(inFlightRecoverSnapshotFileRequests.size(), equalTo(expectedInFlightResponsesBeforeFailure)));
+            if (inFlightRecoverSnapshotFileRequests.isEmpty() == false) {
+                assertThat(retryingUsingFallbackPlan.get(), is(equalTo(false)));
+            }
+            for (RecoverSnapshotFileResponse inFlightRecoverSnapshotRequest : inFlightRecoverSnapshotFileRequests) {
+                if (randomBoolean()) {
+                    inFlightRecoverSnapshotRequest.listener.onFailure(new RuntimeException("boom"));
+                } else {
+                    inFlightRecoverSnapshotRequest.listener.onResponse(null);
+                }
+            }
+
+            future.get();
+
+            assertThat(retryingUsingFallbackPlan.get(), is(equalTo(true)));
+            assertThat(filesRecoveredFromSource.size(), is(equalTo(fallbackPlan.getSourceFilesToRecover().size())));
+            for (StoreFileMetadata fileRecoveredFromSource : filesRecoveredFromSource) {
+                assertThat(containsFile(fallbackPlan.getSourceFilesToRecover(), fileRecoveredFromSource), is(equalTo(true)));
+            }
+        }
+    }
+
     private boolean containsSnapshotFile(ShardRecoveryPlan.SnapshotFilesToRecover snapshotFilesToRecover,
                                          BlobStoreIndexShardSnapshot.FileInfo snapshotFile) {
         return snapshotFilesToRecover.getSnapshotFiles().stream().anyMatch(f -> f.metadata().isSame(snapshotFile.metadata()));
+    }
+
+    private boolean containsFile(List<StoreFileMetadata> filesMetadata, StoreFileMetadata storeFileMetadata) {
+        return filesMetadata.stream().anyMatch(f -> f.isSame(storeFileMetadata));
+    }
+
+    private boolean containsFile(List<StoreFileMetadata> files, String fileName, long length) {
+        return files.stream().anyMatch(file -> file.name().equals(fileName) && file.length() == length);
     }
 
     private ShardRecoveryPlan createShardRecoveryPlan(Store store, int sourceFileCount, int snapshotFileCount) throws Exception {
@@ -1255,6 +1431,48 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             0,
             0,
             metadata
+        );
+    }
+
+    private ShardRecoveryPlan createShardRecoveryPlanWithFallback(Store store,
+                                                                  int sourceFileCount,
+                                                                  int snapshotFileCount) throws Exception {
+        ShardRecoveryPlan shardRecoveryPlan = createShardRecoveryPlan(store, sourceFileCount, snapshotFileCount);
+
+        List<StoreFileMetadata> filesToRecoverFromSource = shardRecoveryPlan.getSourceFilesToRecover();
+        Store.MetadataSnapshot fallbackPlanMetadata = new Store.MetadataSnapshot(
+            filesToRecoverFromSource.stream().collect(Collectors.toMap(StoreFileMetadata::name, Function.identity())),
+            emptyMap(),
+            0
+        );
+
+        ShardRecoveryPlan fallbackPlan = new ShardRecoveryPlan(ShardRecoveryPlan.SnapshotFilesToRecover.EMPTY,
+            filesToRecoverFromSource,
+            emptyList(),
+            0,
+            0,
+            fallbackPlanMetadata
+        );
+
+        Map<String, StoreFileMetadata> snapshotFiles = shardRecoveryPlan.getSnapshotFilesToRecover()
+            .getSnapshotFiles()
+            .stream()
+            .map(BlobStoreIndexShardSnapshot.FileInfo::metadata)
+            .collect(Collectors.toMap(StoreFileMetadata::name, Function.identity()));
+
+        Store.MetadataSnapshot metadata = new Store.MetadataSnapshot(
+            snapshotFiles,
+            emptyMap(),
+            0
+        );
+
+        return new ShardRecoveryPlan(shardRecoveryPlan.getSnapshotFilesToRecover(),
+            emptyList(),
+            emptyList(),
+            0,
+            0,
+            metadata,
+            fallbackPlan
         );
     }
 
@@ -1336,7 +1554,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
 
         @Override
         public void receiveFileInfo(List<String> phase1FileNames, List<Long> phase1FileSizes, List<String> phase1ExistingFileNames,
-                                    List<Long> phase1ExistingFileSizes, int totalTranslogOps, ActionListener<Void> listener) {
+                                    List<Long> phase1ExistingFileSizes, int totalTranslogOps,
+                                    ActionListener<Void> listener) {
 
         }
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -218,7 +218,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                     luceneVersion = randomCompatibleVersion(random(), Version.CURRENT).luceneVersion;
                 }
             } else {
-                snapshotVersion = Version.fromId(Integer.MAX_VALUE);
+                // A future version is not compatible
+                snapshotVersion = Version.fromId(8160099);
                 luceneVersion = org.apache.lucene.util.Version.parse("255.255.255");
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
@@ -57,10 +57,15 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
     }
 
     @Override
-    public void receiveFileInfo(List<String> phase1FileNames, List<Long> phase1FileSizes, List<String> phase1ExistingFileNames,
-                                List<Long> phase1ExistingFileSizes, int totalTranslogOps, ActionListener<Void> listener) {
+    public void receiveFileInfo(List<String> phase1FileNames,
+                                List<Long> phase1FileSizes,
+                                List<String> phase1ExistingFileNames,
+                                List<Long> phase1ExistingFileSizes,
+                                int totalTranslogOps,
+                                ActionListener<Void> listener) {
         executor.execute(() -> target.receiveFileInfo(
-            phase1FileNames, phase1FileSizes, phase1ExistingFileNames, phase1ExistingFileSizes, totalTranslogOps, listener));
+            phase1FileNames, phase1FileSizes, phase1ExistingFileNames, phase1ExistingFileSizes, totalTranslogOps,
+                listener));
     }
 
     @Override


### PR DESCRIPTION
This commit adds support for peer recoveries using snapshots after
a primary failover if the snapshot shares the same logical contents
but the physical files are different. It uses the seq no information
stored in the snapshot to compare against the current shard source
node seq nos and decide whether or not it can use the snapshot to
recover the shard. Since the underlying index files are different
to the source index files, error handling is different than when
the files are shared. In this case, if there's an error while
snapshots files are recovered, we have to cancel the on-going
downloads, wait until all in-flight operations complete, remove
the recovered files and start from scratch using a fallback
recovery plan that uses the files from the source node.

Relates #73496
Backport of #77420