### PR TITLE
[7.9] document accept_enterprise parameter (#79012) (#79256)

### DIFF
--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -29,7 +29,14 @@ https://www.elastic.co/subscriptions.
 `local`::
   (Boolean) Specifies whether to retrieve local information. The default value
   is `false`, which means the information is retrieved from the master node.
-
+  
+ `accept_enterprise`::
+(Boolean) If `true`, this parameter returns `enterprise` for Enterprise
+license types. If `false`, this parameter returns `platinum` for both
+`platinum` and `enterprise` license types. This behavior is maintained for
+backwards compatibility.
+   
+deprecated::[7.6.0,"This parameter is deprecated and will always be set to `true` in 8.x."]
 
 [discrete]
 ==== Authorization


### PR DESCRIPTION
Backports the following commits to 7.9:
 - document accept_enterprise parameter (#79012) (#79256)