### PR TITLE
Add cluster state serialization stats

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
@@ -158,3 +158,49 @@
   - is_true: nodes.$master.discovery.cluster_applier_stats.recordings.0.name
   - gte: { nodes.$master.discovery.cluster_applier_stats.recordings.0.cumulative_execution_count: 1 }
   - gte: { nodes.$master.discovery.cluster_applier_stats.recordings.0.cumulative_execution_time_millis: 1 }
+
+---
+"Master serialization stats":
+  - skip:
+      features: [arbitrary_key]
+      version: "- 7.15.99"
+      reason: "master serialization stats added in 7.16.0"
+
+  - do:
+      nodes.info:
+        node_id: _master
+  - set:
+      nodes._arbitrary_key_: master
+
+  - do:
+      nodes.stats:
+        metric: [ discovery ]
+
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.count: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.uncompressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.compressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.count: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.uncompressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.compressed_size_in_bytes: 0 }
+
+  - is_false: nodes.$master.discovery.serialized_cluster_states.full_states.uncompressed_size
+  - is_false: nodes.$master.discovery.serialized_cluster_states.full_states.compressed_size
+  - is_false: nodes.$master.discovery.serialized_cluster_states.diffs.uncompressed_size
+  - is_false: nodes.$master.discovery.serialized_cluster_states.diffs.compressed_size
+
+  - do:
+      nodes.stats:
+        metric: [ discovery ]
+        human: true
+
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.count: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.uncompressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.full_states.compressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.count: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.uncompressed_size_in_bytes: 0 }
+  - gte: { nodes.$master.discovery.serialized_cluster_states.diffs.compressed_size_in_bytes: 0 }
+
+  - is_true: nodes.$master.discovery.serialized_cluster_states.full_states.uncompressed_size
+  - is_true: nodes.$master.discovery.serialized_cluster_states.full_states.compressed_size
+  - is_true: nodes.$master.discovery.serialized_cluster_states.diffs.uncompressed_size
+  - is_true: nodes.$master.discovery.serialized_cluster_states.diffs.compressed_size

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStateSerializationStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStateSerializationStats.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class ClusterStateSerializationStats implements Writeable, ToXContentObject {
+
+    public static final ClusterStateSerializationStats EMPTY = new ClusterStateSerializationStats(0L, 0L, 0L, 0L, 0L, 0L);
+
+    private final long fullStateCount;
+    private final long totalUncompressedFullStateBytes;
+    private final long totalCompressedFullStateBytes;
+    private final long diffCount;
+    private final long totalUncompressedDiffBytes;
+    private final long totalCompressedDiffBytes;
+
+    public ClusterStateSerializationStats(
+        long fullStateCount,
+        long totalUncompressedFullStateBytes,
+        long totalCompressedFullStateBytes,
+        long diffCount,
+        long totalUncompressedDiffBytes,
+        long totalCompressedDiffBytes
+    ) {
+        this.fullStateCount = fullStateCount;
+        this.totalUncompressedFullStateBytes = totalUncompressedFullStateBytes;
+        this.totalCompressedFullStateBytes = totalCompressedFullStateBytes;
+        this.diffCount = diffCount;
+        this.totalUncompressedDiffBytes = totalUncompressedDiffBytes;
+        this.totalCompressedDiffBytes = totalCompressedDiffBytes;
+    }
+
+    public ClusterStateSerializationStats(StreamInput in) throws IOException {
+        this.fullStateCount = in.readVLong();
+        this.totalUncompressedFullStateBytes = in.readVLong();
+        this.totalCompressedFullStateBytes = in.readVLong();
+        this.diffCount = in.readVLong();
+        this.totalUncompressedDiffBytes = in.readVLong();
+        this.totalCompressedDiffBytes = in.readVLong();
+    }
+
+    public long getFullStateCount() {
+        return fullStateCount;
+    }
+
+    public long getTotalUncompressedFullStateBytes() {
+        return totalUncompressedFullStateBytes;
+    }
+
+    public long getTotalCompressedFullStateBytes() {
+        return totalCompressedFullStateBytes;
+    }
+
+    public long getDiffCount() {
+        return diffCount;
+    }
+
+    public long getTotalUncompressedDiffBytes() {
+        return totalUncompressedDiffBytes;
+    }
+
+    public long getTotalCompressedDiffBytes() {
+        return totalCompressedDiffBytes;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startObject("full_states");
+        builder.field("count", fullStateCount);
+        builder.humanReadableField("uncompressed_size_in_bytes", "uncompressed_size", new ByteSizeValue(totalUncompressedFullStateBytes));
+        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", new ByteSizeValue(totalCompressedFullStateBytes));
+        builder.endObject();
+        builder.startObject("diffs");
+        builder.field("count", diffCount);
+        builder.humanReadableField("uncompressed_size_in_bytes", "uncompressed_size", new ByteSizeValue(totalUncompressedDiffBytes));
+        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", new ByteSizeValue(totalCompressedDiffBytes));
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(fullStateCount);
+        out.writeVLong(totalUncompressedFullStateBytes);
+        out.writeVLong(totalCompressedFullStateBytes);
+        out.writeVLong(diffCount);
+        out.writeVLong(totalUncompressedDiffBytes);
+        out.writeVLong(totalCompressedDiffBytes);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.PositionTrackingOutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -86,6 +86,8 @@ public class PublicationTransportHandler {
     private static final TransportRequestOptions STATE_REQUEST_OPTIONS =
             TransportRequestOptions.of(null, TransportRequestOptions.Type.STATE);
 
+    private final SerializationStatsTracker serializationStatsTracker = new SerializationStatsTracker();
+
     public PublicationTransportHandler(
         BigArrays bigArrays,
         TransportService transportService,
@@ -134,7 +136,8 @@ public class PublicationTransportHandler {
         return new PublishClusterStateStats(
             fullClusterStateReceivedCount.get(),
             incompatibleClusterStateDiffReceivedCount.get(),
-            compatibleClusterStateDiffReceivedCount.get());
+            compatibleClusterStateDiffReceivedCount.get(),
+            serializationStatsTracker.getSerializationStats());
     }
 
     private PublishWithJoinResponse handleIncomingPublishRequest(BytesTransportRequest request) throws IOException {
@@ -232,16 +235,19 @@ public class PublicationTransportHandler {
         final BytesStreamOutput bytesStream = new ReleasableBytesStreamOutput(bigArrays);
         boolean success = false;
         try {
-            try (StreamOutput stream = new OutputStreamStreamOutput(
+            final long uncompressedBytes;
+            try (StreamOutput stream = new PositionTrackingOutputStreamStreamOutput(
                 CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream)))
             ) {
                 stream.setVersion(nodeVersion);
                 stream.writeBoolean(true);
                 clusterState.writeTo(stream);
+                uncompressedBytes = stream.position();
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to serialize cluster state for publishing to node {}", e, node);
             }
             final ReleasableBytesReference result = new ReleasableBytesReference(bytesStream.bytes(), bytesStream::close);
+            serializationStatsTracker.serializedFullState(uncompressedBytes, result.length());
             logger.trace(
                 "serialized full cluster state version [{}] for node version [{}] with size [{}]",
                 clusterState.version(),
@@ -261,16 +267,19 @@ public class PublicationTransportHandler {
         final BytesStreamOutput bytesStream = new ReleasableBytesStreamOutput(bigArrays);
         boolean success = false;
         try {
-            try (StreamOutput stream = new OutputStreamStreamOutput(
+            final long uncompressedBytes;
+            try (StreamOutput stream = new PositionTrackingOutputStreamStreamOutput(
                 CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream)))
             ) {
                 stream.setVersion(nodeVersion);
                 stream.writeBoolean(false);
                 diff.writeTo(stream);
+                uncompressedBytes = stream.position();
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to serialize cluster state diff for publishing to node {}", e, node);
             }
             final ReleasableBytesReference result = new ReleasableBytesReference(bytesStream.bytes(), bytesStream::close);
+            serializationStatsTracker.serializedDiff(uncompressedBytes, result.length());
             logger.trace(
                 "serialized cluster state diff for version [{}] for node version [{}] with size [{}]",
                 clusterStateVersion,
@@ -485,6 +494,39 @@ public class PublicationTransportHandler {
         protected void closeInternal() {
             serializedDiffs.values().forEach(Releasables::closeExpectNoException);
             serializedStates.values().forEach(Releasables::closeExpectNoException);
+        }
+    }
+
+    private static class SerializationStatsTracker {
+
+        private long fullStateCount;
+        private long totalUncompressedFullStateBytes;
+        private long totalCompressedFullStateBytes;
+
+        private long diffCount;
+        private long totalUncompressedDiffBytes;
+        private long totalCompressedDiffBytes;
+
+        public synchronized void serializedFullState(long uncompressedBytes, int compressedBytes) {
+            fullStateCount += 1;
+            totalUncompressedFullStateBytes += uncompressedBytes;
+            totalCompressedFullStateBytes += compressedBytes;
+        }
+
+        public synchronized void serializedDiff(long uncompressedBytes, int compressedBytes) {
+            diffCount += 1;
+            totalUncompressedDiffBytes += uncompressedBytes;
+            totalCompressedDiffBytes += compressedBytes;
+        }
+
+        public synchronized ClusterStateSerializationStats getSerializationStats() {
+            return new ClusterStateSerializationStats(
+                fullStateCount,
+                totalUncompressedFullStateBytes,
+                totalCompressedFullStateBytes,
+                diffCount,
+                totalUncompressedDiffBytes,
+                totalCompressedDiffBytes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/PositionTrackingOutputStreamStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/PositionTrackingOutputStreamStreamOutput.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class PositionTrackingOutputStreamStreamOutput extends OutputStreamStreamOutput {
+
+    private long position;
+
+    public PositionTrackingOutputStreamStreamOutput(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void writeByte(byte b) throws IOException {
+        super.writeByte(b);
+        position += 1;
+    }
+
+    @Override
+    public void writeBytes(byte[] b, int offset, int length) throws IOException {
+        super.writeBytes(b, offset, length);
+        position += length;
+    }
+
+    @Override
+    public long position() throws IOException {
+        return position;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.IncompatibleClusterStateVersionException;
+import org.elasticsearch.cluster.coordination.ClusterStateSerializationStats;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -647,6 +648,7 @@ public class PublishClusterStateAction {
         return new PublishClusterStateStats(
             fullClusterStateReceivedCount.get(),
             incompatibleClusterStateDiffReceivedCount.get(),
-            compatibleClusterStateDiffReceivedCount.get());
+            compatibleClusterStateDiffReceivedCount.get(),
+            ClusterStateSerializationStats.EMPTY);
     }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateStats.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateStats.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.discovery.zen;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.coordination.ClusterStateSerializationStats;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -24,6 +27,7 @@ public class PublishClusterStateStats implements Writeable, ToXContentObject {
     private final long fullClusterStateReceivedCount;
     private final long incompatibleClusterStateDiffReceivedCount;
     private final long compatibleClusterStateDiffReceivedCount;
+    private final ClusterStateSerializationStats clusterStateSerializationStats;
 
     /**
      * @param fullClusterStateReceivedCount the number of times this node has received a full copy of the cluster state from the master.
@@ -32,16 +36,24 @@ public class PublishClusterStateStats implements Writeable, ToXContentObject {
      */
     public PublishClusterStateStats(long fullClusterStateReceivedCount,
                                     long incompatibleClusterStateDiffReceivedCount,
-                                    long compatibleClusterStateDiffReceivedCount) {
+                                    long compatibleClusterStateDiffReceivedCount,
+                                    ClusterStateSerializationStats clusterStateSerializationStats) {
         this.fullClusterStateReceivedCount = fullClusterStateReceivedCount;
         this.incompatibleClusterStateDiffReceivedCount = incompatibleClusterStateDiffReceivedCount;
         this.compatibleClusterStateDiffReceivedCount = compatibleClusterStateDiffReceivedCount;
+        this.clusterStateSerializationStats = clusterStateSerializationStats;
     }
 
     public PublishClusterStateStats(StreamInput in) throws IOException {
         fullClusterStateReceivedCount = in.readVLong();
         incompatibleClusterStateDiffReceivedCount = in.readVLong();
         compatibleClusterStateDiffReceivedCount = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
+            clusterStateSerializationStats = new ClusterStateSerializationStats(in);
+        } else {
+            // else just report zeroes in bwc situations
+            clusterStateSerializationStats = ClusterStateSerializationStats.EMPTY;
+        }
     }
 
     @Override
@@ -49,10 +61,16 @@ public class PublishClusterStateStats implements Writeable, ToXContentObject {
         out.writeVLong(fullClusterStateReceivedCount);
         out.writeVLong(incompatibleClusterStateDiffReceivedCount);
         out.writeVLong(compatibleClusterStateDiffReceivedCount);
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
+            clusterStateSerializationStats.writeTo(out);
+        } // else just drop these stats in bwc situations
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        builder.field("serialized_cluster_states");
+        clusterStateSerializationStats.toXContent(builder, params);
         builder.startObject("published_cluster_states");
         {
             builder.field("full_states", fullClusterStateReceivedCount);
@@ -69,11 +87,16 @@ public class PublishClusterStateStats implements Writeable, ToXContentObject {
 
     public long getCompatibleClusterStateDiffReceivedCount() { return compatibleClusterStateDiffReceivedCount; }
 
+    public ClusterStateSerializationStats getClusterStateSerializationStats() {
+        return clusterStateSerializationStats;
+    }
+
     @Override
     public String toString() {
         return "PublishClusterStateStats(full=" + fullClusterStateReceivedCount
             + ", incompatible=" + incompatibleClusterStateDiffReceivedCount
             + ", compatible=" + compatibleClusterStateDiffReceivedCount
+            + ", serializationStats=" + Strings.toString(clusterStateSerializationStats)
             + ")";
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.stats;
 
+import org.elasticsearch.cluster.coordination.ClusterStateSerializationStats;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Recording;
@@ -623,7 +624,15 @@ public class NodeStatsTests extends ESTestCase {
                 ? new PublishClusterStateStats(
                 randomNonNegativeLong(),
                 randomNonNegativeLong(),
-                randomNonNegativeLong())
+                randomNonNegativeLong(),
+                new ClusterStateSerializationStats(
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong()
+                ))
                 : null,
             randomBoolean()
                 ? new ClusterStateUpdateStats(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -83,6 +84,7 @@ import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -956,6 +958,20 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             final long finalValue = randomLong();
             final Map<ClusterNode, PublishClusterStateStats> prePublishStats = cluster.clusterNodes.stream().collect(
                 Collectors.toMap(Function.identity(), cn -> cn.coordinator.stats().getPublishStats()));
+
+            if (cluster.clusterNodes.size() > 1) {
+                // at least one node must have published at least one full cluster state when other nodes joined
+                final Optional<PublishClusterStateStats> optionalStats = prePublishStats
+                    .values()
+                    .stream()
+                    .filter(stats -> stats.getClusterStateSerializationStats().getFullStateCount() > 0)
+                    .findAny();
+                assertTrue(optionalStats.isPresent());
+                final ClusterStateSerializationStats serializationStats = optionalStats.get().getClusterStateSerializationStats();
+                assertThat(serializationStats.toString(), serializationStats.getTotalUncompressedFullStateBytes(), greaterThan(0L));
+                assertThat(serializationStats.toString(), serializationStats.getTotalCompressedFullStateBytes(), greaterThan(4L));
+            }
+
             logger.info("--> submitting value [{}] to [{}]", finalValue, leader);
             leader.submitValue(finalValue);
             cluster.stabilise(DEFAULT_CLUSTER_STATE_UPDATE_DELAY);
@@ -970,7 +986,32 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     postPublishStats.get(cn).getCompatibleClusterStateDiffReceivedCount());
                 assertEquals(cn.toString(), prePublishStats.get(cn).getIncompatibleClusterStateDiffReceivedCount(),
                     postPublishStats.get(cn).getIncompatibleClusterStateDiffReceivedCount());
+
+                if (cn != leader) {
+                    assertEquals(cn.toString(),
+                        Strings.toString(prePublishStats.get(cn).getClusterStateSerializationStats()),
+                        Strings.toString(postPublishStats.get(cn).getClusterStateSerializationStats()));
+                }
             }
+
+            final ClusterStateSerializationStats serializationStats0 = prePublishStats.get(leader).getClusterStateSerializationStats();
+            final ClusterStateSerializationStats serializationStats1 = postPublishStats.get(leader).getClusterStateSerializationStats();
+
+            assertThat(serializationStats1.getDiffCount(), equalTo(serializationStats0.getDiffCount() + 1));
+            assertThat(
+                serializationStats1.getTotalUncompressedDiffBytes(),
+                greaterThan(serializationStats0.getDiffCount()));
+            assertThat(
+                serializationStats1.getTotalCompressedDiffBytes(),
+                greaterThan(serializationStats0.getDiffCount() + 4 /* compressed data starts with 4 byte header */));
+
+            assertThat(serializationStats1.getFullStateCount(), equalTo(serializationStats0.getFullStateCount()));
+            assertThat(
+                serializationStats1.getTotalUncompressedFullStateBytes(),
+                equalTo(serializationStats0.getTotalUncompressedFullStateBytes()));
+            assertThat(
+                serializationStats1.getTotalCompressedFullStateBytes(),
+                equalTo(serializationStats0.getTotalCompressedFullStateBytes()));
         }
     }
 


### PR DESCRIPTION
This commit adds stats tracking the number and compressed/uncompressed
size of cluster states that the master serializes.

Backport of #78816