### PR TITLE
AllowAll for indicesAccessControl (#78498)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
  */
 public class IndicesAccessControl {
 
-    public static final IndicesAccessControl ALLOW_ALL = new IndicesAccessControl(true, Collections.emptyMap());
     public static final IndicesAccessControl ALLOW_NO_INDICES = new IndicesAccessControl(true,
             Collections.singletonMap(IndicesAndAliasesResolverField.NO_INDEX_PLACEHOLDER,
                     new IndicesAccessControl.IndexAccessControl(true, new FieldPermissions(), DocumentPermissions.allowAll())));
@@ -249,6 +248,12 @@ public class IndicesAccessControl {
      * @return {@link IndicesAccessControl}
      */
     public IndicesAccessControl limitIndicesAccessControl(IndicesAccessControl limitedByIndicesAccessControl) {
+        if (this instanceof AllowAllIndicesAccessControl) {
+            return limitedByIndicesAccessControl;
+        } else if (limitedByIndicesAccessControl instanceof AllowAllIndicesAccessControl) {
+            return this;
+        }
+
         final boolean granted;
         if (this.granted == limitedByIndicesAccessControl.granted) {
             granted = this.granted;
@@ -275,4 +280,35 @@ public class IndicesAccessControl {
                 ", indexPermissions=" + indexPermissions +
                 '}';
     }
+
+    public static IndicesAccessControl allowAll() {
+        return AllowAllIndicesAccessControl.INSTANCE;
+    }
+
+    private static class AllowAllIndicesAccessControl extends IndicesAccessControl {
+
+        private static final IndicesAccessControl INSTANCE = new AllowAllIndicesAccessControl();
+
+        private final IndexAccessControl allowAllIndexAccessControl = new IndexAccessControl(true, null, null);
+
+        private AllowAllIndicesAccessControl() {
+            super(true, null);
+        }
+
+        @Override
+        public IndexAccessControl getIndexPermissions(String index) {
+            return allowAllIndexAccessControl;
+        }
+
+        @Override
+        public boolean isGranted() {
+            return true;
+        }
+
+        @Override
+        public Collection<?> getDeniedIndices() {
+            return org.elasticsearch.core.Set.of();
+        }
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -274,12 +274,16 @@ public final class IndicesPermission {
     /**
      * Authorizes the provided action against the provided indices, given the current cluster metadata
      */
-    public Map<String, IndicesAccessControl.IndexAccessControl> authorize(
+    public IndicesAccessControl authorize(
         String action,
         Set<String> requestedIndicesOrAliases,
         Map<String, IndexAbstraction> lookup,
         FieldPermissionsCache fieldPermissionsCache
     ) {
+        // Short circuit if the indicesPermission allows all access to every index
+        if (Arrays.stream(groups).anyMatch(Group::isTotal)) {
+            return IndicesAccessControl.allowAll();
+        }
 
         final List<IndexResource> resources = new ArrayList<>(requestedIndicesOrAliases.size());
         int totalResourceCount = 0;
@@ -405,6 +409,7 @@ public final class IndicesPermission {
             }
         }
 
+        boolean overallGranted = true;
         Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions = new HashMap<>(grantedBuilder.size());
         for (Map.Entry<String, Boolean> entry : grantedBuilder.entrySet()) {
             String index = entry.getKey();
@@ -424,10 +429,13 @@ public final class IndicesPermission {
             } else {
                 fieldPermissions = FieldPermissions.DEFAULT;
             }
+            if (entry.getValue() == false) {
+                overallGranted = false;
+            }
             indexPermissions.put(index, new IndicesAccessControl.IndexAccessControl(entry.getValue(), fieldPermissions,
                     (roleQueries != null) ? DocumentPermissions.filteredBy(roleQueries) : DocumentPermissions.allowAll()));
         }
-        return unmodifiableMap(indexPermissions);
+        return new IndicesAccessControl(overallGranted, unmodifiableMap(indexPermissions));
     }
 
     private boolean isConcreteRestrictedIndex(String indexPattern) {
@@ -449,7 +457,7 @@ public final class IndicesPermission {
         private final IndexPrivilege privilege;
         private final Predicate<String> actionMatcher;
         private final String[] indices;
-        private final Predicate<String> indexNameMatcher;
+        private final StringMatcher indexNameMatcher;
         private final FieldPermissions fieldPermissions;
         private final Set<BytesReference> query;
         // by default certain restricted indices are exempted when granting privileges, as they should generally be hidden for ordinary
@@ -544,6 +552,14 @@ public final class IndicesPermission {
                                 (indexAbstraction.getParentDataStream() == null) &&
                                 bwcSpecialCaseMatcher.test(indexAbstraction.getName()));
             };
+        }
+
+        boolean isTotal() {
+            return allowRestrictedIndices
+                && indexNameMatcher.isTotal()
+                && privilege == IndexPrivilege.ALL
+                && query == null
+                && false == fieldPermissions.hasFieldLevelSecurity();
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -89,7 +89,6 @@ public final class LimitedRole extends Role {
             super.authorize(action, requestedIndicesOrAliases, aliasAndIndexLookup, fieldPermissionsCache);
         IndicesAccessControl limitedByIndicesAccessControl = limitedBy.authorize(action, requestedIndicesOrAliases, aliasAndIndexLookup,
                 fieldPermissionsCache);
-
         return indicesAccessControl.limitIndicesAccessControl(limitedByIndicesAccessControl);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
@@ -175,19 +175,7 @@ public class Role {
     public IndicesAccessControl authorize(String action, Set<String> requestedIndicesOrAliases,
                                           Map<String, IndexAbstraction> aliasAndIndexLookup,
                                           FieldPermissionsCache fieldPermissionsCache) {
-        Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions = indices.authorize(
-            action, requestedIndicesOrAliases, aliasAndIndexLookup, fieldPermissionsCache
-        );
-
-        // At least one role / indices permission set need to match with all the requested indices/aliases:
-        boolean granted = true;
-        for (Map.Entry<String, IndicesAccessControl.IndexAccessControl> entry : indexPermissions.entrySet()) {
-            if (entry.getValue().isGranted() == false) {
-                granted = false;
-                break;
-            }
-        }
-        return new IndicesAccessControl(granted, indexPermissions);
+        return indices.authorize(action, requestedIndicesOrAliases, aliasAndIndexLookup, fieldPermissionsCache);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/StringMatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/StringMatcher.java
@@ -69,6 +69,10 @@ public class StringMatcher implements Predicate<String> {
         return predicate.test(s);
     }
 
+    public boolean isTotal() {
+        return predicate == ALWAYS_TRUE_PREDICATE;
+    }
+
     // For testing
     Predicate<String> getPredicate() {
         return predicate;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -96,6 +96,7 @@ import org.elasticsearch.xpack.core.security.action.CreateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.GetApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyRequest;
+import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.ml.action.FlushJobAction;
 import org.elasticsearch.xpack.core.ml.action.ForecastJobAction;
@@ -167,7 +168,6 @@ import org.elasticsearch.xpack.core.security.action.token.InvalidateTokenAction;
 import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
-import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl.IndexAccessControl;
 import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissionsCache;
 import org.elasticsearch.xpack.core.security.authz.permission.Role;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
@@ -216,7 +216,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 
 import static org.hamcrest.Matchers.hasEntry;
@@ -1130,12 +1129,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 GetSettingsAction.NAME, IndicesShardStoresAction.NAME, UpgradeStatusAction.NAME, RecoveryAction.NAME);
         for (final String indexMonitoringActionName : indexMonitoringActionNamesList) {
             String asyncSearchIndex = RestrictedIndicesNames.ASYNC_SEARCH_PREFIX + randomAlphaOfLengthBetween(0, 2);
-            final Map<String, IndexAccessControl> authzMap = role.indices().authorize(indexMonitoringActionName,
+            final IndicesAccessControl iac = role.indices().authorize(indexMonitoringActionName,
                 Sets.newHashSet(internalSecurityIndex, RestrictedIndicesNames.SECURITY_MAIN_ALIAS, asyncSearchIndex),
                 metadata.getIndicesLookup(), fieldPermissionsCache);
-            assertThat(authzMap.get(internalSecurityIndex).isGranted(), is(true));
-            assertThat(authzMap.get(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
-            assertThat(authzMap.get(asyncSearchIndex).isGranted(), is(true));
+            assertThat(iac.getIndexPermissions(internalSecurityIndex).isGranted(), is(true));
+            assertThat(iac.getIndexPermissions(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
+            assertThat(iac.getIndexPermissions(asyncSearchIndex).isGranted(), is(true));
         }
     }
 
@@ -1266,25 +1265,25 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         SortedMap<String, IndexAbstraction> lookup = metadata.getIndicesLookup();
-        Map<String, IndexAccessControl> authzMap =
+        IndicesAccessControl iac =
                 superuserRole.indices().authorize(SearchAction.NAME, Sets.newHashSet("a1", "ba"), lookup, fieldPermissionsCache);
-        assertThat(authzMap.get("a1").isGranted(), is(true));
-        assertThat(authzMap.get("b").isGranted(), is(true));
-        authzMap =
+        assertThat(iac.getIndexPermissions("a1").isGranted(), is(true));
+        assertThat(iac.getIndexPermissions("b").isGranted(), is(true));
+        iac =
             superuserRole.indices().authorize(DeleteIndexAction.NAME, Sets.newHashSet("a1", "ba"), lookup, fieldPermissionsCache);
-        assertThat(authzMap.get("a1").isGranted(), is(true));
-        assertThat(authzMap.get("b").isGranted(), is(true));
-        authzMap = superuserRole.indices().authorize(IndexAction.NAME, Sets.newHashSet("a2", "ba"), lookup, fieldPermissionsCache);
-        assertThat(authzMap.get("a2").isGranted(), is(true));
-        assertThat(authzMap.get("b").isGranted(), is(true));
-        authzMap = superuserRole.indices()
+        assertThat(iac.getIndexPermissions("a1").isGranted(), is(true));
+        assertThat(iac.getIndexPermissions("b").isGranted(), is(true));
+        iac = superuserRole.indices().authorize(IndexAction.NAME, Sets.newHashSet("a2", "ba"), lookup, fieldPermissionsCache);
+        assertThat(iac.getIndexPermissions("a2").isGranted(), is(true));
+        assertThat(iac.getIndexPermissions("b").isGranted(), is(true));
+        iac = superuserRole.indices()
                 .authorize(UpdateSettingsAction.NAME, Sets.newHashSet("aaaaaa", "ba"), lookup, fieldPermissionsCache);
-        assertThat(authzMap.get("aaaaaa").isGranted(), is(true));
-        assertThat(authzMap.get("b").isGranted(), is(true));
-        authzMap = superuserRole.indices().authorize(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME, SearchAction.NAME),
+        assertThat(iac.getIndexPermissions("aaaaaa").isGranted(), is(true));
+        assertThat(iac.getIndexPermissions("b").isGranted(), is(true));
+        iac = superuserRole.indices().authorize(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME, SearchAction.NAME),
                 Sets.newHashSet(RestrictedIndicesNames.SECURITY_MAIN_ALIAS), lookup, fieldPermissionsCache);
-        assertThat(authzMap.get(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
-        assertThat(authzMap.get(internalSecurityIndex).isGranted(), is(true));
+        assertThat(iac.getIndexPermissions(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
+        assertThat(iac.getIndexPermissions(internalSecurityIndex).isGranted(), is(true));
         assertTrue(superuserRole.indices().check(SearchAction.NAME));
         assertFalse(superuserRole.indices().check("unknown"));
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -337,7 +337,7 @@ public class AuthorizationService {
         if (ClusterPrivilegeResolver.isClusterAction(action)) {
             final ActionListener<AuthorizationResult> clusterAuthzListener =
                 wrapPreservingContext(new AuthorizationResultListener<>(result -> {
-                        threadContext.putTransient(INDICES_PERMISSIONS_KEY, IndicesAccessControl.ALLOW_ALL);
+                        threadContext.putTransient(INDICES_PERMISSIONS_KEY, IndicesAccessControl.allowAll());
                         listener.onResponse(null);
                     }, listener::onFailure, requestInfo, requestId, authzInfo), threadContext);
             authzEngine.authorizeClusterAction(requestInfo, authzInfo, ActionListener.wrap(result -> {
@@ -513,7 +513,7 @@ public class AuthorizationService {
                                      final TransportRequest request, final ActionListener<Void> listener) {
         final AuditTrail auditTrail = auditTrailService.get();
         if (SystemUser.isAuthorized(action)) {
-            threadContext.putTransient(INDICES_PERMISSIONS_KEY, IndicesAccessControl.ALLOW_ALL);
+            threadContext.putTransient(INDICES_PERMISSIONS_KEY, IndicesAccessControl.allowAll());
             threadContext.putTransient(AUTHORIZATION_INFO_KEY, SYSTEM_AUTHZ_INFO);
             auditTrail.accessGranted(requestId, authentication, action, request, SYSTEM_AUTHZ_INFO);
             listener.onResponse(null);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -566,12 +566,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
                         .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
                         .numberOfShards(1).numberOfReplicas(0).build(), true)
                 .build();
-        Map<String, IndicesAccessControl.IndexAccessControl> acls = role.indices().authorize("indices:data/read/search",
+        IndicesAccessControl iac = role.indices().authorize("indices:data/read/search",
             Collections.singleton("test"), metadata.getIndicesLookup(), cache);
-        assertFalse(acls.isEmpty());
-        assertTrue(acls.get("test").getFieldPermissions().grantsAccessTo("L1.foo"));
-        assertFalse(acls.get("test").getFieldPermissions().grantsAccessTo("L2.foo"));
-        assertTrue(acls.get("test").getFieldPermissions().grantsAccessTo("L3.foo"));
+        assertTrue(iac.getIndexPermissions("test").getFieldPermissions().grantsAccessTo("L1.foo"));
+        assertFalse(iac.getIndexPermissions("test").getFieldPermissions().grantsAccessTo("L2.foo"));
+        assertTrue(iac.getIndexPermissions("test").getFieldPermissions().grantsAccessTo("L3.foo"));
     }
 
     public void testMergingBasicRoles() {


### PR DESCRIPTION
This PR adds a fast path for computing indicesAccessControl if
the role has all access to all indices.

A role is considered to have all access to all indices if any of its
IndicesPermission#Group satisfy the following criteria:

1. Any of the index patterns is a simple match-all wildcard, i.e. "*"
2. It allows access to restricted indices
3. It grants the "all" index privilege
4. It has no DLS or FLS

An example of such role is the builtin superuser role.

Note the fastpath does not apply to roles that have "effective" but not
direct "all access of all indices". For example, if the "effective"
access is achieved by combining multiple Groups belong to the role, or
combining multiple index patterns within a single Group. This fast path
is provided so that we have a reference baseline for authorization
related performance which is useful for both production use and
troubleshooting.
