### PR TITLE
Skipping emitting deprecation logs for settings in deprecation.skip_deprecated_settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -552,10 +552,14 @@ public class Setting<T> implements ToXContentObject {
         if (this.isDeprecated() && this.exists(settings)) {
             // It would be convenient to show its replacement key, but replacement is often not so simple
             final String key = getKey();
-            Settings.DeprecationLoggerHolder.deprecationLogger
-                .critical(DeprecationCategory.SETTINGS, key,
-                    "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                    + "See the breaking changes documentation for the next major version.", key);
+
+            List<String> skipTheseDeprecations = settings.getAsList("deprecation.skip_deprecated_settings");
+            if (Regex.simpleMatch(skipTheseDeprecations, key) == false) {
+                Settings.DeprecationLoggerHolder.deprecationLogger
+                    .critical(DeprecationCategory.SETTINGS, key,
+                        "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                        + "See the breaking changes documentation for the next major version.", key);
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1258,4 +1258,21 @@ public class SettingTests extends ESTestCase {
         assertTrue(setting.isDynamic());
         assertEquals(setting.isOperatorOnly(), property == Property.OperatorDynamic);
     }
+
+    public void testCheckForDeprecation() {
+        final String settingName = "foo.bar";
+        final String settingValue = "blat";
+        final Setting<String> setting = Setting.simpleString(settingName, settingValue);
+        final Settings settings = Settings.builder().put(settingName, settingValue).build();
+        setting.checkDeprecation(settings);
+        ensureNoWarnings();
+        final Setting<String> deprecatedSetting = Setting.simpleString(settingName, settingValue, Property.Deprecated);
+        deprecatedSetting.checkDeprecation(settings);
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ deprecatedSetting });
+        final Settings settingsWithSkipDeprecationSetting = Settings.builder().put(settingName, settingValue)
+            .putList("deprecation.skip_deprecated_settings", settingName)
+            .build();
+        deprecatedSetting.checkDeprecation(settingsWithSkipDeprecationSetting);
+        ensureNoWarnings();
+    }
 }


### PR DESCRIPTION
In #78725 we added a new setting called "deprecation.skip_deprecated_settings" and changed the deprecation
info API to not emit messages for settings in that list. This commit extends that to the deprecation log. This commit
suppresses a deprecation logger message for any setting that explicitly has a Property.Deprecated property and is
in the deprecation.skip_deprecated_settings in elasticsearch.yml.
Relates #78725