### PR TITLE
Convert ccr license object to LicensedFeature (#79215)

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -27,11 +27,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
@@ -43,6 +43,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.ccr.action.ShardChangesAction;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.ccr.CcrConstants;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
@@ -75,7 +76,7 @@ public class CcrLicenseChecker {
      * Constructs a CCR license checker with the default rule based on the license state for checking if CCR is allowed.
      */
     CcrLicenseChecker() {
-        this(() -> XPackPlugin.getSharedLicenseState().checkFeature(XPackLicenseState.Feature.CCR),
+        this(() -> CcrConstants.CCR_FEATURE.check(XPackPlugin.getSharedLicenseState()),
              XPackPlugin.getSharedLicenseState()::isSecurityEnabled);
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
@@ -15,12 +15,11 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.MockLicenseState;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
-import org.elasticsearch.xpack.core.ccr.CcrConstants;
 import org.elasticsearch.xpack.core.ccr.CCRFeatureSet;
+import org.elasticsearch.xpack.core.ccr.CcrConstants;
 import org.junit.Before;
 import org.mockito.Mockito;
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -35,22 +36,22 @@ import static org.mockito.Mockito.when;
 
 public class CCRFeatureSetTests extends ESTestCase {
 
-    private XPackLicenseState licenseState;
+    private MockLicenseState licenseState;
     private ClusterService clusterService;
 
     @Before
     public void init() {
-        licenseState = mock(XPackLicenseState.class);
+        licenseState = mock(MockLicenseState.class);
         clusterService = mock(ClusterService.class);
     }
 
     public void testAvailable() {
         CCRFeatureSet featureSet = new CCRFeatureSet(Settings.EMPTY, licenseState, clusterService);
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(false);
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(false);
         assertThat(featureSet.available(), equalTo(false));
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(true);
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(true);
         assertThat(featureSet.available(), equalTo(true));
 
         featureSet = new CCRFeatureSet(Settings.EMPTY, null, clusterService);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
@@ -10,11 +10,12 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
+import org.elasticsearch.xpack.core.ccr.CcrConstants;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
@@ -44,7 +45,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // regardless of CCR being enabled
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
-        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -57,7 +58,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // this is controls the blockage
         final Settings settings = ccrDisabledSettings();
 
-        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -71,7 +72,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
         // this is controls the blockage
-        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(false);
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -83,7 +84,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
     public void testShouldCollectReturnsTrue() {
         final Settings settings = ccrEnabledSettings();
 
-        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(true);
+        when(licenseState.isAllowed(CcrConstants.CCR_FEATURE)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final StatsCollector collector = createCollector(settings, clusterService, licenseState, client);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -49,8 +49,6 @@ public class XPackLicenseState {
 
         MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
 
-        CCR(OperationMode.PLATINUM, true),
-
         MACHINE_LEARNING(OperationMode.PLATINUM, true),
 
         OPERATOR_PRIVILEGES(OperationMode.ENTERPRISE, true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
@@ -47,7 +47,7 @@ public class CCRFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.CCR);
+        return licenseState != null && CcrConstants.CCR_FEATURE.checkWithoutTracking(licenseState);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CcrConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CcrConstants.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.core.ccr;
 
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
+
 public class CcrConstants {
     public static final String CCR_CUSTOM_METADATA_KEY = "ccr";
     public static final String CCR_CUSTOM_METADATA_LEADER_INDEX_UUID_KEY = "leader_index_uuid";
@@ -14,5 +17,9 @@ public class CcrConstants {
     public static final String CCR_CUSTOM_METADATA_LEADER_INDEX_NAME_KEY = "leader_index_name";
     public static final String CCR_CUSTOM_METADATA_REMOTE_CLUSTER_NAME_KEY = "remote_cluster_name";
 
+    public static final LicensedFeature.Momentary CCR_FEATURE =
+        LicensedFeature.momentary(null, "ccr", License.OperationMode.PLATINUM);
+
+    // no construction
     private CcrConstants() {}
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackClient;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ccr.CcrConstants;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 import org.elasticsearch.xpack.core.ccr.client.CcrClient;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
@@ -66,7 +67,7 @@ public final class StatsCollector extends Collector {
         return isElectedMaster
                 && super.shouldCollect(isElectedMaster)
                 && XPackSettings.CCR_ENABLED_SETTING.get(settings)
-                && licenseState.checkFeature(XPackLicenseState.Feature.CCR);
+                && CcrConstants.CCR_FEATURE.checkWithoutTracking(licenseState);
     }
 
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -38,7 +39,7 @@ public abstract class BaseCollectorTestCase extends ESTestCase {
     protected ClusterState clusterState;
     protected DiscoveryNodes nodes;
     protected Metadata metadata;
-    protected XPackLicenseState licenseState;
+    protected MockLicenseState licenseState;
     protected Client client;
     protected Settings settings;
 
@@ -50,7 +51,7 @@ public abstract class BaseCollectorTestCase extends ESTestCase {
         clusterState = mock(ClusterState.class);
         nodes = mock(DiscoveryNodes.class);
         metadata = mock(Metadata.class);
-        licenseState = mock(XPackLicenseState.class);
+        licenseState = mock(MockLicenseState.class);
         client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(threadPool);


### PR DESCRIPTION
This commit moves the ccr license checks to use the new
LicensedFeature class.