### PR TITLE
[DOCS] Migration information about ES logging breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -24,6 +24,7 @@ coming[8.0.0]
 * <<breaking_80_indices_changes>>
 * <<breaking_80_ingest_changes>>
 * <<breaking_80_java_changes>>
+* <<breaking_80_logging_changes>>
 * <<breaking_80_mappings_changes>>
 * <<breaking_80_monitoring_changes>>
 * <<breaking_80_network_changes>>
@@ -40,7 +41,6 @@ coming[8.0.0]
 * <<breaking_80_threadpool_changes>>
 * <<breaking_80_transport_changes>>
 * <<breaking_80_watcher_changes>>
-* <<breaking_80_logging_changes>>
 
 [discrete]
 [[breaking-changes-8.0]]
@@ -128,6 +128,7 @@ include::migrate_8_0/ilm.asciidoc[]
 include::migrate_8_0/indices.asciidoc[]
 include::migrate_8_0/ingest.asciidoc[]
 include::migrate_8_0/java.asciidoc[]
+include::migrate_8_0/logging.asciidoc[]
 include::migrate_8_0/mappings.asciidoc[]
 include::migrate_8_0/monitoring.asciidoc[]
 include::migrate_8_0/network.asciidoc[]
@@ -145,7 +146,6 @@ include::migrate_8_0/threadpool.asciidoc[]
 include::migrate_8_0/transport.asciidoc[]
 include::migrate_8_0/watcher.asciidoc[]
 include::migrate_8_0/migrate_to_java_time.asciidoc[]
-include::migrate_8_0/logging.asciidoc[]
 
 ////
 [discrete]

--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -40,6 +40,7 @@ coming[8.0.0]
 * <<breaking_80_threadpool_changes>>
 * <<breaking_80_transport_changes>>
 * <<breaking_80_watcher_changes>>
+* <<breaking_80_logging_changes>>
 
 [discrete]
 [[breaking-changes-8.0]]
@@ -144,6 +145,7 @@ include::migrate_8_0/threadpool.asciidoc[]
 include::migrate_8_0/transport.asciidoc[]
 include::migrate_8_0/watcher.asciidoc[]
 include::migrate_8_0/migrate_to_java_time.asciidoc[]
+include::migrate_8_0/logging.asciidoc[]
 
 ////
 [discrete]

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -6,14 +6,21 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-.Elasticsearch JSON logs to comply with ECS
+.{es} JSON logs now comply with ECS
 [%collapsible]
 ====
 *Details* +
-Elasticsearch JSON logs format will be ECS compliant see: {es-pull}47105[#47105] (issue: {es-issue}46119[#46119])
+{es}'s {ref}/logging.html[JSON logs] now comply with the
+{ecs-ref}/index.html[Elastic Common Schema (ECS)]. This includes several notable
+changes:
+
+// * Notable change
+// * Other notable change
+
+Previously, {es}'s JSON logs used a custom schema.
 
 *Impact* +
-If you have a custom tooling around ES JSON logs,
-you need to consider chaning it to be able to parse ECS JSON format.
+If your application parses {es}'s JSON logs, update it to support the new ECS
+format.
 ====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -11,13 +11,8 @@
 ====
 *Details* +
 {es}'s {ref}/logging.html[JSON logs] now comply with the
-{ecs-ref}/index.html[Elastic Common Schema (ECS)]. This includes several notable
-changes:
-
-// * Notable change
-// * Other notable change
-
-Previously, {es}'s JSON logs used a custom schema.
+{ecs-ref}/index.html[Elastic Common Schema (ECS)]. Previously, {es}'s JSON logs
+used a custom schema.
 
 *Impact* +
 If your application parses {es}'s JSON logs, update it to support the new ECS

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -10,9 +10,10 @@
 [%collapsible]
 ====
 *Details* +
-* Make Elasticsearch JSON logs ECS compliant {es-pull}47105[#47105] (issue: {es-issue}46119[#46119])
+Elasticsearch JSON logs format will be ECS compliant see: {es-pull}47105[#47105] (issue: {es-issue}46119[#46119])
 
 *Impact* +
-If you have a custom tooling around ES JSON logs, you need to consider updating it.
+If you have a custom tooling around ES JSON logs,
+you need to consider chaning it to be able to parse ECS JSON format.
 ====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -23,4 +23,20 @@ Previously, {es}'s JSON logs used a custom schema.
 If your application parses {es}'s JSON logs, update it to support the new ECS
 format.
 ====
+
+
+.{es} plaintext logs (except server) are removed
+[%collapsible]
+====
+*Details* +
+{es} no longer emits plaintext search slow logs, indexing slow logs and deprecation logs.
+All of these are available in JSON format.
+
+Server logs are available in both JSON and plaintext format.
+
+*Impact* +
+If your application parses {es}'s plaintext logs, update it to support the new ECS
+JSON logs.
+====
+
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -6,7 +6,7 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-.{es} JSON logs now comply with ECS
+.{es} JSON logs now comply with ECS.
 [%collapsible]
 ====
 *Details* +
@@ -25,17 +25,22 @@ format.
 ====
 
 
-.{es} plaintext logs (except server) are removed
+.{es} no longer emits deprecation logs or slow logs in plaintext.
 [%collapsible]
 ====
 *Details* +
-{es} no longer emits plaintext search slow logs, indexing slow logs and deprecation logs.
-All of these are available in JSON format.
+{es} no longer emits a plaintext version of the following logs:
 
-Server logs are available in both JSON and plaintext format.
+* Deprecation logs
+* Indexing slow logs
+* Search slow logs
+
+These logs are now only available in JSON.
+
+Server logs are still available in both a JSON and plaintext format.
 
 *Impact* +
-If your application parses {es}'s plaintext logs, update it to support the new ECS
+If your application parses {es}'s plaintext logs, update it to use the new ECS
 JSON logs.
 ====
 

--- a/docs/reference/migration/migrate_8_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/logging.asciidoc
@@ -1,0 +1,18 @@
+[discrete]
+[[breaking_80_logging_changes]]
+==== Logging changes
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+.Elasticsearch JSON logs to comply with ECS
+[%collapsible]
+====
+*Details* +
+* Make Elasticsearch JSON logs ECS compliant {es-pull}47105[#47105] (issue: {es-issue}46119[#46119])
+
+*Impact* +
+If you have a custom tooling around ES JSON logs, you need to consider updating it.
+====
+// end::notable-breaking-changes[]


### PR DESCRIPTION
Adds breaking change docs for https://github.com/elastic/elasticsearch/pull/47105. (ECS layout and plaintext log files removal)

Relates to https://github.com/elastic/elasticsearch/issues/46119.