### PR TITLE
rename from DataStreamTimestampFieldMapper to TimestampFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -21,7 +21,7 @@ import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
@@ -301,7 +301,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
          */
         public Map<String, Object> getDataStreamMappingSnippet() {
             // _data_stream_timestamp meta fields default to @timestamp:
-            return Map.of(MapperService.SINGLE_MAPPING_NAME, Map.of(DataStreamTimestampFieldMapper.NAME, Map.of("enabled", true)));
+            return Map.of(MapperService.SINGLE_MAPPING_NAME, Map.of(TimestampFieldMapper.NAME, Map.of("enabled", true)));
         }
 
         public boolean isHidden() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
@@ -264,12 +264,12 @@ public class MetadataCreateDataStreamService {
     }
 
     public static void validateTimestampFieldMapping(MappingLookup mappingLookup) throws IOException {
-        MetadataFieldMapper fieldMapper = (MetadataFieldMapper) mappingLookup.getMapper(DataStreamTimestampFieldMapper.NAME);
-        assert fieldMapper != null : DataStreamTimestampFieldMapper.NAME + " meta field mapper must exist";
+        MetadataFieldMapper fieldMapper = (MetadataFieldMapper) mappingLookup.getMapper(TimestampFieldMapper.NAME);
+        assert fieldMapper != null : TimestampFieldMapper.NAME + " meta field mapper must exist";
         // Sanity check: if this fails then somehow the mapping for _data_stream_timestamp has been overwritten and
         // that would be a bug.
-        if (mappingLookup.isDataStreamTimestampFieldEnabled() == false) {
-            throw new IllegalStateException("[" + DataStreamTimestampFieldMapper.NAME + "] meta field has been disabled");
+        if (mappingLookup.isTimestampFieldEnabled() == false) {
+            throw new IllegalStateException("[" + TimestampFieldMapper.NAME + "] meta field has been disabled");
         }
         // Sanity check (this validation logic should already have been executed when merging mappings):
         fieldMapper.validate(mappingLookup);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -45,7 +45,7 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
@@ -1233,7 +1233,7 @@ public class MetadataIndexTemplateService {
                 if (template.getDataStreamTemplate() != null) {
                     // If there is no _data_stream meta field mapper and a data stream should be created then
                     // fail as if the  data_stream field can't be parsed:
-                    if (tempIndexService.mapperService().isMetadataField(DataStreamTimestampFieldMapper.NAME) == false) {
+                    if (tempIndexService.mapperService().isMetadataField(TimestampFieldMapper.NAME) == false) {
                         // Fail like a parsing expection, since we will be moving data_stream template out of server module and
                         // then we would fail with the same error message, like we do here.
                         throw new XContentParseException("[index_template] unknown field [data_stream]");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.IndicesService;
@@ -151,7 +151,7 @@ public class MetadataMigrateToDataStreamService {
         }
     }
 
-    // hides the index, optionally removes the alias, and adds data stream timestamp field mapper
+    // hides the index, optionally removes the alias, and adds timestamp field mapper
     static void prepareBackingIndex(
         Metadata.Builder b,
         IndexMetadata im,
@@ -165,7 +165,7 @@ public class MetadataMigrateToDataStreamService {
 
         MapperService mapperService = mapperSupplier.apply(im);
         mapperService.merge(im, MapperService.MergeReason.MAPPING_RECOVERY);
-        mapperService.merge("_doc", Map.of(DataStreamTimestampFieldMapper.NAME, Map.of("enabled", true)),
+        mapperService.merge("_doc", Map.of(TimestampFieldMapper.NAME, Map.of("enabled", true)),
             MapperService.MergeReason.MAPPING_UPDATE);
         DocumentMapper mapper = mapperService.documentMapper();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -385,8 +385,8 @@ public final class MappingLookup {
      * Only indices that are a part of a data-stream have this meta-field enabled.
      * @return {@code true} if contains an enabled data-stream's timestamp meta-field, {@code false} otherwise.
      */
-    public boolean isDataStreamTimestampFieldEnabled() {
-        DataStreamTimestampFieldMapper dtfm = mapping.getMetadataMapperByClass(DataStreamTimestampFieldMapper.class);
+    public boolean isTimestampFieldEnabled() {
+        TimestampFieldMapper dtfm = mapping.getMetadataMapperByClass(TimestampFieldMapper.class);
         return dtfm != null && dtfm.isEnabled();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimestampFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimestampFieldMapper.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+
+/**
+ * FieldMapper for timestamp meta-field.
+ */
+public class TimestampFieldMapper extends MetadataFieldMapper {
+
+    public static final String NAME = "_timestamp";
+    private static final String DEFAULT_PATH = "@timestamp";
+
+    private static final TimestampFieldMapper ENABLED_INSTANCE =
+        new TimestampFieldMapper(TimestampFieldType.INSTANCE, true);
+    private static final TimestampFieldMapper DISABLED_INSTANCE =
+        new TimestampFieldMapper(TimestampFieldType.INSTANCE, false);
+
+    // For now the field shouldn't be useable in searches.
+    // In the future it should act as an alias to the actual timestamp field.
+    public static final class TimestampFieldType extends MappedFieldType {
+
+        static final TimestampFieldType INSTANCE = new TimestampFieldType();
+
+        private TimestampFieldType() {
+            super(NAME, false, false, false, TextSearchInfo.NONE, Map.of());
+        }
+
+        @Override
+        public String typeName() {
+            return NAME;
+        }
+
+        @Override
+        public Query termQuery(Object value, SearchExecutionContext context) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support term queries");
+        }
+
+        @Override
+        public Query existsQuery(SearchExecutionContext context) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support exists queries");
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static TimestampFieldMapper toType(FieldMapper in) {
+        return (TimestampFieldMapper) in;
+    }
+
+    public static class Builder extends MetadataFieldMapper.Builder {
+
+        private final Parameter<Boolean> enabled = Parameter.boolParam("enabled", true, m -> toType(m).enabled, false)
+            // this field mapper may be enabled but once enabled, may not be disabled
+            .setMergeValidator((previous, current, conflicts) -> (previous == current) || (previous == false && current));
+
+        public Builder() {
+            super(NAME);
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return List.of(enabled);
+        }
+
+        @Override
+        public MetadataFieldMapper build() {
+            return enabled.getValue() ? ENABLED_INSTANCE : DISABLED_INSTANCE;
+        }
+    }
+
+    public static final TypeParser PARSER = new ConfigurableTypeParser(
+        c -> DISABLED_INSTANCE,
+        c -> new Builder()
+    );
+
+    private final boolean enabled;
+
+    private TimestampFieldMapper(MappedFieldType mappedFieldType, boolean enabled) {
+        super(mappedFieldType);
+        this.enabled = enabled;
+    }
+
+    @Override
+    public FieldMapper.Builder getMergeBuilder() {
+        return new Builder().init(this);
+    }
+
+    public void doValidate(MappingLookup lookup) {
+        if (enabled == false) {
+            // not configured, so skip the validation
+            return;
+        }
+
+        Mapper mapper = lookup.getMapper(DEFAULT_PATH);
+        if (mapper == null) {
+            throw new IllegalArgumentException("timestamp field [" + DEFAULT_PATH + "] does not exist");
+        }
+
+        if (DateFieldMapper.CONTENT_TYPE.equals(mapper.typeName()) == false
+            && DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(mapper.typeName()) == false) {
+            throw new IllegalArgumentException(
+                "timestamp field ["
+                    + DEFAULT_PATH
+                    + "] is of type ["
+                    + mapper.typeName()
+                    + "], but ["
+                    + DateFieldMapper.CONTENT_TYPE
+                    + ","
+                    + DateFieldMapper.DATE_NANOS_CONTENT_TYPE
+                    + "] is expected"
+            );
+        }
+
+        DateFieldMapper dateFieldMapper = (DateFieldMapper) mapper;
+        if (dateFieldMapper.fieldType().isSearchable() == false) {
+            throw new IllegalArgumentException("timestamp field [" + DEFAULT_PATH + "] is not indexed");
+        }
+        if (dateFieldMapper.fieldType().hasDocValues() == false) {
+            throw new IllegalArgumentException("timestamp field [" + DEFAULT_PATH + "] doesn't have doc values");
+        }
+        if (dateFieldMapper.getNullValue() != null) {
+            throw new IllegalArgumentException(
+                "timestamp field [" + DEFAULT_PATH + "] has disallowed [null_value] attribute specified"
+            );
+        }
+        if (dateFieldMapper.getIgnoreMalformed()) {
+            throw new IllegalArgumentException(
+                "timestamp field [" + DEFAULT_PATH + "] has disallowed [ignore_malformed] attribute specified"
+            );
+        }
+
+        // Catch all validation that validates whether disallowed mapping attributes have been specified
+        // on the field this meta field refers to:
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            dateFieldMapper.toXContent(builder, EMPTY_PARAMS);
+            builder.endObject();
+            Map<?, ?> configuredSettings = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+            configuredSettings = (Map<?, ?>) configuredSettings.values().iterator().next();
+
+            // Only type, meta and format attributes are allowed:
+            configuredSettings.remove("type");
+            configuredSettings.remove("meta");
+            configuredSettings.remove("format");
+
+            // ignoring malformed values is disallowed (see previous check),
+            // however if `index.mapping.ignore_malformed` has been set to true then
+            // there is no way to disable ignore_malformed for the timestamp field mapper,
+            // other then not using 'index.mapping.ignore_malformed' at all.
+            // So by ignoring the ignore_malformed here, we allow index.mapping.ignore_malformed
+            // index setting to be set to true and then turned off for the timestamp field mapper.
+            // (ignore_malformed will here always be false, otherwise previous check would have failed)
+            Object value = configuredSettings.remove("ignore_malformed");
+            assert value == null || Boolean.FALSE.equals(value);
+
+            // All other configured attributes are not allowed:
+            if (configuredSettings.isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "timestamp field [@timestamp] has disallowed attributes: " + configuredSettings.keySet()
+                );
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void postParse(DocumentParserContext context) throws IOException {
+        if (enabled == false) {
+            // not configured, so skip the validation
+            return;
+        }
+
+        IndexableField[] fields = context.rootDoc().getFields(DEFAULT_PATH);
+        if (fields.length == 0) {
+            throw new IllegalArgumentException("timestamp field [" + DEFAULT_PATH + "] is missing");
+        }
+
+        long numberOfValues = Arrays.stream(fields)
+            .filter(indexableField -> indexableField.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC)
+            .count();
+        if (numberOfValues > 1) {
+            throw new IllegalArgumentException("timestamp field [" + DEFAULT_PATH + "] encountered multiple values");
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return NAME;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -391,7 +391,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         persistMetadata(path, indexSettings, shardRouting, null, logger);
         this.useRetentionLeasesInPeerRecovery = replicationTracker.hasAllPeerRecoveryRetentionLeases();
         this.refreshPendingLocationListener = new RefreshPendingLocationListener();
-        this.isDataStreamIndex = mapperService == null ? false : mapperService.mappingLookup().isDataStreamTimestampFieldEnabled();
+        this.isDataStreamIndex = mapperService == null ? false : mapperService.mappingLookup().isTimestampFieldEnabled();
     }
 
     public ThreadPool getThreadPool() {
@@ -1730,7 +1730,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             "opening index which was created post 5.5.0 but " + Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID
                 + " is not found in commit";
         final org.apache.lucene.util.Version commitLuceneVersion = segmentCommitInfos.getCommitLuceneVersion();
-        // This relies in the previous minor having another lucene version 
+        // This relies in the previous minor having another lucene version
         assert commitLuceneVersion.onOrAfter(RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion) == false ||
             userData.containsKey(Engine.ES_VERSION) && Version.fromString(userData.get(Engine.ES_VERSION)).onOrBefore(Version.CURRENT) :
             "commit point has an invalid ES_VERSION value. commit point lucene version [" + commitLuceneVersion + "]," +

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.resync.TransportResyncReplicationAction;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -183,6 +184,7 @@ public class IndicesModule extends AbstractModule {
         builtInMetadataMappers.put(VersionFieldMapper.NAME, VersionFieldMapper.PARSER);
         builtInMetadataMappers.put(SeqNoFieldMapper.NAME, SeqNoFieldMapper.PARSER);
         builtInMetadataMappers.put(DocCountFieldMapper.NAME, DocCountFieldMapper.PARSER);
+        builtInMetadataMappers.put(TimestampFieldMapper.NAME, TimestampFieldMapper.PARSER);
         //_field_names must be added last so that it has a chance to see all the other mappers
         builtInMetadataMappers.put(FieldNamesFieldMapper.NAME, FieldNamesFieldMapper.PARSER);
         return Collections.unmodifiableMap(builtInMetadataMappers);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
@@ -572,7 +572,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             RootObjectMapper.Builder root = new RootObjectMapper.Builder("_doc");
             root.add(new DateFieldMapper.Builder(dataStream.getTimeStampField().getName(), DateFieldMapper.Resolution.MILLISECONDS,
                 DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ScriptCompiler.NONE, true, Version.CURRENT));
-            MetadataFieldMapper dtfm = getDataStreamTimestampFieldMapper();
+            MetadataFieldMapper dtfm = getTimestampFieldMapper();
             Mapping mapping = new Mapping(
                 root.build(MapperBuilderContext.ROOT),
                 new MetadataFieldMapper[] {dtfm},
@@ -769,11 +769,11 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             .build();
     }
 
-    private static MetadataFieldMapper getDataStreamTimestampFieldMapper() {
+    private static MetadataFieldMapper getTimestampFieldMapper() {
         Map<String, Object> fieldsMapping = new HashMap<>();
-        fieldsMapping.put("type", DataStreamTimestampFieldMapper.NAME);
+        fieldsMapping.put("type", TimestampFieldMapper.NAME);
         fieldsMapping.put("enabled", true);
         MappingParserContext mockedParserContext = mock(MappingParserContext.class);
-        return DataStreamTimestampFieldMapper.PARSER.parse("field", fieldsMapping, mockedParserContext).build();
+        return TimestampFieldMapper.PARSER.parse("field", fieldsMapping, mockedParserContext).build();
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -1598,7 +1598,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
         @Override
         public Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers() {
-            return Map.of(DataStreamTimestampFieldMapper.NAME, DataStreamTimestampFieldMapper.PARSER);
+            return Map.of(TimestampFieldMapper.NAME, TimestampFieldMapper.PARSER);
         }
     }
 }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -534,7 +534,7 @@ public class DataStreamIT extends ESIntegTestCase {
         );
         assertThat(
             e.getCause().getCause().getMessage(),
-            equalTo("data stream timestamp field [@timestamp] is of type [keyword], but [date,date_nanos] is expected")
+            equalTo("timestamp field [@timestamp] is of type [keyword], but [date,date_nanos] is expected")
         );
     }
 
@@ -1265,7 +1265,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         IndexRequest indexRequest = new IndexRequest(dataStreamName).opType("create").source("{}", XContentType.JSON);
         Exception e = expectThrows(MapperParsingException.class, () -> client().index(indexRequest).actionGet());
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] is missing"));
+        assertThat(e.getCause().getMessage(), equalTo("timestamp field [@timestamp] is missing"));
     }
 
     public void testMultipleTimestampValuesInDocument() throws Exception {
@@ -1277,7 +1277,7 @@ public class DataStreamIT extends ESIntegTestCase {
         IndexRequest indexRequest = new IndexRequest(dataStreamName).opType("create")
             .source("{\"@timestamp\": [\"2020-12-12\",\"2022-12-12\"]}", XContentType.JSON);
         Exception e = expectThrows(MapperParsingException.class, () -> client().index(indexRequest).actionGet());
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] encountered multiple values"));
+        assertThat(e.getCause().getMessage(), equalTo("timestamp field [@timestamp] encountered multiple values"));
     }
 
     public void testMixedAutoCreate() throws Exception {

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
@@ -201,7 +201,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
             () -> client().execute(MigrateToDataStreamAction.INSTANCE, new MigrateToDataStreamAction.Request(alias)).get()
         );
 
-        assertTrue(throwableOrItsCause(e, IllegalArgumentException.class, "data stream timestamp field [@timestamp] does not exist"));
+        assertTrue(throwableOrItsCause(e, IllegalArgumentException.class, "timestamp field [@timestamp] does not exist"));
     }
 
     public void testMigrationWithoutWriteIndex() throws Exception {

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamTimestampFieldMapper.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamTimestampFieldMapper.java
@@ -1,17 +1,25 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
-package org.elasticsearch.index.mapper;
+package org.elasticsearch.xpack.datastreams;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DocumentParserContext;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.MetadataFieldMapper;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentType;
@@ -26,9 +34,9 @@ import java.util.Map;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 /**
- * FieldMapper for the data-stream's timestamp meta-field.
- * This field is added by {@code DataStreamsPlugin}.
+ * Deprecated, and use TimestampFieldMapper instead
  */
+@Deprecated
 public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
 
     public static final String NAME = "_data_stream_timestamp";

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamsPlugin.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamsPlugin.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.MapperPlugin;

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/mapper/MetadataCreateDataStreamServiceTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/mapper/MetadataCreateDataStreamServiceTests.java
@@ -51,7 +51,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
 
         String mapping2 = generateMapping("@timestamp2", "date");
         e = expectThrows(IllegalArgumentException.class, () -> validateTimestampFieldMapping(createMappingLookup(mapping2)));
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] does not exist"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] does not exist"));
     }
 
     public void testValidateTimestampFieldMappingInvalidFieldType() {
@@ -59,7 +59,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         Exception e = expectThrows(IllegalArgumentException.class, () -> validateTimestampFieldMapping(createMappingLookup(mapping)));
         assertThat(
             e.getMessage(),
-            equalTo("data stream timestamp field [@timestamp] is of type [keyword], " + "but [date,date_nanos] is expected")
+            equalTo("timestamp field [@timestamp] is of type [keyword], " + "but [date,date_nanos] is expected")
         );
     }
 

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/mapper/TimestampFieldMapperTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/mapper/TimestampFieldMapperTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.datastreams.mapper;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -29,11 +29,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase {
+public class TimestampFieldMapperTests extends MetadataMapperTestCase {
 
     @Override
     protected String fieldName() {
-        return DataStreamTimestampFieldMapper.NAME;
+        return TimestampFieldMapper.NAME;
     }
 
     @Override
@@ -46,7 +46,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         checker.registerUpdateCheck(
             timestampMapping(false, b -> b.startObject("@timestamp").field("type", "date").endObject()),
             timestampMapping(true, b -> b.startObject("@timestamp").field("type", "date").endObject()),
-            dm -> assertTrue(dm.metadataMapper(DataStreamTimestampFieldMapper.class).isEnabled())
+            dm -> assertTrue(dm.metadataMapper(TimestampFieldMapper.class).isEnabled())
         );
     }
 
@@ -76,10 +76,10 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         assertThat(doc.rootDoc().getFields("@timestamp").length, equalTo(2));
 
         Exception e = expectThrows(MapperException.class, () -> docMapper.parse(source(b -> b.field("@timestamp1", "2020-12-12"))));
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] is missing"));
+        assertThat(e.getCause().getMessage(), equalTo("timestamp field [@timestamp] is missing"));
 
         e = expectThrows(MapperException.class, () -> docMapper.parse(source(b -> b.array("@timestamp", "2020-12-12", "2020-12-13"))));
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] encountered multiple values"));
+        assertThat(e.getCause().getMessage(), equalTo("timestamp field [@timestamp] encountered multiple values"));
     }
 
     public void testValidateNonExistingField() {
@@ -87,7 +87,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
             IllegalArgumentException.class,
             () -> createMapperService(timestampMapping(true, b -> b.startObject("my_date_field").field("type", "date").endObject()))
         );
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] does not exist"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] does not exist"));
     }
 
     public void testValidateInvalidFieldType() {
@@ -97,7 +97,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         );
         assertThat(
             e.getMessage(),
-            equalTo("data stream timestamp field [@timestamp] is of type [keyword], but [date,date_nanos] is expected")
+            equalTo("timestamp field [@timestamp] is of type [keyword], but [date,date_nanos] is expected")
         );
     }
 
@@ -108,7 +108,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
             b.field("index", false);
             b.endObject();
         })));
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] is not indexed"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] is not indexed"));
     }
 
     public void testValidateNotDocValues() {
@@ -118,7 +118,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
             b.field("doc_values", false);
             b.endObject();
         })));
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] doesn't have doc values"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] doesn't have doc values"));
     }
 
     public void testValidateNullValue() {
@@ -128,7 +128,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
             b.field("null_value", "2020-12-12");
             b.endObject();
         })));
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] has disallowed [null_value] attribute specified"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] has disallowed [null_value] attribute specified"));
     }
 
     public void testValidateIgnoreMalformed() {
@@ -140,7 +140,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         })));
         assertThat(
             e.getMessage(),
-            equalTo("data stream timestamp field [@timestamp] has disallowed [ignore_malformed] attribute specified")
+            equalTo("timestamp field [@timestamp] has disallowed [ignore_malformed] attribute specified")
         );
     }
 
@@ -151,7 +151,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
             b.field("store", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), equalTo("data stream timestamp field [@timestamp] has disallowed attributes: [store]"));
+        assertThat(e.getMessage(), equalTo("timestamp field [@timestamp] has disallowed attributes: [store]"));
     }
 
     public void testValidateDefaultIgnoreMalformed() throws Exception {
@@ -166,7 +166,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         );
         assertThat(
             e.getMessage(),
-            equalTo("data stream timestamp field [@timestamp] has disallowed [ignore_malformed] attribute specified")
+            equalTo("timestamp field [@timestamp] has disallowed [ignore_malformed] attribute specified")
         );
 
         MapperService mapperService = createMapperService(Version.CURRENT, indexSettings, () -> true, timestampMapping(true, b -> {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -539,12 +539,12 @@ setup:
   - match: { errors: true }
   - match: { items.0.create.status: 400 }
   - match: { items.0.create.error.caused_by.type: illegal_argument_exception }
-  - match: { items.0.create.error.caused_by.reason: "data stream timestamp field [@timestamp] is missing" }
+  - match: { items.0.create.error.caused_by.reason: "timestamp field [@timestamp] is missing" }
   - match: { items.1.create.result: created }
   - match: { items.1.create._index: "/\\.ds-logs-foobar-(\\d{4}\\.\\d{2}\\.\\d{2}-)?000001/" }
   - match: { items.2.create.status: 400 }
   - match: { items.2.create.error.caused_by.type: illegal_argument_exception }
-  - match: { items.2.create.error.caused_by.reason: "data stream timestamp field [@timestamp] encountered multiple values" }
+  - match: { items.2.create.error.caused_by.reason: "timestamp field [@timestamp] encountered multiple values" }
 
   - do:
       indices.delete_data_stream:


### PR DESCRIPTION
Since time series index also needs to use the timestamp field, rename from DataStreamTimestampFieldMapper to TimestampFieldMapper.

 As DataStream rename TimestampFieldMapper to DataStreamTimestampFieldMapper in https://github.com/elastic/elasticsearch/pull/59293.

Now time series index also needs timestamp field. I rename DataStreamTimestampFieldMapper to TimestampFieldMapper, and move DataStreamTimestampFieldMapper to DataStream plugins for Forward compatible.

