### PR TITLE
Better logging and internal user handling for operator privileges

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -68,10 +68,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         );
         assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(403));
         assertThat(responseException.getMessage(), containsString("Operator privileges are required for action"));
-        assertThat(
-            responseException.getMessage(),
-            containsString("because it requires operator privileges")
-        );
+        assertThat(responseException.getMessage(), containsString("because it requires operator privileges"));
     }
 
     public void testOperatorUserWillSucceedToCallOperatorOnlyApi() throws IOException {

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -68,6 +68,8 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         );
         assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(403));
         assertThat(responseException.getMessage(), containsString("Operator privileges are required for action"));
+        assertThat(responseException.getMessage(),
+            containsString("granted by the cluster privileges [manage,all] and operator privileges"));
     }
 
     public void testOperatorUserWillSucceedToCallOperatorOnlyApi() throws IOException {

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -70,7 +70,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         assertThat(responseException.getMessage(), containsString("Operator privileges are required for action"));
         assertThat(
             responseException.getMessage(),
-            containsString("granted by the cluster privileges [manage,all] and operator privileges")
+            containsString("because it requires operator privileges")
         );
     }
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -68,8 +68,10 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         );
         assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(403));
         assertThat(responseException.getMessage(), containsString("Operator privileges are required for action"));
-        assertThat(responseException.getMessage(),
-            containsString("granted by the cluster privileges [manage,all] and operator privileges"));
+        assertThat(
+            responseException.getMessage(),
+            containsString("granted by the cluster privileges [manage,all] and operator privileges")
+        );
     }
 
     public void testOperatorUserWillSucceedToCallOperatorOnlyApi() throws IOException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -285,9 +285,10 @@ public class AuthorizationService {
         throws ElasticsearchSecurityException {
         // Check operator privileges
         // TODO: audit?
-        final ElasticsearchSecurityException operatorException = operatorPrivilegesService.check(action, originalRequest, threadContext);
+        final ElasticsearchSecurityException operatorException =
+            operatorPrivilegesService.check(authentication, action, originalRequest, threadContext);
         if (operatorException != null) {
-            throw denialException(authentication, action, originalRequest, operatorException);
+            throw denialException(authentication, action, originalRequest, "and operator privileges", operatorException);
         }
         operatorPrivilegesService.maybeInterceptRequest(threadContext, originalRequest);
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
-import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 
 import java.io.IOException;
@@ -65,13 +64,6 @@ public class FileOperatorUsersStore {
     }
 
     public boolean isOperatorUser(Authentication authentication) {
-        if (authentication.getUser().isRunAs()) {
-            return false;
-        } else if (User.isInternal(authentication.getUser())) {
-            // Internal user are considered operator users
-            return true;
-        }
-
         // Other than realm name, other criteria must always be an exact match for the user to be an operator.
         // Realm name of a descriptor can be null. When it is null, it is ignored for comparison.
         // If not null, it will be compared exactly as well.
@@ -217,7 +209,13 @@ public class FileOperatorUsersStore {
         } else {
             logger.debug("Reading operator users file [{}]", file.toAbsolutePath());
             try (InputStream in = Files.newInputStream(file, StandardOpenOption.READ)) {
-                return parseConfig(in);
+                final OperatorUsersDescriptor operatorUsersDescriptor = parseConfig(in);
+                logger.info("parsed [{}] group(s) with a total of [{}] operator user(s) from file [{}]",
+                    operatorUsersDescriptor.groups.size(),
+                    operatorUsersDescriptor.groups.stream().mapToLong(g -> g.usernames.size()).sum(),
+                    file.toAbsolutePath());
+                logger.trace("operator user descriptor: [{}]", operatorUsersDescriptor);
+                return operatorUsersDescriptor;
             } catch (IOException | RuntimeException e) {
                 logger.error(new ParameterizedMessage("Failed to parse operator users file [{}].", file), e);
                 throw new ElasticsearchParseException("Error parsing operator users file [{}]", e, file.toAbsolutePath());
@@ -225,11 +223,10 @@ public class FileOperatorUsersStore {
         }
     }
 
-    public static OperatorUsersDescriptor parseConfig(InputStream in) throws IOException {
+    // package method for testing
+    static OperatorUsersDescriptor parseConfig(InputStream in) throws IOException {
         try (XContentParser parser = yamlParser(in)) {
-            final OperatorUsersDescriptor operatorUsersDescriptor = OPERATOR_USER_PARSER.parse(parser, null);
-            logger.trace("Parsed: [{}]", operatorUsersDescriptor);
-            return operatorUsersDescriptor;
+            return OPERATOR_USER_PARSER.parse(parser, null);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
@@ -69,19 +69,16 @@ public class FileOperatorUsersStore {
         // If not null, it will be compared exactly as well.
         // The special handling for realm name is because there can only be one file or native realm and it does
         // not matter what the name is.
-        final boolean userIsOperator = operatorUsersDescriptor.groups.stream().anyMatch(group -> {
+        return operatorUsersDescriptor.groups.stream().anyMatch(group -> {
             final Authentication.RealmRef realm = authentication.getSourceRealm();
             final boolean match = group.usernames.contains(authentication.getUser().principal())
                 && group.authenticationType == authentication.getAuthenticationType()
                 && realm.getType().equals(group.realmType)
                 && (group.realmName == null || group.realmName.equals(realm.getName()));
-            logger.trace("Matching user [{}] against operator rule [{}] is [{}]", authentication, group, match);
-            return match; 
+            logger.trace("Matching user [{}] against operator rule [{}] is [{}]",
+                authentication.getUser(), group, match);
+            return match;
         });
-        if (false == userIsOperator) {
-            logger.trace("User [{}] is not an operator", authentication.getUser());
-        }
-        return userIsOperator;
     }
 
     // Package private for tests

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
@@ -69,13 +69,17 @@ public class FileOperatorUsersStore {
         // If not null, it will be compared exactly as well.
         // The special handling for realm name is because there can only be one file or native realm and it does
         // not matter what the name is.
-        return operatorUsersDescriptor.groups.stream().anyMatch(group -> {
+        final boolean userIsOperator = operatorUsersDescriptor.groups.stream().anyMatch(group -> {
             final Authentication.RealmRef realm = authentication.getSourceRealm();
             return group.usernames.contains(authentication.getUser().principal())
                 && group.authenticationType == authentication.getAuthenticationType()
                 && realm.getType().equals(group.realmType)
                 && (group.realmName == null || group.realmName.equals(realm.getName()));
         });
+        if (false == userIsOperator) {
+            logger.trace("User [{}] is not an operator", authentication.getUser());
+        }
+        return userIsOperator;
     }
 
     // Package private for tests
@@ -214,7 +218,7 @@ public class FileOperatorUsersStore {
                     operatorUsersDescriptor.groups.size(),
                     operatorUsersDescriptor.groups.stream().mapToLong(g -> g.usernames.size()).sum(),
                     file.toAbsolutePath());
-                logger.trace("operator user descriptor: [{}]", operatorUsersDescriptor);
+                logger.debug("operator user descriptor: [{}]", operatorUsersDescriptor);
                 return operatorUsersDescriptor;
             } catch (IOException | RuntimeException e) {
                 logger.error(new ParameterizedMessage("Failed to parse operator users file [{}].", file), e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
@@ -71,10 +71,12 @@ public class FileOperatorUsersStore {
         // not matter what the name is.
         final boolean userIsOperator = operatorUsersDescriptor.groups.stream().anyMatch(group -> {
             final Authentication.RealmRef realm = authentication.getSourceRealm();
-            return group.usernames.contains(authentication.getUser().principal())
+            final boolean match = group.usernames.contains(authentication.getUser().principal())
                 && group.authenticationType == authentication.getAuthenticationType()
                 && realm.getType().equals(group.realmType)
                 && (group.realmName == null || group.realmName.equals(realm.getName()));
+            logger.trace("Matching user [{}] against operator rule [{}] is [{}]", authentication, group, match);
+            return match; 
         });
         if (false == userIsOperator) {
             logger.trace("User [{}] is not an operator", authentication.getUser());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
@@ -72,11 +72,8 @@ public class OperatorPrivileges {
             if (User.isInternal(authentication.getUser())) {
                 return;
             }
-            // Do not support run_as operator user, checking will fail later if this action requires operator privilege
-            if (authentication.getUser().isRunAs()) {
-                return;
-            }
-            if (fileOperatorUsersStore.isOperatorUser(authentication)) {
+            // An operator user must not be a run_as user, it also must be recognised by the operatorUserStore
+            if (authentication.getUser().isRunAs() && fileOperatorUsersStore.isOperatorUser(authentication)) {
                 logger.debug("Marking user [{}] as an operator", authentication.getUser());
                 threadContext.putHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY, AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
@@ -17,6 +17,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+import org.elasticsearch.xpack.core.security.user.User;
 
 public class OperatorPrivileges {
 
@@ -36,10 +37,14 @@ public class OperatorPrivileges {
          * Check whether the user is an operator and whether the request is an operator-only.
          * @return An exception if user is an non-operator and the request is operator-only. Otherwise returns null.
          */
-        ElasticsearchSecurityException check(String action, TransportRequest request, ThreadContext threadContext);
+        ElasticsearchSecurityException check(
+            Authentication authentication, String action, TransportRequest request, ThreadContext threadContext);
 
         /**
-         * Check the threadContext to see whether the current authenticating user is an operator user
+         * When operator privileges are enabled, certain requests needs to be configured in a specific way
+         * so that they respect operator only settings. For an example, the restore snapshot request
+         * should not restore operator only states from the snapshot.
+         * This method is where that requests are configured when necessary.
          */
         void maybeInterceptRequest(ThreadContext threadContext, TransportRequest request);
     }
@@ -63,20 +68,35 @@ public class OperatorPrivileges {
             if (false == shouldProcess()) {
                 return;
             }
+            // Let internal users pass, they are exempt from marking and checking
+            if (User.isInternal(authentication.getUser())) {
+                return;
+            }
+            // Do not support run_as operator user, checking will fail later if this action requires operator privilege
+            if (authentication.getUser().isRunAs()) {
+                return;
+            }
             if (fileOperatorUsersStore.isOperatorUser(authentication)) {
-                logger.trace("User [{}] is an operator", authentication.getUser().principal());
+                logger.debug("Marking user [{}] as an operator", authentication.getUser());
                 threadContext.putHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY, AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR);
             }
         }
 
-        public ElasticsearchSecurityException check(String action, TransportRequest request, ThreadContext threadContext) {
+        public ElasticsearchSecurityException check(
+            Authentication authentication, String action, TransportRequest request, ThreadContext threadContext
+        ) {
             if (false == shouldProcess()) {
+                return null;
+            }
+            final User user = authentication.getUser();
+            // Let internal users pass (also check run_as, it is impossible to run_as internal users, but just to be extra safe)
+            if (User.isInternal(user) && false == user.isRunAs()) {
                 return null;
             }
             if (false == AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR.equals(
                 threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY))) {
                 // Only check whether request is operator-only when user is NOT an operator
-                logger.trace("Checking operator-only violation for: action [{}]", action);
+                logger.trace("Checking operator-only violation for user [{}] and action [{}]", user, action);
                 final OperatorOnlyRegistry.OperatorPrivilegesViolation violation = operatorOnlyRegistry.check(action, request);
                 if (violation != null) {
                     return new ElasticsearchSecurityException("Operator privileges are required for " + violation.message());
@@ -87,6 +107,7 @@ public class OperatorPrivileges {
 
         public void maybeInterceptRequest(ThreadContext threadContext, TransportRequest request) {
             if (request instanceof RestoreSnapshotRequest) {
+                logger.debug("Intercepting [{}] for operator privileges", request);
                 ((RestoreSnapshotRequest) request).skipOperatorOnlyState(shouldProcess());
             }
         }
@@ -102,7 +123,9 @@ public class OperatorPrivileges {
         }
 
         @Override
-        public ElasticsearchSecurityException check(String action, TransportRequest request, ThreadContext threadContext) {
+        public ElasticsearchSecurityException check(
+            Authentication authentication, String action, TransportRequest request, ThreadContext threadContext
+        ) {
             return null;
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
@@ -73,7 +73,7 @@ public class OperatorPrivileges {
                 return;
             }
             // An operator user must not be a run_as user, it also must be recognised by the operatorUserStore
-            if (authentication.getUser().isRunAs() && fileOperatorUsersStore.isOperatorUser(authentication)) {
+            if (false == authentication.getUser().isRunAs() && fileOperatorUsersStore.isOperatorUser(authentication)) {
                 logger.debug("Marking user [{}] as an operator", authentication.getUser());
                 threadContext.putHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY, AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -364,7 +364,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         final ElasticsearchSecurityException operatorPrivilegesException =
             new ElasticsearchSecurityException("Operator privileges check failed");
         if (shouldFailOperatorPrivilegesCheck) {
-            when(operatorPrivilegesService.check(action, request, threadContext)).thenAnswer(invocationOnMock -> {
+            when(operatorPrivilegesService.check(authentication, action, request, threadContext)).thenAnswer(invocationOnMock -> {
                 operatorPrivilegesChecked.set(true);
                 return operatorPrivilegesException;
             });
@@ -376,7 +376,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             authorizationInfo.onResponse(threadContext.getTransient(AUTHORIZATION_INFO_KEY));
             indicesPermissions.onResponse(threadContext.getTransient(INDICES_PERMISSIONS_KEY));
 
-            assertNull(verify(operatorPrivilegesService).check(action, request, threadContext));
+            assertNull(verify(operatorPrivilegesService).check(authentication, action, request, threadContext));
 
             if (listenerBody != null) {
                 listenerBody.run();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -24,11 +24,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.audit.logfile.CapturingLogger;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
-import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
-import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
-import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
-import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.junit.After;
 import org.junit.Before;
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -97,18 +97,6 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         // user operator_1 with non realm auth type is not an operator
         assertFalse(fileOperatorUsersStore.isOperatorUser(
             new Authentication(operator_1, fileRealm, fileRealm, Version.CURRENT, Authentication.AuthenticationType.TOKEN, Map.of())));
-
-        // Run as user operator_1 is not an operator
-        final User runAsOperator_1 = new User(operator_1, new User(randomAlphaOfLengthBetween(5, 8), randomRoles()));
-        assertFalse(fileOperatorUsersStore.isOperatorUser(new Authentication(runAsOperator_1, fileRealm, fileRealm)));
-
-        // Internal users are operator
-        final Authentication.RealmRef realm =
-            new Authentication.RealmRef(randomAlphaOfLength(8), randomAlphaOfLength(8), randomAlphaOfLength(8));
-        final Authentication authentication = new Authentication(
-            randomFrom(SystemUser.INSTANCE, XPackUser.INSTANCE, XPackSecurityUser.INSTANCE, AsyncSearchUser.INSTANCE),
-            realm, realm);
-        assertTrue(fileOperatorUsersStore.isOperatorUser(authentication));
     }
 
     public void testFileAutoReload() throws Exception {
@@ -119,19 +107,19 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(FileOperatorUsersStore.class);
         final MockLogAppender appender = new MockLogAppender();
         appender.start();
-        appender.addExpectation(
-            new MockLogAppender.ExceptionSeenEventExpectation(
-                getTestName(),
-                logger.getName(),
-                Level.ERROR,
-                "Failed to parse operator users file",
-                XContentParseException.class,
-                "[10:1] [operator_privileges.operator] failed to parse field [operator]"
-            )
-        );
         Loggers.addAppender(logger, appender);
+        Loggers.setLevel(logger, Level.TRACE);
 
         try (ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)) {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "1st file parsing",
+                    logger.getName(),
+                    Level.INFO,
+                    "parsed [2] group(s) with a total of [3] operator user(s) from file [" + inUseFile.toAbsolutePath() + "]"
+                )
+            );
+
             final FileOperatorUsersStore fileOperatorUsersStore = new FileOperatorUsersStore(env, watcherService);
             final List<FileOperatorUsersStore.Group> groups = fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups();
 
@@ -139,6 +127,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             assertEquals(new FileOperatorUsersStore.Group(Set.of("operator_1", "operator_2"),
                 "file"), groups.get(0));
             assertEquals(new FileOperatorUsersStore.Group(Set.of("operator_3"), null), groups.get(1));
+            appender.assertAllExpectationsMatched();
 
             // Content does not change, the groups should not be updated
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
@@ -146,8 +135,17 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             }
             watcherService.notifyNow(ResourceWatcherService.Frequency.HIGH);
             assertSame(groups, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups());
+            appender.assertAllExpectationsMatched();
 
             // Add one more entry
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "updating",
+                    logger.getName(),
+                    Level.INFO,
+                    "operator users file [" + inUseFile.toAbsolutePath() + "] changed. updating operator users"
+                )
+            );
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 writer.append("  - usernames: [ 'operator_4' ]\n");
             }
@@ -156,8 +154,19 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
                 assertEquals(3, newGroups.size());
                 assertEquals(new FileOperatorUsersStore.Group(Set.of("operator_4")), newGroups.get(2));
             });
+            appender.assertAllExpectationsMatched();
 
             // Add mal-formatted entry
+            appender.addExpectation(
+                new MockLogAppender.ExceptionSeenEventExpectation(
+                    "mal-formatted",
+                    logger.getName(),
+                    Level.ERROR,
+                    "Failed to parse operator users file",
+                    XContentParseException.class,
+                    "[10:1] [operator_privileges.operator] failed to parse field [operator]"
+                )
+            );
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 writer.append("  - blah\n");
             }
@@ -166,8 +175,18 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             // Delete the file will remove all the operator users
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "file not exist warning",
+                    logger.getName(),
+                    Level.WARN,
+                    "Operator privileges [xpack.security.operator_privileges.enabled] is enabled, " +
+                        "but operator user file does not exist. No user will be able to perform operator-only actions."
+                )
+            );
             Files.delete(inUseFile);
             assertBusy(() -> assertEquals(0, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups().size()));
+            appender.assertAllExpectationsMatched();
 
             // Back to original content
             Files.copy(sampleFile, inUseFile, StandardCopyOption.REPLACE_EXISTING);
@@ -175,6 +194,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         } finally {
             Loggers.removeAppender(logger, appender);
             appender.stop();
+            Loggers.setLevel(logger, (Level) null);
         }
     }
 


### PR DESCRIPTION
This PR improves logging situation for operator privilegs. The loggings
are now more informational and also do not rely on the tracing level.
Internal user handling is also improved by skipping them more
consistently when marking and checking for operator users.

The existing code performs unnecessary checks for internal actions such
as leader/follower checks. It is technically a bug because threadContext
is prepared differently for internal actions and does not have the
operatorUser marking. However, the bug currently does not manifest
itself since internal actions are not protected by operator privileges.
