### PR TITLE
Filter Unneeded SnapshotInfo Instances Early in TransportGetSnapshotsAction (#78032)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
@@ -113,7 +114,12 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         getMultipleReposSnapshotInfo(
             request.isSingleRepositoryRequest() == false,
             state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY),
-            TransportGetRepositoriesAction.getRepositories(state, request.repositories()),
+            maybeFilterRepositories(
+                TransportGetRepositoriesAction.getRepositories(state, request.repositories()),
+                request.sort(),
+                request.order(),
+                request.fromSortValue()
+            ),
             request.snapshots(),
             request.ignoreUnavailable(),
             request.verbose(),
@@ -123,9 +129,29 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             request.offset(),
             request.size(),
             request.order(),
-            buildSnapshotPredicate(request.sort(), request.order(), request.policies(), request.fromSortValue()),
+            new SnapshotPredicates(request),
             listener
         );
+    }
+
+    /**
+     * Filters the list of repositories that a request will fetch snapshots from in the special case of sorting by repository
+     * name and having a non-null value for {@link GetSnapshotsRequest#fromSortValue()} on the request to exclude repositories outside
+     * the sort value range if possible.
+     */
+    private static List<RepositoryMetadata> maybeFilterRepositories(
+        List<RepositoryMetadata> repositories,
+        GetSnapshotsRequest.SortBy sortBy,
+        SortOrder order,
+        @Nullable String fromSortValue
+    ) {
+        if (sortBy != GetSnapshotsRequest.SortBy.REPOSITORY || fromSortValue == null) {
+            return repositories;
+        }
+        final Predicate<RepositoryMetadata> predicate = order == SortOrder.ASC
+            ? repositoryMetadata -> fromSortValue.compareTo(repositoryMetadata.name()) <= 0
+            : repositoryMetadata -> fromSortValue.compareTo(repositoryMetadata.name()) >= 0;
+        return Collections.unmodifiableList(repositories.stream().filter(predicate).collect(Collectors.toList()));
     }
 
     private void getMultipleReposSnapshotInfo(
@@ -141,7 +167,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         int offset,
         int size,
         SortOrder order,
-        @Nullable Predicate<SnapshotInfo> predicate,
+        SnapshotPredicates predicates,
         ActionListener<GetSnapshotsResponse> listener
     ) {
         // short-circuit if there are no repos, because we can not create GroupedActionListener of size 0
@@ -161,7 +187,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     .map(Tuple::v1)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
-                final SnapshotsInRepo snInfos = sortAndFilterSnapshots(allSnapshots, sortBy, after, offset, size, order, predicate);
+                final SnapshotsInRepo snInfos = sortSnapshots(allSnapshots, sortBy, after, offset, size, order);
                 final List<SnapshotInfo> snapshotInfos = snInfos.snapshotInfos;
                 final int remaining = snInfos.remaining + responses.stream()
                     .map(Tuple::v2)
@@ -185,7 +211,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 snapshotsInProgress,
                 repoName,
                 snapshots,
-                predicate,
+                predicates,
                 ignoreUnavailable,
                 verbose,
                 cancellableTask,
@@ -207,7 +233,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         SnapshotsInProgress snapshotsInProgress,
         String repo,
         String[] snapshots,
-        Predicate<SnapshotInfo> predicate,
+        SnapshotPredicates predicates,
         boolean ignoreUnavailable,
         boolean verbose,
         CancellableTask task,
@@ -245,7 +271,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 sortBy,
                 after,
                 order,
-                predicate,
+                predicates,
                 listener
             ),
             listener::onFailure
@@ -285,16 +311,19 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         GetSnapshotsRequest.SortBy sortBy,
         @Nullable final GetSnapshotsRequest.After after,
         SortOrder order,
-        @Nullable Predicate<SnapshotInfo> predicate,
+        SnapshotPredicates predicates,
         ActionListener<SnapshotsInRepo> listener
     ) {
         if (task.notifyIfCancelled(listener)) {
             return;
         }
 
+        final BiPredicate<SnapshotId, RepositoryData> preflightPredicate = predicates.preflightPredicate();
         if (repositoryData != null) {
             for (SnapshotId snapshotId : repositoryData.getSnapshotIds()) {
-                allSnapshotIds.put(snapshotId.getName(), new Snapshot(repo, snapshotId));
+                if (preflightPredicate == null || preflightPredicate.test(snapshotId, repositoryData)) {
+                    allSnapshotIds.put(snapshotId.getName(), new Snapshot(repo, snapshotId));
+                }
             }
         }
 
@@ -357,11 +386,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 sortBy,
                 after,
                 order,
-                predicate,
+                predicates.snapshotPredicate(),
                 listener
             );
         } else {
-            assert predicate == null : "filtering is not supported in non-verbose mode";
+            assert predicates.snapshotPredicate() == null : "filtering is not supported in non-verbose mode";
             final SnapshotsInRepo snapshotInfos;
             if (repositoryData != null) {
                 // want non-current snapshots as well, which are found in the repository data
@@ -413,7 +442,10 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         );
         for (SnapshotsInProgress.Entry entry : entries) {
             if (snapshotIdsToIterate.remove(entry.snapshot().getSnapshotId())) {
-                snapshotSet.add(new SnapshotInfo(entry));
+                final SnapshotInfo snapshotInfo = new SnapshotInfo(entry);
+                if (predicate == null || predicate.test(snapshotInfo)) {
+                    snapshotSet.add(new SnapshotInfo(entry));
+                }
             }
         }
         // then, look in the repository if there's any matching snapshots left
@@ -426,7 +458,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         final ActionListener<Void> allDoneListener = listener.delegateFailure((l, v) -> {
             final ArrayList<SnapshotInfo> snapshotList = new ArrayList<>(snapshotInfos);
             snapshotList.addAll(snapshotSet);
-            listener.onResponse(sortAndFilterSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order, predicate));
+            listener.onResponse(sortSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order));
         });
         if (snapshotIdsToIterate.isEmpty()) {
             allDoneListener.onResponse(null);
@@ -444,7 +476,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 snapshotIdsToIterate,
                 ignoreUnavailable == false,
                 task::isCancelled,
-                (context, snapshotInfo) -> snapshotInfos.add(snapshotInfo),
+                predicate == null ? (context, snapshotInfo) -> snapshotInfos.add(snapshotInfo) : (context, snapshotInfo) -> {
+                    if (predicate.test(snapshotInfo)) {
+                        snapshotInfos.add(snapshotInfo);
+                    }
+                },
                 allDoneListener
             )
         );
@@ -514,43 +550,36 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
     private static final Comparator<SnapshotInfo> BY_REPOSITORY = Comparator.comparing(SnapshotInfo::repository)
         .thenComparing(SnapshotInfo::snapshotId);
 
-    private static SnapshotsInRepo sortAndFilterSnapshots(
-        final List<SnapshotInfo> snapshotInfos,
-        final GetSnapshotsRequest.SortBy sortBy,
-        final @Nullable GetSnapshotsRequest.After after,
-        final int offset,
-        final int size,
-        final SortOrder order,
-        final @Nullable Predicate<SnapshotInfo> predicate
-    ) {
-        final List<SnapshotInfo> filteredSnapshotInfos;
-        if (predicate == null) {
-            filteredSnapshotInfos = snapshotInfos;
-        } else {
-            filteredSnapshotInfos = Collections.unmodifiableList(snapshotInfos.stream().filter(predicate).collect(Collectors.toList()));
+    private static long getDuration(SnapshotId snapshotId, RepositoryData repositoryData) {
+        final RepositoryData.SnapshotDetails details = repositoryData.getSnapshotDetails(snapshotId);
+        if (details == null) {
+            return -1;
         }
-        return sortSnapshots(filteredSnapshotInfos, sortBy, after, offset, size, order);
+        final long startTime = details.getStartTimeMillis();
+        if (startTime == -1) {
+            return -1;
+        }
+        final long endTime = details.getEndTimeMillis();
+        if (endTime == -1) {
+            return -1;
+        }
+        return endTime - startTime;
     }
 
-    private static Predicate<SnapshotInfo> buildSnapshotPredicate(
-        GetSnapshotsRequest.SortBy sortBy,
-        SortOrder order,
-        String[] slmPolicies,
-        String fromSortValue
-    ) {
-        Predicate<SnapshotInfo> predicate = null;
-        if (slmPolicies.length > 0) {
-            predicate = filterBySLMPolicies(slmPolicies);
-        }
-        if (fromSortValue != null) {
-            final Predicate<SnapshotInfo> fromSortValuePredicate = buildFromSortValuePredicate(sortBy, fromSortValue, order, null, null);
-            if (predicate == null) {
-                predicate = fromSortValuePredicate;
-            } else {
-                predicate = fromSortValuePredicate.and(predicate);
+    private static long getStartTime(SnapshotId snapshotId, RepositoryData repositoryData) {
+        final RepositoryData.SnapshotDetails details = repositoryData.getSnapshotDetails(snapshotId);
+        return details == null ? -1 : details.getStartTimeMillis();
+    }
+
+    private static int indexCount(SnapshotId snapshotId, RepositoryData repositoryData) {
+        // TODO: this could be made more efficient by caching this number in RepositoryData
+        int indexCount = 0;
+        for (IndexId idx : repositoryData.getIndices().values()) {
+            if (repositoryData.getSnapshots(idx).contains(snapshotId)) {
+                indexCount++;
             }
         }
-        return predicate;
+        return indexCount;
     }
 
     private static SnapshotsInRepo sortSnapshots(
@@ -592,7 +621,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
 
         if (after != null) {
             assert offset == 0 : "can't combine after and offset but saw [" + after + "] and offset [" + offset + "]";
-            infos = infos.filter(buildFromSortValuePredicate(sortBy, after.value(), order, after.snapshotName(), after.repoName()));
+            infos = infos.filter(buildAfterPredicate(sortBy, after, order));
         }
         infos = infos.sorted(order == SortOrder.DESC ? comparator.reversed() : comparator).skip(offset);
         final List<SnapshotInfo> allSnapshots = infos.collect(Collectors.toList());
@@ -608,64 +637,39 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         return new SnapshotsInRepo(resultSet, snapshotInfos.size(), allSnapshots.size() - resultSet.size());
     }
 
-    private static Predicate<SnapshotInfo> buildFromSortValuePredicate(
+    private static Predicate<SnapshotInfo> buildAfterPredicate(
         GetSnapshotsRequest.SortBy sortBy,
-        String after,
-        SortOrder order,
-        @Nullable String snapshotName,
-        @Nullable String repoName
+        GetSnapshotsRequest.After after,
+        SortOrder order
     ) {
-        final Predicate<SnapshotInfo> isAfter;
+        final String snapshotName = after.snapshotName();
+        final String repoName = after.repoName();
+        final String value = after.value();
         switch (sortBy) {
             case START_TIME:
-                isAfter = filterByLongOffset(SnapshotInfo::startTime, Long.parseLong(after), snapshotName, repoName, order);
-                break;
+                return filterByLongOffset(SnapshotInfo::startTime, Long.parseLong(value), snapshotName, repoName, order);
             case NAME:
-                if (snapshotName == null) {
-                    assert repoName == null : "no snapshot name given but saw repo name [" + repoName + "]";
-                    isAfter = order == SortOrder.ASC
-                        ? snapshotInfo -> after.compareTo(snapshotInfo.snapshotId().getName()) <= 0
-                        : snapshotInfo -> after.compareTo(snapshotInfo.snapshotId().getName()) >= 0;
-                } else {
-                    isAfter = order == SortOrder.ASC
-                        ? (info -> compareName(snapshotName, repoName, info) < 0)
-                        : (info -> compareName(snapshotName, repoName, info) > 0);
-                }
-                break;
+                // TODO: cover via pre-flight predicate
+                return order == SortOrder.ASC
+                    ? (info -> compareName(snapshotName, repoName, info) < 0)
+                    : (info -> compareName(snapshotName, repoName, info) > 0);
             case DURATION:
-                isAfter = filterByLongOffset(
-                    info -> info.endTime() - info.startTime(),
-                    Long.parseLong(after),
-                    snapshotName,
-                    repoName,
-                    order
-                );
-                break;
+                return filterByLongOffset(info -> info.endTime() - info.startTime(), Long.parseLong(value), snapshotName, repoName, order);
             case INDICES:
-                isAfter = filterByLongOffset(info -> info.indices().size(), Integer.parseInt(after), snapshotName, repoName, order);
-                break;
+                // TODO: cover via pre-flight predicate
+                return filterByLongOffset(info -> info.indices().size(), Integer.parseInt(value), snapshotName, repoName, order);
             case SHARDS:
-                isAfter = filterByLongOffset(SnapshotInfo::totalShards, Integer.parseInt(after), snapshotName, repoName, order);
-                break;
+                return filterByLongOffset(SnapshotInfo::totalShards, Integer.parseInt(value), snapshotName, repoName, order);
             case FAILED_SHARDS:
-                isAfter = filterByLongOffset(SnapshotInfo::failedShards, Integer.parseInt(after), snapshotName, repoName, order);
-                break;
+                return filterByLongOffset(SnapshotInfo::failedShards, Integer.parseInt(value), snapshotName, repoName, order);
             case REPOSITORY:
-                if (snapshotName == null) {
-                    assert repoName == null : "no snapshot name given but saw repo name [" + repoName + "]";
-                    isAfter = order == SortOrder.ASC
-                        ? snapshotInfo -> after.compareTo(snapshotInfo.repository()) <= 0
-                        : snapshotInfo -> after.compareTo(snapshotInfo.repository()) >= 0;
-                } else {
-                    isAfter = order == SortOrder.ASC
-                        ? (info -> compareRepositoryName(snapshotName, repoName, info) < 0)
-                        : (info -> compareRepositoryName(snapshotName, repoName, info) > 0);
-                }
-                break;
+                // TODO: cover via pre-flight predicate
+                return order == SortOrder.ASC
+                    ? (info -> compareRepositoryName(snapshotName, repoName, info) < 0)
+                    : (info -> compareRepositoryName(snapshotName, repoName, info) > 0);
             default:
                 throw new AssertionError("unexpected sort column [" + sortBy + "]");
         }
-        return isAfter;
     }
 
     private static Predicate<SnapshotInfo> filterBySLMPolicies(String[] slmPolicies) {
@@ -707,20 +711,19 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         };
     }
 
+    private static Predicate<SnapshotInfo> filterByLongOffset(ToLongFunction<SnapshotInfo> extractor, long after, SortOrder order) {
+        return order == SortOrder.ASC ? info -> after <= extractor.applyAsLong(info) : info -> after >= extractor.applyAsLong(info);
+    }
+
     private static Predicate<SnapshotInfo> filterByLongOffset(
         ToLongFunction<SnapshotInfo> extractor,
         long after,
-        @Nullable String snapshotName,
-        @Nullable String repoName,
+        String snapshotName,
+        String repoName,
         SortOrder order
     ) {
-        if (snapshotName == null) {
-            assert repoName == null : "no snapshot name given but saw repo name [" + repoName + "]";
-            return order == SortOrder.ASC ? info -> after <= extractor.applyAsLong(info) : info -> after >= extractor.applyAsLong(info);
-        }
         return order == SortOrder.ASC ? info -> {
             final long val = extractor.applyAsLong(info);
-
             return after < val || (after == val && compareName(snapshotName, repoName, info) < 0);
         } : info -> {
             final long val = extractor.applyAsLong(info);
@@ -742,6 +745,107 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             return res;
         }
         return repoName.compareTo(info.repository());
+    }
+
+    /**
+     * A pair of predicates for the get snapshots action. The {@link #preflightPredicate()} is applied to combinations of snapshot id and
+     * repository data to determine which snapshots to fully load from the repository and rules out all snapshots that do not match the
+     * given {@link GetSnapshotsRequest} that can be ruled out through the information in {@link RepositoryData}.
+     * The predicate returned by {@link #snapshotPredicate()} is then applied the instances of {@link SnapshotInfo} that were loaded from
+     * the repository to filter out those remaining that did not match the request but could not be ruled out without loading their
+     * {@link SnapshotInfo}.
+     */
+    private static final class SnapshotPredicates {
+
+        private final Predicate<SnapshotInfo> snapshotPredicate;
+
+        private final BiPredicate<SnapshotId, RepositoryData> preflightPredicate;
+
+        SnapshotPredicates(GetSnapshotsRequest request) {
+            Predicate<SnapshotInfo> snapshotPredicate = null;
+            final String[] slmPolicies = request.policies();
+            final String fromSortValue = request.fromSortValue();
+            if (slmPolicies.length > 0) {
+                snapshotPredicate = filterBySLMPolicies(slmPolicies);
+            }
+            final GetSnapshotsRequest.SortBy sortBy = request.sort();
+            final SortOrder order = request.order();
+            if (fromSortValue == null) {
+                preflightPredicate = null;
+            } else {
+                final Predicate<SnapshotInfo> fromSortValuePredicate;
+                switch (sortBy) {
+                    case START_TIME:
+                        final long after = Long.parseLong(fromSortValue);
+                        preflightPredicate = order == SortOrder.ASC ? (snapshotId, repositoryData) -> {
+                            final long startTime = getStartTime(snapshotId, repositoryData);
+                            return startTime == -1 || after <= startTime;
+                        } : (snapshotId, repositoryData) -> {
+                            final long startTime = getStartTime(snapshotId, repositoryData);
+                            return startTime == -1 || after >= startTime;
+                        };
+                        fromSortValuePredicate = filterByLongOffset(SnapshotInfo::startTime, after, order);
+                        break;
+                    case NAME:
+                        preflightPredicate = order == SortOrder.ASC
+                            ? (snapshotId, repositoryData) -> fromSortValue.compareTo(snapshotId.getName()) <= 0
+                            : (snapshotId, repositoryData) -> fromSortValue.compareTo(snapshotId.getName()) >= 0;
+                        fromSortValuePredicate = null;
+                        break;
+                    case DURATION:
+                        final long afterDuration = Long.parseLong(fromSortValue);
+                        preflightPredicate = order == SortOrder.ASC ? (snapshotId, repositoryData) -> {
+                            final long duration = getDuration(snapshotId, repositoryData);
+                            return duration == -1 || afterDuration <= duration;
+                        } : (snapshotId, repositoryData) -> {
+                            final long duration = getDuration(snapshotId, repositoryData);
+                            return duration == -1 || afterDuration >= duration;
+                        };
+                        fromSortValuePredicate = filterByLongOffset(info -> info.endTime() - info.startTime(), afterDuration, order);
+                        break;
+                    case INDICES:
+                        final int afterIndexCount = Integer.parseInt(fromSortValue);
+                        preflightPredicate = order == SortOrder.ASC
+                            ? (snapshotId, repositoryData) -> afterIndexCount <= indexCount(snapshotId, repositoryData)
+                            : (snapshotId, repositoryData) -> afterIndexCount >= indexCount(snapshotId, repositoryData);
+                        fromSortValuePredicate = null;
+                        break;
+                    case REPOSITORY:
+                        // already handled in #maybeFilterRepositories
+                        preflightPredicate = null;
+                        fromSortValuePredicate = null;
+                        break;
+                    case SHARDS:
+                        preflightPredicate = null;
+                        fromSortValuePredicate = filterByLongOffset(SnapshotInfo::totalShards, Integer.parseInt(fromSortValue), order);
+                        break;
+                    case FAILED_SHARDS:
+                        preflightPredicate = null;
+                        fromSortValuePredicate = filterByLongOffset(SnapshotInfo::failedShards, Integer.parseInt(fromSortValue), order);
+                        break;
+                    default:
+                        throw new AssertionError("unexpected sort column [" + sortBy + "]");
+                }
+
+                if (snapshotPredicate == null) {
+                    snapshotPredicate = fromSortValuePredicate;
+                } else if (fromSortValuePredicate != null) {
+                    snapshotPredicate = fromSortValuePredicate.and(snapshotPredicate);
+                }
+            }
+            this.snapshotPredicate = snapshotPredicate;
+        }
+
+        @Nullable
+        public Predicate<SnapshotInfo> snapshotPredicate() {
+            return snapshotPredicate;
+        }
+
+        @Nullable
+        public BiPredicate<SnapshotId, RepositoryData> preflightPredicate() {
+            return preflightPredicate;
+        }
+
     }
 
     private static final class SnapshotsInRepo {


### PR DESCRIPTION
Better to filter as early as possible to release the memory asap and not even fetch things we don't need to fetch to begin with.
There's still a bunch of spots remaining where similar optimizations can be added quickly before we implement the system index for the remaining searching/fetching that we can't easily exclude up-front.
This already gives vastly improved performance for many requests though for obvious reasons.

backport of #78032