### PR TITLE
Fix eclipse compilation for categorization agg

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -171,7 +171,10 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
 
     }
 
-    public static class Bucket extends InternalBucket implements MultiBucketsAggregation.Bucket, Comparable<Bucket> {
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket
+        implements
+            MultiBucketsAggregation.Bucket,
+            Comparable<Bucket> {
         // Used on the shard level to keep track of sub aggregations
         long bucketOrd;
 


### PR DESCRIPTION
Works around an eclipse bug where nested classes can't see things
imported by their parameterized outer classes. Tracked here:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=565255
