### PR TITLE
EQL: Rename a test class for eclipse

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/eql/EqlClientYamlIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/eql/EqlClientYamlIT.java
@@ -12,9 +12,9 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-public class EqlRestIT extends ESClientYamlSuiteTestCase {
+public class EqlClientYamlIT extends ESClientYamlSuiteTestCase {
 
-    public EqlRestIT(final ClientYamlTestCandidate testCandidate) {
+    public EqlClientYamlIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
 


### PR DESCRIPTION
Eclipse puts all of a project's classes into the same classpath. It's a
silly thing but that's what it does. This was causing an error importing
the EQL rest tests because we had two classes named `EqlRestIT`. I
usually just closed that project after importing into eclipse. Today I
decided to make Eclipse happy and rename the test.
