### PR TITLE
Cleanup BWC projects for versions bigger than 7.12

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -66,18 +66,16 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         """
         when:
         def result = gradleRunner(":distribution:bwc:${bwcProject}:buildBwcDarwinTar",
-                ":distribution:bwc:${bwcProject}:buildBwcOssDarwinTar",
+                ":distribution:bwc:${bwcProject}:buildBwcDarwinTar",
                 "-DtestRemoteRepo=" + remoteGitRepo,
                 "-Dbwc.remote=origin",
                 "-Dbwc.dist.version=${bwcDistVersion}-SNAPSHOT")
                 .build()
         then:
         result.task(":distribution:bwc:${bwcProject}:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
-        result.task(":distribution:bwc:${bwcProject}:buildBwcOssDarwinTar").outcome == TaskOutcome.SUCCESS
 
         and: "assemble task triggered"
         assertOutputContains(result.output, "[$bwcDistVersion] > Task :distribution:archives:darwin-tar:${expectedAssembleTaskName}")
-        assertOutputContains(result.output, "[$bwcDistVersion] > Task :distribution:archives:oss-darwin-tar:${expectedAssembleTaskName}")
 
         where:
         bwcDistVersion | bwcProject | expectedAssembleTaskName

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -166,18 +166,22 @@ public class InternalDistributionBwcSetupPlugin implements InternalPlugin {
 
     private static List<DistributionProject> resolveArchiveProjects(File checkoutDir, Version bwcVersion) {
         List<String> projects = new ArrayList<>();
-        // All active BWC branches publish default and oss variants of rpm and deb packages
-        projects.addAll(asList("deb", "rpm", "oss-deb", "oss-rpm"));
+        if (bwcVersion.onOrAfter("7.13.0")) {
+            projects.addAll(asList("deb", "rpm"));
+            projects.addAll(asList("windows-zip", "darwin-tar", "linux-tar"));
+            projects.addAll(asList("darwin-aarch64-tar", "linux-aarch64-tar"));
+        } else {
+            projects.addAll(asList("deb", "rpm", "oss-deb", "oss-rpm"));
+            if (bwcVersion.onOrAfter("7.0.0")) { // starting with 7.0 we bundle a jdk which means we have platform-specific archives
+                projects.addAll(asList("oss-windows-zip", "windows-zip", "oss-darwin-tar", "darwin-tar", "oss-linux-tar", "linux-tar"));
 
-        if (bwcVersion.onOrAfter("7.0.0")) { // starting with 7.0 we bundle a jdk which means we have platform-specific archives
-            projects.addAll(asList("oss-windows-zip", "windows-zip", "oss-darwin-tar", "darwin-tar", "oss-linux-tar", "linux-tar"));
-
-            // We support aarch64 for linux and mac starting from 7.12
-            if (bwcVersion.onOrAfter("7.12.0")) {
-                projects.addAll(asList("oss-darwin-aarch64-tar", "oss-linux-aarch64-tar", "darwin-aarch64-tar", "linux-aarch64-tar"));
+                // We support aarch64 for linux and mac starting from 7.12
+                if (bwcVersion.onOrAfter("7.12.0")) {
+                    projects.addAll(asList("oss-darwin-aarch64-tar", "oss-linux-aarch64-tar", "darwin-aarch64-tar", "linux-aarch64-tar"));
+                }
+            } else { // prior to 7.0 we published only a single zip and tar archives for oss and default distributions
+                projects.addAll(asList("oss-zip", "zip", "tar", "oss-tar"));
             }
-        } else { // prior to 7.0 we published only a single zip and tar archives for oss and default distributions
-            projects.addAll(asList("oss-zip", "zip", "tar", "oss-tar"));
         }
 
         return projects.stream().map(name -> {


### PR DESCRIPTION
This should fix the failing release build.
More cleanup on the ES build is required and will be done in a
follow up PR