### PR TITLE
Optimize SLM Retention a Little (#77342)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.slm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
@@ -24,17 +25,14 @@ import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class SnapshotRetentionConfiguration implements ToXContentObject, Writeable {
 
@@ -44,6 +42,8 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
     private static final ParseField MINIMUM_SNAPSHOT_COUNT = new ParseField("min_count");
     private static final ParseField MAXIMUM_SNAPSHOT_COUNT = new ParseField("max_count");
     private static final Logger logger = LogManager.getLogger(SnapshotRetentionConfiguration.class);
+
+    private static final Set<SnapshotState> UNSUCCESSFUL_STATES = EnumSet.of(SnapshotState.FAILED, SnapshotState.PARTIAL);
 
     private static final ConstructingObjectParser<SnapshotRetentionConfiguration, Void> PARSER =
         new ConstructingObjectParser<>("snapshot_retention", true, a -> {
@@ -123,21 +123,21 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
         final List<SnapshotInfo> sortedSnapshots = allSnapshots.stream()
             .sorted(Comparator.comparingLong(SnapshotInfo::startTime))
             .collect(Collectors.toList());
-        final long successfulSnapshotCount = allSnapshots.stream()
-            .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
-            .count();
-        final long newestSuccessfulTimestamp = allSnapshots.stream()
-            .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
-            .mapToLong(SnapshotInfo::startTime)
-            .max()
-            .orElse(Long.MIN_VALUE);
-        final Set<SnapshotState> unsuccessfulStates = new HashSet<>(Arrays.asList(SnapshotState.FAILED, SnapshotState.PARTIAL));
-
+        int successCount = 0;
+        long latestSuccessfulTimestamp = Long.MIN_VALUE;
+        for (SnapshotInfo snapshot : allSnapshots) {
+            if (snapshot.state() == SnapshotState.SUCCESS) {
+                successCount++;
+                latestSuccessfulTimestamp = Math.max(latestSuccessfulTimestamp, snapshot.startTime());
+            }
+        }
+        final long newestSuccessfulTimestamp = latestSuccessfulTimestamp;
+        final int successfulSnapshotCount = successCount;
         return si -> {
             final String snapName = si.snapshotId().getName();
 
             // First, if there's no expire_after and a more recent successful snapshot, we can delete all the failed ones
-            if (this.expireAfter == null && unsuccessfulStates.contains(si.state()) && newestSuccessfulTimestamp > si.startTime()) {
+            if (this.expireAfter == null && UNSUCCESSFUL_STATES.contains(si.state()) && newestSuccessfulTimestamp > si.startTime()) {
                 // There's no expire_after and there's a more recent successful snapshot, delete this failed one
                 logger.trace("[{}]: ELIGIBLE as it is {} and there is a more recent successful snapshot", snapName, si.state());
                 return true;
@@ -146,68 +146,69 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
             // Next, enforce the maximum count, if the size is over the maximum number of
             // snapshots, then allow the oldest N (where N is the number over the maximum snapshot
             // count) snapshots to be eligible for deletion
-            if (this.maximumSnapshotCount != null) {
-                if (successfulSnapshotCount > this.maximumSnapshotCount) {
-                    final long successfulSnapsToDelete = successfulSnapshotCount - this.maximumSnapshotCount;
-                    final Optional<SnapshotInfo> firstNonEligible = sortedSnapshots.stream()
-                        .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
-                        .skip(successfulSnapsToDelete)
-                        .findFirst();
-                    assert firstNonEligible.isPresent();
-                    final int snapsToDelete = sortedSnapshots.indexOf(firstNonEligible.get());
-                    final boolean eligible = sortedSnapshots.stream()
-                        .limit(snapsToDelete)
-                        .anyMatch(s -> s.equals(si));
-
-                    if (eligible) {
-                        logger.trace("[{}]: ELIGIBLE as it is one of the {} oldest snapshots with " +
-                                "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
-                            snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
-                        return true;
-                    } else {
-                        logger.trace("[{}]: SKIPPING as it is not one of the {} oldest snapshots with " +
-                                "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
-                            snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
+            if (this.maximumSnapshotCount != null && successfulSnapshotCount > this.maximumSnapshotCount) {
+                final long successfulSnapsToDelete = successfulSnapshotCount - this.maximumSnapshotCount;
+                boolean found = false;
+                int successfulSeen = 0;
+                for (SnapshotInfo s : sortedSnapshots) {
+                    if (s.state() == SnapshotState.SUCCESS) {
+                        successfulSeen++;
                     }
+                    if (successfulSeen > successfulSnapsToDelete) {
+                        break;
+                    }
+                    if (s.equals(si)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) {
+                    logger.trace("[{}]: ELIGIBLE as it is one of the {} oldest snapshots with " +
+                        "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
+                        snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount
+                    );
+                    return true;
+                } else {
+                    logger.trace("[{}]: SKIPPING as it is not one of the {} oldest snapshots with " +
+                        "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
+                        snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount
+                    );
                 }
             }
 
             // Next check the minimum count, since that is a blanket requirement regardless of time,
             // if we haven't hit the minimum then we need to keep the snapshot regardless of
             // expiration time
-            if (this.minimumSnapshotCount != null) {
-                if (successfulSnapshotCount <= this.minimumSnapshotCount)
-                    if (unsuccessfulStates.contains(si.state()) == false) {
-                        logger.trace("[{}]: INELIGIBLE as there are {} non-failed snapshots ({} total) and {} minimum snapshots needed",
+            if (this.minimumSnapshotCount != null && successfulSnapshotCount <= this.minimumSnapshotCount) {
+                if (UNSUCCESSFUL_STATES.contains(si.state()) == false) {
+                    logger.trace("[{}]: INELIGIBLE as there are {} non-failed snapshots ({} total) and {} minimum snapshots needed",
                             snapName, successfulSnapshotCount, totalSnapshotCount, this.minimumSnapshotCount);
-                        return false;
-                    } else {
-                        logger.trace("[{}]: SKIPPING minimum snapshot count check as this snapshot is {} and not counted " +
+                    return false;
+                } else {
+                    logger.trace("[{}]: SKIPPING minimum snapshot count check as this snapshot is {} and not counted " +
                             "towards the minimum snapshot count.", snapName, si.state());
-                    }
+                }
             }
 
             // Finally, check the expiration time of the snapshot, if it is past, then it is
             // eligible for deletion
             if (this.expireAfter != null) {
-                final TimeValue snapshotAge = new TimeValue(nowSupplier.getAsLong() - si.startTime());
-
                 if (this.minimumSnapshotCount != null) {
-                    final long eligibleForExpiration = Math.max(0, successfulSnapshotCount - minimumSnapshotCount);
-
                     // Only the oldest N snapshots are actually eligible, since if we went below this we
                     // would fall below the configured minimum number of snapshots to keep
-                    final Stream<SnapshotInfo> successfulSnapsEligibleForExpiration = sortedSnapshots.stream()
-                        .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
-                        .limit(eligibleForExpiration);
-                    final Stream<SnapshotInfo> unsucessfulSnaps = sortedSnapshots.stream()
-                        .filter(snap -> unsuccessfulStates.contains(snap.state()));
-
-                    final Set<SnapshotInfo> snapsEligibleForExpiration = Stream
-                        .concat(successfulSnapsEligibleForExpiration, unsucessfulSnaps)
-                        .collect(Collectors.toSet());
-
-                    if (snapsEligibleForExpiration.contains(si) == false) {
+                    final boolean maybeEligible;
+                    if (si.state() == SnapshotState.SUCCESS) {
+                        maybeEligible = sortedSnapshots.stream()
+                            .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
+                            .limit(Math.max(0, successfulSnapshotCount - minimumSnapshotCount))
+                            .anyMatch(si::equals);
+                    } else if (UNSUCCESSFUL_STATES.contains(si.state())) {
+                        maybeEligible = sortedSnapshots.contains(si);
+                    } else {
+                        logger.trace("[{}] INELIGIBLE because snapshot is in state [{}]", snapName, si.state());
+                        return false;
+                    }
+                    if (maybeEligible == false) {
                         // This snapshot is *not* one of the N oldest snapshots, so even if it were
                         // old enough, the other snapshots would be deleted before it
                         logger.trace("[{}]: INELIGIBLE as snapshot expiration would pass the " +
@@ -216,14 +217,14 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
                         return false;
                     }
                 }
-
-                if (snapshotAge.compareTo(this.expireAfter) > 0) {
-                    logger.trace("[{}]: ELIGIBLE as snapshot age of {} is older than {}",
-                        snapName, snapshotAge.toHumanReadableString(3), this.expireAfter.toHumanReadableString(3));
+                final long snapshotAge = nowSupplier.getAsLong() - si.startTime();
+                if (snapshotAge > this.expireAfter.getMillis()) {
+                    logger.trace(() -> new ParameterizedMessage("[{}]: ELIGIBLE as snapshot age of {} is older than {}",
+                        snapName, new TimeValue(snapshotAge).toHumanReadableString(3), this.expireAfter.toHumanReadableString(3)));
                     return true;
                 } else {
-                    logger.trace("[{}]: INELIGIBLE as snapshot age of {} is newer than {}",
-                        snapName, snapshotAge.toHumanReadableString(3), this.expireAfter.toHumanReadableString(3));
+                    logger.trace(() -> new ParameterizedMessage("[{}]: INELIGIBLE as snapshot age of [{}ms] is newer than {}",
+                        snapName, new TimeValue(snapshotAge).toHumanReadableString(3), this.expireAfter.toHumanReadableString(3)));
                     return false;
                 }
             }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -34,8 +34,10 @@ import org.elasticsearch.xpack.core.slm.history.SnapshotHistoryStore;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -58,6 +60,9 @@ import static org.elasticsearch.snapshots.SnapshotsService.POLICY_ID_METADATA_FI
 public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     private static final Logger logger = LogManager.getLogger(SnapshotRetentionTask.class);
+
+    private static final Set<SnapshotState> RETAINABLE_STATES =
+        EnumSet.of(SnapshotState.SUCCESS, SnapshotState.FAILED, SnapshotState.PARTIAL);
 
     private final Client client;
     private final ClusterService clusterService;
@@ -137,7 +142,8 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
             // Finally, asynchronously retrieve all the snapshots, deleting them serially,
             // before updating the cluster state with the new metrics and setting 'running'
             // back to false
-            getAllRetainableSnapshots(repositioriesToFetch, new ActionListener<Map<String, List<SnapshotInfo>>>() {
+            getAllRetainableSnapshots(repositioriesToFetch, policiesWithRetention.keySet(),
+                    new ActionListener<Map<String, List<SnapshotInfo>>>() {
                 @Override
                 public void onResponse(Map<String, List<SnapshotInfo>> allSnapshots) {
                     if (logger.isTraceEnabled()) {
@@ -168,7 +174,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                 public void onFailure(Exception e) {
                     failureHandler.accept(e);
                 }
-            }, failureHandler);
+            });
         } catch (Exception e) {
             failureHandler.accept(e);
         }
@@ -187,24 +193,11 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     static boolean snapshotEligibleForDeletion(SnapshotInfo snapshot, Map<String, List<SnapshotInfo>> allSnapshots,
                                                Map<String, SnapshotLifecyclePolicy> policies) {
-        if (snapshot.userMetadata() == null) {
-            // This snapshot has no metadata, it is not eligible for deletion
-            return false;
-        }
-
-        final String policyId;
-        try {
-            policyId = (String) snapshot.userMetadata().get(POLICY_ID_METADATA_FIELD);
-        } catch (Exception e) {
-            logger.debug("unable to retrieve policy id from snapshot metadata [" + snapshot.userMetadata() + "]", e);
-            return false;
-        }
-
-        if (policyId == null) {
-            // policyId was null in the metadata, so it's not eligible
-            return false;
-        }
-
+        assert snapshot.userMetadata() != null : "snapshots without user metadata should have gotten filtered by the caller but saw ["
+            + snapshot + "]";
+        final Object policyId = snapshot.userMetadata().get(POLICY_ID_METADATA_FIELD);
+        assert policyId instanceof String
+            : "snapshots without a policy id should have gotten filtered by the caller but saw [" + snapshot + "]";
         SnapshotLifecyclePolicy policy = policies.get(policyId);
         if (policy == null) {
             // This snapshot was taking by a policy that doesn't exist, so it's not eligible
@@ -232,8 +225,9 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
         return eligible;
     }
 
-    void getAllRetainableSnapshots(Collection<String> repositories, ActionListener<Map<String, List<SnapshotInfo>>> listener,
-                                   Consumer<Exception> errorHandler) {
+    void getAllRetainableSnapshots(Collection<String> repositories,
+                                   Set<String> policies,
+                                   ActionListener<Map<String, List<SnapshotInfo>>> listener) {
         if (repositories.isEmpty()) {
             // Skip retrieving anything if there are no repositories to fetch
             listener.onResponse(Collections.emptyMap());
@@ -257,21 +251,21 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                                 ).collect(Collectors.toList()));
                     }
                     Map<String, List<SnapshotInfo>> snapshots = new HashMap<>();
-                    final Set<SnapshotState> retainableStates =
-                        org.elasticsearch.core.Set.of(SnapshotState.SUCCESS, SnapshotState.FAILED, SnapshotState.PARTIAL);
-                    repositories.forEach(repo -> {
-                        snapshots.put(repo,
-                            // Only return snapshots in the SUCCESS state
-                            resp.getSnapshots().stream()
-                                .filter(info -> repo.equals(info.repository()) && retainableStates.contains(info.state()))
-                                .collect(Collectors.toList()));
-                    });
+                    for (SnapshotInfo info : resp.getSnapshots()) {
+                        if (RETAINABLE_STATES.contains(info.state()) && info.userMetadata() != null) {
+                            final Object policy = info.userMetadata().get(POLICY_ID_METADATA_FIELD);
+                            if (policy instanceof String && policies.contains(policy)) {
+                                snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
+                            }
+                        }
+                    }
                     listener.onResponse(snapshots);
                 },
                 e -> {
                     logger.debug(new ParameterizedMessage("unable to retrieve snapshots for [{}] repositories", repositories), e);
-                    errorHandler.accept(e);
-                }));
+                    listener.onFailure(e);
+                })
+            );
     }
 
     static String getPolicyId(SnapshotInfo snapshotInfo) {


### PR DESCRIPTION
Optimizing the algorithm slightly as well as simplifying things a little.
This isn't so much done to speed up SLM itself, but mainly to set up the
necessary adjustments towards using the enhanced get snaphots APIs
that were introduced recently a little.
Still, for larger/multiple repos this should already be a visible change
by removing some contributors to quadratic complexity in the retention
task.

backport of #77342
