### PR TITLE
Refactor SnapshotsInProgress to Track Snapshots By Repository (#77984)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -699,7 +699,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
             public ClusterState.Custom randomCreate(String name) {
                 switch (randomIntBetween(0, 1)) {
                     case 0:
-                        return SnapshotsInProgress.of(Collections.singletonList(new SnapshotsInProgress.Entry(
+                        return SnapshotsInProgress.EMPTY.withAddedEntry(new SnapshotsInProgress.Entry(
                                 new Snapshot(randomName("repo"), new SnapshotId(randomName("snap"), UUIDs.randomBase64UUID())),
                                 randomBoolean(),
                                 randomBoolean(),
@@ -711,7 +711,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                                 ImmutableOpenMap.of(),
                                 null,
                                 SnapshotInfoTestUtils.randomUserMetadata(),
-                                randomVersion(random()))));
+                                randomVersion(random())));
                     case 1:
                         return new RestoreInProgress.Builder().add(
                             new RestoreInProgress.Entry(

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
@@ -69,7 +69,8 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
         createRandomIndex(idxName);
 
-        createRepository("test-repo", "fs");
+        final String repoName = "test-repo";
+        createRepository(repoName, "fs");
 
         final String masterNode1 = internalCluster().getMasterName();
 
@@ -82,12 +83,12 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
             @Override
             public void clusterChanged(ClusterChangedEvent event) {
                 SnapshotsInProgress snapshots = event.state().custom(SnapshotsInProgress.TYPE);
-                if (snapshots != null && snapshots.entries().size() > 0) {
-                    final SnapshotsInProgress.Entry snapshotEntry = snapshots.entries().get(0);
+                if (snapshots != null && snapshots.isEmpty() == false) {
+                    final SnapshotsInProgress.Entry snapshotEntry = snapshots.forRepo(repoName).get(0);
                     if (snapshotEntry.state() == SnapshotsInProgress.State.SUCCESS) {
                         final RepositoriesMetadata repoMeta =
                             event.state().metadata().custom(RepositoriesMetadata.TYPE);
-                        final RepositoryMetadata metadata = repoMeta.repository("test-repo");
+                        final RepositoryMetadata metadata = repoMeta.repository(repoName);
                         if (metadata.pendingGeneration() > snapshotEntry.repositoryStateId()) {
                             logger.info("--> starting disruption");
                             networkDisruption.startDisrupting();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -642,7 +642,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         try {
             awaitClusterState(clusterState -> {
                 final List<SnapshotsInProgress.Entry> entries = clusterState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                    .entries();
+                    .forRepo(repoName);
                 return entries.size() == 2 && entries.get(1).shardsByRepoShardId().isEmpty() == false;
             });
             assertFalse(blockedSnapshot.isDone());
@@ -679,7 +679,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final ActionFuture<AcknowledgedResponse> cloneFuture = startClone(repoName, sourceSnapshot, "target-snapshot", indexName);
         logger.info("--> waiting for snapshot clone to be fully initialized");
         awaitClusterState(state -> {
-            for (SnapshotsInProgress.Entry entry : state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries()) {
+            for (SnapshotsInProgress.Entry entry : state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).forRepo(repoName)) {
                 if (entry.shardsByRepoShardId().isEmpty() == false) {
                     assertEquals(sourceSnapshot, entry.source().getName());
                     for (SnapshotsInProgress.ShardSnapshotStatus value : entry.shardsByRepoShardId().values()) {
@@ -722,7 +722,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         awaitNumberOfSnapshotsInProgress(2);
         awaitClusterState(
             state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .entries()
+                .forRepo(repoName)
                 .stream()
                 .anyMatch(entry -> entry.state().completed())
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -317,7 +317,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> wait for snapshot on second data node to finish");
         awaitClusterState(state -> {
             final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-            return snapshotsInProgress.entries().size() == 2 && snapshotHasCompletedShard(secondSnapshot, snapshotsInProgress);
+            return snapshotsInProgress.count() == 2 && snapshotHasCompletedShard(repoName, secondSnapshot, snapshotsInProgress);
         });
 
         final ActionFuture<AcknowledgedResponse> deleteSnapshotsResponse = startDeleteSnapshot(repoName, firstSnapshot);
@@ -375,7 +375,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> wait for snapshot on second data node to finish");
         awaitClusterState(state -> {
             final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-            return snapshotsInProgress.entries().size() == 2 && snapshotHasCompletedShard(secondSnapshot, snapshotsInProgress);
+            return snapshotsInProgress.count() == 2 && snapshotHasCompletedShard(repoName, secondSnapshot, snapshotsInProgress);
         });
 
         final ActionFuture<AcknowledgedResponse> deleteSnapshotsResponse = startDeleteSnapshot(repoName, firstSnapshot);
@@ -395,7 +395,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertBusy(() -> {
             assertThat(currentSnapshots(repoName), hasSize(1));
             final SnapshotsInProgress snapshotsInProgress = clusterService().state().custom(SnapshotsInProgress.TYPE);
-            assertThat(snapshotsInProgress.entries().get(0).state(), is(SnapshotsInProgress.State.ABORTED));
+            assertThat(snapshotsInProgress.forRepo(repoName).get(0).state(), is(SnapshotsInProgress.State.ABORTED));
         }, 30L, TimeUnit.SECONDS);
 
         unblockNode(repoName, dataNode);
@@ -438,7 +438,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> wait for snapshot on second data node to finish");
         awaitClusterState(state -> {
             final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-            return snapshotsInProgress.entries().size() == 2 && snapshotHasCompletedShard(secondSnapshot, snapshotsInProgress);
+            return snapshotsInProgress.count() == 2 && snapshotHasCompletedShard(repoName, secondSnapshot, snapshotsInProgress);
         });
 
         final ActionFuture<AcknowledgedResponse> firstDeleteFuture = startDeleteFromNonMasterClient(repoName, firstSnapshot);
@@ -466,7 +466,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             assertThat(currentSnapshots(repoName), hasSize(2));
             for (SnapshotsInProgress.Entry entry : clusterService().state()
                 .custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .entries()) {
+                .forRepo(repoName)) {
                 assertThat(entry.state(), is(SnapshotsInProgress.State.ABORTED));
                 assertThat(entry.snapshot().getSnapshotId().getName(), not(secondSnapshot));
             }
@@ -1500,12 +1500,15 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .execute();
 
         awaitClusterState(state -> {
-            final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE);
-            return snapshotsInProgress.entries().size() == 2 && snapshotsInProgress.entries().get(1).state().completed();
+            final List<SnapshotsInProgress.Entry> snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
+                .forRepo(repository);
+            return snapshotsInProgress.size() == 2 && snapshotsInProgress.get(1).state().completed();
         });
 
         unblockAllDataNodes(repository);
-        awaitClusterState(state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().get(0).state().completed());
+        awaitClusterState(
+            state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).forRepo(repository).get(0).state().completed()
+        );
 
         unblockNode(repository, master);
         assertSuccessful(snapshot2);
@@ -1987,8 +1990,8 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         );
     }
 
-    private static boolean snapshotHasCompletedShard(String snapshot, SnapshotsInProgress snapshotsInProgress) {
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+    private static boolean snapshotHasCompletedShard(String repoName, String snapshot, SnapshotsInProgress snapshotsInProgress) {
+        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repoName)) {
             if (entry.snapshot().getSnapshotId().getName().equals(snapshot)) {
                 for (SnapshotsInProgress.ShardSnapshotStatus shard : entry.shards().values()) {
                     if (shard.state().completed()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1071,7 +1071,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             logger,
             otherDataNode,
             state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .entries()
+                .forRepo(repoName)
                 .stream()
                 .anyMatch(entry -> entry.state() == SnapshotsInProgress.State.ABORTED)
         );

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -212,7 +212,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                             );
                         }
                         SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                        if (snapshots.entries().isEmpty() == false) {
+                        if (snapshots.isEmpty() == false) {
                             throw new IllegalStateException(
                                 "Cannot cleanup [" + repositoryName + "] - a snapshot is currently running in [" + snapshots + "]"
                             );

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -35,14 +35,17 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.snapshots.SnapshotInfo.METADATA_FIELD_INTRODUCED;
 import static org.elasticsearch.snapshots.SnapshotInfo.DATA_STREAMS_IN_SNAPSHOT;
@@ -53,38 +56,90 @@ import static org.elasticsearch.snapshots.SnapshotsService.FEATURE_STATES_VERSIO
  */
 public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implements Custom {
 
-    public static final SnapshotsInProgress EMPTY = new SnapshotsInProgress(Collections.emptyList());
-
     private static final Version VERSION_IN_SNAPSHOT_VERSION = Version.V_7_7_0;
+
+    public static final SnapshotsInProgress EMPTY = new SnapshotsInProgress(org.elasticsearch.core.Map.of());
 
     public static final String TYPE = "snapshots";
 
     public static final String ABORTED_FAILURE_TEXT = "Snapshot was aborted by deletion";
 
-    private final List<Entry> entries;
-
-    public static SnapshotsInProgress of(List<Entry> entries) {
-        if (entries.isEmpty()) {
-            return EMPTY;
-        }
-        return new SnapshotsInProgress(Collections.unmodifiableList(entries));
-    }
+    // keyed by repository name
+    private final Map<String, List<Entry>> entries;
 
     public SnapshotsInProgress(StreamInput in) throws IOException {
-        this(in.readList(SnapshotsInProgress.Entry::readFrom));
+        this(collectByRepo(in));
     }
 
-    private SnapshotsInProgress(List<Entry> entries) {
-        this.entries = entries;
-        assert assertConsistentEntries(entries);
+    private static Map<String, List<Entry>> collectByRepo(StreamInput in) throws IOException {
+        final int count = in.readVInt();
+        if (count == 0) {
+            return org.elasticsearch.core.Map.of();
+        }
+        final Map<String, List<Entry>> entriesByRepo = new HashMap<>();
+        for (int i = 0; i < count; i++) {
+            final Entry entry = Entry.readFrom(in);
+            entriesByRepo.computeIfAbsent(entry.repository(), repo -> new ArrayList<>()).add(entry);
+        }
+        for (Map.Entry<String, List<Entry>> entryForRepo : entriesByRepo.entrySet()) {
+            entryForRepo.setValue(org.elasticsearch.core.List.copyOf(entryForRepo.getValue()));
+        }
+        return entriesByRepo;
     }
 
-    public List<Entry> entries() {
-        return this.entries;
+    private SnapshotsInProgress(Map<String, List<Entry>> entries) {
+        this.entries = org.elasticsearch.core.Map.copyOf(entries);
+        assert assertConsistentEntries(this.entries);
+    }
+
+    public SnapshotsInProgress withUpdatedEntriesForRepo(String repository, List<Entry> updatedEntries) {
+        if (updatedEntries.equals(forRepo(repository))) {
+            return this;
+        }
+        final Map<String, List<Entry>> copy = new HashMap<>(this.entries);
+        if (updatedEntries.isEmpty()) {
+            copy.remove(repository);
+            if (copy.isEmpty()) {
+                return EMPTY;
+            }
+        } else {
+            copy.put(repository, org.elasticsearch.core.List.copyOf(updatedEntries));
+        }
+        return new SnapshotsInProgress(copy);
+    }
+
+    public SnapshotsInProgress withAddedEntry(Entry entry) {
+        final List<Entry> forRepo = new ArrayList<>(entries.getOrDefault(entry.repository(), org.elasticsearch.core.List.of()));
+        forRepo.add(entry);
+        return withUpdatedEntriesForRepo(entry.repository(), forRepo);
+    }
+
+    public List<Entry> forRepo(String repository) {
+        return entries.getOrDefault(repository, org.elasticsearch.core.List.of());
+    }
+
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    public int count() {
+        int count = 0;
+        for (List<Entry> list : entries.values()) {
+            count += list.size();
+        }
+        return count;
+    }
+
+    public Collection<List<Entry>> entriesByRepo() {
+        return entries.values();
+    }
+
+    public Stream<Entry> asStream() {
+        return entries.values().stream().flatMap(Collection::stream);
     }
 
     public Entry snapshot(final Snapshot snapshot) {
-        for (Entry entry : entries) {
+        for (Entry entry : forRepo(snapshot.getRepository())) {
             final Snapshot curr = entry.snapshot();
             if (curr.equals(snapshot)) {
                 return entry;
@@ -98,9 +153,9 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
      * deleted from the repository as the cluster state moved from the given {@code old} value of {@link SnapshotsInProgress} to this
      * instance.
      */
-    public Map<RepositoryShardId, Set<ShardGeneration>> obsoleteGenerations(SnapshotsInProgress old) {
+    public Map<RepositoryShardId, Set<ShardGeneration>> obsoleteGenerations(String repository, SnapshotsInProgress old) {
         final Map<RepositoryShardId, Set<ShardGeneration>> obsoleteGenerations = new HashMap<>();
-        for (Entry entry : old.entries()) {
+        for (Entry entry : old.forRepo(repository)) {
             final Entry updatedEntry = snapshot(entry.snapshot());
             if (updatedEntry == null) {
                 continue;
@@ -141,14 +196,19 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(entries);
+        out.writeVInt(count());
+        final Iterator<Entry> iterator = asStream().iterator();
+        while (iterator.hasNext()) {
+            iterator.next().writeTo(out);
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startArray("snapshots");
-        for (Entry entry : entries) {
-            entry.toXContent(builder, params);
+        final Iterator<Entry> iterator = asStream().iterator();
+        while (iterator.hasNext()) {
+            iterator.next().toXContent(builder, params);
         }
         builder.endArray();
         return builder;
@@ -169,11 +229,14 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("SnapshotsInProgress[");
-        for (int i = 0; i < entries.size(); i++) {
-            builder.append(entries.get(i).snapshot().getSnapshotId().getName());
-            if (i + 1 < entries.size()) {
+        final Iterator<SnapshotsInProgress.Entry> entryList = asStream().iterator();
+        boolean firstEntry = true;
+        while (entryList.hasNext()) {
+            if (firstEntry == false) {
                 builder.append(",");
             }
+            builder.append(entryList.next().snapshot().getSnapshotId().getName());
+            firstEntry = false;
         }
         return builder.append("]").toString();
     }
@@ -233,34 +296,38 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         return false;
     }
 
-    private static boolean assertConsistentEntries(List<Entry> entries) {
-        final Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo = new HashMap<>();
-        final Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo = new HashMap<>();
-        for (Entry entry : entries) {
-            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shard : entry.shardsByRepoShardId()) {
-                final RepositoryShardId sid = shard.key;
-                assert assertShardStateConsistent(entries, assignedShardsByRepo, queuedShardsByRepo, entry, sid.indexName(), sid.shardId(),
-                        shard.value);
+    private static boolean assertConsistentEntries(Map<String, List<Entry>> entries) {
+        for (Map.Entry<String, List<Entry>> repoEntries : entries.entrySet()) {
+            final Set<Tuple<String, Integer>> assignedShards = new HashSet<>();
+            final Set<Tuple<String, Integer>> queuedShards = new HashSet<>();
+            final List<Entry> entriesForRepository = repoEntries.getValue();
+            final String repository = repoEntries.getKey();
+            assert entriesForRepository.isEmpty() == false
+                : "found empty list of snapshots for " + repository + " in " + entries;
+            for (Entry entry : entriesForRepository) {
+                assert entry.repository().equals(repository) : "mismatched repository " + entry + " tracked under " + repository;
+                for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shard : entry.shardsByRepoShardId()) {
+                    final RepositoryShardId sid = shard.key;
+                    assert assertShardStateConsistent(entriesForRepository,
+                        assignedShards, queuedShards, sid.indexName(), sid.shardId(), shard.value);
+                }
             }
-        }
-        for (String repoName : assignedShardsByRepo.keySet()) {
             // make sure in-flight-shard-states can be built cleanly for the entries without tripping assertions
-            InFlightShardSnapshotStates.forRepo(repoName, entries);
+            InFlightShardSnapshotStates.forEntries(entriesForRepository);
         }
         return true;
     }
 
-    private static boolean assertShardStateConsistent(List<Entry> entries, Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo,
-                                                      Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo, Entry entry,
+    private static boolean assertShardStateConsistent(List<Entry> entries, Set<Tuple<String, Integer>> assignedShards,
+                                                      Set<Tuple<String, Integer>> queuedShards,
                                                       String indexName, int shardId, ShardSnapshotStatus shardSnapshotStatus) {
         if (shardSnapshotStatus.isActive()) {
             Tuple<String, Integer> plainShardId = Tuple.tuple(indexName, shardId);
-            assert assignedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>())
-                    .add(plainShardId) : "Found duplicate shard assignments in " + entries;
-            assert queuedShardsByRepo.getOrDefault(entry.repository(), Collections.emptySet()).contains(plainShardId) == false
-                    : "Found active shard assignments after queued shard assignments in " + entries;
+            assert assignedShards.add(plainShardId) : plainShardId + " is assigned twice in " + entries;
+            assert queuedShards.contains(plainShardId) == false:
+                plainShardId + " is queued then assigned in " + entries;
         } else if (shardSnapshotStatus.state() == ShardState.QUEUED) {
-            queuedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>()).add(Tuple.tuple(indexName, shardId));
+            queuedShards.add(Tuple.tuple(indexName, shardId));
         }
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 
+import java.util.Iterator;
+
 /**
  * This {@link org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider} prevents shards that
  * are currently been snapshotted to be moved to other nodes.
@@ -54,12 +56,14 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
             // Only primary shards are snapshotted
 
             SnapshotsInProgress snapshotsInProgress = allocation.custom(SnapshotsInProgress.TYPE);
-            if (snapshotsInProgress == null || snapshotsInProgress.entries().isEmpty()) {
+            if (snapshotsInProgress == null || snapshotsInProgress.isEmpty()) {
                 // Snapshots are not running
                 return allocation.decision(Decision.YES, NAME, "no snapshots are currently running");
             }
 
-            for (SnapshotsInProgress.Entry snapshot : snapshotsInProgress.entries()) {
+            final Iterator<SnapshotsInProgress.Entry> entryIterator = snapshotsInProgress.asStream().iterator();
+            while (entryIterator.hasNext()) {
+                final SnapshotsInProgress.Entry snapshot = entryIterator.next();
                 if (snapshot.isClone()) {
                     continue;
                 }
@@ -71,8 +75,8 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
                                 shardRouting.shardId(), shardSnapshotStatus.nodeId());
                     }
                     return allocation.decision(Decision.THROTTLE, NAME,
-                        "waiting for snapshotting of shard [%s] to complete on this node [%s]",
-                        shardRouting.shardId(), shardSnapshotStatus.nodeId());
+                            "waiting for snapshotting of shard [%s] to complete on this node [%s]",
+                            shardRouting.shardId(), shardSnapshotStatus.nodeId());
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/repositories/FinalizeSnapshotContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FinalizeSnapshotContext.java
@@ -98,7 +98,7 @@ public final class FinalizeSnapshotContext extends ActionListener.Delegating<
         final ClusterState updatedState = SnapshotsService.stateWithoutSnapshot(state, snapshotInfo.snapshot());
         obsoleteGenerations.set(
             updatedState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .obsoleteGenerations(state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY))
+                .obsoleteGenerations(snapshotInfo.repository(), state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY))
         );
         return updatedState;
     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -682,10 +682,8 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
     private static void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {
         final SnapshotsInProgress snapshots = clusterState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-        for (SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
-            if (repository.equals(snapshot.snapshot().getRepository())) {
-                throw newRepositoryInUseException(repository, "snapshot is in progress");
-            }
+        if (snapshots.forRepo(repository).isEmpty() == false) {
+            throw newRepositoryInUseException(repository, "snapshot is in progress");
         }
         for (SnapshotDeletionsInProgress.Entry entry : clusterState.custom(
             SnapshotDeletionsInProgress.TYPE,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -652,7 +652,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
         if (bestEffortConsistency) {
             final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-            long bestGenerationFromCS = bestGeneration(snapshotsInProgress.entries());
+            long bestGenerationFromCS = bestGeneration(snapshotsInProgress.forRepo(this.metadata.name()));
             // Don't use generation from the delete task if we already found a generation for an in progress snapshot.
             // In this case, the generation points at the generation the repo will be in after the snapshot finishes so it may not yet
             // exist
@@ -2505,15 +2505,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         final SnapshotsInProgress updatedSnapshotsInProgress;
         boolean changedSnapshots = false;
         final List<SnapshotsInProgress.Entry> snapshotEntries = new ArrayList<>();
-        for (SnapshotsInProgress.Entry entry : state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries()) {
-            if (entry.repository().equals(repoName) && entry.repositoryStateId() == oldGen) {
+        final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+        for (SnapshotsInProgress.Entry entry : state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).forRepo(repoName)) {
+            if (entry.repositoryStateId() == oldGen) {
                 snapshotEntries.add(entry.withRepoGen(newGen));
                 changedSnapshots = true;
             } else {
                 snapshotEntries.add(entry);
             }
         }
-        updatedSnapshotsInProgress = changedSnapshots ? SnapshotsInProgress.of(snapshotEntries) : null;
+        updatedSnapshotsInProgress = changedSnapshots ? snapshotsInProgress.withUpdatedEntriesForRepo(repoName, snapshotEntries) : null;
         final SnapshotDeletionsInProgress updatedDeletionsInProgress;
         boolean changedDeletions = false;
         final List<SnapshotDeletionsInProgress.Entry> deletionEntries = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/snapshots/InFlightShardSnapshotStates.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InFlightShardSnapshotStates.java
@@ -33,20 +33,26 @@ import java.util.Set;
  */
 public final class InFlightShardSnapshotStates {
 
+    private static final InFlightShardSnapshotStates EMPTY = new InFlightShardSnapshotStates(
+        org.elasticsearch.core.Map.of(),
+        org.elasticsearch.core.Map.of()
+    );
+
     /**
      * Compute information about all shard ids that currently have in-flight state for the given repository.
      *
-     * @param repoName  repository name
-     * @param snapshots snapshots in progress
-     * @return in flight shard states for all snapshot operation running for the given repository name
+     * @param snapshots snapshots in progress for a single repository
+     * @return in flight shard states for all snapshot operations
      */
-    public static InFlightShardSnapshotStates forRepo(String repoName, List<SnapshotsInProgress.Entry> snapshots) {
+    public static InFlightShardSnapshotStates forEntries(List<SnapshotsInProgress.Entry> snapshots) {
+        if (snapshots.isEmpty()) {
+            return EMPTY;
+        }
         final Map<String, Map<Integer, ShardGeneration>> generations = new HashMap<>();
         final Map<String, Set<Integer>> busyIds = new HashMap<>();
+        assert snapshots.stream().map(SnapshotsInProgress.Entry::repository).distinct().count() == 1
+            : "snapshots must either be an empty list or all belong to the same repository but saw " + snapshots;
         for (SnapshotsInProgress.Entry runningSnapshot : snapshots) {
-            if (runningSnapshot.repository().equals(repoName) == false) {
-                continue;
-            }
             for (ObjectObjectCursor<RepositoryShardId, SnapshotsInProgress.ShardSnapshotStatus> shard : runningSnapshot
                 .shardsByRepoShardId()) {
                 final RepositoryShardId sid = shard.key;

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -58,6 +58,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -123,14 +124,21 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             if (previousSnapshots.equals(currentSnapshots) == false) {
                 synchronized (shardSnapshots) {
                     cancelRemoved(currentSnapshots);
-                    startNewSnapshots(currentSnapshots);
+                    for (List<SnapshotsInProgress.Entry> snapshots : currentSnapshots.entriesByRepo()) {
+                        startNewSnapshots(snapshots);
+                    }
                 }
             }
 
             String previousMasterNodeId = event.previousState().nodes().getMasterNodeId();
             String currentMasterNodeId = event.state().nodes().getMasterNodeId();
             if (currentMasterNodeId != null && currentMasterNodeId.equals(previousMasterNodeId) == false) {
-                syncShardStatsOnNewMaster(event);
+                // Clear request deduplicator since we need to send all requests that were potentially not handled by the previous
+                // master again
+                remoteFailedRequestDeduplicator.clear();
+                for (List<SnapshotsInProgress.Entry> snapshots : currentSnapshots.entriesByRepo()) {
+                    syncShardStatsOnNewMaster(snapshots);
+                }
             }
 
         } catch (Exception e) {
@@ -192,9 +200,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         }
     }
 
-    private void startNewSnapshots(SnapshotsInProgress snapshotsInProgress) {
+    private void startNewSnapshots(List<SnapshotsInProgress.Entry> snapshotsInProgress) {
         final String localNodeId = clusterService.localNode().getId();
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+        for (SnapshotsInProgress.Entry entry : snapshotsInProgress) {
             final State entryState = entry.state();
             if (entry.isClone()) {
                 // This is a snapshot clone, it will be executed on the current master
@@ -413,16 +421,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     /**
      * Checks if any shards were processed that the new master doesn't know about
      */
-    private void syncShardStatsOnNewMaster(ClusterChangedEvent event) {
-        SnapshotsInProgress snapshotsInProgress = event.state().custom(SnapshotsInProgress.TYPE);
-        if (snapshotsInProgress == null) {
-            return;
-        }
-
-        // Clear request deduplicator since we need to send all requests that were potentially not handled by the previous
-        // master again
-        remoteFailedRequestDeduplicator.clear();
-        for (SnapshotsInProgress.Entry snapshot : snapshotsInProgress.entries()) {
+    private void syncShardStatsOnNewMaster(List<SnapshotsInProgress.Entry> entries) {
+        for (SnapshotsInProgress.Entry snapshot : entries) {
             if (snapshot.state() == State.STARTED || snapshot.state() == State.ABORTED) {
                 Map<ShardId, IndexShardSnapshotStatus> localShards = currentSnapshotShards(snapshot.snapshot());
                 if (localShards != null) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -64,7 +64,6 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -111,7 +110,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
 
@@ -195,8 +193,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     /**
      * Setting that specifies the maximum number of allowed concurrent snapshot create and delete operations in the
-     * cluster state. The number of concurrent operations in a cluster state is defined as the sum of the sizes of
-     * {@link SnapshotsInProgress#entries()} and {@link SnapshotDeletionsInProgress#getEntries()}.
+     * cluster state. The number of concurrent operations in a cluster state is defined as the sum of
+     * {@link SnapshotsInProgress#count()} and the size of {@link SnapshotDeletionsInProgress#getEntries()}.
      */
     public static final Setting<Integer> MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING = Setting.intSetting(
         "snapshot.max_concurrent_operations",
@@ -299,8 +297,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     // previous master that we can simply ignore and remove from the cluster state because we would clean it up from the
                     // cluster state anyway in #applyClusterState.
                     if (snapshots != null
-                        && snapshots.entries()
-                            .stream()
+                        && snapshots.asStream()
                             .anyMatch(
                                 entry -> (entry.state() == State.INIT && initializingSnapshots.contains(entry.snapshot()) == false) == false
                             )) {
@@ -330,7 +327,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         Version.CURRENT
                     );
                     initializingSnapshots.add(newEntry.snapshot());
-                    snapshots = SnapshotsInProgress.of(Collections.singletonList(newEntry));
+                    snapshots = SnapshotsInProgress.EMPTY.withAddedEntry(newEntry);
                     return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, snapshots).build();
                 }
 
@@ -463,8 +460,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 ensureRepositoryExists(repositoryName, currentState);
                 ensureSnapshotNameAvailableInRepo(repositoryData, snapshotName, repository);
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                final List<SnapshotsInProgress.Entry> runningSnapshots = snapshots.entries();
-                ensureSnapshotNameNotRunning(runningSnapshots, repositoryName, snapshotName);
+                ensureSnapshotNameNotRunning(snapshots, repositoryName, snapshotName);
                 validate(repositoryName, snapshotName, currentState);
                 final boolean concurrentOperationsAllowed = currentState.nodes().getMinNodeVersion().onOrAfter(FULL_CONCURRENCY_VERSION);
                 final SnapshotDeletionsInProgress deletionsInProgress = currentState.custom(
@@ -492,7 +488,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 // Fail if there are any concurrently running snapshots. The only exception to this being a snapshot in INIT state from a
                 // previous master that we can simply ignore and remove from the cluster state because we would clean it up from the
                 // cluster state anyway in #applyClusterState.
-                if (concurrentOperationsAllowed == false && runningSnapshots.stream().anyMatch(entry -> entry.state() != State.INIT)) {
+                if (concurrentOperationsAllowed == false
+                    && snapshots.forRepo(repositoryName).stream().anyMatch(entry -> entry.state() != State.INIT)) {
                     throw new ConcurrentSnapshotExecutionException(repositoryName, snapshotName, " a snapshot is already running");
                 }
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName, "create snapshot");
@@ -551,10 +548,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                 logger.trace("[{}][{}] creating snapshot for indices [{}]", repositoryName, snapshotName, indices);
 
-                final Map<String, IndexId> indexIds = repositoryData.resolveNewIndices(
-                    indices,
-                    getInFlightIndexIds(runningSnapshots, repositoryName)
-                );
+                final Map<String, IndexId> allIndices = new HashMap<>();
+                for (SnapshotsInProgress.Entry runningSnapshot : snapshots.forRepo(repositoryName)) {
+                    allIndices.putAll(runningSnapshot.indices());
+                }
+                final Map<String, IndexId> indexIds = repositoryData.resolveNewIndices(indices, allIndices);
                 final Version version = minCompatibleVersion(currentState.nodes().getMinNodeVersion(), repositoryData, null);
                 ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards = shards(
                     snapshots,
@@ -592,9 +590,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     version,
                     Collections.unmodifiableList(new ArrayList<>(featureStates))
                 );
-                return ClusterState.builder(currentState)
-                    .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(CollectionUtils.appendToCopy(runningSnapshots, newEntry)))
-                    .build();
+                return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, snapshots.withAddedEntry(newEntry)).build();
             }
 
             @Override
@@ -617,27 +613,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }, "create_snapshot [" + snapshotName + ']', listener::onFailure);
     }
 
-    private static void ensureSnapshotNameNotRunning(
-        List<SnapshotsInProgress.Entry> runningSnapshots,
-        String repositoryName,
-        String snapshotName
-    ) {
-        if (runningSnapshots.stream().anyMatch(s -> {
-            final Snapshot running = s.snapshot();
-            return running.getRepository().equals(repositoryName) && running.getSnapshotId().getName().equals(snapshotName);
-        })) {
+    private static void ensureSnapshotNameNotRunning(SnapshotsInProgress runningSnapshots, String repositoryName, String snapshotName) {
+        if (runningSnapshots.forRepo(repositoryName).stream().anyMatch(s -> s.snapshot().getSnapshotId().getName().equals(snapshotName))) {
             throw new InvalidSnapshotNameException(repositoryName, snapshotName, "snapshot with the same name is already in-progress");
         }
-    }
-
-    private static Map<String, IndexId> getInFlightIndexIds(List<SnapshotsInProgress.Entry> runningSnapshots, String repositoryName) {
-        final Map<String, IndexId> allIndices = new HashMap<>();
-        for (SnapshotsInProgress.Entry runningSnapshot : runningSnapshots) {
-            if (runningSnapshot.repository().equals(repositoryName)) {
-                allIndices.putAll(runningSnapshot.indices());
-            }
-        }
-        return Collections.unmodifiableMap(allIndices);
     }
 
     // TODO: It is worth revisiting the design choice of creating a placeholder entry in snapshots-in-progress here once we have a cache
@@ -666,8 +645,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 ensureSnapshotNameAvailableInRepo(repositoryData, snapshotName, repository);
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName, "clone snapshot");
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                final List<SnapshotsInProgress.Entry> runningSnapshots = snapshots.entries();
-                ensureSnapshotNameNotRunning(runningSnapshots, repositoryName, snapshotName);
+                ensureSnapshotNameNotRunning(snapshots, repositoryName, snapshotName);
                 validate(repositoryName, snapshotName, currentState);
 
                 final SnapshotId sourceSnapshotId = repositoryData.getSnapshotIds()
@@ -716,9 +694,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     repositoryData.getGenId(),
                     minCompatibleVersion(currentState.nodes().getMinNodeVersion(), repositoryData, null)
                 );
-                return ClusterState.builder(currentState)
-                    .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(CollectionUtils.appendToCopy(runningSnapshots, newEntry)))
-                    .build();
+                return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, snapshots.withAddedEntry(newEntry)).build();
             }
 
             @Override
@@ -831,18 +807,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final SnapshotsInProgress snapshotsInProgress = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                final List<SnapshotsInProgress.Entry> updatedEntries = new ArrayList<>(snapshotsInProgress.entries());
-                boolean changed = false;
-                final String localNodeId = currentState.nodes().getLocalNodeId();
                 final String repoName = cloneEntry.repository();
+                final List<SnapshotsInProgress.Entry> existingEntries = snapshotsInProgress.forRepo(repoName);
+                final List<SnapshotsInProgress.Entry> updatedEntries = new ArrayList<>(existingEntries.size());
+                final String localNodeId = currentState.nodes().getLocalNodeId();
                 final ShardGenerations shardGenerations = repoData.shardGenerations();
-                for (int i = 0; i < updatedEntries.size(); i++) {
-                    final SnapshotsInProgress.Entry entry = updatedEntries.get(i);
-                    if (cloneEntry.repository().equals(entry.repository()) == false) {
-                        // different repo => just continue without modification
-                        continue;
-                    }
-                    if (cloneEntry.snapshot().getSnapshotId().equals(entry.snapshot().getSnapshotId())) {
+                for (SnapshotsInProgress.Entry existing : existingEntries) {
+                    if (cloneEntry.snapshot().getSnapshotId().equals(existing.snapshot().getSnapshotId())) {
                         final ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> clonesBuilder = ImmutableOpenMap.builder();
                         final boolean readyToExecute = currentState.custom(
                             SnapshotDeletionsInProgress.TYPE,
@@ -850,7 +821,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         ).hasExecutingDeletion(repoName) == false;
                         final InFlightShardSnapshotStates inFlightShardStates;
                         if (readyToExecute) {
-                            inFlightShardStates = InFlightShardSnapshotStates.forRepo(repoName, snapshotsInProgress.entries());
+                            inFlightShardStates = InFlightShardSnapshotStates.forEntries(snapshotsInProgress.forRepo(repoName));
                         } else {
                             // no need to compute these, we'll mark all shards as queued anyway because we wait for the delete
                             inFlightShardStates = null;
@@ -873,16 +844,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             }
                         }
                         updatedEntry = cloneEntry.withClones(clonesBuilder.build());
-                        // Move the now ready to execute clone operation to the back of the snapshot operations order because its
-                        // shard snapshot state was based on all previous existing operations in progress
-                        // TODO: If we could eventually drop the snapshot clone init phase we don't need this any longer
-                        updatedEntries.remove(i);
-                        updatedEntries.add(updatedEntry);
-                        changed = true;
-                        break;
+                    } else {
+                        updatedEntries.add(existing);
                     }
                 }
-                return updateWithSnapshots(currentState, changed ? SnapshotsInProgress.of(updatedEntries) : null, null);
+                if (updatedEntry != null) {
+                    // Move the now ready to execute clone operation to the back of the snapshot operations order because its
+                    // shard snapshot state was based on all previous existing operations in progress
+                    // TODO: If we could eventually drop the snapshot clone init phase we don't need this any longer
+                    updatedEntries.add(updatedEntry);
+                    return updateWithSnapshots(currentState, snapshotsInProgress.withUpdatedEntriesForRepo(repoName, updatedEntries), null);
+                }
+                return currentState;
             }
 
             @Override
@@ -989,7 +962,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         SnapshotsInProgress snapshotsInProgress,
         SnapshotDeletionsInProgress deletionsInProgress
     ) {
-        final int inProgressOperations = snapshotsInProgress.entries().size() + deletionsInProgress.getEntries().size();
+        final int inProgressOperations = snapshotsInProgress.count() + deletionsInProgress.getEntries().size();
         final int maxOps = maxConcurrentOperations;
         if (inProgressOperations >= maxOps) {
             throw new ConcurrentSnapshotExecutionException(
@@ -1140,9 +1113,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                         @Override
                         public ClusterState execute(ClusterState currentState) {
-                            SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
+                            SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
                             List<SnapshotsInProgress.Entry> entries = new ArrayList<>();
-                            for (SnapshotsInProgress.Entry entry : snapshots.entries()) {
+                            for (SnapshotsInProgress.Entry entry : snapshots.forRepo(snapshot.repository())) {
                                 if (entry.snapshot().equals(snapshot.snapshot()) == false) {
                                     entries.add(entry);
                                     continue;
@@ -1212,7 +1185,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                 }
                             }
                             return ClusterState.builder(currentState)
-                                .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(unmodifiableList(entries)))
+                                .putCustom(SnapshotsInProgress.TYPE, snapshots.withUpdatedEntriesForRepo(snapshot.repository(), entries))
                                 .build();
                         }
 
@@ -1371,44 +1344,22 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         String repository,
         List<String> snapshots
     ) {
-        if (snapshotsInProgress == null || snapshotsInProgress.entries().isEmpty()) {
+        if (snapshotsInProgress == null || snapshotsInProgress.isEmpty()) {
             return Collections.emptyList();
         }
         if ("_all".equals(repository)) {
-            return snapshotsInProgress.entries();
+            return Collections.unmodifiableList(snapshotsInProgress.asStream().collect(Collectors.toList()));
         }
-        if (snapshotsInProgress.entries().size() == 1) {
-            // Most likely scenario - one snapshot is currently running
-            // Check this snapshot against the query
-            SnapshotsInProgress.Entry entry = snapshotsInProgress.entries().get(0);
-            if (entry.snapshot().getRepository().equals(repository) == false) {
-                return Collections.emptyList();
-            }
-            if (snapshots.isEmpty() == false) {
-                for (String snapshot : snapshots) {
-                    if (entry.snapshot().getSnapshotId().getName().equals(snapshot)) {
-                        return snapshotsInProgress.entries();
-                    }
-                }
-                return Collections.emptyList();
-            } else {
-                return snapshotsInProgress.entries();
-            }
+        if (snapshots.isEmpty()) {
+            return snapshotsInProgress.forRepo(repository);
         }
         List<SnapshotsInProgress.Entry> builder = new ArrayList<>();
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-            if (entry.snapshot().getRepository().equals(repository) == false) {
-                continue;
-            }
-            if (snapshots.isEmpty() == false) {
-                for (String snapshot : snapshots) {
-                    if (entry.snapshot().getSnapshotId().getName().equals(snapshot)) {
-                        builder.add(entry);
-                        break;
-                    }
+        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repository)) {
+            for (String snapshot : snapshots) {
+                if (entry.snapshot().getSnapshotId().getName().equals(snapshot)) {
+                    builder.add(entry);
+                    break;
                 }
-            } else {
-                builder.add(entry);
             }
         }
         return unmodifiableList(builder);
@@ -1452,18 +1403,17 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private void endCompletedSnapshots(ClusterState state) {
         SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE);
         assert snapshotsInProgress != null;
-        snapshotsInProgress.entries()
-            .stream()
+        snapshotsInProgress.asStream()
             .filter(entry -> entry.state().completed() || entry.state() == State.INIT || completed(entry.shards().values()))
             .forEach(entry -> endSnapshot(entry, state.metadata(), null));
     }
 
     private boolean assertConsistentWithClusterState(ClusterState state) {
         final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-        if (snapshotsInProgress.entries().isEmpty() == false) {
+        if (snapshotsInProgress.isEmpty() == false) {
             synchronized (endingSnapshots) {
                 final Set<Snapshot> runningSnapshots = Stream.concat(
-                    snapshotsInProgress.entries().stream().map(SnapshotsInProgress.Entry::snapshot),
+                    snapshotsInProgress.asStream().map(SnapshotsInProgress.Entry::snapshot),
                     endingSnapshots.stream()
                 ).collect(Collectors.toSet());
                 final Set<Snapshot> snapshotListenerKeys = snapshotCompletionListeners.keySet();
@@ -1505,21 +1455,19 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             .filter(entry -> entry.state() == SnapshotDeletionsInProgress.State.STARTED)
             .map(SnapshotDeletionsInProgress.Entry::repository)
             .collect(Collectors.toSet());
-        final Set<String> reposSeen = new HashSet<>();
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-            if (reposSeen.add(entry.repository())) {
-                for (ShardSnapshotStatus value : entry.shardsByRepoShardId().values()) {
-                    if (value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)) {
-                        assert reposWithRunningDelete.contains(entry.repository())
-                            : "Found shard snapshot waiting to be assigned in [" + entry + "] but it is not blocked by any running delete";
-                    } else if (value.isActive()) {
-                        assert reposWithRunningDelete.contains(entry.repository()) == false
-                            : "Found shard snapshot actively executing in ["
-                                + entry
-                                + "] when it should be blocked by a running delete ["
-                                + Strings.toString(snapshotDeletionsInProgress)
-                                + "]";
-                    }
+        for (List<SnapshotsInProgress.Entry> repoEntry : snapshotsInProgress.entriesByRepo()) {
+            final SnapshotsInProgress.Entry entry = repoEntry.get(0);
+            for (ShardSnapshotStatus value : entry.shardsByRepoShardId().values()) {
+                if (value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)) {
+                    assert reposWithRunningDelete.contains(entry.repository())
+                        : "Found shard snapshot waiting to be assigned in [" + entry + "] but it is not blocked by any running delete";
+                } else if (value.isActive()) {
+                    assert reposWithRunningDelete.contains(entry.repository()) == false
+                        : "Found shard snapshot actively executing in ["
+                            + entry
+                            + "] when it should be blocked by a running delete ["
+                            + Strings.toString(snapshotDeletionsInProgress)
+                            + "]";
                 }
             }
         }
@@ -1557,7 +1505,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         SnapshotDeletionsInProgress.EMPTY
                     );
                     DiscoveryNodes nodes = currentState.nodes();
-                    boolean changed = false;
                     final EnumSet<State> statesToUpdate;
                     // If we are reacting to a change in the cluster node configuration we have to update the shard states of both started
                     // and
@@ -1569,7 +1516,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         // snapshots
                         statesToUpdate = EnumSet.of(State.STARTED);
                     }
-                    ArrayList<SnapshotsInProgress.Entry> updatedSnapshotEntries = new ArrayList<>();
 
                     // We keep a cache of shards that failed in this map. If we fail a shardId for a given repository because of
                     // a node leaving or shard becoming unassigned for one snapshot, we will also fail it for all subsequent enqueued
@@ -1577,106 +1523,110 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     // TODO: the code in this state update duplicates large chunks of the logic in #SHARD_STATE_EXECUTOR.
                     // We should refactor it to ideally also go through #SHARD_STATE_EXECUTOR by hand-crafting shard state updates
                     // that encapsulate nodes leaving or indices having been deleted and passing them to the executor instead.
-                    final Map<String, Map<RepositoryShardId, ShardSnapshotStatus>> knownFailures = new HashMap<>();
-                    for (final SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
-                        if (statesToUpdate.contains(snapshot.state())) {
-                            if (snapshot.isClone()) {
-                                if (snapshot.shardsByRepoShardId().isEmpty()) {
-                                    // Currently initializing clone
-                                    if (initializingClones.contains(snapshot.snapshot())) {
-                                        updatedSnapshotEntries.add(snapshot);
+                    SnapshotsInProgress updated = snapshots;
+                    for (final List<SnapshotsInProgress.Entry> snapshotsInRepo : snapshots.entriesByRepo()) {
+                        boolean changed = false;
+                        final List<SnapshotsInProgress.Entry> updatedEntriesForRepo = new ArrayList<>();
+                        final Map<RepositoryShardId, ShardSnapshotStatus> knownFailures = new HashMap<>();
+                        final String repository = snapshotsInRepo.get(0).repository();
+                        for (SnapshotsInProgress.Entry snapshot : snapshotsInRepo) {
+                            if (statesToUpdate.contains(snapshot.state())) {
+                                if (snapshot.isClone()) {
+                                    if (snapshot.shardsByRepoShardId().isEmpty()) {
+                                        // Currently initializing clone
+                                        if (initializingClones.contains(snapshot.snapshot())) {
+                                            updatedEntriesForRepo.add(snapshot);
+                                        } else {
+                                            logger.debug("removing not yet start clone operation [{}]", snapshot);
+                                            changed = true;
+                                        }
                                     } else {
-                                        logger.debug("removing not yet start clone operation [{}]", snapshot);
-                                        changed = true;
-                                    }
-                                } else {
-                                    // see if any clones may have had a shard become available for execution because of failures
-                                    if (deletes.hasExecutingDeletion(snapshot.repository())) {
-                                        // Currently executing a delete for this repo, no need to try and update any clone operations.
-                                        // The logic for finishing the delete will update running clones with the latest changes.
-                                        updatedSnapshotEntries.add(snapshot);
-                                        continue;
-                                    }
-                                    ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> clones = null;
-                                    InFlightShardSnapshotStates inFlightShardSnapshotStates = null;
-                                    for (Map.Entry<RepositoryShardId, ShardSnapshotStatus> failureEntry : knownFailures.getOrDefault(
-                                        snapshot.repository(),
-                                        Collections.emptyMap()
-                                    ).entrySet()) {
-                                        final RepositoryShardId repositoryShardId = failureEntry.getKey();
-                                        final ShardSnapshotStatus existingStatus = snapshot.shardsByRepoShardId().get(repositoryShardId);
-                                        if (ShardSnapshotStatus.UNASSIGNED_QUEUED.equals(existingStatus)) {
-                                            if (inFlightShardSnapshotStates == null) {
-                                                inFlightShardSnapshotStates = InFlightShardSnapshotStates.forRepo(
-                                                    snapshot.repository(),
-                                                    updatedSnapshotEntries
+                                        // see if any clones may have had a shard become available for execution because of failures
+                                        if (deletes.hasExecutingDeletion(repository)) {
+                                            // Currently executing a delete for this repo, no need to try and update any clone operations.
+                                            // The logic for finishing the delete will update running clones with the latest changes.
+                                            updatedEntriesForRepo.add(snapshot);
+                                            continue;
+                                        }
+                                        ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> clones = null;
+                                        InFlightShardSnapshotStates inFlightShardSnapshotStates = null;
+                                        for (Map.Entry<RepositoryShardId, ShardSnapshotStatus> failureEntry : knownFailures.entrySet()) {
+                                            final RepositoryShardId repositoryShardId = failureEntry.getKey();
+                                            final ShardSnapshotStatus existingStatus = snapshot.shardsByRepoShardId()
+                                                .get(repositoryShardId);
+                                            if (ShardSnapshotStatus.UNASSIGNED_QUEUED.equals(existingStatus)) {
+                                                if (inFlightShardSnapshotStates == null) {
+                                                    inFlightShardSnapshotStates = InFlightShardSnapshotStates.forEntries(
+                                                        updatedEntriesForRepo
+                                                    );
+                                                }
+                                                if (inFlightShardSnapshotStates.isActive(
+                                                    repositoryShardId.indexName(),
+                                                    repositoryShardId.shardId()
+                                                )) {
+                                                    // we already have this shard assigned to another task
+                                                    continue;
+                                                }
+                                                if (clones == null) {
+                                                    clones = ImmutableOpenMap.builder(snapshot.shardsByRepoShardId());
+                                                }
+                                                // We can use the generation from the shard failure to start the clone operation here
+                                                // because #processWaitingShardsAndRemovedNodes adds generations to failure statuses that
+                                                // allow us to start another clone.
+                                                // The usual route via InFlightShardSnapshotStates is not viable here because it would
+                                                // require a consistent view of the RepositoryData which we don't have here because this
+                                                // state update runs over all repositories at once.
+                                                clones.put(
+                                                    repositoryShardId,
+                                                    new ShardSnapshotStatus(nodes.getLocalNodeId(), failureEntry.getValue().generation())
                                                 );
                                             }
-                                            if (inFlightShardSnapshotStates.isActive(
-                                                repositoryShardId.indexName(),
-                                                repositoryShardId.shardId()
-                                            )) {
-                                                // we already have this shard assigned to another task
-                                                continue;
-                                            }
-                                            if (clones == null) {
-                                                clones = ImmutableOpenMap.builder(snapshot.shardsByRepoShardId());
-                                            }
-                                            // We can use the generation from the shard failure to start the clone operation here
-                                            // because #processWaitingShardsAndRemovedNodes adds generations to failure statuses that allow
-                                            // us to start another clone.
-                                            // The usual route via InFlightShardSnapshotStates is not viable here because it would require
-                                            // a consistent view of the RepositoryData which we don't have here because this state update
-                                            // runs over all repositories at once.
-                                            clones.put(
-                                                repositoryShardId,
-                                                new ShardSnapshotStatus(nodes.getLocalNodeId(), failureEntry.getValue().generation())
-                                            );
+                                        }
+                                        if (clones != null) {
+                                            changed = true;
+                                            updatedEntriesForRepo.add(snapshot.withClones(clones.build()));
+                                        } else {
+                                            updatedEntriesForRepo.add(snapshot);
                                         }
                                     }
-                                    if (clones != null) {
-                                        changed = true;
-                                        updatedSnapshotEntries.add(snapshot.withClones(clones.build()));
-                                    } else {
-                                        updatedSnapshotEntries.add(snapshot);
-                                    }
-                                }
-                            } else {
-                                ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards = processWaitingShardsAndRemovedNodes(
-                                    snapshot,
-                                    routingTable,
-                                    nodes,
-                                    knownFailures.computeIfAbsent(snapshot.repository(), k -> new HashMap<>())
-                                );
-                                if (shards != null) {
-                                    final SnapshotsInProgress.Entry updatedSnapshot = snapshot.withShardStates(shards);
-                                    changed = true;
-                                    if (updatedSnapshot.state().completed()) {
-                                        finishedSnapshots.add(updatedSnapshot);
-                                    }
-                                    updatedSnapshotEntries.add(updatedSnapshot);
                                 } else {
-                                    updatedSnapshotEntries.add(snapshot);
+                                    ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards = processWaitingShardsAndRemovedNodes(
+                                        snapshot,
+                                        routingTable,
+                                        nodes,
+                                        knownFailures
+                                    );
+                                    if (shards != null) {
+                                        final SnapshotsInProgress.Entry updatedSnapshot = snapshot.withShardStates(shards);
+                                        changed = true;
+                                        if (updatedSnapshot.state().completed()) {
+                                            finishedSnapshots.add(updatedSnapshot);
+                                        }
+                                        updatedEntriesForRepo.add(updatedSnapshot);
+                                    } else {
+                                        updatedEntriesForRepo.add(snapshot);
+                                    }
                                 }
+                            } else if (snapshot.repositoryStateId() == RepositoryData.UNKNOWN_REPO_GEN) {
+                                // BwC path, older versions could create entries with unknown repo GEN in INIT or ABORTED state that did not
+                                // yet write anything to the repository physically. This means we can simply remove these from the cluster
+                                // state without having to do any additional cleanup.
+                                changed = true;
+                                logger.debug("[{}] was found in dangling INIT or ABORTED state", snapshot);
+                            } else {
+                                if (snapshot.state().completed() || completed(snapshot.shardsByRepoShardId().values())) {
+                                    finishedSnapshots.add(snapshot);
+                                }
+                                updatedEntriesForRepo.add(snapshot);
                             }
-                        } else if (snapshot.repositoryStateId() == RepositoryData.UNKNOWN_REPO_GEN) {
-                            // BwC path, older versions could create entries with unknown repo GEN in INIT or ABORTED state that did not yet
-                            // write anything to the repository physically. This means we can simply remove these from the cluster state
-                            // without having to do any additional cleanup.
-                            changed = true;
-                            logger.debug("[{}] was found in dangling INIT or ABORTED state", snapshot);
-                        } else {
-                            if (snapshot.state().completed() || completed(snapshot.shardsByRepoShardId().values())) {
-                                finishedSnapshots.add(snapshot);
-                            }
-                            updatedSnapshotEntries.add(snapshot);
+                        }
+                        if (changed) {
+                            updated = updated.withUpdatedEntriesForRepo(repository, updatedEntriesForRepo);
                         }
                     }
                     final ClusterState res = readyDeletions(
-                        changed
-                            ? ClusterState.builder(currentState)
-                                .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(updatedSnapshotEntries))
-                                .build()
+                        updated != snapshots
+                            ? ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, updated).build()
                             : currentState
                     ).v1();
                     for (SnapshotDeletionsInProgress.Entry delete : res.custom(
@@ -1831,25 +1781,27 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private static boolean waitingShardsStartedOrUnassigned(SnapshotsInProgress snapshotsInProgress, ClusterChangedEvent event) {
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-            if (entry.state() == State.STARTED && entry.isClone() == false) {
-                for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shardStatus : entry.shardsByRepoShardId()) {
-                    final ShardState state = shardStatus.value.state();
-                    if (state != ShardState.WAITING && state != ShardState.QUEUED) {
-                        continue;
-                    }
-                    final RepositoryShardId shardId = shardStatus.key;
-                    if (event.indexRoutingTableChanged(shardId.indexName())) {
-                        IndexRoutingTable indexShardRoutingTable = event.state()
-                            .getRoutingTable()
-                            .index(entry.indexByName(shardId.indexName()));
-                        if (indexShardRoutingTable == null) {
-                            // index got removed concurrently and we have to fail WAITING or QUEUED state shards
-                            return true;
+        for (List<SnapshotsInProgress.Entry> entries : snapshotsInProgress.entriesByRepo()) {
+            for (SnapshotsInProgress.Entry entry : entries) {
+                if (entry.state() == State.STARTED && entry.isClone() == false) {
+                    for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shardStatus : entry.shardsByRepoShardId()) {
+                        final ShardState state = shardStatus.value.state();
+                        if (state != ShardState.WAITING && state != ShardState.QUEUED) {
+                            continue;
                         }
-                        ShardRouting shardRouting = indexShardRoutingTable.shard(shardId.shardId()).primaryShard();
-                        if (shardRouting != null && (shardRouting.started() || shardRouting.unassigned())) {
-                            return true;
+                        final RepositoryShardId shardId = shardStatus.key;
+                        if (event.indexRoutingTableChanged(shardId.indexName())) {
+                            IndexRoutingTable indexShardRoutingTable = event.state()
+                                .getRoutingTable()
+                                .index(entry.indexByName(shardId.indexName()));
+                            if (indexShardRoutingTable == null) {
+                                // index got removed concurrently and we have to fail WAITING or QUEUED state shards
+                                return true;
+                            }
+                            ShardRouting shardRouting = indexShardRoutingTable.shard(shardId.shardId()).primaryShard();
+                            if (shardRouting != null && (shardRouting.started() || shardRouting.unassigned())) {
+                                return true;
+                            }
                         }
                     }
                 }
@@ -1864,7 +1816,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             return false;
         }
         final Set<String> removedNodeIds = removedNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
-        return snapshotsInProgress.entries().stream().anyMatch(snapshot -> {
+        return snapshotsInProgress.asStream().anyMatch(snapshot -> {
             if (snapshot.state().completed() || snapshot.isClone()) {
                 // nothing to do for already completed snapshots or clones that run on master anyways
                 return false;
@@ -2268,10 +2220,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             final String repo = entry.repository();
             if (repositoriesSeen.add(entry.repository())
                 && entry.state() == SnapshotDeletionsInProgress.State.WAITING
-                && snapshotsInProgress.entries()
-                    .stream()
-                    .filter(se -> se.repository().equals(repo))
-                    .noneMatch(SnapshotsService::isWritingToRepository)) {
+                && snapshotsInProgress.forRepo(repo).stream().noneMatch(SnapshotsService::isWritingToRepository)) {
                 changed = true;
                 final SnapshotDeletionsInProgress.Entry newEntry = entry.started();
                 readyDeletions.add(newEntry);
@@ -2300,10 +2249,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @return updated cluster state
      */
     public static ClusterState stateWithoutSnapshot(ClusterState state, Snapshot snapshot) {
-        SnapshotsInProgress snapshots = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+        final SnapshotsInProgress snapshots = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
         ClusterState result = state;
         int indexOfEntry = -1;
-        final List<SnapshotsInProgress.Entry> entryList = snapshots.entries();
+        final List<SnapshotsInProgress.Entry> entryList = snapshots.forRepo(snapshot.getRepository());
         for (int i = 0; i < entryList.size(); i++) {
             SnapshotsInProgress.Entry entry = entryList.get(i);
             if (entry.snapshot().equals(snapshot)) {
@@ -2316,88 +2265,86 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             final SnapshotsInProgress.Entry removedEntry = entryList.get(indexOfEntry);
             for (int i = 0; i < indexOfEntry; i++) {
                 final SnapshotsInProgress.Entry previousEntry = entryList.get(i);
-                if (previousEntry.repository().equals(removedEntry.repository())) {
-                    if (removedEntry.isClone()) {
-                        if (previousEntry.isClone()) {
-                            ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedShardAssignments = null;
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
-                                .shardsByRepoShardId()) {
-                                final ShardSnapshotStatus shardState = finishedShardEntry.value;
-                                if (shardState.state() == ShardState.SUCCESS) {
-                                    updatedShardAssignments = maybeAddUpdatedAssignment(
-                                        updatedShardAssignments,
-                                        shardState,
-                                        finishedShardEntry.key,
-                                        previousEntry.shardsByRepoShardId()
-                                    );
-                                }
-                            }
-                            addCloneEntry(entries, previousEntry, updatedShardAssignments);
-                        } else {
-                            ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedShardAssignments = null;
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
-                                .shardsByRepoShardId()) {
-                                final ShardSnapshotStatus shardState = finishedShardEntry.value;
-                                final RepositoryShardId repositoryShardId = finishedShardEntry.key;
-                                if (shardState.state() != ShardState.SUCCESS
-                                    || previousEntry.shardsByRepoShardId().containsKey(repositoryShardId) == false) {
-                                    continue;
-                                }
+                if (removedEntry.isClone()) {
+                    if (previousEntry.isClone()) {
+                        ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedShardAssignments = null;
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
+                            .shardsByRepoShardId()) {
+                            final ShardSnapshotStatus shardState = finishedShardEntry.value;
+                            if (shardState.state() == ShardState.SUCCESS) {
                                 updatedShardAssignments = maybeAddUpdatedAssignment(
                                     updatedShardAssignments,
                                     shardState,
-                                    previousEntry.shardId(repositoryShardId),
-                                    previousEntry.shards()
-                                );
-
-                            }
-                            addSnapshotEntry(entries, previousEntry, updatedShardAssignments);
-                        }
-                    } else {
-                        if (previousEntry.isClone()) {
-                            ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedShardAssignments = null;
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
-                                .shardsByRepoShardId()) {
-                                final ShardSnapshotStatus shardState = finishedShardEntry.value;
-                                final RepositoryShardId repositoryShardId = finishedShardEntry.key;
-                                if (shardState.state() != ShardState.SUCCESS
-                                    || previousEntry.shardsByRepoShardId().containsKey(repositoryShardId) == false) {
-                                    continue;
-                                }
-                                updatedShardAssignments = maybeAddUpdatedAssignment(
-                                    updatedShardAssignments,
-                                    shardState,
-                                    repositoryShardId,
+                                    finishedShardEntry.key,
                                     previousEntry.shardsByRepoShardId()
                                 );
                             }
-                            addCloneEntry(entries, previousEntry, updatedShardAssignments);
-                        } else {
-                            ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedShardAssignments = null;
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
-                                .shardsByRepoShardId()) {
-                                final ShardSnapshotStatus shardState = finishedShardEntry.value;
-                                if (shardState.state() == ShardState.SUCCESS
-                                    && previousEntry.shardsByRepoShardId().containsKey(finishedShardEntry.key)) {
-                                    updatedShardAssignments = maybeAddUpdatedAssignment(
-                                        updatedShardAssignments,
-                                        shardState,
-                                        previousEntry.shardId(finishedShardEntry.key),
-                                        previousEntry.shards()
-                                    );
-                                }
-                            }
-                            addSnapshotEntry(entries, previousEntry, updatedShardAssignments);
                         }
+                        addCloneEntry(entries, previousEntry, updatedShardAssignments);
+                    } else {
+                        ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedShardAssignments = null;
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
+                            .shardsByRepoShardId()) {
+                            final ShardSnapshotStatus shardState = finishedShardEntry.value;
+                            final RepositoryShardId repositoryShardId = finishedShardEntry.key;
+                            if (shardState.state() != ShardState.SUCCESS
+                                || previousEntry.shardsByRepoShardId().containsKey(repositoryShardId) == false) {
+                                continue;
+                            }
+                            updatedShardAssignments = maybeAddUpdatedAssignment(
+                                updatedShardAssignments,
+                                shardState,
+                                previousEntry.shardId(repositoryShardId),
+                                previousEntry.shards()
+                            );
+
+                        }
+                        addSnapshotEntry(entries, previousEntry, updatedShardAssignments);
                     }
                 } else {
-                    entries.add(previousEntry);
+                    if (previousEntry.isClone()) {
+                        ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedShardAssignments = null;
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
+                            .shardsByRepoShardId()) {
+                            final ShardSnapshotStatus shardState = finishedShardEntry.value;
+                            final RepositoryShardId repositoryShardId = finishedShardEntry.key;
+                            if (shardState.state() != ShardState.SUCCESS
+                                || previousEntry.shardsByRepoShardId().containsKey(repositoryShardId) == false) {
+                                continue;
+                            }
+                            updatedShardAssignments = maybeAddUpdatedAssignment(
+                                updatedShardAssignments,
+                                shardState,
+                                repositoryShardId,
+                                previousEntry.shardsByRepoShardId()
+                            );
+                        }
+                        addCloneEntry(entries, previousEntry, updatedShardAssignments);
+                    } else {
+                        ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedShardAssignments = null;
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> finishedShardEntry : removedEntry
+                            .shardsByRepoShardId()) {
+                            final ShardSnapshotStatus shardState = finishedShardEntry.value;
+                            if (shardState.state() == ShardState.SUCCESS
+                                && previousEntry.shardsByRepoShardId().containsKey(finishedShardEntry.key)) {
+                                updatedShardAssignments = maybeAddUpdatedAssignment(
+                                    updatedShardAssignments,
+                                    shardState,
+                                    previousEntry.shardId(finishedShardEntry.key),
+                                    previousEntry.shards()
+                                );
+                            }
+                        }
+                        addSnapshotEntry(entries, previousEntry, updatedShardAssignments);
+                    }
                 }
             }
             for (int i = indexOfEntry + 1; i < entryList.size(); i++) {
                 entries.add(entryList.get(i));
             }
-            result = ClusterState.builder(state).putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(entries)).build();
+            result = ClusterState.builder(state)
+                .putCustom(SnapshotsInProgress.TYPE, snapshots.withUpdatedEntriesForRepo(snapshot.getRepository(), entries))
+                .build();
         }
         return readyDeletions(result).v1();
     }
@@ -2611,9 +2558,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                 // find in-progress snapshots to delete in cluster state
                 final SnapshotsInProgress snapshotsInProgress = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+                for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repositoryName)) {
                     final SnapshotId snapshotId = entry.snapshot().getSnapshotId();
-                    if (entry.repository().equals(repositoryName) && Regex.simpleMatch(snapshotNames, snapshotId.getName())) {
+                    if (Regex.simpleMatch(snapshotNames, snapshotId.getName())) {
                         snapshotIds.add(snapshotId);
                         snapshotEntries.add(entry);
                     }
@@ -2698,8 +2645,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 return ClusterState.builder(currentState)
                     .putCustom(
                         SnapshotsInProgress.TYPE,
-                        SnapshotsInProgress.of(
-                            snapshotsInProgress.entries()
+                        snapshotsInProgress.withUpdatedEntriesForRepo(
+                            repositoryName,
+                            snapshotsInProgress.forRepo(repositoryName)
                                 .stream()
                                 // remove init state snapshot we found from a previous master if there was one
                                 .filter(existing -> abortedDuringInit == false || existing.equals(snapshotEntry) == false)
@@ -2837,8 +2785,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     }
                 }
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                final Set<SnapshotId> activeCloneSources = snapshots.entries()
-                    .stream()
+                final Set<SnapshotId> activeCloneSources = snapshots.asStream()
                     .filter(SnapshotsInProgress.Entry::isClone)
                     .map(SnapshotsInProgress.Entry::source)
                     .collect(Collectors.toSet());
@@ -2854,7 +2801,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 final Set<SnapshotId> snapshotIdsRequiringCleanup = new HashSet<>(snapshotIds);
                 final SnapshotsInProgress updatedSnapshots;
                 if (minNodeVersion.onOrAfter(FULL_CONCURRENCY_VERSION)) {
-                    updatedSnapshots = SnapshotsInProgress.of(snapshots.entries().stream().map(existing -> {
+                    updatedSnapshots = snapshots.withUpdatedEntriesForRepo(repoName, snapshots.forRepo(repoName).stream().map(existing -> {
                         if (existing.state() == State.STARTED
                             && snapshotIdsRequiringCleanup.contains(existing.snapshot().getSnapshotId())) {
                             // snapshot is started - mark every non completed shard as aborted
@@ -2880,7 +2827,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         return updateWithSnapshots(currentState, updatedSnapshots, null);
                     }
                 } else {
-                    if (snapshots.entries().isEmpty() == false) {
+                    if (snapshots.isEmpty() == false) {
                         // However other snapshots are running - cannot continue
                         throw new ConcurrentSnapshotExecutionException(
                             repoName,
@@ -2915,10 +2862,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         repoName,
                         threadPool.absoluteTimeInMillis(),
                         repositoryData.getGenId(),
-                        updatedSnapshots.entries()
-                            .stream()
-                            .filter(entry -> repoName.equals(entry.repository()))
-                            .noneMatch(SnapshotsService::isWritingToRepository)
+                        updatedSnapshots.forRepo(repoName).stream().noneMatch(SnapshotsService::isWritingToRepository)
                             && deletionsInProgress.hasExecutingDeletion(repoName) == false
                                 ? SnapshotDeletionsInProgress.State.STARTED
                                 : SnapshotDeletionsInProgress.State.WAITING
@@ -3319,109 +3263,104 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             final String localNodeId = currentState.nodes().getLocalNodeId();
             final String repoName = deleteEntry.repository();
             InFlightShardSnapshotStates inFlightShardStates = null;
-            for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-                if (entry.repository().equals(repoName)) {
-                    if (entry.state().completed() == false) {
-                        // TODO: dry up redundant computation and code between clone and non-clone case, in particular reuse
-                        // `inFlightShardStates` across both clone and standard snapshot code
-                        if (entry.isClone()) {
-                            // Collect waiting shards from that entry that we can assign now that we are done with the deletion
-                            final List<RepositoryShardId> canBeUpdated = new ArrayList<>();
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> value : entry.shardsByRepoShardId()) {
-                                if (value.value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)
-                                    && reassignedShardIds.contains(value.key) == false) {
-                                    canBeUpdated.add(value.key);
-                                }
-                            }
-                            // TODO: the below logic is very similar to that in #startCloning and both could be dried up against each other
-                            // also the code for standard snapshots could make use of this breakout as well
-                            if (canBeUpdated.isEmpty() || updatedDeletions.hasExecutingDeletion(repoName)) {
-                                // No shards can be updated in this snapshot so we just add it as is again
-                                snapshotEntries.add(entry);
-                            } else {
-                                if (inFlightShardStates == null) {
-                                    inFlightShardStates = InFlightShardSnapshotStates.forRepo(repoName, snapshotsInProgress.entries());
-                                }
-                                final ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedAssignmentsBuilder =
-                                    ImmutableOpenMap.builder(entry.shardsByRepoShardId());
-                                for (RepositoryShardId shardId : canBeUpdated) {
-                                    if (inFlightShardStates.isActive(shardId.indexName(), shardId.shardId()) == false) {
-                                        markShardReassigned(shardId, reassignedShardIds);
-                                        updatedAssignmentsBuilder.put(
-                                            shardId,
-                                            new ShardSnapshotStatus(
-                                                localNodeId,
-                                                inFlightShardStates.generationForShard(
-                                                    shardId.index(),
-                                                    shardId.shardId(),
-                                                    repositoryData.shardGenerations()
-                                                )
-                                            )
-                                        );
-                                    }
-                                }
-                                snapshotEntries.add(entry.withClones(updatedAssignmentsBuilder.build()));
-                                changed = true;
-                            }
-                        } else {
-                            // Collect waiting shards that in entry that we can assign now that we are done with the deletion
-                            final List<RepositoryShardId> canBeUpdated = new ArrayList<>();
-                            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> value : entry.shardsByRepoShardId()) {
-                                if (value.value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)
-                                    && reassignedShardIds.contains(value.key) == false) {
-                                    canBeUpdated.add(value.key);
-                                }
-                            }
-                            if (canBeUpdated.isEmpty()) {
-                                // No shards can be updated in this snapshot so we just add it as is again
-                                snapshotEntries.add(entry);
-                            } else {
-                                final ImmutableOpenMap<ShardId, ShardSnapshotStatus> shardAssignments = shards(
-                                    snapshotsInProgress,
-                                    updatedDeletions,
-                                    currentState,
-                                    entry.indices().values(),
-                                    entry.version().onOrAfter(SHARD_GEN_IN_REPO_DATA_VERSION),
-                                    repositoryData,
-                                    repoName
-                                );
-                                final ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedAssignmentsBuilder = ImmutableOpenMap
-                                    .builder(entry.shards());
-                                for (RepositoryShardId shardId : canBeUpdated) {
-                                    final ShardId sid = entry.shardId(shardId);
-                                    final ShardSnapshotStatus updated = shardAssignments.get(sid);
-                                    if (updated == null) {
-                                        // We don't have a new assignment for this shard because its index was concurrently deleted
-                                        assert currentState.routingTable().hasIndex(sid.getIndex()) == false
-                                            : "Missing assignment for [" + sid + "]";
-                                        updatedAssignmentsBuilder.put(sid, ShardSnapshotStatus.MISSING);
-                                    } else {
-                                        if (updated.isActive()) {
-                                            markShardReassigned(shardId, reassignedShardIds);
-                                        }
-                                        updatedAssignmentsBuilder.put(sid, updated);
-                                    }
-                                }
-                                final SnapshotsInProgress.Entry updatedEntry = entry.withShardStates(updatedAssignmentsBuilder.build());
-                                snapshotEntries.add(updatedEntry);
-                                changed = true;
-                                if (updatedEntry.state().completed()) {
-                                    newFinalizations.add(entry);
-                                }
+            for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repoName)) {
+                if (entry.state().completed() == false) {
+                    // TODO: dry up redundant computation and code between clone and non-clone case, in particular reuse
+                    // `inFlightShardStates` across both clone and standard snapshot code
+                    if (entry.isClone()) {
+                        // Collect waiting shards from that entry that we can assign now that we are done with the deletion
+                        final List<RepositoryShardId> canBeUpdated = new ArrayList<>();
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> value : entry.shardsByRepoShardId()) {
+                            if (value.value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)
+                                && reassignedShardIds.contains(value.key) == false) {
+                                canBeUpdated.add(value.key);
                             }
                         }
+                        // TODO: the below logic is very similar to that in #startCloning and both could be dried up against each other
+                        // also the code for standard snapshots could make use of this breakout as well
+                        if (canBeUpdated.isEmpty() || updatedDeletions.hasExecutingDeletion(repoName)) {
+                            // No shards can be updated in this snapshot so we just add it as is again
+                            snapshotEntries.add(entry);
+                        } else {
+                            if (inFlightShardStates == null) {
+                                inFlightShardStates = InFlightShardSnapshotStates.forEntries(snapshotsInProgress.forRepo(repoName));
+                            }
+                            final ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> updatedAssignmentsBuilder =
+                                ImmutableOpenMap.builder(entry.shardsByRepoShardId());
+                            for (RepositoryShardId shardId : canBeUpdated) {
+                                if (inFlightShardStates.isActive(shardId.indexName(), shardId.shardId()) == false) {
+                                    markShardReassigned(shardId, reassignedShardIds);
+                                    updatedAssignmentsBuilder.put(
+                                        shardId,
+                                        new ShardSnapshotStatus(
+                                            localNodeId,
+                                            inFlightShardStates.generationForShard(
+                                                shardId.index(),
+                                                shardId.shardId(),
+                                                repositoryData.shardGenerations()
+                                            )
+                                        )
+                                    );
+                                }
+                            }
+                            snapshotEntries.add(entry.withClones(updatedAssignmentsBuilder.build()));
+                            changed = true;
+                        }
                     } else {
-                        // Entry is already completed so we will finalize it now that the delete doesn't block us after
-                        // this CS update finishes
-                        newFinalizations.add(entry);
-                        snapshotEntries.add(entry);
+                        // Collect waiting shards that in entry that we can assign now that we are done with the deletion
+                        final List<RepositoryShardId> canBeUpdated = new ArrayList<>();
+                        for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> value : entry.shardsByRepoShardId()) {
+                            if (value.value.equals(ShardSnapshotStatus.UNASSIGNED_QUEUED)
+                                && reassignedShardIds.contains(value.key) == false) {
+                                canBeUpdated.add(value.key);
+                            }
+                        }
+                        if (canBeUpdated.isEmpty()) {
+                            // No shards can be updated in this snapshot so we just add it as is again
+                            snapshotEntries.add(entry);
+                        } else {
+                            final ImmutableOpenMap<ShardId, ShardSnapshotStatus> shardAssignments = shards(
+                                snapshotsInProgress,
+                                updatedDeletions,
+                                currentState,
+                                entry.indices().values(),
+                                entry.version().onOrAfter(SHARD_GEN_IN_REPO_DATA_VERSION),
+                                repositoryData,
+                                repoName
+                            );
+                            final ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> updatedAssignmentsBuilder = ImmutableOpenMap
+                                .builder(entry.shards());
+                            for (RepositoryShardId shardId : canBeUpdated) {
+                                final ShardId sid = entry.shardId(shardId);
+                                final ShardSnapshotStatus updated = shardAssignments.get(sid);
+                                if (updated == null) {
+                                    // We don't have a new assignment for this shard because its index was concurrently deleted
+                                    assert currentState.routingTable().hasIndex(sid.getIndex()) == false
+                                        : "Missing assignment for [" + sid + "]";
+                                    updatedAssignmentsBuilder.put(sid, ShardSnapshotStatus.MISSING);
+                                } else {
+                                    if (updated.isActive()) {
+                                        markShardReassigned(shardId, reassignedShardIds);
+                                    }
+                                    updatedAssignmentsBuilder.put(sid, updated);
+                                }
+                            }
+                            final SnapshotsInProgress.Entry updatedEntry = entry.withShardStates(updatedAssignmentsBuilder.build());
+                            snapshotEntries.add(updatedEntry);
+                            changed = true;
+                            if (updatedEntry.state().completed()) {
+                                newFinalizations.add(entry);
+                            }
+                        }
                     }
                 } else {
-                    // Entry is for another repository we just keep it as is
+                    // Entry is already completed so we will finalize it now that the delete doesn't block us after
+                    // this CS update finishes
+                    newFinalizations.add(entry);
                     snapshotEntries.add(entry);
                 }
             }
-            return changed ? SnapshotsInProgress.of(snapshotEntries) : null;
+            return changed ? snapshotsInProgress.withUpdatedEntriesForRepo(repoName, snapshotEntries) : null;
         }
 
         private void markShardReassigned(RepositoryShardId shardId, Set<RepositoryShardId> reassignments) {
@@ -3498,9 +3437,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     ) {
         ImmutableOpenMap.Builder<ShardId, SnapshotsInProgress.ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
         final ShardGenerations shardGenerations = repositoryData.shardGenerations();
-        final InFlightShardSnapshotStates inFlightShardStates = InFlightShardSnapshotStates.forRepo(
-            repoName,
-            snapshotsInProgress.entries()
+        final InFlightShardSnapshotStates inFlightShardStates = InFlightShardSnapshotStates.forEntries(
+            snapshotsInProgress.forRepo(repoName)
         );
         final boolean readyToExecute = deletionsInProgress.hasExecutingDeletion(repoName) == false;
         for (IndexId index : indices) {
@@ -3577,14 +3515,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * indices-to-check set.
      */
     public static Set<String> snapshottingDataStreams(final ClusterState currentState, final Set<String> dataStreamsToCheck) {
-        final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
-        if (snapshots == null) {
-            return emptySet();
-        }
-
         Map<String, DataStream> dataStreams = currentState.metadata().dataStreams();
-        return snapshots.entries()
-            .stream()
+        return currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
+            .asStream()
             .filter(e -> e.partial() == false)
             .flatMap(e -> e.dataStreams().stream())
             .filter(ds -> dataStreams.containsKey(ds) && dataStreamsToCheck.contains(ds))
@@ -3595,18 +3528,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * Returns the indices that are currently being snapshotted (with partial == false) and that are contained in the indices-to-check set.
      */
     public static Set<Index> snapshottingIndices(final ClusterState currentState, final Set<Index> indicesToCheck) {
-        final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
-        if (snapshots == null) {
-            return emptySet();
-        }
-
         final Set<Index> indices = new HashSet<>();
-        for (final SnapshotsInProgress.Entry entry : snapshots.entries()) {
-            if (entry.partial() == false && entry.isClone() == false) {
-                for (String indexName : entry.indices().keySet()) {
-                    IndexMetadata indexMetadata = currentState.metadata().index(indexName);
-                    if (indexMetadata != null && indicesToCheck.contains(indexMetadata.getIndex())) {
-                        indices.add(indexMetadata.getIndex());
+        for (List<SnapshotsInProgress.Entry> snapshotsInRepo : currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
+            .entriesByRepo()) {
+            for (final SnapshotsInProgress.Entry entry : snapshotsInRepo) {
+                if (entry.partial() == false && entry.isClone() == false) {
+                    for (String indexName : entry.indices().keySet()) {
+                        IndexMetadata indexMetadata = currentState.metadata().index(indexName);
+                        if (indexMetadata != null && indicesToCheck.contains(indexMetadata.getIndex())) {
+                            indices.add(indexMetadata.getIndex());
+                        }
                     }
                 }
             }
@@ -3724,22 +3655,33 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         private final ClusterState currentState;
 
         // updates outstanding to be applied to existing snapshot entries
-        private final List<ShardSnapshotUpdate> unconsumedUpdates;
+        private final Map<String, List<ShardSnapshotUpdate>> updatesByRepo;
 
         // updates that were used to update an existing in-progress shard snapshot
         private final Set<ShardSnapshotUpdate> executedUpdates = new HashSet<>();
 
         SnapshotShardsUpdateContext(ClusterState currentState, List<ShardSnapshotUpdate> updates) {
             this.currentState = currentState;
-            unconsumedUpdates = new ArrayList<>(updates);
+            updatesByRepo = new HashMap<>();
+            for (ShardSnapshotUpdate update : updates) {
+                updatesByRepo.computeIfAbsent(update.snapshot.getRepository(), r -> new ArrayList<>()).add(update);
+            }
         }
 
         ClusterState computeUpdatedState() {
-            final List<SnapshotsInProgress.Entry> oldEntries = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .entries();
-            final List<SnapshotsInProgress.Entry> newEntries = new ArrayList<>(oldEntries.size());
-            for (SnapshotsInProgress.Entry entry : oldEntries) {
-                newEntries.add(applyToEntry(entry));
+            final SnapshotsInProgress existing = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+            SnapshotsInProgress updated = existing;
+            for (Map.Entry<String, List<ShardSnapshotUpdate>> updates : updatesByRepo.entrySet()) {
+                final String repoName = updates.getKey();
+                final List<SnapshotsInProgress.Entry> oldEntries = existing.forRepo(repoName);
+                if (oldEntries.isEmpty()) {
+                    continue;
+                }
+                final List<SnapshotsInProgress.Entry> newEntries = new ArrayList<>(oldEntries.size());
+                for (SnapshotsInProgress.Entry entry : oldEntries) {
+                    newEntries.add(applyToEntry(entry, updates.getValue()));
+                }
+                updated = updated.withUpdatedEntriesForRepo(repoName, newEntries);
             }
 
             if (changedCount > 0) {
@@ -3748,18 +3690,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     changedCount,
                     startedCount
                 );
-                return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(newEntries)).build();
+                return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, updated).build();
             }
             return currentState;
         }
 
-        private SnapshotsInProgress.Entry applyToEntry(SnapshotsInProgress.Entry entry) {
+        private SnapshotsInProgress.Entry applyToEntry(SnapshotsInProgress.Entry entry, List<ShardSnapshotUpdate> updates) {
             // Completed snapshots do not require any updates so we just add them to the output list and keep going.
             // Also we short circuit if there are no more unconsumed updates to apply.
-            if (entry.state().completed() || unconsumedUpdates.isEmpty()) {
+            if (entry.state().completed() || updates.isEmpty()) {
                 return entry;
             }
-            return new EntryContext(entry).computeUpdatedEntry();
+            return new EntryContext(entry, updates).computeUpdatedEntry();
         }
 
         // Per snapshot entry state
@@ -3776,9 +3718,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             // builder for updated shard clone status mappings if any could be computed
             private ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> clonesBuilder = null;
 
-            EntryContext(SnapshotsInProgress.Entry entry) {
+            EntryContext(SnapshotsInProgress.Entry entry, List<ShardSnapshotUpdate> updates) {
                 this.entry = entry;
-                this.iterator = unconsumedUpdates.iterator();
+                this.iterator = updates.iterator();
             }
 
             SnapshotsInProgress.Entry computeUpdatedEntry() {
@@ -3787,12 +3729,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 // loop over all the shard updates that are potentially applicable to the current snapshot entry
                 while (iterator.hasNext()) {
                     final ShardSnapshotUpdate update = iterator.next();
-                    final Snapshot updatedSnapshot = update.snapshot;
-                    if (entry.repository().equals(updatedSnapshot.getRepository()) == false) {
-                        // the update applies to a different repository so it is irrelevant here
-                        continue;
-                    }
-                    if (entry.snapshot().getSnapshotId().equals(updatedSnapshot.getSnapshotId())) {
+                    if (entry.snapshot().getSnapshotId().equals(update.snapshot.getSnapshotId())) {
                         // update a currently running shard level operation
                         if (update.isClone()) {
                             executeShardSnapshotUpdate(entry.shardsByRepoShardId(), this::clonesBuilder, update, update.repoShardId);
@@ -4100,8 +4037,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private void startExecutableClones(SnapshotsInProgress snapshotsInProgress, @Nullable String repoName) {
-        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-            if (entry.isClone() && entry.state() == State.STARTED && (repoName == null || entry.repository().equals(repoName))) {
+        if (repoName == null) {
+            for (List<SnapshotsInProgress.Entry> entries : snapshotsInProgress.entriesByRepo()) {
+                startExecutableClones(entries);
+            }
+        } else {
+            startExecutableClones(snapshotsInProgress.forRepo(repoName));
+        }
+    }
+
+    private void startExecutableClones(List<SnapshotsInProgress.Entry> entries) {
+        for (SnapshotsInProgress.Entry entry : entries) {
+            if (entry.isClone() && entry.state() == State.STARTED) {
                 // this is a clone, see if new work is ready
                 for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> clone : entry.shardsByRepoShardId()) {
                     if (clone.value.state() == ShardState.INIT) {
@@ -4202,20 +4149,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
             final SnapshotDeletionsInProgress updatedDeletions = changed ? SnapshotDeletionsInProgress.of(updatedEntries) : null;
             final SnapshotsInProgress snapshotsInProgress = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-            final List<SnapshotsInProgress.Entry> snapshotEntries = new ArrayList<>();
             boolean changedSnapshots = false;
-            for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-                if (entry.repository().equals(repository)) {
-                    // We failed to read repository data for this delete, it is not the job of SnapshotsService to
-                    // retry these kinds of issues so we fail all the pending snapshots
-                    snapshotsToFail.add(entry.snapshot());
-                    changedSnapshots = true;
-                } else {
-                    // Entry is for another repository we just keep it as is
-                    snapshotEntries.add(entry);
-                }
+            for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repository)) {
+                // We failed to read repository data for this delete, it is not the job of SnapshotsService to
+                // retry these kinds of issues so we fail all the pending snapshots
+                snapshotsToFail.add(entry.snapshot());
+                changedSnapshots = true;
             }
-            final SnapshotsInProgress updatedSnapshotsInProgress = changedSnapshots ? SnapshotsInProgress.of(snapshotEntries) : null;
+            final SnapshotsInProgress updatedSnapshotsInProgress = changedSnapshots
+                ? snapshotsInProgress.withUpdatedEntriesForRepo(repository, org.elasticsearch.core.List.of())
+                : null;
             return updateWithSnapshots(currentState, updatedSnapshotsInProgress, updatedDeletions);
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
@@ -70,10 +70,10 @@ public class MetadataDeleteIndexServiceTests extends ESTestCase {
     public void testDeleteSnapshotting() {
         String index = randomAlphaOfLength(5);
         Snapshot snapshot = new Snapshot("doesn't matter", new SnapshotId("snapshot name", "snapshot uuid"));
-        SnapshotsInProgress snaps = SnapshotsInProgress.of(Collections.singletonList(new SnapshotsInProgress.Entry(snapshot, true, false,
+        SnapshotsInProgress snaps = SnapshotsInProgress.EMPTY.withAddedEntry(new SnapshotsInProgress.Entry(snapshot, true, false,
                 SnapshotsInProgress.State.INIT, singletonMap(index, new IndexId(index, "doesn't matter")),
                 Collections.emptyList(), Collections.emptyList(), System.currentTimeMillis(), (long) randomIntBetween(0, 1000),
-                ImmutableOpenMap.of(), null, SnapshotInfoTestUtils.randomUserMetadata(), VersionUtils.randomVersion(random()))));
+                ImmutableOpenMap.of(), null, SnapshotInfoTestUtils.randomUserMetadata(), VersionUtils.randomVersion(random())));
         ClusterState state = ClusterState.builder(clusterState(index))
                 .putCustom(SnapshotsInProgress.TYPE, snaps)
                 .build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -416,8 +416,7 @@ public class MetadataIndexStateServiceTests extends ESTestCase {
                 randomNonNegativeLong(), randomLong(), shardsBuilder.build(), null, SnapshotInfoTestUtils.randomUserMetadata(),
                 VersionUtils.randomVersion(random())
             );
-        return ClusterState.builder(newState).putCustom(SnapshotsInProgress.TYPE,
-                SnapshotsInProgress.of(Collections.singletonList(entry))).build();
+        return ClusterState.builder(newState).putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY.withAddedEntry(entry)).build();
     }
 
     private static ClusterState addIndex(final ClusterState currentState,

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -348,8 +348,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         assertNotNull(createSnapshotResponseListener.result());
         assertNotNull(restoreSnapshotResponseListener.result());
         assertTrue(documentCountVerified.get());
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         assertThat(snapshotIds, hasSize(1));
@@ -427,7 +426,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 return true;
             }
             final SnapshotsInProgress snapshotsInProgress = master.clusterService.state().custom(SnapshotsInProgress.TYPE);
-            return snapshotsInProgress != null && snapshotsInProgress.entries().isEmpty();
+            return snapshotsInProgress != null && snapshotsInProgress.isEmpty();
         }).orElse(false), TimeUnit.MINUTES.toMillis(1L));
 
         clearDisruptionsAndAwaitSync();
@@ -436,7 +435,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             .orElseThrow(() -> new AssertionError("expected to find at least one active master node"));
         SnapshotsInProgress finalSnapshotsInProgress = randomMaster.clusterService.state()
             .custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-        assertThat(finalSnapshotsInProgress.entries(), empty());
+        assertTrue(finalSnapshotsInProgress.isEmpty());
         final Repository repository = randomMaster.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         if (snapshotNeverStarted.get()) {
@@ -494,7 +493,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         final TestClusterNodes.TestClusterNode randomMaster = testClusterNodes.randomMasterNode()
             .orElseThrow(() -> new AssertionError("expected to find at least one active master node"));
         SnapshotsInProgress finalSnapshotsInProgress = randomMaster.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertThat(finalSnapshotsInProgress.entries(), empty());
+        assertTrue(finalSnapshotsInProgress.isEmpty());
         final Repository repository = randomMaster.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         assertThat(snapshotIds, hasSize(0));
@@ -527,7 +526,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         masterNode.clusterService.addListener(new ClusterStateListener() {
             @Override
             public void clusterChanged(ClusterChangedEvent event) {
-                if (event.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().isEmpty() == false) {
+                if (event.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty() == false) {
                     client().admin().cluster().prepareDeleteSnapshot(repoName, snapshotName).execute(deleteSnapshotStepListener);
                     masterNode.clusterService.removeListener(this);
                 }
@@ -553,8 +552,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         assertNotNull(createSnapshotResponseStepListener.result());
         assertNotNull(createAnotherSnapshotResponseStepListener.result());
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         assertThat(snapshotIds, hasSize(1));
@@ -625,8 +623,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         deterministicTaskQueue.runAllRunnableTasks();
 
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         // We end up with two snapshots no matter if the delete worked out or not
@@ -688,8 +685,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         deterministicTaskQueue.runAllRunnableTasks();
 
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         // No snapshots should be left in the repository
@@ -873,8 +869,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         deterministicTaskQueue.runAllRunnableTasks();
 
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         final RepositoryData repositoryData = getRepositoryData(repository);
         Collection<SnapshotId> snapshotIds = repositoryData.getSnapshotIds();
@@ -1050,17 +1045,16 @@ public class SnapshotResiliencyTests extends ESTestCase {
             if (createdSnapshot.get() == false) {
                 return false;
             }
-            return master.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().isEmpty();
+            return master.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty();
         }).orElse(false), TimeUnit.MINUTES.toMillis(1L));
 
         clearDisruptionsAndAwaitSync();
 
         assertTrue(createdSnapshot.get());
-        assertThat(
+        assertTrue(
             testClusterNodes.randomDataNodeSafe().clusterService.state()
                 .custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
-                .entries(),
-            empty()
+                .isEmpty()
         );
         final Repository repository = testClusterNodes.randomMasterNodeSafe().repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
@@ -1152,8 +1146,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         assertNotNull(createSnapshotResponseStepListener.result());
         assertNotNull(restoreSnapshotResponseStepListener.result());
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         assertThat(snapshotIds, hasSize(1));
@@ -1219,8 +1212,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         });
 
         runUntil(() -> doneIndexing.get() && doneSnapshotting.get(), TimeUnit.MINUTES.toMillis(5L));
-        SnapshotsInProgress finalSnapshotsInProgress = masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE);
-        assertFalse(finalSnapshotsInProgress.entries().stream().anyMatch(entry -> entry.state().completed() == false));
+        assertTrue(masterNode.clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty());
         final Repository repository = masterNode.repositoriesService.repository(repoName);
         Collection<SnapshotId> snapshotIds = getRepositoryData(repository).getSnapshotIds();
         assertThat(snapshotIds, hasSize(snapshotNames.size()));

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -51,11 +51,11 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
     @Override
     protected Custom createTestInstance() {
         int numberOfSnapshots = randomInt(10);
-        List<Entry> entries = new ArrayList<>();
+        SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.EMPTY;
         for (int i = 0; i < numberOfSnapshots; i++) {
-            entries.add(randomSnapshot());
+            snapshotsInProgress.withAddedEntry(randomSnapshot());
         }
-        return SnapshotsInProgress.of(entries);
+        return snapshotsInProgress;
     }
 
     private Entry randomSnapshot() {
@@ -121,30 +121,43 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
 
     @Override
     protected Custom makeTestChanges(Custom testInstance) {
-        SnapshotsInProgress snapshots = (SnapshotsInProgress) testInstance;
-        List<Entry> entries = new ArrayList<>(snapshots.entries());
-        if (randomBoolean() && entries.size() > 1) {
+        final SnapshotsInProgress snapshots = (SnapshotsInProgress) testInstance;
+        SnapshotsInProgress updatedInstance = SnapshotsInProgress.EMPTY;
+        if (randomBoolean() && snapshots.count() > 1) {
             // remove some elements
-            int leaveElements = randomIntBetween(0, entries.size() - 1);
-            entries = randomSubsetOf(leaveElements, entries.toArray(new Entry[leaveElements]));
+            int leaveElements = randomIntBetween(0, snapshots.count() - 1);
+            for (List<Entry> entriesForRepo : snapshots.entriesByRepo()) {
+                for (Entry entry : entriesForRepo) {
+                    if (updatedInstance.count() == leaveElements) {
+                        break;
+                    }
+                    if (randomBoolean()) {
+                        updatedInstance = updatedInstance.withAddedEntry(entry);
+                    }
+                }
+            }
         }
         if (randomBoolean()) {
             // add some elements
             int addElements = randomInt(10);
             for (int i = 0; i < addElements; i++) {
-                entries.add(randomSnapshot());
+                updatedInstance = updatedInstance.withAddedEntry(randomSnapshot());
             }
         }
         if (randomBoolean()) {
             // modify some elements
-            for (int i = 0; i < entries.size(); i++) {
-                if (randomBoolean()) {
-                    final Entry entry = entries.get(i);
-                    entries.set(i, mutateEntry(entry));
+            for (List<Entry> perRepoEntries : updatedInstance.entriesByRepo()) {
+                final List<Entry> entries = new ArrayList<>(perRepoEntries);
+                for (int i = 0; i < entries.size(); i++) {
+                    if (randomBoolean()) {
+                        final Entry entry = entries.get(i);
+                        entries.set(i, mutateEntry(entry));
+                    }
                 }
+                updatedInstance = updatedInstance.withUpdatedEntriesForRepo(perRepoEntries.get(0).repository(), entries);
             }
         }
-        return SnapshotsInProgress.of(entries);
+        return updatedInstance;
     }
 
     @Override
@@ -159,22 +172,22 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
 
     @Override
     protected Custom mutateInstance(Custom instance) {
-        List<Entry> entries = new ArrayList<>(((SnapshotsInProgress) instance).entries());
-        if (false || entries.isEmpty()) {
+        final SnapshotsInProgress snapshotsInProgress = (SnapshotsInProgress) instance;
+        if (snapshotsInProgress.isEmpty()) {
             // add or remove an entry
-            boolean addEntry = entries.isEmpty() ? true : randomBoolean();
-            if (addEntry) {
-                entries.add(randomSnapshot());
-            } else {
-                entries.remove(randomIntBetween(0, entries.size() - 1));
-            }
+            return snapshotsInProgress.withAddedEntry(randomSnapshot());
         } else {
             // mutate an entry
-            int index = randomIntBetween(0, entries.size() - 1);
-            Entry entry = entries.get(index);
-            entries.set(index, mutateEntry(entry));
+            final String repo = randomFrom(
+                snapshotsInProgress.asStream().map(SnapshotsInProgress.Entry::repository).collect(Collectors.toSet())
+            );
+            final List<Entry> forRepo = snapshotsInProgress.forRepo(repo);
+            int index = randomIntBetween(0, forRepo.size() - 1);
+            Entry entry = forRepo.get(index);
+            final List<Entry> updatedEntries = new ArrayList<>(forRepo);
+            updatedEntries.set(index, mutateEntry(entry));
+            return snapshotsInProgress.withUpdatedEntriesForRepo(repo, updatedEntries);
         }
-        return SnapshotsInProgress.of(entries);
     }
 
     private Entry mutateEntry(Entry entry) {
@@ -360,40 +373,38 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
 
     public void testXContent() throws IOException {
         final IndexId indexId = new IndexId("index", "uuid");
-        SnapshotsInProgress sip = SnapshotsInProgress.of(
-            Collections.singletonList(
-                new Entry(
-                    new Snapshot("repo", new SnapshotId("name", "uuid")),
-                    true,
-                    true,
-                    State.SUCCESS,
-                    Collections.singletonMap(indexId.getName(), indexId),
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    1234567,
-                    0,
-                    ImmutableOpenMap.<ShardId, SnapshotsInProgress.ShardSnapshotStatus>builder()
-                        .fPut(
-                            new ShardId("index", "uuid", 0),
-                            SnapshotsInProgress.ShardSnapshotStatus.success(
-                                "nodeId",
-                                new ShardSnapshotResult(new ShardGeneration("shardgen"), new ByteSizeValue(1L), 1)
-                            )
+        SnapshotsInProgress sip = SnapshotsInProgress.EMPTY.withAddedEntry(
+            new Entry(
+                new Snapshot("repo", new SnapshotId("name", "uuid")),
+                true,
+                true,
+                State.SUCCESS,
+                Collections.singletonMap(indexId.getName(), indexId),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                1234567,
+                0,
+                ImmutableOpenMap.<ShardId, SnapshotsInProgress.ShardSnapshotStatus>builder()
+                    .fPut(
+                        new ShardId("index", "uuid", 0),
+                        SnapshotsInProgress.ShardSnapshotStatus.success(
+                            "nodeId",
+                            new ShardSnapshotResult(new ShardGeneration("shardgen"), new ByteSizeValue(1L), 1)
                         )
-                        .fPut(
-                            new ShardId("index", "uuid", 1),
-                            new SnapshotsInProgress.ShardSnapshotStatus(
-                                "nodeId",
-                                ShardState.FAILED,
-                                "failure-reason",
-                                new ShardGeneration("fail-gen")
-                            )
+                    )
+                    .fPut(
+                        new ShardId("index", "uuid", 1),
+                        new SnapshotsInProgress.ShardSnapshotStatus(
+                            "nodeId",
+                            ShardState.FAILED,
+                            "failure-reason",
+                            new ShardGeneration("fail-gen")
                         )
-                        .build(),
-                    null,
-                    null,
-                    Version.CURRENT
-                )
+                    )
+                    .build(),
+                null,
+                null,
+                Version.CURRENT
             )
         );
 

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -53,7 +53,7 @@ public class SnapshotsServiceTests extends ESTestCase {
         final String indexName1 = "index-1";
         final ShardId shardId1 = new ShardId(index(indexName1), 0);
         {
-            final ClusterState state = stateWithSnapshots(snapshotNoShards);
+            final ClusterState state = stateWithSnapshots(repoName, snapshotNoShards);
             final SnapshotsService.ShardSnapshotUpdate shardCompletion = new SnapshotsService.ShardSnapshotUpdate(
                 snapshot,
                 shardId1,
@@ -64,6 +64,7 @@ public class SnapshotsServiceTests extends ESTestCase {
         {
             final IndexId indexId = indexId(indexName1);
             final ClusterState state = stateWithSnapshots(
+                repoName,
                 snapshotEntry(snapshot, Collections.singletonMap(indexId.getName(), indexId), shardsMap(shardId1, initShardStatus(uuid())))
             );
             final SnapshotsService.ShardSnapshotUpdate shardCompletion = new SnapshotsService.ShardSnapshotUpdate(
@@ -91,9 +92,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(snapshotSingleShard.state(), is(SnapshotsInProgress.State.STARTED));
 
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(sn1, shardId1, dataNodeId);
-        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(snapshotSingleShard), completeShard);
+        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(repoName, snapshotSingleShard), completeShard);
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(updatedSnapshot1.state(), is(SnapshotsInProgress.State.SUCCESS));
         assertIsNoop(updatedClusterState, completeShard);
     }
@@ -117,9 +118,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(snapshotSingleShard.state(), is(SnapshotsInProgress.State.STARTED));
 
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(sn1, shardId1, dataNodeId);
-        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(snapshotSingleShard), completeShard);
+        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(repoName, snapshotSingleShard), completeShard);
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(updatedSnapshot1.state(), is(SnapshotsInProgress.State.STARTED));
         assertIsNoop(updatedClusterState, completeShard);
     }
@@ -141,9 +142,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(cloneSingleShard.state(), is(SnapshotsInProgress.State.STARTED));
 
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(targetSnapshot, shardId1, dataNodeId);
-        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(cloneSingleShard), completeShard);
+        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(repoName, cloneSingleShard), completeShard);
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(updatedSnapshot1.state(), is(SnapshotsInProgress.State.SUCCESS));
         assertIsNoop(updatedClusterState, completeShard);
     }
@@ -167,9 +168,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(cloneMultipleShards.state(), is(SnapshotsInProgress.State.STARTED));
 
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(targetSnapshot, shardId1, dataNodeId);
-        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(cloneMultipleShards), completeShard);
+        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(repoName, cloneMultipleShards), completeShard);
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry updatedSnapshot1 = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(updatedSnapshot1.state(), is(SnapshotsInProgress.State.STARTED));
         assertIsNoop(updatedClusterState, completeShard);
     }
@@ -201,14 +202,19 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(cloneSingleShard.state(), is(SnapshotsInProgress.State.STARTED));
 
         // 1. case: shard that just finished cloning is unassigned -> shard snapshot should go to MISSING state
-        final ClusterState stateWithUnassignedRoutingShard = stateWithSnapshots(stateWithIndex, cloneSingleShard, snapshotSingleShard);
+        final ClusterState stateWithUnassignedRoutingShard = stateWithSnapshots(
+            stateWithIndex,
+            repoName,
+            cloneSingleShard,
+            snapshotSingleShard
+        );
         final SnapshotsService.ShardSnapshotUpdate completeShardClone = successUpdate(targetSnapshot, shardId1, uuid());
         {
             final ClusterState updatedClusterState = applyUpdates(stateWithUnassignedRoutingShard, completeShardClone);
             final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.entries().get(0);
+            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.forRepo(repoName).get(0);
             assertThat(completedClone.state(), is(SnapshotsInProgress.State.SUCCESS));
-            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
             assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.SUCCESS));
             assertThat(startedSnapshot.shards().get(routingShardId1).state(), is(SnapshotsInProgress.ShardState.MISSING));
             assertIsNoop(updatedClusterState, completeShardClone);
@@ -232,9 +238,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         {
             final ClusterState updatedClusterState = applyUpdates(stateWithAssignedRoutingShard, completeShardClone);
             final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.entries().get(0);
+            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.forRepo(repoName).get(0);
             assertThat(completedClone.state(), is(SnapshotsInProgress.State.SUCCESS));
-            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
             assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
             final SnapshotsInProgress.ShardSnapshotStatus shardSnapshotStatus = startedSnapshot.shards().get(routingShardId1);
             assertThat(shardSnapshotStatus.state(), is(SnapshotsInProgress.ShardState.INIT));
@@ -260,9 +266,9 @@ public class SnapshotsServiceTests extends ESTestCase {
         {
             final ClusterState updatedClusterState = applyUpdates(stateWithInitializingRoutingShard, completeShardClone);
             final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.entries().get(0);
+            final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.forRepo(repoName).get(0);
             assertThat(completedClone.state(), is(SnapshotsInProgress.State.SUCCESS));
-            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+            final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
             assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
             assertThat(startedSnapshot.shards().get(routingShardId1).state(), is(SnapshotsInProgress.ShardState.WAITING));
             assertIsNoop(updatedClusterState, completeShardClone);
@@ -296,11 +302,14 @@ public class SnapshotsServiceTests extends ESTestCase {
 
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(plainSnapshot, routingShardId, dataNodeId);
 
-        final ClusterState updatedClusterState = applyUpdates(stateWithSnapshots(snapshotSingleShard, cloneSingleShard), completeShard);
+        final ClusterState updatedClusterState = applyUpdates(
+            stateWithSnapshots(repoName, snapshotSingleShard, cloneSingleShard),
+            completeShard
+        );
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(completedClone.state(), is(SnapshotsInProgress.State.SUCCESS));
-        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
         assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
         final SnapshotsInProgress.ShardSnapshotStatus shardCloneStatus = startedSnapshot.shardsByRepoShardId().get(repositoryShardId);
         assertThat(shardCloneStatus.state(), is(SnapshotsInProgress.ShardState.INIT));
@@ -333,13 +342,13 @@ public class SnapshotsServiceTests extends ESTestCase {
         final SnapshotsService.ShardSnapshotUpdate completeShard = successUpdate(plainSnapshot, routingShardId, dataNodeId);
 
         final ClusterState updatedClusterState = applyUpdates(
-            stateWithSnapshots(snapshotSingleShard, queuedSnapshotSingleShard),
+            stateWithSnapshots(repoName, snapshotSingleShard, queuedSnapshotSingleShard),
             completeShard
         );
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry completedSnapshot = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry completedSnapshot = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(completedSnapshot.state(), is(SnapshotsInProgress.State.SUCCESS));
-        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
         assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
         final SnapshotsInProgress.ShardSnapshotStatus shardSnapshotStatus = startedSnapshot.shards().get(routingShardId);
         assertThat(shardSnapshotStatus.state(), is(SnapshotsInProgress.ShardState.INIT));
@@ -372,6 +381,7 @@ public class SnapshotsServiceTests extends ESTestCase {
 
         final ClusterState stateWithUnassignedRoutingShard = stateWithSnapshots(
             ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes(masterNodeId)).build(),
+            repoName,
             cloneSingleShard,
             queuedClone
         );
@@ -379,9 +389,9 @@ public class SnapshotsServiceTests extends ESTestCase {
 
         final ClusterState updatedClusterState = applyUpdates(stateWithUnassignedRoutingShard, completeShardClone);
         final SnapshotsInProgress snapshotsInProgress = updatedClusterState.custom(SnapshotsInProgress.TYPE);
-        final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.entries().get(0);
+        final SnapshotsInProgress.Entry completedClone = snapshotsInProgress.forRepo(repoName).get(0);
         assertThat(completedClone.state(), is(SnapshotsInProgress.State.SUCCESS));
-        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.entries().get(1);
+        final SnapshotsInProgress.Entry startedSnapshot = snapshotsInProgress.forRepo(repoName).get(1);
         assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
         assertThat(startedSnapshot.shardsByRepoShardId().get(shardId1).state(), is(SnapshotsInProgress.ShardState.INIT));
         assertIsNoop(updatedClusterState, completeShardClone);
@@ -392,6 +402,7 @@ public class SnapshotsServiceTests extends ESTestCase {
         final String indexName = "index";
         final ClusterState clusterState = stateWithSnapshots(
             stateWithUnassignedIndices(indexName),
+            repoName,
             cloneEntry(
                 snapshot(repoName, "target-snapshot"),
                 snapshot(repoName, "source-snapshot").getSnapshotId(),
@@ -451,15 +462,19 @@ public class SnapshotsServiceTests extends ESTestCase {
         return ClusterState.builder(ClusterState.EMPTY_STATE).metadata(metaBuilder).routingTable(routingTable.build()).build();
     }
 
-    private static ClusterState stateWithSnapshots(ClusterState state, SnapshotsInProgress.Entry... entries) {
+    private static ClusterState stateWithSnapshots(ClusterState state, String repository, SnapshotsInProgress.Entry... entries) {
         return ClusterState.builder(state)
             .version(state.version() + 1L)
-            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(Arrays.asList(entries)))
+            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY.withUpdatedEntriesForRepo(repository, Arrays.asList(entries)))
             .build();
     }
 
-    private static ClusterState stateWithSnapshots(SnapshotsInProgress.Entry... entries) {
-        return stateWithSnapshots(ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes(uuid())).build(), entries);
+    private static ClusterState stateWithSnapshots(String repository, SnapshotsInProgress.Entry... entries) {
+        return stateWithSnapshots(
+            ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes(uuid())).build(),
+            repository,
+            entries
+        );
     }
 
     private static void assertIsNoop(ClusterState state, SnapshotsService.ShardSnapshotUpdate shardCompletion) throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -519,7 +519,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         awaitClusterState(
                 logger,
                 viaNode,
-                state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().isEmpty()
+                state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).isEmpty()
                     && state.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY)
                         .hasDeletionsInProgress() == false
         );
@@ -564,14 +564,12 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     protected void awaitNumberOfSnapshotsInProgress(int count) throws Exception {
         logger.info("--> wait for [{}] snapshots to show up in the cluster state", count);
-        awaitClusterState(state ->
-                state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().size() == count);
+        awaitClusterState(state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).count() == count);
     }
 
     public static void awaitNumberOfSnapshotsInProgress(Logger logger, int count) throws Exception {
         logger.info("--> wait for [{}] snapshots to show up in the cluster state", count);
-        awaitClusterState(logger, state ->
-                state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().size() == count);
+        awaitClusterState(logger, state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).count() == count);
     }
 
     protected SnapshotInfo assertSuccessful(ActionFuture<CreateSnapshotResponse> future) throws Exception {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
@@ -22,6 +22,8 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.snapshots.SnapshotInProgressException;
 
+import java.util.List;
+
 /**
  * This is an abstract AsyncActionStep that wraps the performed action listener, checking to see
  * if the action fails due to a snapshot being in progress. If a snapshot is in progress, it
@@ -124,11 +126,13 @@ public abstract class AsyncRetryDuringSnapshotActionStep extends AsyncActionStep
                                     // The index has since been deleted, mission accomplished!
                                     return true;
                                 }
-                                for (SnapshotsInProgress.Entry snapshot :
-                                        state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries()) {
-                                    if (snapshot.indices().containsKey(indexName)) {
-                                        // There is a snapshot running with this index name
-                                        return false;
+                                for (List<SnapshotsInProgress.Entry> snapshots :
+                                        state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entriesByRepo()) {
+                                    for (SnapshotsInProgress.Entry snapshot : snapshots) {
+                                        if (snapshot.indices().containsKey(indexName)) {
+                                            // There is a snapshot running with this index name
+                                            return false;
+                                        }
                                     }
                                 }
                                 // There are no snapshots for this index, so it's okay to proceed with this state

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportActionTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportActionTests.java
@@ -94,9 +94,8 @@ public class DeleteDataStreamTransportActionTests extends ESTestCase {
             Arrays.asList(new Tuple<>(dataStreamName, 2), new Tuple<>(dataStreamName2, 2)),
             otherIndices
         );
-        SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.of(
-            Arrays.asList(createEntry(dataStreamName, "repo1", false), createEntry(dataStreamName2, "repo2", true))
-        );
+        SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.EMPTY.withAddedEntry(createEntry(dataStreamName, "repo1", false))
+            .withAddedEntry(createEntry(dataStreamName2, "repo2", true));
         ClusterState snapshotCs = ClusterState.builder(cs).putCustom(SnapshotsInProgress.TYPE, snapshotsInProgress).build();
 
         DeleteDataStreamAction.Request req = new DeleteDataStreamAction.Request(new String[] { dataStreamName });

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
@@ -67,16 +67,18 @@ public class TransportGetSnapshotLifecycleAction extends
                 inProgress = Collections.emptyMap();
             } else {
                 inProgress = new HashMap<>();
-                for (SnapshotsInProgress.Entry entry : sip.entries()) {
-                    Map<String, Object> meta = entry.userMetadata();
-                    if (meta == null ||
-                        meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) == null ||
-                        (meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) instanceof String == false)) {
-                        continue;
-                    }
+                for (List<SnapshotsInProgress.Entry> entriesForRepo : sip.entriesByRepo()) {
+                    for (SnapshotsInProgress.Entry entry : entriesForRepo) {
+                        Map<String, Object> meta = entry.userMetadata();
+                        if (meta == null ||
+                                meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) == null ||
+                                (meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD) instanceof String == false)) {
+                            continue;
+                        }
 
-                    String policyId = (String) meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD);
-                    inProgress.put(policyId, SnapshotLifecyclePolicyItem.SnapshotInProgress.fromEntry(entry));
+                        String policyId = (String) meta.get(SnapshotsService.POLICY_ID_METADATA_FIELD);
+                        inProgress.put(policyId, SnapshotLifecyclePolicyItem.SnapshotInProgress.fromEntry(entry));
+                    }
                 }
             }
 

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -773,9 +773,9 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
                     return snapshotInfos.get(0);
                 } else {
                     boolean found = false;
-                    for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+                    for (SnapshotsInProgress.Entry entry : snapshotsInProgress.forRepo(repository)) {
                         final Snapshot curr = entry.snapshot();
-                        if (curr.getRepository().equals(repository) && curr.getSnapshotId().getName().equals(snapshotName)) {
+                        if (curr.getSnapshotId().getName().equals(snapshotName)) {
                             found = true;
                             break;
                         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -236,7 +235,7 @@ public class ClusterPrivilegeIntegrationTests extends AbstractPrivilegeTestCase 
             // it to disappear from the cluster state as well
             SnapshotsInProgress snapshotsInProgress =
                 client().admin().cluster().state(new ClusterStateRequest()).get().getState().custom(SnapshotsInProgress.TYPE);
-            assertThat(snapshotsInProgress.entries(), Matchers.empty());
+            assertTrue(snapshotsInProgress.isEmpty());
         });
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -168,7 +167,7 @@ public class SecurityFeatureStateIntegTests extends AbstractPrivilegeTestCase {
             // it to disappear from the cluster state as well
             SnapshotsInProgress snapshotsInProgress =
                 client().admin().cluster().state(new ClusterStateRequest()).get().getState().custom(SnapshotsInProgress.TYPE);
-            assertThat(snapshotsInProgress.entries(), Matchers.empty());
+            assertTrue(snapshotsInProgress.isEmpty());
         });
     }
 }


### PR DESCRIPTION
First step in making `SnapshotsInProgress` easier to work with
by tracking snapshots per repository. This allows simplifying the
concurrency logic in a couple of places and sets up a follow-up
that would invert the current list of maps for snapshots that is
very hard to reason about in the concurrency logic into a map
of lists that maps repo-shard to snapshots to make the logic
more obviously correct.

backport of #77984