### PR TITLE
Fix failure in IngestServiceTests > testValidateNotInUse

### DIFF
--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -316,7 +316,7 @@ public class IngestServiceTests extends ESTestCase {
             indices.put(indexName, indexMetadata);
         }
 
-        int finalIndicesCount = randomIntBetween(0, 4);
+        int finalIndicesCount = randomIntBetween(defaultIndicesCount > 0 ? 0 : 1, 4);
         List<String> finalIndices = new ArrayList<>();
         for (int i = defaultIndicesCount; i < (finalIndicesCount + defaultIndicesCount); i++) {
             String indexName = "index" + i;


### PR DESCRIPTION
Fixes the case where both `defaultIndicesCount` and `finalIndicesCount` were randomly assigned `0`.