### PR TITLE
[DOCS] Drafts docs for Upgrade Transforms API

### DIFF
--- a/docs/reference/transform/apis/index.asciidoc
+++ b/docs/reference/transform/apis/index.asciidoc
@@ -13,5 +13,6 @@ include::preview-transform.asciidoc[leveloffset=+2]
 include::start-transform.asciidoc[leveloffset=+2]
 //STOP
 include::stop-transform.asciidoc[leveloffset=+2]
-//UPDATE
+//UPDATE-UPGRADE
 include::update-transform.asciidoc[leveloffset=+2]
+include::upgrade-transforms.asciidoc[leveloffset=+2]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -22,35 +22,35 @@ Requires the following privileges:
 
 * cluster: `manage_transform` (the `transform_admin` built-in role grants this
   privilege)
-* source indices: `read`, `view_index_metadata`
-* destination index: `read`, `index`.
 
 
 [[upgrade-transforms-desc]]
 == {api-description-title}
 
-{transforms-cap} are compatible across minor versions and backwards compatibile 
-between major versions. However, over time, the format of {transforms} may 
-change. This API upgrades all {transforms} that can be upgraded to meet the 
-functional requirements of the latest available version. Upgrading {transforms} 
-may also enable new features and improve performance.
+{transforms-cap} are compatible across minor versions and between supported 
+major versions. However, over time, the format of {transform} configuration 
+information may change. This API identifies {transforms} which have a legacy 
+configuration format and upgrades them to the latest version; including clean up 
+of the internal data structures that store {transform} state and checkpoints. 
+{transform-cap} upgrade does not effect the source and destination indices.
 
-The process converts any {transforms} with older formats into the latest format; 
-including internal data structures that store {transform} state and checkpoints. 
-Previous versions are removed which frees up resources.
+It is recommended to have a recent cluster backup prior to performing a 
+{transform} upgrade which can be run either before or after an {es} upgrade. 
+However, it is recommended to perform it prior to upgrading {es} to the next 
+major version to ensure {ctransforms} remain started.
 
-If an upgrade step fails, the upgrade stops, and an error is returned about the 
-underlying issue. Resolve the issue then re-run the process again. A summary is 
-returned when the upgrade is finished.
+If a {transform} upgrade step fails, the upgrade stops, and an error is returned 
+about the underlying issue. Resolve the issue then re-run the process again. A 
+summary is returned when the upgrade is finished.
 
 [IMPORTANT]
 ====
 
 * When {es} {security-features} are enabled, your {transform} remembers the 
 roles of the user who created or updated it last. In contrast to 
-<<update-transform,update transform>>, upgrade {transforms} does not change the 
-stored roles, therefore it can be run by a super user without impacting existing 
-permissions.
+<<update-transform,update transform>>, a {transform} upgrade does not change the 
+stored roles, therefore the role used to read source data and write to the 
+destination index remains unchanged.
 
 ====
 
@@ -66,7 +66,8 @@ permissions.
 [[upgrade-transforms-example]]
 == {api-examples-title}
 
-To upgrade the {transforms}, perform the following API call:
+To upgrade the legacy {transforms} to the latest configuration format, perform 
+the following API call:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -8,7 +8,7 @@
 <titleabbrev>Upgrade {transform}</titleabbrev>
 ++++
 
-Upgrades all {transform}s.
+Upgrades all {transforms}.
 
 [[upgrade-transforms-request]]
 == {api-request-title}
@@ -29,16 +29,29 @@ Requires the following privileges:
 [[upgrade-transforms-desc]]
 == {api-description-title}
 
-This API upgrades all existing {transform}s.
+This API upgrades all existing {transforms} that are necessary to upgrade. As 
+part of the process the {transforms} are rewritten into the latest format 
+including internal data structures that store state and checkpoints. The process 
+also frees up resources by cleaning up previous versions.
+
+If a step in the upgrade fails, it doesn't proceed and an error is returned that 
+informs about the underlying issues. It might be necessary to manually resolve 
+the problems. After resolving the problems, the upgrade can be re-run again. A 
+summary is returned at the end of the process.
+
 
 [[upgrade-transforms-query-parms]]
 == {api-query-parms-title}
 
 `dry_run`::
-  (Optional, Boolean) When `true`, only checks for updates but does not execute them.
+  (Optional, Boolean) When `true`, only checks for updates but does not execute 
+  them. Defaults to `false`.
+
 
 [[upgrade-transforms-example]]
 == {api-examples-title}
+
+To upgrade the {transforms}, perform the following API call:
 
 [source,console]
 --------------------------------------------------
@@ -46,7 +59,7 @@ POST _transform/_upgrade
 --------------------------------------------------
 // TEST[setup:simple_kibana_continuous_pivot]
 
-When all {transform}s are upgraded, you receive a summary:
+When all {transforms} are upgraded, you receive a summary:
 
 [source,console-result]
 ----

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -52,7 +52,8 @@ the upgrade is finished.
 * When {es} {security-features} are enabled, your {transform} remembers the 
 roles of the user who created or updated it last. In contrast to 
 <<update-transform,update transform>>, upgrade {transforms} does not change the 
-stored roles, therefore it needs to be run by a super user.
+stored roles, therefore it can be run by a super user without impacting existing 
+permissions.
 
 ====
 

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -86,5 +86,4 @@ When all {transforms} are upgraded, you receive a summary:
   "no_action": 1
 }
 ----
-// TESTRESPONSE[s/"updated": 2/"updated" : $body.updated/]
-// TESTRESPONSE[s/"no_action" : 1/"no_action" : $body.no_action/]
+// TESTRESPONSE[skip:TBD]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -29,22 +29,19 @@ Requires the following privileges:
 [[upgrade-transforms-desc]]
 == {api-description-title}
 
+{transforms-cap} are compatible across minor versions and backwards compatibile 
+between major versions. However, over time, the format of {transforms} may 
+change. This API upgrades all {transforms} that can be upgraded to meet the 
+functional requirements of the latest available version. Upgrading {transforms} 
+may also enable new features and improve performance.
 
+The process converts any {transforms} with older formats into the latest format; 
+including internal data structures that store {transform} state and checkpoints. 
+Previous versions are removed which frees up resources.
 
-This API upgrades all existing {transforms} that are necessary to be upgraded.
-{transforms-cap} are compatible between different versions and backwards 
-compatibility is kept between major versions. However, it is still necessary to 
-upgrade them to meet functional requirements. Upgrading {transforms} might also 
-enable new features or improve performance.
-
-During upgrade, the {transforms} are rewritten into the latest format including 
-internal data structures that store state and checkpoints. Resources are also 
-freed up by cleaning up previous versions.
-
-If an upgrade step fails, the process stops, and an error is returned that 
-informs about the underlying issues. It might be necessary to manually resolve 
-the problems then the process can be re-run again. A summary is returned when 
-the upgrade is finished.
+If an upgrade step fails, the upgrade stops, and an error is returned about the 
+underlying issue. Resolve the issue then re-run the process again. A summary is 
+returned when the upgrade is finished.
 
 [IMPORTANT]
 ====

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -82,7 +82,7 @@ When all {transforms} are upgraded, you receive a summary:
 [source,console-result]
 ----
 {
-  "updated": 2
+  "updated": 2,
   "no_action": 1
 }
 ----

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -1,11 +1,11 @@
 [role="xpack"]
 [testenv="basic"]
 [[upgrade-transforms]]
-= Upgrade {transform} API
+= Upgrade {transforms} API
 
 [subs="attributes"]
 ++++
-<titleabbrev>Upgrade {transform}</titleabbrev>
+<titleabbrev>Upgrade {transforms}</titleabbrev>
 ++++
 
 Upgrades all {transforms}.
@@ -29,15 +29,15 @@ Requires the following privileges:
 [[upgrade-transforms-desc]]
 == {api-description-title}
 
-This API upgrades all existing {transforms} that are necessary to upgrade. As 
-part of the process the {transforms} are rewritten into the latest format 
-including internal data structures that store state and checkpoints. The process 
-also frees up resources by cleaning up previous versions.
+This API upgrades all existing {transforms} that are necessary to be upgraded. 
+The {transforms} are rewritten into the latest format including internal data 
+structures that store state and checkpoints. Resources are also freed up by 
+cleaning up previous versions.
 
-If a step in the upgrade fails, it doesn't proceed and an error is returned that 
+If an upgrade step fails, the upgrade stops, and an error is returned that 
 informs about the underlying issues. It might be necessary to manually resolve 
-the problems. After resolving the problems, the upgrade can be re-run again. A 
-summary is returned at the end of the process.
+the problems then the process can be re-run again. A summary is returned when 
+the upgrade is finished.
 
 
 [[upgrade-transforms-query-parms]]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -34,14 +34,16 @@ configuration format and upgrades them to the latest version; including clean up
 of the internal data structures that store {transform} state and checkpoints. 
 {transform-cap} upgrade does not effect the source and destination indices.
 
-It is recommended to have a recent cluster backup prior to performing a 
-{transform} upgrade which can be run either before or after an {es} upgrade. 
-However, it is recommended to perform it prior to upgrading {es} to the next 
-major version to ensure {ctransforms} remain started.
-
 If a {transform} upgrade step fails, the upgrade stops, and an error is returned 
 about the underlying issue. Resolve the issue then re-run the process again. A 
 summary is returned when the upgrade is finished.
+
+For a major version update – for example, from 7.16 to 8.0 –, it is recommended 
+to have a recent cluster backup prior to performing a {transform} upgrade which 
+can be run either before or after an {es} upgrade. However, it is recommended to 
+perform it before upgrading {es} to the next major version to ensure 
+{ctransforms} remain running.
+
 
 [IMPORTANT]
 ====
@@ -80,6 +82,7 @@ When all {transforms} are upgraded, you receive a summary:
 [source,console-result]
 ----
 {
+  "updated": 2
   "no_action": 1
 }
 ----

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -29,15 +29,32 @@ Requires the following privileges:
 [[upgrade-transforms-desc]]
 == {api-description-title}
 
-This API upgrades all existing {transforms} that are necessary to be upgraded. 
-The {transforms} are rewritten into the latest format including internal data 
-structures that store state and checkpoints. Resources are also freed up by 
-cleaning up previous versions.
 
-If an upgrade step fails, the upgrade stops, and an error is returned that 
+
+This API upgrades all existing {transforms} that are necessary to be upgraded.
+{transforms-cap} are compatible between different versions and backwards 
+compatibility is kept between major versions. However, it is still necessary to 
+upgrade them to meet functional requirements. Upgrading {transforms} might also 
+enable new features or improve performance.
+
+During upgrade, the {transforms} are rewritten into the latest format including 
+internal data structures that store state and checkpoints. Resources are also 
+freed up by cleaning up previous versions.
+
+If an upgrade step fails, the process stops, and an error is returned that 
 informs about the underlying issues. It might be necessary to manually resolve 
 the problems then the process can be re-run again. A summary is returned when 
 the upgrade is finished.
+
+[IMPORTANT]
+====
+
+* When {es} {security-features} are enabled, your {transform} remembers the 
+roles of the user who created or updated it last. In contrast to 
+<<update-transform,update transform>>, upgrade {transforms} does not change the 
+stored roles, therefore it needs to be run by a super user.
+
+====
 
 
 [[upgrade-transforms-query-parms]]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -86,4 +86,5 @@ When all {transforms} are upgraded, you receive a summary:
   "no_action": 1
 }
 ----
+// TESTRESPONSE[s/"updated": 2/"updated" : $body.updated/]
 // TESTRESPONSE[s/"no_action" : 1/"no_action" : $body.no_action/]


### PR DESCRIPTION
## Overview

This PR adds documentation about the Upgrade Transforms API to the Transforms API docs section.

### Preview

[Upgrade transforms API](https://elasticsearch_79139.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html)