### PR TITLE
Make disk.threshold_enabled operator only (#78822)

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -9,8 +9,8 @@ your application to {es} 7.16.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_716_disk_threshold_enabled_operator_only>>
 * <<breaking_716_ilm_changes>>
-
 * <<breaking_716_monitoring_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
@@ -31,6 +31,28 @@ Significant changes in behavior are deprecated in a minor release and
 the old behavior is supported until the next major release.
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
+
+// tag::notable-breaking-changes[]
+[discrete]
+[[breaking_716_settings_changes]]
+==== Settings changes
+
+[[breaking_716_disk_threshold_enabled_operator_only]]
+.Disk threshold enabled setting is operator only
+[%collapsible]
+====
+*Details* +
+Disabling <<cluster-routing-disk-threshold,disk thresholds>> in orchestrated
+environments can have negative impact on the orchestration systems ability to
+move nodes around and also does not work with orchestration. The
+`cluster.routing.allocation.disk.threshold_enabled` has therefore been changed
+to be an <<operator-only-dynamic-cluster-settings, operator only>> setting.
+
+This breaks any attempt to dynamically update this setting in orchestrated
+environments such as Elasticsearch Service and Elastic Cloud Enterprise.
+
+====
+// end::notable-breaking-changes[]
 
 [discrete]
 [[deprecated-7.16]]

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -9,7 +9,7 @@ your application to {es} 7.16.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-* <<breaking_716_disk_threshold_enabled_operator_only>>
+* <<breaking_716_settings_changes>>
 * <<breaking_716_ilm_changes>>
 * <<breaking_716_monitoring_changes>>
 

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -44,7 +44,7 @@ enable <<deprecation-logging, deprecation logging>>.
 *Details* +
 Disabling <<cluster-routing-disk-threshold,disk thresholds>> in orchestrated
 environments can have negative impact on the orchestration systems ability to
-move nodes around and also does not work with orchestration. The
+move nodes around and also does not work with autoscaling. The
 `cluster.routing.allocation.disk.threshold_enabled` has therefore been changed
 to be an <<operator-only-dynamic-cluster-settings, operator only>> setting.
 

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -42,15 +42,21 @@ enable <<deprecation-logging, deprecation logging>>.
 [%collapsible]
 ====
 *Details* +
-Disabling <<cluster-routing-disk-threshold,disk thresholds>> in orchestrated
-environments can have negative impact on the orchestration systems ability to
-move nodes around and also does not work with autoscaling. The
-`cluster.routing.allocation.disk.threshold_enabled` has therefore been changed
-to be an <<operator-only-dynamic-cluster-settings, operator only>> setting.
+Orchestrated environments such as {ess} and Elastic Cloud Enterprise rely on
+the <<cluster-routing-disk-threshold,disk thresholds>> in {es} to operate the
+cluster correctly. For example the disk thresholds help determine how large an
+auto-scaled cluster should be. Disabling these disk thresholds prevents the
+orchestration system from working correctly, so starting in 7.16.0 the
+`cluster.routing.allocation.disk.threshold_enabled` setting is an
+<<operator-only-dynamic-cluster-settings, operator only>> setting which cannot
+be changed by end-users.
 
-This breaks any attempt to dynamically update this setting in orchestrated
-environments such as Elasticsearch Service and Elastic Cloud Enterprise.
-
+*Impact* +
+Discontinue use of this setting in orchestrated environments such as {ess} and
+Elastic Cloud Enterprise. Contact the environment administrator for help with
+disk space management if needed.
++
+This change has no impact on users outside of orchestrated environments.
 ====
 // end::notable-breaking-changes[]
 

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -63,7 +63,7 @@ You can use the following settings to control disk-based allocation:
 
 [[cluster-routing-disk-threshold]]
 // tag::cluster-routing-disk-threshold-tag[]
-`cluster.routing.allocation.disk.threshold_enabled` {ess-icon}::
+`cluster.routing.allocation.disk.threshold_enabled`::
 (<<dynamic-cluster-setting,Dynamic>>)
 Defaults to `true`. Set to `false` to disable the disk allocation decider.
 // end::cluster-routing-disk-threshold-tag[]

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class DiskThresholdSettings {
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING =
         Setting.boolSetting("cluster.routing.allocation.disk.threshold_enabled", true,
-            Setting.Property.Dynamic, Setting.Property.NodeScope);
+            Setting.Property.OperatorDynamic, Setting.Property.NodeScope);
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING =
         new Setting<>("cluster.routing.allocation.disk.watermark.low", "85%",
             (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.low"),

--- a/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
@@ -6,8 +6,8 @@
 NOTE: {cloud-only}
 
 Operator privileges provide protection for APIs and dynamic cluster settings.
-Any API or cluster setting that is protected by operator privileges is known as 
-_operator-only functionality_. When the operator privileges feature is enabled, 
+Any API or cluster setting that is protected by operator privileges is known as
+_operator-only functionality_. When the operator privileges feature is enabled,
 operator-only APIs can be executed only by operator users. Likewise,
 operator-only settings can be updated only by operator users. The list of
 operator-only APIs and dynamic cluster settings are pre-determined in the
@@ -38,3 +38,4 @@ given {es} version.
   - `xpack.ml.max_ml_node_size`
   - `xpack.ml.enable_config_migration`
   - `xpack.ml.persist_results_max_retries`
+* The <<cluster-routing-disk-threshold,`cluster.routing.allocation.disk.threshold_enabled` setting>>


### PR DESCRIPTION
Orchestrated environments should not allow users to override
`cluster.routing.allocation.disk.threshold_enabled`, so making this
operator only.

Closes #77846

Backport of #78822 

[docs changes preview](https://elasticsearch_79217.docs-preview.app.elstc.co/diff)