### PR TITLE
Default ENFORCE_DEFAULT_TIER_PREFERENCE to true

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
@@ -50,7 +50,7 @@ public class DataTier {
     // it will be removed as a breaking change in some future version, likely 9.0.
     public static final String ENFORCE_DEFAULT_TIER_PREFERENCE = "cluster.routing.allocation.enforce_default_tier_preference";
     public static final Setting<Boolean> ENFORCE_DEFAULT_TIER_PREFERENCE_SETTING =
-        Setting.boolSetting(ENFORCE_DEFAULT_TIER_PREFERENCE, false, Property.Dynamic, Property.NodeScope);
+        Setting.boolSetting(ENFORCE_DEFAULT_TIER_PREFERENCE, true, Property.Dynamic, Property.NodeScope);
 
     public static final String TIER_PREFERENCE = "index.routing.allocation.include._tier_preference";
 


### PR DESCRIPTION
Part of #76147, follow up to #79210 (where the default was `false`), now the default will be `true`. 

This will not be backported to 7.x, that is, on 7.x the default for this setting will be `false` and on 8.0+ it will be `true`. A subsequent PR will force this setting to only ever be true for 8.0+.

No test changes or the like here, I was very careful on #79210 to make sure all the tests that cared about the value would specify the value they needed, so everything should pass here just fine.