### PR TITLE
[DOCS] Fixes indentation issue in GET trained models API docs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1003,9 +1003,11 @@ Configures a zero-shot classification task. Zero-shot classification allows for
 text classification to occur without pre-determined labels. At inference time,
 it is possible to adjust the labels to classify. This makes this type of model
 and task exceptionally flexible.
-
++
+--
 If consistently classifying the same labels, it may be better to use a fine turned
 text classification model.
+--
 end::inference-config-zero-shot-classification[]
 
 tag::inference-config-zero-shot-classification-classification-labels[]


### PR DESCRIPTION
## Overview

As the title states.

### Preview

[GET Trained Models](https://elasticsearch_79347.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models.html)