### PR TITLE
Set Auto expand replica on deprecation log data stream

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -322,7 +322,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
             if (node.getTestDistribution().equals(TestDistribution.INTEG_TEST)) {
                 node.defaultConfig.put("xpack.security.enabled", "false");
             } else {
-                if (node.getVersion().onOrAfter("8.0.0")) {
+                if (node.getVersion().onOrAfter("7.16.0")) {
                     node.defaultConfig.put("cluster.deprecation_indexing.enabled", "false");
                 }
             }
@@ -383,6 +383,11 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         node.goToNextVersion();
         commonNodeConfig();
         nodeIndex += 1;
+        if (node.getTestDistribution().equals(TestDistribution.DEFAULT)) {
+            if (node.getVersion().onOrAfter("7.16.0")) {
+                node.setting("cluster.deprecation_indexing.enabled", "false");
+            }
+        }
         node.start();
     }
 

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/deprecation/deprecation-indexing-settings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/deprecation/deprecation-indexing-settings.json
@@ -2,6 +2,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas" : "0-1",
         "hidden" : true,
         "lifecycle": {
           "name": ".deprecation-indexing-ilm-policy"


### PR DESCRIPTION
In order to prevent cluster to be in yellow state when starting up only
one node - often when testing or trying things - autoexpand should be
set on that data stream

Also to making sure the deprecation log indexing is disabled on all
nodes in mixed-cluster and rolling upgrade

relates #78991