### PR TITLE
Add deprecated methods for JodaCompatibleZonedDateTime to docs

### DIFF
--- a/docs/reference/migration/migrate_8_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_8_0/scripting.asciidoc
@@ -6,14 +6,15 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-.The `JodaCompatibleDateTime` class has been removed.
+.The `JodaCompatibleZonedDateTime` class has been removed.
 [%collapsible]
 ====
 *Details* +
 As a transition from Joda datetime to Java datetime, scripting used
-an intermediate class called `JodaCompatibleDateTime`. This class has
-been removed and is replaced by `ZonedDateTime`. Any use of casting
-to a `JodaCompatibleDateTime` in a script will result in a compilation
+an intermediate class called `JodaCompatibleZonedDateTime`. This class
+has been removed and is replaced by `ZonedDateTime`. Any use of casting
+to a `JodaCompatibleZonedDateTime` or use of method calls only available
+in `JodaCompatibleZonedDateTime` in a script will result in a compilation
 error, and may not allow the upgraded node to start.
 
 *Impact* +
@@ -21,6 +22,26 @@ Before upgrading, replace `getDayOfWeek` with `getDayOfWeekEnum().value` in any
 scripts. Any use of `getDayOfWeek` expecting a return value of `int` will result
 in a compilation error or runtime error and may not allow the upgraded node to
 start.
+
+The following `JodaCompatibleZonedDateTime` methods must be replaced using
+`ZonedDateTime` methods prior to upgrade:
+
+* `getMillis()` -> `toInstant().toEpochMilli()`
+* `getCenturyOfEra()` -> `get(ChronoField.YEAR_OF_ERA) / 100`
+* `getEra()` -> `get(ChronoField.ERA)`
+* `getHourOfDay()` -> `getHour()`
+* `getMillisOfDay()` -> `get(ChronoField.MILLI_OF_DAY)`
+* `getMillisOfSecond()` -> `get(ChronoField.MILLI_OF_SECOND)`
+* `getMinuteOfDay()` -> `get(ChronoField.MINUTE_OF_DAY)`
+* `getMinuteOfHour()` -> `getMinute()`
+* `getMonthOfYear()` -> `getMonthValue()`
+* `getSecondOfDay()` -> `get(ChronoField.SECOND_OF_DAY)`
+* `getSecondOfMinute()` -> `getSecond()`
+* `getWeekOfWeekyear()` -> `get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear())`
+* `getYearOfCentury()` -> `get(ChronoField.YEAR_OF_ERA) % 100`
+* `getYearOfEra()` -> `get(ChronoField.YEAR_OF_ERA)`
+* `toString(String)` -> a DateTimeFormatter
+* `toString(String, Locale)` -> a DateTimeFormatter
 ====
 
 .Stored scripts no longer support empty scripts or search templates.


### PR DESCRIPTION
This change adds all the JodaCompatibleZonedDateTime methods that no longer exist to the migration docs with their ZonedDateTime equivalents.

Fixes: https://github.com/elastic/elasticsearch/issues/78739