### PR TITLE
[7.x] Document a number of enrich node settings. (#78930)

### DIFF
--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -220,3 +220,54 @@ Instead, you can:
 
 include::geo-match-enrich-policy-type-ex.asciidoc[]
 include::match-enrich-policy-type-ex.asciidoc[]
+
+[[ingest-enrich-components]]
+==== Enrich components
+
+The enrich coordinator is a component that manages and performs the searches 
+required to enrich documents on each ingest node. It combines searches from all enrich
+processors in all pipelines into bulk <<search-multi-search,multi-searches>>.
+
+The enrich policy executor is a component that manages the executions of all 
+enrich policies. When an enrich policy is executed, this component creates 
+a new enrich index and removes the previous enrich index. The enrich policy
+executions are managed from the elected master node. The execution of these
+policies occurs on a different node.
+
+[[ingest-enrich-settings]]
+==== Node Settings
+
+The `enrich` processor has node settings for enrich coordinator and
+enrich policy executor.
+
+The enrich coordinator supports the following node settings:
+
+`enrich.cache_size`::
+Maximum number of searches to cache for enriching documents. Defaults to `1000`.
+There is a single cache for all enrich processors in the cluster. This setting
+determines the size of that cache.
+
+`enrich.coordinator_proxy.max_concurrent_requests`::
+Maximum number of concurrent <<search-multi-search,multi-search requests>> to
+run when enriching documents. Defaults to `8`.
+
+`enrich.coordinator_proxy.max_lookups_per_request`::
+Maximum number of searches to include in a <<search-multi-search,multi-search
+request>> when enriching documents. Defaults to `128`.
+
+The enrich policy executor supports the following node settings:
+
+`enrich.fetch_size`::
+Maximum batch size when reindexing a source index into an enrich index. Defaults
+to `10000`.
+
+`enrich.max_force_merge_attempts`::
+Maximum number of <<indices-forcemerge,force merge>> attempts allowed on an
+enrich index. Defaults to `3`.
+
+`enrich.cleanup_period`::
+How often {es} checks whether unused enrich indices can be deleted. Defaults to
+`15m`.
+
+`enrich.max_concurrent_policy_executions`::
+Maximum number of enrich policies to execute concurrently. Defaults to `50`.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Document a number of enrich node settings. (#78930)