### PR TITLE
Make use of new Get Snapshots Filtering in SLM Retention (#77423)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -239,6 +239,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
             // don't time out on this request to not produce failed SLM runs in case of a temporarily slow master node
             .setMasterNodeTimeout(TimeValue.MAX_VALUE)
             .setIgnoreUnavailable(true)
+            .setPolicies(policies.toArray(Strings.EMPTY_ARRAY))
             .execute(ActionListener.wrap(resp -> {
                     if (logger.isTraceEnabled()) {
                         logger.trace("retrieved snapshots: {}",
@@ -253,10 +254,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                     Map<String, List<SnapshotInfo>> snapshots = new HashMap<>();
                     for (SnapshotInfo info : resp.getSnapshots()) {
                         if (RETAINABLE_STATES.contains(info.state()) && info.userMetadata() != null) {
-                            final Object policy = info.userMetadata().get(POLICY_ID_METADATA_FIELD);
-                            if (policy instanceof String && policies.contains(policy)) {
-                                snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
-                            }
+                            snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
                         }
                     }
                     listener.onResponse(snapshots);


### PR DESCRIPTION
We can save ourselves the trouble of even looking at snapshots that don't have a relevant
policy on the SLM side now.

backport of #77423 