### PR TITLE
Run test task in BuildToolsInternal with junit5

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -235,13 +235,17 @@ dependencies {
   compileOnly "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
   runtimeOnly "org.elasticsearch.gradle:reaper:$version"
   testImplementation "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
-  testImplementation "junit:junit:${versions.getProperty('junit')}"
+//  testImplementation "junit:junit:${versions.getProperty('junit')}"
   testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
   testImplementation 'org.mockito:mockito-core:1.9.5'
   testImplementation "org.hamcrest:hamcrest:${versions.getProperty('hamcrest')}"
 
   testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
+  testImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
+  testImplementation("org.junit.jupiter:junit-jupiter") {
+    because 'allows to write and run Jupiter tests'
+  }
   integTestImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
@@ -252,7 +256,7 @@ dependencies {
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
     because 'allows JUnit 3 and JUnit 4 tests to run'
   }
-  integTestRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 
@@ -266,9 +270,13 @@ dependencies {
   }
   // required as we rely on junit4 rules
   integTestImplementation "org.spockframework:spock-junit4"
+  testImplementation "org.spockframework:spock-junit4"
   integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
 }
 
+tasks.named('test').configure {
+  useJUnitPlatform()
+}
 tasks.register("integTest", Test) {
   inputs.dir(file("src/testKit")).withPropertyName("testkit dir").withPathSensitivity(PathSensitivity.RELATIVE)
   systemProperty 'test.version_under_test', version


### PR DESCRIPTION
- fixes missing execution of spock tests