### PR TITLE
Add Filtering by SLM Policy to Get Snapshots API (#77321)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -148,12 +148,20 @@ Offset identifier to start pagination from as returned by the `next` field in th
 Numeric offset to start pagination from based on the snapshots matching this request. Using a non-zero value for this parameter is mutually
 exclusive with using the `after` parameter. Defaults to `0`.
 
+`slm_policy_filter`::
+(Optional, string)
+Filter snapshots by a comma-separated list of SLM policy names that snapshots belong to. Also accepts wildcards (`\*`) and combinations
+of wildcards followed by exclude patterns starting in `-`. For example, the pattern `*,-policy-a-\*` will return all snapshots except
+for those that were created by an SLM policy with a name starting in `policy-a-`. Note that the wildcard pattern `*` matches all snapshots
+created by an SLM policy but not those snapshots that were not created by an SLM policy. To include snapshots not created by an SLM
+policy you can use the special pattern `_none` that will match all snapshots without an SLM policy.
+
 NOTE: The `after` parameter and `next` field allow for iterating through snapshots with some consistency guarantees regarding concurrent
 creation or deletion of snapshots. It is guaranteed that  any snapshot that exists at the beginning of the iteration and not concurrently
 deleted will be seen during the iteration. Snapshots concurrently created may be seen during an iteration.
 
-NOTE: The pagination parameters `size`, `order`, `after`, `offset` and `sort` are not supported when using `verbose=false` and the sort
-order for requests with `verbose=false` is undefined.
+NOTE: The parameters `size`, `order`, `after`, `offset`, `slm_policy_filter` and `sort` are not supported when using `verbose=false` and
+the sort order for requests with `verbose=false` is undefined.
 
 [role="child_attributes"]
 [[get-snapshot-api-response-body]]

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -38,7 +38,10 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
 
     public static final String ALL_SNAPSHOTS = "_all";
     public static final String CURRENT_SNAPSHOT = "_current";
+    public static final String NO_POLICY_PATTERN = "_none";
     public static final boolean DEFAULT_VERBOSE_MODE = true;
+
+    public static final Version SLM_POLICY_FILTERING_VERSION = Version.V_7_16_0;
 
     public static final Version MULTIPLE_REPOSITORIES_SUPPORT_ADDED = Version.V_7_14_0;
 
@@ -70,6 +73,8 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
     private String[] repositories;
 
     private String[] snapshots = Strings.EMPTY_ARRAY;
+
+    private String[] policies = Strings.EMPTY_ARRAY;
 
     private boolean ignoreUnavailable;
 
@@ -126,6 +131,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
             if (in.getVersion().onOrAfter(NUMERIC_PAGINATION_VERSION)) {
                 offset = in.readVInt();
             }
+            if (in.getVersion().onOrAfter(SLM_POLICY_FILTERING_VERSION)) {
+                policies = in.readStringArray();
+            }
         }
     }
 
@@ -168,6 +176,13 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         } else if (sort != SortBy.START_TIME || size != NO_LIMIT || after != null || order != SortOrder.ASC) {
             throw new IllegalArgumentException("can't use paginated get snapshots request with node version [" + out.getVersion() + "]");
         }
+        if (out.getVersion().onOrAfter(SLM_POLICY_FILTERING_VERSION)) {
+            out.writeStringArray(policies);
+        } else if (policies.length > 0) {
+            throw new IllegalArgumentException(
+                "can't use slm policy filter in snapshots request with node version [" + out.getVersion() + "]"
+            );
+        }
     }
 
     @Override
@@ -195,6 +210,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
             if (order != SortOrder.ASC) {
                 validationException = addValidationError("can't use non-default sort order with verbose=false", validationException);
             }
+            if (policies.length != 0) {
+                validationException = addValidationError("can't use slm policy filter with verbose=false", validationException);
+            }
         } else if (after != null && offset > 0) {
             validationException = addValidationError("can't use after and offset simultaneously", validationException);
         }
@@ -219,6 +237,26 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
      */
     public String[] repositories() {
         return this.repositories;
+    }
+
+    /**
+     * Sets slm policy patterns
+     *
+     * @param policies policy patterns
+     * @return this request
+     */
+    public GetSnapshotsRequest policies(String... policies) {
+        this.policies = policies;
+        return this;
+    }
+
+    /**
+     * Returns policy patterns
+     *
+     * @return policy patterns
+     */
+    public String[] policies() {
+        return policies;
     }
 
     public boolean isSingleRepositoryRequest() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
@@ -66,6 +66,17 @@ public class GetSnapshotsRequestBuilder extends MasterNodeOperationRequestBuilde
     }
 
     /**
+     * Sets slm policy patterns
+     *
+     * @param policies slm policy patterns
+     * @return this builder
+     */
+    public GetSnapshotsRequestBuilder setPolicies(String... policies) {
+        request.policies(policies);
+        return this;
+    }
+
+    /**
      * Sets list of snapshots to return
      *
      * @param snapshots list of snapshots

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Nullable;
@@ -122,6 +123,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             request.offset(),
             request.size(),
             request.order(),
+            request.policies(),
             listener
         );
     }
@@ -139,6 +141,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         int offset,
         int size,
         SortOrder order,
+        String[] slmPolicies,
         ActionListener<GetSnapshotsResponse> listener
     ) {
         // short-circuit if there are no repos, because we can not create GroupedActionListener of size 0
@@ -158,7 +161,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     .map(Tuple::v1)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
-                final SnapshotsInRepo snInfos = sortSnapshots(allSnapshots, sortBy, after, offset, size, order);
+                final SnapshotsInRepo snInfos = sortAndFilterSnapshots(allSnapshots, sortBy, after, offset, size, order, slmPolicies);
                 final List<SnapshotInfo> snapshotInfos = snInfos.snapshotInfos;
                 final int remaining = snInfos.remaining + responses.stream()
                     .map(Tuple::v2)
@@ -182,6 +185,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 snapshotsInProgress,
                 repoName,
                 snapshots,
+                slmPolicies,
                 ignoreUnavailable,
                 verbose,
                 cancellableTask,
@@ -203,6 +207,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         SnapshotsInProgress snapshotsInProgress,
         String repo,
         String[] snapshots,
+        String[] slmPolicies,
         boolean ignoreUnavailable,
         boolean verbose,
         CancellableTask task,
@@ -240,6 +245,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 sortBy,
                 after,
                 order,
+                slmPolicies,
                 listener
             ),
             listener::onFailure
@@ -279,6 +285,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         GetSnapshotsRequest.SortBy sortBy,
         @Nullable final GetSnapshotsRequest.After after,
         SortOrder order,
+        String[] slmPolicies,
         ActionListener<SnapshotsInRepo> listener
     ) {
         if (task.notifyIfCancelled(listener)) {
@@ -328,9 +335,14 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 sortBy,
                 after,
                 order,
+                slmPolicies,
                 listener
             );
         } else {
+            assert slmPolicies.length == 0
+                : "slm policy filtering not support for non-verbose request but saw ["
+                    + Strings.arrayToCommaDelimitedString(slmPolicies)
+                    + "]";
             final SnapshotsInRepo snapshotInfos;
             if (repositoryData != null) {
                 // want non-current snapshots as well, which are found in the repository data
@@ -366,6 +378,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         GetSnapshotsRequest.SortBy sortBy,
         @Nullable GetSnapshotsRequest.After after,
         SortOrder order,
+        String[] slmPolicies,
         ActionListener<SnapshotsInRepo> listener
     ) {
         if (task.notifyIfCancelled(listener)) {
@@ -394,7 +407,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         final ActionListener<Void> allDoneListener = listener.delegateFailure((l, v) -> {
             final ArrayList<SnapshotInfo> snapshotList = new ArrayList<>(snapshotInfos);
             snapshotList.addAll(snapshotSet);
-            listener.onResponse(sortSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order));
+            listener.onResponse(sortAndFilterSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order, slmPolicies));
         });
         if (snapshotIdsToIterate.isEmpty()) {
             allDoneListener.onResponse(null);
@@ -486,13 +499,31 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
     private static final Comparator<SnapshotInfo> BY_REPOSITORY = Comparator.comparing(SnapshotInfo::repository)
         .thenComparing(SnapshotInfo::snapshotId);
 
-    private static SnapshotsInRepo sortSnapshots(
+    private static SnapshotsInRepo sortAndFilterSnapshots(
         final List<SnapshotInfo> snapshotInfos,
         final GetSnapshotsRequest.SortBy sortBy,
         final @Nullable GetSnapshotsRequest.After after,
         final int offset,
         final int size,
-        final SortOrder order
+        final SortOrder order,
+        final String[] slmPolicies
+    ) {
+        final List<SnapshotInfo> filteredSnapshotInfos;
+        if (slmPolicies.length == 0) {
+            filteredSnapshotInfos = snapshotInfos;
+        } else {
+            filteredSnapshotInfos = filterBySLMPolicies(snapshotInfos, slmPolicies);
+        }
+        return sortSnapshots(filteredSnapshotInfos, sortBy, after, offset, size, order);
+    }
+
+    private static SnapshotsInRepo sortSnapshots(
+        List<SnapshotInfo> snapshotInfos,
+        GetSnapshotsRequest.SortBy sortBy,
+        @Nullable GetSnapshotsRequest.After after,
+        int offset,
+        int size,
+        SortOrder order
     ) {
         final Comparator<SnapshotInfo> comparator;
         switch (sortBy) {
@@ -589,6 +620,45 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             ? snapshots.subList(0, size)
             : snapshots;
         return new SnapshotsInRepo(resultSet, snapshotInfos.size(), allSnapshots.size() - resultSet.size());
+    }
+
+    private static List<SnapshotInfo> filterBySLMPolicies(List<SnapshotInfo> snapshotInfos, String[] slmPolicies) {
+        final List<String> includePatterns = new ArrayList<>();
+        final List<String> excludePatterns = new ArrayList<>();
+        boolean seenWildcard = false;
+        boolean matchNoPolicy = false;
+        for (String slmPolicy : slmPolicies) {
+            if (seenWildcard && slmPolicy.length() > 1 && slmPolicy.startsWith("-")) {
+                excludePatterns.add(slmPolicy.substring(1));
+            } else {
+                if (Regex.isSimpleMatchPattern(slmPolicy)) {
+                    seenWildcard = true;
+                } else if (GetSnapshotsRequest.NO_POLICY_PATTERN.equals(slmPolicy)) {
+                    matchNoPolicy = true;
+                }
+                includePatterns.add(slmPolicy);
+            }
+        }
+        final String[] includes = includePatterns.toArray(Strings.EMPTY_ARRAY);
+        final String[] excludes = excludePatterns.toArray(Strings.EMPTY_ARRAY);
+        final boolean matchWithoutPolicy = matchNoPolicy;
+        return Collections.unmodifiableList(snapshotInfos.stream().filter(snapshotInfo -> {
+            final Map<String, Object> metadata = snapshotInfo.userMetadata();
+            final String policy;
+            if (metadata == null) {
+                policy = null;
+            } else {
+                final Object policyFound = metadata.get(SnapshotsService.POLICY_ID_METADATA_FIELD);
+                policy = policyFound instanceof String ? (String) policyFound : null;
+            }
+            if (policy == null) {
+                return matchWithoutPolicy;
+            }
+            if (Regex.simpleMatch(includes, policy) == false) {
+                return false;
+            }
+            return excludes.length == 0 || Regex.simpleMatch(excludes, policy) == false;
+        }).collect(Collectors.toList()));
     }
 
     private static Predicate<SnapshotInfo> filterByLongOffset(

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
@@ -65,6 +65,8 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         if (afterString != null) {
             getSnapshotsRequest.after(GetSnapshotsRequest.After.fromQueryParam(afterString));
         }
+        final String[] policies = request.paramAsStringArray("slm_policy_filter", Strings.EMPTY_ARRAY);
+        getSnapshotsRequest.policies(policies);
 
         final SortOrder order = SortOrder.fromString(request.param("order", getSnapshotsRequest.order().toString()));
         getSnapshotsRequest.order(order);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -149,6 +149,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static final Version INDEX_DETAILS_INTRODUCED = Version.V_7_13_0;
 
+    public static final String POLICY_ID_METADATA_FIELD = "policy";
+
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
 
     public static final String UPDATE_SNAPSHOT_STATUS_ACTION_NAME = "internal:cluster/snapshot/update_snapshot_status";

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestTests.java
@@ -62,6 +62,11 @@ public class GetSnapshotsRequestTests extends ESTestCase {
             final ActionRequestValidationException e = request.validate();
             assertThat(e.getMessage(), containsString("can't use after and offset simultaneously"));
         }
+        {
+            final GetSnapshotsRequest request = new GetSnapshotsRequest("repo", "snapshot").policies("some-policy").verbose(false);
+            final ActionRequestValidationException e = request.validate();
+            assertThat(e.getMessage(), containsString("can't use slm policy filter with verbose=false"));
+        }
     }
 
     public void testGetDescription() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.xpack.core.scheduler.Cron;
 
 import java.io.IOException;
@@ -43,8 +44,6 @@ import static org.elasticsearch.xpack.core.ilm.GenerateSnapshotNameStep.validate
  */
 public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecyclePolicy>
     implements Writeable, Diffable<SnapshotLifecyclePolicy>, ToXContentObject {
-
-    public static final String POLICY_ID_METADATA_FIELD = "policy";
 
     private final String id;
     private final String name;
@@ -199,9 +198,9 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
             } else {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> metadata = (Map<String, Object>) configuration.get(METADATA_FIELD_NAME);
-                if (metadata.containsKey(POLICY_ID_METADATA_FIELD)) {
-                    err.addValidationError("invalid configuration." + METADATA_FIELD_NAME + ": field name [" + POLICY_ID_METADATA_FIELD +
-                        "] is reserved and will be added automatically");
+                if (metadata.containsKey(SnapshotsService.POLICY_ID_METADATA_FIELD)) {
+                    err.addValidationError("invalid configuration." + METADATA_FIELD_NAME + ": field name ["
+                        + SnapshotsService.POLICY_ID_METADATA_FIELD + "] is reserved and will be added automatically");
                 } else {
                     Map<String, Object> metadataWithPolicyField = addPolicyNameToMetadata(metadata);
                     int serializedSizeOriginal = CreateSnapshotRequest.metadataSize(metadata);
@@ -232,7 +231,7 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
         } else {
             newMetadata = new HashMap<>(metadata);
         }
-        newMetadata.put(POLICY_ID_METADATA_FIELD, this.id);
+        newMetadata.put(SnapshotsService.POLICY_ID_METADATA_FIELD, this.id);
         return newMetadata;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -284,7 +285,7 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
 
     private SnapshotInfo makeInfo(long startTime) {
         final Map<String, Object> meta = new HashMap<>();
-        meta.put(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD, REPO);
+        meta.put(SnapshotsService.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(1,20);
         SnapshotInfo snapInfo = new SnapshotInfo(
             new Snapshot(REPO, new SnapshotId("snap-" + randomAlphaOfLength(3), "uuid")),
@@ -314,7 +315,7 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
 
     private SnapshotInfo makeFailureInfo(long startTime) {
         final Map<String, Object> meta = new HashMap<>();
-        meta.put(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD, REPO);
+        meta.put(SnapshotsService.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(1,20);
         final List<SnapshotShardFailure> failures = new ArrayList<>();
         final int failureCount = between(1,totalShards);
@@ -342,7 +343,7 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
 
     private SnapshotInfo makePartialInfo(long startTime) {
         final Map<String, Object> meta = new HashMap<>();
-        meta.put(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD, REPO);
+        meta.put(SnapshotsService.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(2,20);
         final List<SnapshotShardFailure> failures = new ArrayList<>();
         final int failureCount = between(1,totalShards - 1);

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.snapshots.ConcurrentSnapshotExecutionException;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
@@ -346,7 +347,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
             } else {
                 final String snapshotName = "failed-snapshot-1";
                 addBwCFailedSnapshot(REPO, snapshotName,
-                        Collections.singletonMap(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD, policyId));
+                        Collections.singletonMap(SnapshotsService.POLICY_ID_METADATA_FIELD, policyId));
                 failedSnapshotName.set(snapshotName);
             }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -47,7 +47,7 @@ import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD;
+import static org.elasticsearch.snapshots.SnapshotsService.POLICY_ID_METADATA_FIELD;
 
 /**
  * The {@code SnapshotRetentionTask} is invoked by the scheduled job from the
@@ -276,9 +276,9 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     static String getPolicyId(SnapshotInfo snapshotInfo) {
         return Optional.ofNullable(snapshotInfo.userMetadata())
-            .filter(meta -> meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD) != null)
-            .filter(meta -> meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD) instanceof String)
-            .map(meta -> (String) meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD))
+            .filter(meta -> meta.get(POLICY_ID_METADATA_FIELD) != null)
+            .filter(meta -> meta.get(POLICY_ID_METADATA_FIELD) instanceof String)
+            .map(meta -> (String) meta.get(POLICY_ID_METADATA_FIELD))
             .orElseThrow(() -> new IllegalStateException("expected snapshot " + snapshotInfo +
                 " to have a policy in its metadata, but it did not"));
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
@@ -18,10 +18,11 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
-import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyItem;
 import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleStats;
@@ -69,12 +70,12 @@ public class TransportGetSnapshotLifecycleAction extends
                 for (SnapshotsInProgress.Entry entry : sip.entries()) {
                     Map<String, Object> meta = entry.userMetadata();
                     if (meta == null ||
-                        meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD) == null ||
-                        (meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD) instanceof String == false)) {
+                        meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) == null ||
+                        (meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) instanceof String == false)) {
                         continue;
                     }
 
-                    String policyId = (String) meta.get(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD);
+                    String policyId = (String) meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD);
                     inProgress.put(policyId, SnapshotLifecyclePolicyItem.SnapshotInProgress.fromEntry(entry));
                 }
             }


### PR DESCRIPTION
It's in the title, add new `slm_policy_filter` param as a filter to the get snapshots API.

backport of #77321