### PR TITLE
fix feature reset call lost for ESSingleNodeTestCase

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -6,12 +6,16 @@
  */
 package org.elasticsearch.xpack.core;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.RequestValidators;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse.ResetFeatureStateStatus;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,7 +41,6 @@ import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -85,6 +88,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 
 import java.io.IOException;
@@ -591,10 +595,30 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin implements Scrip
 
     }
 
+    @Override
+    public void cleanUpFeature(
+        ClusterService clusterService,
+        Client client,
+        ActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> finalListener
+    ) {
+        List<SystemIndexPlugin> systemPlugins = filterPlugins(SystemIndexPlugin.class);
+
+        GroupedActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> allListeners = new GroupedActionListener<>(
+            ActionListener.wrap(
+                listenerResults -> finalListener.onResponse(ResetFeatureStateStatus.success(getFeatureName())),
+                finalListener::onFailure
+            ),
+            systemPlugins.size()
+        );
+        systemPlugins.forEach(plugin -> plugin.cleanUpFeature(clusterService, client, allListeners));
+    }
+
+    @Override
     public boolean safeToShutdown(String nodeId, SingleNodeShutdownMetadata.Type shutdownType) {
         return filterPlugins(ShutdownAwarePlugin.class).stream().allMatch(plugin -> plugin.safeToShutdown(nodeId, shutdownType));
     }
 
+    @Override
     public void signalShutdown(Collection<String> shutdownNodeIds) {
         filterPlugins(ShutdownAwarePlugin.class).forEach(plugin -> plugin.signalShutdown(shutdownNodeIds));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
@@ -9,11 +9,8 @@ package org.elasticsearch.xpack.ml;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -78,14 +75,6 @@ public class LocalStateMachineLearning extends LocalStateCompositeXPackPlugin {
             protected XPackLicenseState getLicenseState() { return thisVar.getLicenseState(); }
         });
         plugins.add(new MockedRollupPlugin());
-    }
-
-    @Override
-    public void cleanUpFeature(
-        ClusterService clusterService,
-        Client client,
-        ActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> finalListener) {
-        mlPlugin.cleanUpFeature(clusterService, client, finalListener);
     }
 
     @Override


### PR DESCRIPTION
call feature reset API for all plugins inside LocalStateCompositeXPackPlugin


Note: This has been found while debugging integration tests for transform. `ESSingleNodeTestCase` uses a proxy class called `LocalState{Transform, MachineLearning, Enrich, ...}` which proxies a set of plugins. `LocalStateMachineLearning` was the only one implementing `cleanUpFeature`. Instead of adding the same for transform I decided to implement it in the super class.

/CC @williamrandolph (FYI, as you are working/worked on feature reset) 