### PR TITLE
Skip building of BWC distributions when building release artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -422,7 +422,11 @@ tasks.register("buildReleaseArtifacts").configure {
   group = 'build'
   description = 'Builds all artifacts required for release manager'
 
-  dependsOn allprojects.findAll { it.path.startsWith(':distribution:docker') == false && it.path.startsWith(':ml-cpp') == false }
+  dependsOn allprojects.findAll {
+    it.path.startsWith(':distribution:docker') == false
+      && it.path.startsWith(':ml-cpp') == false
+      && it.path.startsWith(':distribution:bwc') == false
+  }
     .collect { GradleUtils.findByName(it.tasks, 'assemble') }
     .findAll { it != null }
 }


### PR DESCRIPTION
Building BWC distributions is purely for internal testing, we don't release these artifacts so running the `buildReleaseArtifacts` task shouldn't build them.