### PR TITLE
[DOCS] Fix create snapshot API parameters

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -102,7 +102,7 @@ initializes. Defaults to `false`.
 --
 (Optional, string) Determines how wildcard patterns in the `indices` parameter
 match data streams and indices. Supports comma-separated values, such as
-`open,hidden`. Valid values are:
+`open,hidden`. Defaults to `all`. Valid values are:
 
 `all`:::
 Match any data stream or index, including <<hidden,hidden>> ones.

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -157,7 +157,7 @@ default. If `include_global_state` is `false`, the snapshot includes no feature
 states by default.
 +
 To exclude all feature states, regardless of the `include_global_state` value,
-use an empty array (`[]`) or `none`.
+specify an empty array (`[]`) or `none`.
 
 `metadata`::
 (Optional, object)

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -73,11 +73,12 @@ Besides creating a copy of each data stream and index, the snapshot process can 
 
 `<repository>`::
 (Required, string)
-Name of the repository to create a snapshot in.
+Name of the snapshot repository.
 
 `<snapshot>`::
 (Required, string)
-Name of the snapshot to create. This name must be unique in the snapshot repository.
+Name of the snapshot. Supports <<api-date-math-index-names,date math>>. Must be
+unique within the snapshot repository.
 
 [[create-snapshot-api-query-params]]
 ==== {api-query-parms-title}
@@ -96,50 +97,67 @@ initializes. Defaults to `false`.
 // Set an attribute so we can reuse these params with anchors
 :page-id: create-snapshot-api
 // tag::snapshot-config[]
+`expand_wildcards`::
++
+--
+(Optional, string) Determines how wildcard patterns in the `indices` parameter
+match data streams and indices. Supports comma-separated values, such as
+`open,hidden`. Valid values are:
+
+`all`:::
+Match any data stream or index, including <<hidden,hidden>> ones.
+
+`open`:::
+Match open indices and data streams.
+
+`closed`:::
+Match closed indices and data streams.
+
+`hidden`:::
+Match hidden data streams and indices. Must be combined with `open`, `closed`,
+or both.
+
+`none`:::
+Don't expand wildcard patterns.
+--
+
 `ignore_unavailable`::
 (Optional, Boolean)
 If `false`, the snapshot fails if any data stream or index in `indices` is
 missing or closed. If `true`, the snapshot ignores missing or closed data
 streams and indices. Defaults to `false`.
 
-`indices`::
-(Optional, string)
-A comma-separated list of data streams and indices to include in the snapshot.
-<<multi-index,Multi-index syntax>> is supported.
-+
-By default, a snapshot includes all data streams and indices in the cluster. If this
-argument is provided, the snapshot only includes the specified data streams and clusters.
-
 `include_global_state`::
 +
 --
 (Optional, Boolean)
-If `true`, the current global state is included in the snapshot.
-Defaults to `true`.
+If `true`, include the cluster state in the snapshot. Defaults to `true`.
+The cluster state includes:
 
-The global state includes:
-
-* Persistent cluster settings
-* Index templates
-* Legacy index templates
-* Ingest pipelines
-* {ilm-init} lifecycle policies
-* Data stored in system indices, such as Watches and task records (configurable via `feature_states`)
+include::restore-snapshot-api.asciidoc[tag=cluster-state-contents]
 --
+
+`indices`::
+(Optional, string or array of strings)
+Comma-separated list of data streams and indices to include in the snapshot.
+Supports <<api-multi-index,multi-index syntax>>. Defaults to an empty array
+(`[]`), which includes all data streams and indices, including system indices.
++
+To exclude all data streams and indices, use `-*` or `none`.
 
 [id="{page-id}-feature-states"]
 `feature_states`::
 (Optional, array of strings)
-A list of feature states to be included in this snapshot. A list of features
-available for inclusion in the snapshot and their descriptions be can be
-retrieved using the <<get-features-api,get features API>>.
-Each feature state includes one or more system indices containing data necessary
-for the function of that feature. Providing an empty array will include no feature
-states in the snapshot, regardless of the value of `include_global_state`.
+Feature states to include in the snapshot. To get a list of possible feature
+state values and their descriptions, use the <<get-features-api,get features
+API>>. Each feature state includes one or more system indices.
 +
-By default, all available feature states will be included in the snapshot if
-`include_global_state` is `true`, or no feature states if `include_global_state`
-is `false`.
+If `include_global_state` is `true`, the snapshot includes all feature states by
+default. If `include_global_state` is `false`, the snapshot includes no feature
+states by default.
++
+To exclude all feature states, regardless of the `include_global_state` value,
+use an empty array (`[]`) or `none`.
 
 `metadata`::
 (Optional, object)

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -135,18 +135,19 @@ indices. If `false`, the request doesn't restore aliases. Defaults to `true`.
 +
 --
 (Optional, Boolean)
-If `false`, the global state is not restored. Defaults to `false`.
+If `true`, restore the cluster state. Defaults to `false`.
 
-If `true`, the current global state is included in the restore operation.
+The cluster state includes:
 
-The global state includes:
-
-* Persistent cluster settings
-* Index templates
-* Legacy index templates
-* Ingest pipelines
-* {ilm-init} lifecycle policies
-* For snapshots taken after 7.12.0, data stored in system indices, such as Watches and task records, replacing any existing configuration (configurable via `feature_states`)
+// tag::cluster-state-contents[]
+* <<cluster-setting-types,Persistent cluster settings>>
+* <<index-templates,Index templates>>
+* <<indices-templates-v1,Legacy index templates>>
+* <<ingest,Ingest pipelines>>
+* <<index-lifecycle-management,{ilm-init} policies>>
+* For snapshots taken after 7.12.0, data stored in system indices, such as
+  Watches and task records.
+// end::cluster-state-contents[]
 
 If `include_global_state` is `true` then the restore operation merges the
 legacy index templates in your cluster with the templates contained in the
@@ -154,6 +155,9 @@ snapshot, replacing any existing ones whose name matches one in the snapshot.
 It completely removes all persistent settings, non-legacy index templates,
 ingest pipelines and {ilm-init} lifecycle policies that exist in your cluster
 and replaces them with the corresponding items from the snapshot.
+
+You can use the `feature_states` parameter to configure how system indices
+are restored from the cluster state.
 --
 
 [[restore-snapshot-api-feature-states]]


### PR DESCRIPTION
Changes:

- Notes snapshot names support date math
- Sorts request body parameters alphabetically
- Adds the `expand_wildcards` request body parameter
- Reuses cluster state contents list from the restore snapshot API
- Notes the `indices` and `feature_states` parameters support a special `none` value

Relates to #79081

### Preview
https://elasticsearch_79209.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/create-snapshot-api.html#create-snapshot-api-path-params