### PR TITLE
[7.x] Remove license check for monitoring data retention (#79010)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -15,7 +15,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.License.OperationMode;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
-import org.elasticsearch.xpack.core.monitoring.MonitoringField;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -50,7 +49,6 @@ public class XPackLicenseState {
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),
 
         MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
-        MONITORING_UPDATE_RETENTION(OperationMode.STANDARD, false),
 
         CCR(OperationMode.PLATINUM, true),
 
@@ -88,8 +86,7 @@ public class XPackLicenseState {
             "The actions of the watches don't execute"
         });
         messages.put(XPackField.MONITORING, new String[] {
-            "The agent will stop collecting cluster and indices metrics",
-            "The agent will stop automatically cleaning indices older than [xpack.monitoring.history.duration]"
+            "The agent will stop collecting cluster and indices metrics"
         });
         messages.put(XPackField.GRAPH, new String[] {
             "Graph explore APIs are disabled"
@@ -241,10 +238,7 @@ public class XPackLicenseState {
                                     "running multiple clusters, users won't be able to access the clusters with\n" +
                                     "[{}] licenses from within a single X-Pack Kibana instance. You will have to deploy a\n" +
                                     "separate and dedicated X-pack Kibana instance for each [{}] cluster you wish to monitor.",
-                                newMode, newMode, newMode),
-                            LoggerMessageFormat.format(
-                                "Automatic index cleanup is locked to {} days for clusters with [{}] license.",
-                                MonitoringField.HISTORY_DURATION.getDefault(Settings.EMPTY).days(), newMode)
+                                newMode, newMode, newMode)
                         };
                 }
                 break;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -259,7 +259,7 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testMonitoringAckNotBasicToBasic() {
         OperationMode from = randomFrom(STANDARD, GOLD, PLATINUM, TRIAL);
-        assertAckMessages(XPackField.MONITORING, from, BASIC, 2);
+        assertAckMessages(XPackField.MONITORING, from, BASIC, 1);
     }
 
     public void testSqlAckAnyToTrialOrPlatinum() {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -11,11 +11,10 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractLifecycleRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.monitoring.MonitoringField;
@@ -84,36 +83,19 @@ public class CleanerService extends AbstractLifecycleComponent {
 
     /**
      * Get the retention that can be used.
-     * <p>
-     * This will ignore the global retention if the license does not allow retention updates.
      *
      * @return Never {@code null}
-     * @see XPackLicenseState.Feature#MONITORING_UPDATE_RETENTION
      */
     public TimeValue getRetention() {
-        // we only care about their value if they are allowed to set it
-        if (licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION) && globalRetention != null) {
-            return globalRetention;
-        }
-        else {
-            return MonitoringField.HISTORY_DURATION.getDefault(Settings.EMPTY);
-        }
+        return globalRetention;
     }
 
     /**
      * Set the global retention. This is expected to be used by the cluster settings to dynamically control the global retention time.
-     * <p>
-     * Even if the current license prevents retention updates, it will accept the change so that they do not need to re-set it if they
-     * upgrade their license (they can always unset it).
      *
      * @param globalRetention The global retention to use dynamically.
      */
     public void setGlobalRetention(TimeValue globalRetention) {
-        // notify the user that their setting will be ignored until they get the right license
-        if (licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION) == false) {
-            logger.warn("[{}] setting will be ignored until an appropriate license is applied", MonitoringField.HISTORY_DURATION.getKey());
-        }
-
         this.globalRetention = globalRetention;
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -30,9 +29,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class CleanerServiceTests extends ESTestCase {
     @Rule
@@ -63,36 +59,11 @@ public class CleanerServiceTests extends ESTestCase {
         new CleanerService(settings, clusterSettings, threadPool, licenseState);
     }
 
-    public void testGetRetentionWithSettingWithUpdatesAllowed() {
+    public void testGetRetention() {
         TimeValue expected = TimeValue.timeValueHours(25);
         Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), expected.getStringRep()).build();
 
-        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
-
         assertEquals(expected, new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
-
-        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
-    }
-
-    public void testGetRetentionDefaultValueWithNoSettings() {
-        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
-
-        assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
-                     new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState).getRetention());
-
-        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
-    }
-
-    public void testGetRetentionDefaultValueWithSettingsButUpdatesNotAllowed() {
-        TimeValue notExpected = TimeValue.timeValueHours(25);
-        Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), notExpected.getStringRep()).build();
-
-        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false);
-
-        assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
-                     new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
-
-        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testSetGlobalRetention() {
@@ -100,34 +71,9 @@ public class CleanerServiceTests extends ESTestCase {
         // only thing calling this method and it will use the settings object to validate the time value
         TimeValue expected = TimeValue.timeValueHours(2);
 
-        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
-
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
-
         service.setGlobalRetention(expected);
-
         assertEquals(expected, service.getRetention());
-
-        verify(licenseState, times(2)).checkFeature(Feature.MONITORING_UPDATE_RETENTION); // once by set, once by get
-    }
-
-    public void testSetGlobalRetentionAppliesEvenIfLicenseDisallows() {
-        // Note: I used this value to ensure we're not double-validating the setter; the cluster state should be the
-        // only thing calling this method and it will use the settings object to validate the time value
-        TimeValue expected = TimeValue.timeValueHours(2);
-
-        // required to be true on the second call for it to see it take effect
-        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false).thenReturn(true);
-
-        CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
-
-        // uses allow=false
-        service.setGlobalRetention(expected);
-
-        // uses allow=true
-        assertEquals(expected, service.getRetention());
-
-        verify(licenseState, times(2)).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testNextExecutionDelay() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove license check for monitoring data retention (#79010)