### PR TITLE
[7.x] Skip building of BWC distributions when building release artifacts (#79180)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,7 +399,11 @@ tasks.register("buildReleaseArtifacts").configure {
   group = 'build'
   description = 'Builds all artifacts required for release manager'
 
-  dependsOn allprojects.findAll { it.path.startsWith(':distribution:docker') == false && it.path.startsWith(':ml-cpp') == false }
+  dependsOn allprojects.findAll {
+    it.path.startsWith(':distribution:docker') == false
+      && it.path.startsWith(':ml-cpp') == false
+      && it.path.startsWith(':distribution:bwc') == false
+  }
     .collect { GradleUtils.findByName(it.tasks, 'assemble') }
     .findAll { it != null }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Skip building of BWC distributions when building release artifacts (#79180)