### PR TITLE
Better logging and internal user handling for operator privileges (#79331)

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -68,6 +68,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         );
         assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(403));
         assertThat(responseException.getMessage(), containsString("Operator privileges are required for action"));
+        assertThat(responseException.getMessage(), containsString("because it requires operator privileges"));
     }
 
     public void testOperatorUserWillSucceedToCallOperatorOnlyApi() throws IOException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -216,9 +216,10 @@ public class AuthorizationService {
             // Check operator privileges
             // TODO: audit?
             final ElasticsearchSecurityException operatorException =
-                operatorPrivilegesService.check(action, originalRequest, threadContext);
+                operatorPrivilegesService.check(authentication, action, originalRequest, threadContext);
             if (operatorException != null) {
-                listener.onFailure(denialException(authentication, action, originalRequest, operatorException));
+                listener.onFailure(denialException(
+                    authentication, action, originalRequest, "because it requires operator privileges", operatorException));
                 return;
             }
             operatorPrivilegesService.maybeInterceptRequest(threadContext, originalRequest);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStore.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
-import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 
 import java.io.IOException;
@@ -65,13 +64,6 @@ public class FileOperatorUsersStore {
     }
 
     public boolean isOperatorUser(Authentication authentication) {
-        if (authentication.getUser().isRunAs()) {
-            return false;
-        } else if (User.isInternal(authentication.getUser())) {
-            // Internal user are considered operator users
-            return true;
-        }
-
         // Other than realm name, other criteria must always be an exact match for the user to be an operator.
         // Realm name of a descriptor can be null. When it is null, it is ignored for comparison.
         // If not null, it will be compared exactly as well.
@@ -79,10 +71,13 @@ public class FileOperatorUsersStore {
         // not matter what the name is.
         return operatorUsersDescriptor.groups.stream().anyMatch(group -> {
             final Authentication.RealmRef realm = authentication.getSourceRealm();
-            return group.usernames.contains(authentication.getUser().principal())
+            final boolean match = group.usernames.contains(authentication.getUser().principal())
                 && group.authenticationType == authentication.getAuthenticationType()
                 && realm.getType().equals(group.realmType)
                 && (group.realmName == null || group.realmName.equals(realm.getName()));
+            logger.trace("Matching user [{}] against operator rule [{}] is [{}]",
+                authentication.getUser(), group, match);
+            return match;
         });
     }
 
@@ -218,7 +213,13 @@ public class FileOperatorUsersStore {
         } else {
             logger.debug("Reading operator users file [{}]", file.toAbsolutePath());
             try (InputStream in = Files.newInputStream(file, StandardOpenOption.READ)) {
-                return parseConfig(in);
+                final OperatorUsersDescriptor operatorUsersDescriptor = parseConfig(in);
+                logger.info("parsed [{}] group(s) with a total of [{}] operator user(s) from file [{}]",
+                    operatorUsersDescriptor.groups.size(),
+                    operatorUsersDescriptor.groups.stream().mapToLong(g -> g.usernames.size()).sum(),
+                    file.toAbsolutePath());
+                logger.debug("operator user descriptor: [{}]", operatorUsersDescriptor);
+                return operatorUsersDescriptor;
             } catch (IOException | RuntimeException e) {
                 logger.error(new ParameterizedMessage("Failed to parse operator users file [{}].", file), e);
                 throw new ElasticsearchParseException("Error parsing operator users file [{}]", e, file.toAbsolutePath());
@@ -226,11 +227,10 @@ public class FileOperatorUsersStore {
         }
     }
 
-    public static OperatorUsersDescriptor parseConfig(InputStream in) throws IOException {
+    // package method for testing
+    static OperatorUsersDescriptor parseConfig(InputStream in) throws IOException {
         try (XContentParser parser = yamlParser(in)) {
-            final OperatorUsersDescriptor operatorUsersDescriptor = OPERATOR_USER_PARSER.parse(parser, null);
-            logger.trace("Parsed: [{}]", operatorUsersDescriptor);
-            return operatorUsersDescriptor;
+            return OPERATOR_USER_PARSER.parse(parser, null);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -323,7 +323,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         final ElasticsearchSecurityException operatorPrivilegesException =
             new ElasticsearchSecurityException("Operator privileges check failed");
         if (shouldFailOperatorPrivilegesCheck) {
-            when(operatorPrivilegesService.check(action, request, threadContext)).thenAnswer(invocationOnMock -> {
+            when(operatorPrivilegesService.check(authentication, action, request, threadContext)).thenAnswer(invocationOnMock -> {
                 operatorPrivilegesChecked.set(true);
                 return operatorPrivilegesException;
             });
@@ -335,7 +335,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             authorizationInfo.onResponse(threadContext.getTransient(AUTHORIZATION_INFO_KEY));
             indicesPermissions.onResponse(threadContext.getTransient(INDICES_PERMISSIONS_KEY));
             done.onResponse(threadContext.getTransient(someRandomHeader));
-            assertNull(verify(operatorPrivilegesService).check(action, request, threadContext));
+            assertNull(verify(operatorPrivilegesService).check(authentication, action, request, threadContext));
         }, e -> {
             if (shouldFailOperatorPrivilegesCheck && operatorPrivilegesChecked.get()) {
                 assertSame(operatorPrivilegesException, e.getCause());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -26,11 +26,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.audit.logfile.CapturingLogger;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
-import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
-import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
-import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
-import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.junit.After;
 import org.junit.Before;
 
@@ -98,18 +94,6 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         assertFalse(fileOperatorUsersStore.isOperatorUser(
             new Authentication(operator_1, fileRealm, fileRealm, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
                 Map.of())));
-
-        // Run as user operator_1 is not an operator
-        final User runAsOperator_1 = new User(operator_1, new User(randomAlphaOfLengthBetween(5, 8), randomRoles()));
-        assertFalse(fileOperatorUsersStore.isOperatorUser(new Authentication(runAsOperator_1, fileRealm, fileRealm)));
-
-        // Internal users are operator
-        final Authentication.RealmRef realm =
-            new Authentication.RealmRef(randomAlphaOfLength(8), randomAlphaOfLength(8), randomAlphaOfLength(8));
-        final Authentication authentication = new Authentication(
-            randomFrom(SystemUser.INSTANCE, XPackUser.INSTANCE, XPackSecurityUser.INSTANCE, AsyncSearchUser.INSTANCE),
-            realm, realm);
-        assertTrue(fileOperatorUsersStore.isOperatorUser(authentication));
     }
 
     public void testFileAutoReload() throws Exception {
@@ -120,19 +104,19 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(FileOperatorUsersStore.class);
         final MockLogAppender appender = new MockLogAppender();
         appender.start();
-        appender.addExpectation(
-            new MockLogAppender.ExceptionSeenEventExpectation(
-                getTestName(),
-                logger.getName(),
-                Level.ERROR,
-                "Failed to parse operator users file",
-                XContentParseException.class,
-                "[10:1] [operator_privileges.operator] failed to parse field [operator]"
-            )
-        );
         Loggers.addAppender(logger, appender);
+        Loggers.setLevel(logger, Level.TRACE);
 
         try (ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)) {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "1st file parsing",
+                    logger.getName(),
+                    Level.INFO,
+                    "parsed [2] group(s) with a total of [3] operator user(s) from file [" + inUseFile.toAbsolutePath() + "]"
+                )
+            );
+
             final FileOperatorUsersStore fileOperatorUsersStore = new FileOperatorUsersStore(env, watcherService);
             final List<FileOperatorUsersStore.Group> groups = fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups();
 
@@ -142,6 +126,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
                 "file"), groups.get(0));
             assertEquals(new FileOperatorUsersStore.Group(
                 Set.of("operator_3"), null), groups.get(1));
+            appender.assertAllExpectationsMatched();
 
             // Content does not change, the groups should not be updated
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
@@ -149,8 +134,17 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             }
             watcherService.notifyNow(ResourceWatcherService.Frequency.HIGH);
             assertSame(groups, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups());
+            appender.assertAllExpectationsMatched();
 
             // Add one more entry
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "updating",
+                    logger.getName(),
+                    Level.INFO,
+                    "operator users file [" + inUseFile.toAbsolutePath() + "] changed. updating operator users"
+                )
+            );
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 writer.append("  - usernames: [ 'operator_4' ]\n");
             }
@@ -160,8 +154,19 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
                 assertEquals(new FileOperatorUsersStore.Group(
                     Set.of("operator_4")), newGroups.get(2));
             });
+            appender.assertAllExpectationsMatched();
 
             // Add mal-formatted entry
+            appender.addExpectation(
+                new MockLogAppender.ExceptionSeenEventExpectation(
+                    "mal-formatted",
+                    logger.getName(),
+                    Level.ERROR,
+                    "Failed to parse operator users file",
+                    XContentParseException.class,
+                    "[10:1] [operator_privileges.operator] failed to parse field [operator]"
+                )
+            );
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 writer.append("  - blah\n");
             }
@@ -170,8 +175,18 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             // Delete the file will remove all the operator users
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "file not exist warning",
+                    logger.getName(),
+                    Level.WARN,
+                    "Operator privileges [xpack.security.operator_privileges.enabled] is enabled, " +
+                        "but operator user file does not exist. No user will be able to perform operator-only actions."
+                )
+            );
             Files.delete(inUseFile);
             assertBusy(() -> assertEquals(0, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups().size()));
+            appender.assertAllExpectationsMatched();
 
             // Back to original content
             Files.copy(sampleFile, inUseFile, StandardCopyOption.REPLACE_EXISTING);
@@ -179,6 +194,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         } finally {
             Loggers.removeAppender(logger, appender);
             appender.stop();
+            Loggers.setLevel(logger, (Level) null);
         }
     }
 


### PR DESCRIPTION
This PR improves logging situation for operator privilegs. The loggings
are now more informational and also do not rely on the tracing level.
Internal user handling is also improved by skipping them more
consistently when marking and checking for operator users.

The existing code performs unnecessary checks for internal actions such
as leader/follower checks. It is technically a bug because threadContext
is prepared differently for internal actions and does not have the
operatorUser marking. However, the bug currently does not manifest
itself since internal actions are not protected by operator privileges.