### PR TITLE
Fix Snapshot BwC Version Randomization Behavior (#77057)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -117,9 +117,6 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         if (useBwCFormat) {
             final Version version = randomVersionBetween(random(), Version.V_7_5_0, Version.CURRENT);
             initWithSnapshotVersion(repoName, repoPath, version);
-            // Re-create repo to clear repository data cache
-            assertAcked(clusterAdmin().prepareDeleteRepository(repoName).get());
-            createRepository(repoName, "fs", repoPath);
         }
 
         createSnapshot(repoName, "empty-snap", Collections.emptyList());

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -56,9 +56,6 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final boolean useBwCFormat = randomBoolean();
         if (useBwCFormat) {
             initWithSnapshotVersion(repoName, repoPath, SnapshotsService.OLD_SNAPSHOT_FORMAT);
-            // Re-create repo to clear repository data cache
-            assertAcked(clusterAdmin().prepareDeleteRepository(repoName).get());
-            createRepository(repoName, "fs", repoPath);
         }
 
         final String indexName = "test-index";

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentFactory;
 
-import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -438,15 +436,11 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         expectThrows(RepositoryException.class, () -> getRepositoryData(otherRepo));
     }
 
-    public void testHandleSnapshotErrorWithBwCFormat() throws IOException, ExecutionException, InterruptedException {
+    public void testHandleSnapshotErrorWithBwCFormat() throws Exception {
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
         createRepository(repoName, "fs", repoPath);
         final String oldVersionSnapshot = initWithSnapshotVersion(repoName, repoPath, SnapshotsService.OLD_SNAPSHOT_FORMAT);
-
-        logger.info("--> recreating repository to clear caches");
-        client().admin().cluster().prepareDeleteRepository(repoName).get();
-        createRepository(repoName, "fs", repoPath);
 
         final String indexName = "test-index";
         createIndex(indexName);
@@ -472,10 +466,6 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         final Path repoPath = randomRepoPath();
         createRepository(repoName, "fs", repoPath);
         final String oldVersionSnapshot = initWithSnapshotVersion(repoName, repoPath, SnapshotsService.OLD_SNAPSHOT_FORMAT);
-
-        logger.info("--> recreating repository to clear caches");
-        client().admin().cluster().prepareDeleteRepository(repoName).get();
-        createRepository(repoName, "fs", repoPath);
 
         final String indexName = "test-index";
         createIndex(indexName);

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -350,7 +350,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     /**
      * Randomly write an empty snapshot of an older version to an empty repository to simulate an older repository metadata format.
      */
-    protected void maybeInitWithOldSnapshotVersion(String repoName, Path repoPath) throws IOException {
+    protected void maybeInitWithOldSnapshotVersion(String repoName, Path repoPath) throws Exception {
         if (randomBoolean() && randomBoolean()) {
             initWithSnapshotVersion(repoName, repoPath, VersionUtils.randomIndexCompatibleVersion(random()));
         }
@@ -360,7 +360,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
      * Workaround to simulate BwC situation: taking a snapshot without indices here so that we don't create any new version shard
      * generations (the existence of which would short-circuit checks for the repo containing old version snapshots)
      */
-    protected String initWithSnapshotVersion(String repoName, Path repoPath, Version version) throws IOException {
+    protected String initWithSnapshotVersion(String repoName, Path repoPath, Version version) throws Exception {
         assertThat("This hack only works on an empty repository", getRepositoryData(repoName).getSnapshotIds(), empty());
         final String oldVersionSnapshot = OLD_VERSION_SNAPSHOT_PREFIX + version.id;
         final CreateSnapshotResponse createSnapshotResponse = clusterAdmin()
@@ -394,6 +394,13 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
                 BlobStoreRepository.SNAPSHOT_FORMAT.write(downgradedSnapshotInfo,
                         blobStoreRepository.blobStore().blobContainer(blobStoreRepository.basePath()), snapshotInfo.snapshotId().getUUID(),
                         randomBoolean()))));
+
+        final RepositoryMetadata repoMetadata = blobStoreRepository.getMetadata();
+        if (BlobStoreRepository.CACHE_REPOSITORY_DATA.get(repoMetadata.settings())) {
+            logger.info("--> recreating repository to clear caches");
+            assertAcked(client().admin().cluster().prepareDeleteRepository(repoName));
+            createRepository(repoName, repoMetadata.type(), Settings.builder().put(repoMetadata.settings()));
+        }
         return oldVersionSnapshot;
     }
 


### PR DESCRIPTION
The randomization of the repo version often wasn't used because of the repository cache.
Force re-creating the repository every time we manually mess with the versions.

backport of #77057