### PR TITLE
[7.x] Separate minimum compiler and runtime Java version properties (#79108)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
@@ -15,13 +15,11 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutFactory;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import javax.inject.Inject;
 
 abstract class VersionPropertiesBuildService implements BuildService<VersionPropertiesBuildService.Params>, AutoCloseable {
 
@@ -33,12 +31,33 @@ abstract class VersionPropertiesBuildService implements BuildService<VersionProp
         try {
             File propertiesInputFile = new File(infoPath, "version.properties");
             properties = VersionPropertiesLoader.loadBuildSrcVersion(propertiesInputFile, providerFactory);
-            properties.put("minimumJava", 11);
+            properties.computeIfAbsent("minimumRuntimeJava", s -> resolveMinimumRuntimeJavaVersion(infoPath));
+            properties.computeIfAbsent("minimumCompilerJava", s -> resolveMinimumCompilerJavaVersion(infoPath));
         } catch (IOException e) {
             throw new GradleException("Cannot load VersionPropertiesBuildService", e);
         }
     }
-    
+
+    private JavaVersion resolveMinimumRuntimeJavaVersion(File infoPath) {
+        return resolveJavaVersion(infoPath, "src/main/resources/minimumRuntimeVersion");
+    }
+
+    private JavaVersion resolveMinimumCompilerJavaVersion(File infoPath) {
+        return resolveJavaVersion(infoPath, "src/main/resources/minimumCompilerVersion");
+    }
+
+    private JavaVersion resolveJavaVersion(File infoPath, String path) {
+        final JavaVersion minimumJavaVersion;
+        File minimumJavaInfoSource = new File(infoPath, path);
+        try {
+            String versionString = FileUtils.readFileToString(minimumJavaInfoSource);
+            minimumJavaVersion = JavaVersion.toVersion(versionString);
+        } catch (IOException e) {
+            throw new GradleException("Cannot resolve minimum compiler version via VersionPropertiesBuildService", e);
+        }
+        return minimumJavaVersion;
+    }
+
     public Properties getProperties() {
         return properties;
     }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -167,7 +167,7 @@ gradlePlugin {
  *         Java version                                                      *
  *****************************************************************************/
 
-def minCompilerJava = versions.get("minimumJava")
+def minCompilerJava = versions.get("minimumCompilerJava")
 targetCompatibility = minCompilerJava
 sourceCompatibility = minCompilerJava
 

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import org.elasticsearch.gradle.internal.conventions.VersionPropertiesLoader
 
 plugins {
     id 'java-gradle-plugin'
@@ -22,8 +21,8 @@ description = "The elasticsearch build tools"
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumJava")
-sourceCompatibility = versions.get("minimumJava")
+targetCompatibility = versions.get("minimumRuntimeJava")
+sourceCompatibility = versions.get("minimumRuntimeJava")
 
 gradlePlugin {
     // We already configure publication and we don't need or want the one that comes

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -21,8 +21,8 @@ description = "The elasticsearch build tools"
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumRuntimeJava")
-sourceCompatibility = versions.get("minimumRuntimeJava")
+targetCompatibility = 11
+sourceCompatibility = 11
 
 gradlePlugin {
     // We already configure publication and we don't need or want the one that comes

--- a/build-tools/reaper/build.gradle
+++ b/build-tools/reaper/build.gradle
@@ -7,8 +7,8 @@ plugins {
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumJava")
-sourceCompatibility = versions.get("minimumJava")
+targetCompatibility = versions.get("minimumRuntimeJava")
+sourceCompatibility = versions.get("minimumRuntimeJava")
 
 tasks.named("jar").configure {
   archiveFileName = "${project.name}.jar"

--- a/build-tools/reaper/build.gradle
+++ b/build-tools/reaper/build.gradle
@@ -7,8 +7,8 @@ plugins {
 
 group = "org.elasticsearch.gradle"
 version = versions.getProperty("elasticsearch")
-targetCompatibility = versions.get("minimumRuntimeJava")
-sourceCompatibility = versions.get("minimumRuntimeJava")
+targetCompatibility = 11
+sourceCompatibility = 11
 
 tasks.named("jar").configure {
   archiveFileName = "${project.name}.jar"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Separate minimum compiler and runtime Java version properties (#79108)