### PR TITLE
[DOCS] Deprecate transient settings

### DIFF
--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -69,7 +69,7 @@ the older round robin of search requests, you can use the
 --------------------------------------------------
 PUT /_cluster/settings
 {
-  "transient": {
+  "persistent": {
     "cluster.routing.use_adaptive_replica_selection": false
   }
 }

--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -166,9 +166,9 @@ each data path.
 
 // tag::mdp-migration[]
 If you currently use multiple data paths in a
-{ref}/high-availability-cluster-design.html[highly available cluster] then you 
-can migrate to a setup that uses a single path for each node without downtime 
-using a process similar to a 
+{ref}/high-availability-cluster-design.html[highly available cluster] then you
+can migrate to a setup that uses a single path for each node without downtime
+using a process similar to a
 {ref}/restart-cluster.html#restart-cluster-rolling[rolling restart]: shut each
 node down in turn and replace it with one or more nodes each configured to use
 a single data path. In more detail, for each node that currently has multiple
@@ -183,18 +183,18 @@ data paths you should follow the following process.
 --------------------------------------------------
 PUT _cluster/settings
 {
-  "transient": {
+  "persistent": {
     "cluster.routing.allocation.exclude._name": "target-node-name"
   }
 }
 --------------------------------------------------
 +
-You can use the {ref}/cat-allocation.html[cat allocation API] to track progress 
+You can use the {ref}/cat-allocation.html[cat allocation API] to track progress
 of this data migration. If some shards do not migrate then the
-{ref}/cluster-allocation-explain.html[cluster allocation explain API] will help 
+{ref}/cluster-allocation-explain.html[cluster allocation explain API] will help
 you to determine why.
 
-3. Follow the steps in the 
+3. Follow the steps in the
 {ref}/restart-cluster.html#restart-cluster-rolling[rolling restart process]
 up to and including shutting the target node down.
 
@@ -207,7 +207,7 @@ of every shard assigned to at least one of the other nodes in your cluster.
 --------------------------------------------------
 PUT _cluster/settings
 {
-  "transient": {
+  "persistent": {
     "cluster.routing.allocation.exclude._name": null
   }
 }
@@ -225,7 +225,7 @@ has sufficient space for the data that it will hold.
 `path.data` setting pointing at a separate data path.
 
 9. Start the new nodes and follow the rest of the
-{ref}/restart-cluster.html#restart-cluster-rolling[rolling restart process] for 
+{ref}/restart-cluster.html#restart-cluster-rolling[rolling restart process] for
 them.
 
 10. Ensure your cluster health is `green`, so that every shard has been
@@ -233,9 +233,9 @@ assigned.
 
 You can alternatively add some number of single-data-path nodes to your
 cluster, migrate all your data over to these new nodes using
-{ref}/modules-cluster.html#cluster-shard-allocation-filtering[allocation filters], 
-and then remove the old nodes from the cluster. This approach will temporarily 
-double the size of your cluster so it will only work if you have the capacity to 
+{ref}/modules-cluster.html#cluster-shard-allocation-filtering[allocation filters],
+and then remove the old nodes from the cluster. This approach will temporarily
+double the size of your cluster so it will only work if you have the capacity to
 expand your cluster like this.
 
 If you currently use multiple data paths but your cluster is not highly

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -118,7 +118,7 @@ as it will no longer be recognized in the next major release.
 [[breaking_716_settings_deprecations]]
 ==== Settings deprecations
 
-[[deprecate-transient-cluster-settings]]
+[[transient-cluster-settings]]
 .Transient cluster settings are now deprecated.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -118,7 +118,7 @@ as it will no longer be recognized in the next major release.
 [[breaking_716_settings_deprecations]]
 ==== Settings deprecations
 
-[[transient-cluster-settings]]
+[[deprecate-transient-cluster-settings]]
 .Transient cluster settings are now deprecated.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -114,4 +114,24 @@ Discontinue the use of the `xpack.monitoring.exporters.*.index.template.create_l
 as it will no longer be recognized in the next major release.
 ====
 
+[discrete]
+[[breaking_716_settings_deprecations]]
+==== Settings deprecations
+
+[[deprecate-transient-cluster-settings]]
+.Transient cluster settings are now deprecated.
+[%collapsible]
+====
+*Details* +
+Transient cluster settings are now deprecated and will be removed in 8.0. This is because transient cluster
+settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts, which
+can forcibly happen if enough master-eligible nodes fail. In such an event, the cluster state will be recovered
+from persistent storage, effectively erasing the transient settings. The loss of transient settings can happen
+unexpectedly, leading to potentially undesired cluster configuration.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of transient settings when modifying
+your cluster settings through the `PUT _cluster/settings` REST API. When modifying cluster settings
+use only persistent settings.
+====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -13,6 +13,8 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_716_monitoring_changes>>
 
+* <<breaking_716_settings_deprecations>>
+
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -123,11 +123,11 @@ as it will no longer be recognized in the next major release.
 [%collapsible]
 ====
 *Details* +
-Transient cluster settings are now deprecated and will be removed in 8.0. This is because transient cluster
-settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts, which
-can forcibly happen if enough master-eligible nodes fail. In such an event, the cluster state will be recovered
+Transient cluster settings are now deprecated and will be removed in a future release. This is because transient
+cluster settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts,
+which can forcibly happen if enough master-eligible nodes fail. In such an event, the cluster state will be recovered
 from persistent storage, effectively erasing the transient settings. The loss of transient settings can happen
-unexpectedly, leading to potentially undesired cluster configuration.
+unexpectedly, leading to a potentially undesired cluster configuration.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of transient settings when modifying

--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -378,7 +378,7 @@ Mapping::
 * Merge V2 index/component template mappings in specific manner {es-pull}55607[#55607] (issue: {es-issue}53101[#53101])
 
 Recovery::
-* Avoid copying file chunks in peer covery {es-pull}56072[#56072] (issue: {es-issue}55353[#55353])
+* Avoid copying file chunks in peer recovery {es-pull}56072[#56072] (issue: {es-issue}55353[#55353])
 * Retry failed peer recovery due to transient errors {es-pull}55353[#55353]
 
 SQL::


### PR DESCRIPTION
This PR adds the deprecation documentation for transient cluster settings.

It relates to #49540 and it should be merged after https://github.com/elastic/elasticsearch/pull/78794 is merged and back ported to 7.x