### PR TITLE
Remove stale AwaitsFix in InternalEngineTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1887,7 +1887,6 @@ public class InternalEngineTests extends EngineTestCase {
         return opsPerformed;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/53182")
     public void testNonInternalVersioningOnPrimary() throws IOException {
         final Set<VersionType> nonInternalVersioning = new HashSet<>(Arrays.asList(VersionType.values()));
         nonInternalVersioning.remove(VersionType.INTERNAL);


### PR DESCRIPTION
I found this stale AwaitsFix while debugging a Lucene issue.

Relates #53182