### PR TITLE
Update links to Fleet/Agent docs

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -507,7 +507,7 @@ include::{es-repo-dir}/tab-widgets/quick-start-cleanup-widget.asciidoc[]
 
 * Use {fleet} and {agent} to collect logs and metrics directly from your data
 sources and send them to {es}. See the
-{fleet-guide}/fleet-quick-start.html[{fleet} quick start guide].
+{observability-guide}/ingest-logs-metrics-uptime.html[Ingest logs, metrics, and uptime data with {agent}].
 
 * Use {kib} to explore, visualize, and manage your {es} data. See the
 {kibana-ref}/get-started.html[{kib} quick start guide].

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -432,8 +432,7 @@ If you run {agent} standalone, you can apply pipelines using an
 <<index-default-pipeline,`index.default_pipeline`>> or
 <<index-final-pipeline,`index.final_pipeline`>> index setting. Alternatively,
 you can specify the `pipeline` policy setting in your `elastic-agent.yml`
-configuration. See {fleet-guide}/run-elastic-agent-standalone.html[Run {agent}
-standalone].
+configuration. See {fleet-guide}/install-standalone-elastic-agent.html[Install standalone {agent}s].
 
 [discrete]
 [[access-source-fields]]


### PR DESCRIPTION
## Motivation/summary

Updates links to Fleet/Agent docs in preparation for removing the temporary manual redirect file in https://github.com/elastic/observability-docs/pull/1168

## Checklist

N/A

## How to test these changes

Navigate to the changed page and click the links to verify that they work.

## Related issues

https://github.com/elastic/observability-docs/issues/784

