### PR TITLE
[DOCS] disk.threshold_enabled not cloud

### DIFF
--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -63,7 +63,7 @@ You can use the following settings to control disk-based allocation:
 
 [[cluster-routing-disk-threshold]]
 // tag::cluster-routing-disk-threshold-tag[]
-`cluster.routing.allocation.disk.threshold_enabled` {ess-icon}::
+`cluster.routing.allocation.disk.threshold_enabled`::
 (<<dynamic-cluster-setting,Dynamic>>)
 Defaults to `true`. Set to `false` to disable the disk allocation decider.
 // end::cluster-routing-disk-threshold-tag[]

--- a/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
@@ -6,8 +6,8 @@
 NOTE: {cloud-only}
 
 Operator privileges provide protection for APIs and dynamic cluster settings.
-Any API or cluster setting that is protected by operator privileges is known as 
-_operator-only functionality_. When the operator privileges feature is enabled, 
+Any API or cluster setting that is protected by operator privileges is known as
+_operator-only functionality_. When the operator privileges feature is enabled,
 operator-only APIs can be executed only by operator users. Likewise,
 operator-only settings can be updated only by operator users. The list of
 operator-only APIs and dynamic cluster settings are pre-determined in the
@@ -38,3 +38,4 @@ given {es} version.
   - `xpack.ml.max_ml_node_size`
   - `xpack.ml.enable_config_migration`
   - `xpack.ml.persist_results_max_retries`
+* The <<cluster-routing-disk-threshold,`cluster.routing.allocation.disk.threshold_enabled` setting>>


### PR DESCRIPTION
Mark `cluster.routing.allocation.disk.threshold_enabled` not for cloud
and add it to list of operator only settings.

Relates #78822

(changes were added to 7.x backport in #79217) so this is master only.