### PR TITLE
[7.x] Ensure modules extending x-pack modules properly configure test clusters (#79176)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -15,7 +15,10 @@ import org.elasticsearch.gradle.internal.precommit.TestingConventionsTasks;
 import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskContainer;
@@ -82,7 +85,28 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
             if (isModule == false || isXPackModule) {
                 addNoticeGeneration(p, extension);
             }
+
+            NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
+                .getExtensions()
+                .getByName(TestClustersPlugin.EXTENSION_NAME);
+            p.getExtensions().getByType(PluginPropertiesExtension.class).getExtendedPlugins().forEach(pluginName -> {
+                // Auto add any dependent modules
+                findModulePath(project, pluginName).ifPresent(
+                    path -> testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.module(path))
+                );
+            });
         });
+    }
+
+    Optional<String> findModulePath(Project project, String pluginName) {
+        return project.getRootProject()
+            .getAllprojects()
+            .stream()
+            .filter(p -> GradleUtils.isModuleProject(p.getPath()))
+            .filter(p -> p.getPlugins().hasPlugin(PluginBuildPlugin.class))
+            .filter(p -> p.getExtensions().getByType(PluginPropertiesExtension.class).getName().equals(pluginName))
+            .findFirst()
+            .map(Project::getPath);
     }
 
     /**

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -79,13 +79,6 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
         final TaskProvider<Zip> bundleTask = createBundleTasks(project, extension);
         project.afterEvaluate(project1 -> {
-            project1.getExtensions().getByType(PluginPropertiesExtension.class).getExtendedPlugins().forEach(pluginName -> {
-                // Auto add dependent modules to the test cluster
-                if (project1.findProject(":modules:" + pluginName) != null) {
-                    NamedDomainObjectContainer<ElasticsearchCluster> testClusters = testClusters(project, "testClusters");
-                    testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.module(":modules:" + pluginName));
-                }
-            });
             final PluginPropertiesExtension extension1 = project1.getExtensions().getByType(PluginPropertiesExtension.class);
             configurePublishing(project1, extension1);
             String name = extension1.getName();
@@ -126,7 +119,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
         // allow running ES with this plugin in the foreground of a build
         var testClusters = testClusters(project, TestClustersPlugin.EXTENSION_NAME);
-        var runCluster = testClusters.register("runtTask", c -> {
+        var runCluster = testClusters.register("runTask", c -> {
             if (GradleUtils.isModuleProject(project.getPath())) {
                 c.module(bundleTask.flatMap((Transformer<Provider<RegularFile>, Zip>) zip -> zip.getArchiveFile()));
             } else {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure modules extending x-pack modules properly configure test clusters (#79176)