### PR TITLE
[7.x] [ML] address potential ml feature reset permissions bug (#79179)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1325,10 +1325,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     @Override
     public void cleanUpFeature(
         ClusterService clusterService,
-        Client client,
+        Client unwrappedClient,
         ActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> finalListener
     ) {
         logger.info("Starting machine learning feature reset");
+        OriginSettingClient client = new OriginSettingClient(unwrappedClient, ML_ORIGIN);
 
         final Map<String, Boolean> results = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] address potential ml feature reset permissions bug (#79179)