### PR TITLE
Migrate custom role providers to licensed feature

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -42,7 +42,6 @@ public class XPackLicenseState {
      */
     public enum Feature {
         SECURITY_AUDITING(OperationMode.GOLD, false),
-        SECURITY_CUSTOM_ROLE_PROVIDERS(OperationMode.PLATINUM, true),
         SECURITY_TOKEN_SERVICE(OperationMode.STANDARD, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/MockLicenseState.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/MockLicenseState.java
@@ -9,7 +9,12 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.common.settings.Settings;
 
+import org.mockito.Mockito;
+
+import java.util.function.Consumer;
 import java.util.function.LongSupplier;
+
+import static org.mockito.Mockito.doAnswer;
 
 /** A license state that may be mocked by testing because the internal methods are made public */
 public class MockLicenseState extends XPackLicenseState {
@@ -31,5 +36,19 @@ public class MockLicenseState extends XPackLicenseState {
     @Override
     public void disableUsageTracking(LicensedFeature feature, String contextName) {
         super.disableUsageTracking(feature, contextName);
+    }
+
+    public static MockLicenseState createMock() {
+        MockLicenseState mock = Mockito.mock(MockLicenseState.class);
+        Mockito.when(mock.copyCurrentLicenseState()).thenReturn(mock);
+        return mock;
+    }
+
+    public static void acceptListeners(MockLicenseState licenseState, Consumer<LicenseStateListener> addListener) {
+        doAnswer(inv -> {
+            final LicenseStateListener listener = (LicenseStateListener) inv.getArguments()[0];
+            addListener.accept(listener);
+            return null;
+        }).when(licenseState).addListener(Mockito.any());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -93,7 +93,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
 
         licenseState = TestUtils.newTestLicenseState();
         assertSecurityNotAllowed(licenseState);
@@ -111,7 +110,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
@@ -123,7 +121,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(BASIC, true, null);
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
@@ -137,7 +134,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
@@ -149,7 +145,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
@@ -161,7 +156,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
@@ -173,7 +167,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
@@ -185,7 +178,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
@@ -197,7 +189,6 @@ public class XPackLicenseStateTests extends ESTestCase {
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.common.IteratingActionListener;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -81,8 +80,8 @@ import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isIn
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isMoveFromRedToNonRed;
 
 /**
- * A composite roles store that combines built in roles, file-based roles, and index-based roles. Checks the built in roles first, then the
- * file roles, and finally the index roles.
+ * A composite roles store that can retrieve roles from multiple sources.
+ * @see RoleProviders
  */
 public class CompositeRolesStore {
 
@@ -95,8 +94,7 @@ public class CompositeRolesStore {
 
     private final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(CompositeRolesStore.class);
 
-    private final FileRolesStore fileRolesStore;
-    private final NativeRolesStore nativeRolesStore;
+    private final RoleProviders roleProviders;
     private final NativePrivilegeStore privilegeStore;
     private final XPackLicenseState licenseState;
     private final Consumer<Collection<RoleDescriptor>> effectiveRoleDescriptorsConsumer;
@@ -111,21 +109,27 @@ public class CompositeRolesStore {
     private final ApiKeyService apiKeyService;
     private final ServiceAccountService serviceAccountService;
     private final boolean isAnonymousEnabled;
-    private final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> builtInRoleProviders;
-    private final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> allRoleProviders;
 
-    public CompositeRolesStore(Settings settings, FileRolesStore fileRolesStore, NativeRolesStore nativeRolesStore,
-                               ReservedRolesStore reservedRolesStore, NativePrivilegeStore privilegeStore,
-                               List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> rolesProviders,
+    public CompositeRolesStore(Settings settings, RoleProviders roleProviders, NativePrivilegeStore privilegeStore,
                                ThreadContext threadContext, XPackLicenseState licenseState, FieldPermissionsCache fieldPermissionsCache,
                                ApiKeyService apiKeyService, ServiceAccountService serviceAccountService,
                                DocumentSubsetBitsetCache dlsBitsetCache,
                                Consumer<Collection<RoleDescriptor>> effectiveRoleDescriptorsConsumer) {
-        this.fileRolesStore = Objects.requireNonNull(fileRolesStore);
-        this.dlsBitsetCache = Objects.requireNonNull(dlsBitsetCache);
-        fileRolesStore.addListener(this::invalidate);
-        this.nativeRolesStore = Objects.requireNonNull(nativeRolesStore);
+        this.roleProviders = roleProviders;
+        roleProviders.addChangeListener(new RoleProviders.ChangeListener() {
+            @Override
+            public void rolesChanged(Set<String> roles) {
+                CompositeRolesStore.this.invalidate(roles);
+            }
+
+            @Override
+            public void providersChanged() {
+                CompositeRolesStore.this.invalidateAll();
+            }
+        });
+
         this.privilegeStore = Objects.requireNonNull(privilegeStore);
+        this.dlsBitsetCache = Objects.requireNonNull(dlsBitsetCache);
         this.licenseState = Objects.requireNonNull(licenseState);
         this.fieldPermissionsCache = Objects.requireNonNull(fieldPermissionsCache);
         this.apiKeyService = Objects.requireNonNull(apiKeyService);
@@ -145,16 +149,6 @@ public class CompositeRolesStore {
             nlcBuilder.setMaximumWeight(nlcCacheSize);
         }
         this.negativeLookupCache = nlcBuilder.build();
-        this.builtInRoleProviders = Collections.unmodifiableList(Arrays.asList(reservedRolesStore, fileRolesStore, nativeRolesStore));
-        if (rolesProviders.isEmpty()) {
-            this.allRoleProviders = this.builtInRoleProviders;
-        } else {
-            List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> allList =
-                new ArrayList<>(builtInRoleProviders.size() + rolesProviders.size());
-            allList.addAll(builtInRoleProviders);
-            allList.addAll(rolesProviders);
-            this.allRoleProviders = Collections.unmodifiableList(allList);
-        }
         this.anonymousUser = new AnonymousUser(settings);
         this.isAnonymousEnabled = AnonymousUser.isAnonymousEnabled(settings);
     }
@@ -386,9 +380,7 @@ public class CompositeRolesStore {
 
     private void loadRoleDescriptorsAsync(Set<String> roleNames, ActionListener<RolesRetrievalResult> listener) {
         final RolesRetrievalResult rolesResult = new RolesRetrievalResult();
-        final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> asyncRoleProviders =
-            licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS) ? allRoleProviders : builtInRoleProviders;
-
+        final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> asyncRoleProviders = roleProviders.getProviders();
         final ActionListener<RoleRetrievalResult> descriptorsListener =
             ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(ignore -> {
                     rolesResult.setMissingRoles(roleNames);
@@ -519,13 +511,12 @@ public class CompositeRolesStore {
     }
 
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        final Map<String, Object> usage = new HashMap<>(2);
-        usage.put("file", fileRolesStore.usageStats());
+        final Map<String, Object> usage = new HashMap<>();
         usage.put("dls", Collections.singletonMap("bit_set_cache", dlsBitsetCache.usageStats()));
-        nativeRolesStore.usageStats(ActionListener.wrap(map -> {
-            usage.put("native", map);
-            listener.onResponse(usage);
-        }, listener::onFailure));
+        roleProviders.usageStats(listener.map(roleUsage -> {
+            usage.putAll(roleUsage);
+            return usage;
+        }));
     }
 
     public void onSecurityIndexStateChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleProviders.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleProviders.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.store;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
+import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
+import org.elasticsearch.xpack.security.Security;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+
+import static org.elasticsearch.core.Map.entry;
+
+/**
+ * Encapsulates logic regarding the active set of role providers in the system, and their order
+ * The supported providers are (in order):
+ *  - built in (reserved) roles
+ *  - file-based roles
+ *  - index-based roles
+ *  - custom (plugin) providers.
+ * The set of permitted role providers can change due to changes in the license state.
+ */
+public class RoleProviders {
+
+    private final List<ChangeListener> changeListeners;
+
+    private final FileRolesStore fileRolesStore;
+    private final NativeRolesStore nativeRolesStore;
+    private final ReservedRolesStore reservedRolesStore;
+
+    private final Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders;
+
+    private final XPackLicenseState licenseState;
+
+    private List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> activeRoleProviders;
+
+    public RoleProviders(
+        ReservedRolesStore reservedRolesStore,
+        FileRolesStore fileRolesStore,
+        NativeRolesStore nativeRolesStore,
+        Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders,
+        XPackLicenseState licenseState
+    ) {
+        this.changeListeners = new CopyOnWriteArrayList<>();
+
+        this.reservedRolesStore = Objects.requireNonNull(reservedRolesStore);
+        this.fileRolesStore = Objects.requireNonNull(fileRolesStore);
+        this.fileRolesStore.addListener(this::onRoleModification);
+        this.nativeRolesStore = Objects.requireNonNull(nativeRolesStore);
+        this.customRoleProviders = Objects.requireNonNull(customRoleProviders);
+
+        this.licenseState = licenseState;
+        this.licenseState.addListener(this::onLicenseChange);
+
+        this.activeRoleProviders = calculateActiveRoleProviders();
+    }
+
+    private void onLicenseChange() {
+        List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> previousProviders = activeRoleProviders;
+        activeRoleProviders = calculateActiveRoleProviders();
+        if (activeRoleProviders.equals(previousProviders) == false) {
+            changeListeners.forEach(ChangeListener::providersChanged);
+        }
+    }
+
+    private List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> calculateActiveRoleProviders() {
+        final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> builtInRoleProviders = Arrays.asList(
+            reservedRolesStore,
+            fileRolesStore,
+            nativeRolesStore
+        );
+        if (customRoleProviders.isEmpty()) {
+            return builtInRoleProviders;
+        }
+
+        final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> providers = new ArrayList<>();
+        providers.addAll(builtInRoleProviders);
+
+        final XPackLicenseState fixedLicenseState = this.licenseState.copyCurrentLicenseState();
+        this.customRoleProviders.forEach((name, customProviders) -> {
+            if (Security.CUSTOM_ROLE_PROVIDERS_FEATURE.checkAndStartTracking(fixedLicenseState, name)) {
+                providers.addAll(customProviders);
+            } else {
+                Security.CUSTOM_ROLE_PROVIDERS_FEATURE.stopTracking(fixedLicenseState, name);
+            }
+        });
+        return org.elasticsearch.core.List.copyOf(providers);
+    }
+
+    private void onRoleModification(Set<String> roles) {
+        changeListeners.forEach(l -> l.rolesChanged(roles));
+    }
+
+    public void addChangeListener(ChangeListener listener) {
+        changeListeners.add(Objects.requireNonNull(listener));
+    }
+
+    public List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> getProviders() {
+        return this.activeRoleProviders;
+    }
+
+    public void usageStats(ActionListener<Map<String, Object>> listener) {
+        final Map<String, Object> fileUsage = fileRolesStore.usageStats();
+        nativeRolesStore.usageStats(
+            listener.map(nativeUsage -> org.elasticsearch.core.Map.ofEntries(entry("file", fileUsage), entry("native", nativeUsage)))
+        );
+    }
+
+    interface ChangeListener {
+        void rolesChanged(Set<String> roles);
+        void providersChanged();
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -25,14 +25,13 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.license.LicenseStateListener;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.license.License.OperationMode;
-import org.elasticsearch.license.TestUtils.UpdatableLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -67,6 +66,7 @@ import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
@@ -362,12 +362,18 @@ public class CompositeRolesStoreTests extends ESTestCase {
             .put("xpack.security.authz.store.roles.negative_lookup_cache.max_size", 0)
             .build();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        final CompositeRolesStore compositeRolesStore = new CompositeRolesStore(settings, fileRolesStore, nativeRolesStore,
-            reservedRolesStore, mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(settings),
-            new XPackLicenseState(settings, () -> 0), cache, mock(ApiKeyService.class),
-            mock(ServiceAccountService.class), documentSubsetBitsetCache,
-            rds -> effectiveRoleDescriptors.set(rds));
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            settings,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            null,
+            null,
+            null,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds)
+        );
         verify(fileRolesStore).addListener(anyConsumer()); // adds a listener in ctor
 
         final String roleName = randomAlphaOfLengthBetween(1, 10);
@@ -402,13 +408,21 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final ReservedRolesStore reservedRolesStore = spy(new ReservedRolesStore());
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
+        final XPackLicenseState licenseState = new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0);
+        final RoleProviders roleProviders = buildRolesProvider(fileRolesStore, nativeRolesStore, reservedRolesStore, null, licenseState);
         final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, mock(ApiKeyService.class),
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> effectiveRoleDescriptors.set(rds));
+        final CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            roleProviders,
+            mock(NativePrivilegeStore.class),
+            new ThreadContext(SECURITY_ENABLED_SETTINGS),
+            licenseState,
+            cache,
+            mock(ApiKeyService.class),
+            mock(ServiceAccountService.class),
+            documentSubsetBitsetCache,
+            rds -> effectiveRoleDescriptors.set(rds)
+        );
         verify(fileRolesStore).addListener(anyConsumer()); // adds a listener in ctor
 
         final String roleName = randomAlphaOfLengthBetween(1, 10);
@@ -491,13 +505,22 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }));
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        final CompositeRolesStore compositeRolesStore =
-                new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                                mock(NativePrivilegeStore.class), Arrays.asList(inMemoryProvider1, inMemoryProvider2),
-                                new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0),
-                                cache, mock(ApiKeyService.class), mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                                rds -> effectiveRoleDescriptors.set(rds));
+        final Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders
+            = Collections.singletonMap("custom", Arrays.asList(inMemoryProvider1, inMemoryProvider2));
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            customRoleProviders,
+            null,
+            null,
+            null,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds),
+            null
+        );
 
         final Set<String> roleNames = Sets.newHashSet("roleA", "roleB", "unknown");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
@@ -722,13 +745,28 @@ public class CompositeRolesStoreTests extends ESTestCase {
             (roles, listener) -> listener.onFailure(new Exception("fake failure"));
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Arrays.asList(inMemoryProvider1, failingProvider),
-                new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0),
-                cache, mock(ApiKeyService.class), mock(ServiceAccountService.class),
-                documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
+        final Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders = randomBoolean()
+            ? org.elasticsearch.core.Map.of("custom", Arrays.asList(inMemoryProvider1, failingProvider))
+            : org.elasticsearch.core.Map.of(
+                "custom",
+                Collections.singletonList(inMemoryProvider1),
+                "failing",
+                Collections.singletonList(failingProvider)
+            );
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            customRoleProviders,
+            null,
+            null,
+            null,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds),
+            null
+        );
 
         final Set<String> roleNames = Sets.newHashSet("roleA", "roleB", "unknown");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
@@ -768,57 +806,64 @@ public class CompositeRolesStoreTests extends ESTestCase {
             return RoleRetrievalResult.success(descriptors);
         });
 
-        UpdatableLicenseState xPackLicenseState = new UpdatableLicenseState(SECURITY_ENABLED_SETTINGS);
-        // these licenses don't allow custom role providers
-        xPackLicenseState.update(randomFrom(OperationMode.BASIC, OperationMode.GOLD, OperationMode.STANDARD), true, null);
+        final MockLicenseState xPackLicenseState = MockLicenseState.createMock();
+        when(xPackLicenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(false);
+        final AtomicReference<LicenseStateListener> licenseListener = new AtomicReference<>(null);
+        MockLicenseState.acceptListeners(xPackLicenseState, licenseListener::set);
+
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
-            Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache,
-            mock(ApiKeyService.class), mock(ServiceAccountService.class),
-            documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
+        final Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders
+            = Collections.singletonMap("custom", Collections.singletonList(inMemoryProvider));
+        CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            Settings.EMPTY,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            customRoleProviders,
+            null,
+            xPackLicenseState,
+            null,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds),
+            null
+        );
 
         Set<String> roleNames = Sets.newHashSet("roleA");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
         compositeRolesStore.roles(roleNames, future);
         Role role = future.actionGet();
-        assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
+        assertThat(effectiveRoleDescriptors.get(), hasSize(0));
         effectiveRoleDescriptors.set(null);
+        verify(xPackLicenseState).disableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, "custom");
 
         // no roles should've been populated, as the license doesn't permit custom role providers
         assertEquals(0, role.indices().groups().length);
 
-        compositeRolesStore = new CompositeRolesStore(
-            Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache,
-            mock(ApiKeyService.class), mock(ServiceAccountService.class),
-            documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
-        // these licenses allow custom role providers
-        xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.ENTERPRISE, OperationMode.TRIAL), true, null);
+        when(xPackLicenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(true);
+        licenseListener.get().licenseStateChanged();
+
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
         compositeRolesStore.roles(roleNames, future);
         role = future.actionGet();
         assertThat(effectiveRoleDescriptors.get(), containsInAnyOrder(roleA));
         effectiveRoleDescriptors.set(null);
+        verify(xPackLicenseState).enableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, "custom");
 
         // roleA should've been populated by the custom role provider, because the license allows it
         assertEquals(1, role.indices().groups().length);
 
-        // license expired, don't allow custom role providers
-        compositeRolesStore = new CompositeRolesStore(
-            Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache,
-            mock(ApiKeyService.class), mock(ServiceAccountService.class),
-            documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
-        xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.ENTERPRISE, OperationMode.TRIAL), false, null);
+        when(xPackLicenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(false);
+        licenseListener.get().licenseStateChanged();
+
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
         compositeRolesStore.roles(roleNames, future);
         role = future.actionGet();
         assertEquals(0, role.indices().groups().length);
-        assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
+        assertThat(effectiveRoleDescriptors.get(), hasSize(0));
+        verify(xPackLicenseState, times(2)).disableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, "custom");
     }
 
     private SecurityIndexManager.State dummyState(ClusterHealthStatus indexStatus) {
@@ -840,18 +885,21 @@ public class CompositeRolesStoreTests extends ESTestCase {
         doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
         NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
         doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
-                Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(Settings.EMPTY),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, mock(ApiKeyService.class),
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> {}) {
-            @Override
-            public void invalidateAll() {
-                numInvalidation.incrementAndGet();
-            }
-        };
+
+        CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            Settings.EMPTY,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            store -> numInvalidation.incrementAndGet()
+        );
 
         int expectedInvalidation = 0;
         // existing to no longer present
@@ -895,17 +943,20 @@ public class CompositeRolesStoreTests extends ESTestCase {
         doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
         NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
         doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
-        CompositeRolesStore compositeRolesStore = new CompositeRolesStore(SECURITY_ENABLED_SETTINGS,
-                fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, mock(ApiKeyService.class),
-            mock(ServiceAccountService.class), documentSubsetBitsetCache, rds -> {}) {
-            @Override
-            public void invalidateAll() {
-                numInvalidation.incrementAndGet();
-            }
-        };
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            store -> numInvalidation.incrementAndGet()
+        );
 
         compositeRolesStore.onSecurityIndexStateChange(dummyIndexState(false, null), dummyIndexState(true, null));
         assertEquals(1, numInvalidation.get());
@@ -995,14 +1046,20 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }).when(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
         final ReservedRolesStore reservedRolesStore = spy(new ReservedRolesStore());
 
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, mock(ApiKeyService.class),
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> effectiveRoleDescriptors.set(rds));
+            buildCompositeRolesStore(
+                SECURITY_ENABLED_SETTINGS,
+                fileRolesStore,
+                nativeRolesStore,
+                reservedRolesStore,
+                null,
+                null,
+                null,
+                null,
+                null,
+                rds -> effectiveRoleDescriptors.set(rds)
+            );
         verify(fileRolesStore).addListener(anyConsumer()); // adds a listener in ctor
 
         // test Xpack user short circuits to its own reserved role
@@ -1038,14 +1095,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }).when(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
         final ReservedRolesStore reservedRolesStore = spy(new ReservedRolesStore());
 
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, mock(ApiKeyService.class),
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> effectiveRoleDescriptors.set(rds));
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            null,
+            null,
+            null,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds)
+        );
         verify(fileRolesStore).addListener(anyConsumer()); // adds a listener in ctor
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
             () -> compositeRolesStore.getRoles(SystemUser.INSTANCE, null, null));
@@ -1081,14 +1143,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
             return Void.TYPE;
         }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
 
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                nativePrivStore, Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, apiKeyService,
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> effectiveRoleDescriptors.set(rds));
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            nativePrivStore,
+            null,
+            apiKeyService,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds)
+        );
         AuditUtil.getOrGenerateRequestId(threadContext);
         final Version version = randomFrom(Version.CURRENT, VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_8_1));
         final Authentication authentication = createApiKeyAuthentication(apiKeyService, createAuthentication(),
@@ -1139,14 +1206,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
             return Void.TYPE;
         }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
 
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final CompositeRolesStore compositeRolesStore =
-            new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
-                nativePrivStore, Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0), cache, apiKeyService,
-                mock(ServiceAccountService.class), documentSubsetBitsetCache,
-                rds -> effectiveRoleDescriptors.set(rds));
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            nativePrivStore,
+            null,
+            apiKeyService,
+            null,
+            null,
+            rds -> effectiveRoleDescriptors.set(rds)
+        );
         AuditUtil.getOrGenerateRequestId(threadContext);
         final Version version = randomFrom(Version.CURRENT, VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_8_1));
         final Authentication authentication = createApiKeyAuthentication(apiKeyService, createAuthentication(),
@@ -1276,20 +1348,16 @@ public class CompositeRolesStoreTests extends ESTestCase {
             return Void.TYPE;
         }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
 
-        final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
-        final CompositeRolesStore compositeRolesStore = new CompositeRolesStore(SECURITY_ENABLED_SETTINGS,
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(SECURITY_ENABLED_SETTINGS,
             fileRolesStore,
             nativeRolesStore,
             reservedRolesStore,
             nativePrivStore,
-            Collections.emptyList(),
-            new ThreadContext(SECURITY_ENABLED_SETTINGS),
-            new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0),
-            cache,
+            null,
             apiKeyService,
-            mock(ServiceAccountService.class),
-            documentSubsetBitsetCache,
+            null,
+            null,
             rds -> effectiveRoleDescriptors.set(rds));
         AuditUtil.getOrGenerateRequestId(threadContext);
         final BytesArray roleBytes = new BytesArray("{\"a role\": {\"cluster\": [\"all\"]}}");
@@ -1375,16 +1443,113 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 AuthenticationType.ANONYMOUS), Collections.emptyMap());
     }
 
-    private CompositeRolesStore buildCompositeRolesStore(Settings settings,
-                                                         @Nullable FileRolesStore fileRolesStore,
-                                                         @Nullable NativeRolesStore nativeRolesStore,
-                                                         @Nullable ReservedRolesStore reservedRolesStore,
-                                                         @Nullable NativePrivilegeStore privilegeStore,
-                                                         @Nullable XPackLicenseState licenseState,
-                                                         @Nullable ApiKeyService apiKeyService,
-                                                         @Nullable ServiceAccountService serviceAccountService,
-                                                         @Nullable DocumentSubsetBitsetCache documentSubsetBitsetCache,
-                                                         @Nullable Consumer<Collection<RoleDescriptor>> roleConsumer) {
+    private CompositeRolesStore buildCompositeRolesStore(
+        Settings settings,
+        @Nullable FileRolesStore fileRolesStore,
+        @Nullable NativeRolesStore nativeRolesStore,
+        @Nullable ReservedRolesStore reservedRolesStore,
+        @Nullable NativePrivilegeStore privilegeStore,
+        @Nullable XPackLicenseState licenseState,
+        @Nullable ApiKeyService apiKeyService,
+        @Nullable ServiceAccountService serviceAccountService,
+        @Nullable DocumentSubsetBitsetCache documentSubsetBitsetCache,
+        @Nullable Consumer<Collection<RoleDescriptor>> roleConsumer
+    ) {
+        return buildCompositeRolesStore(
+            settings,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            null,
+            privilegeStore,
+            licenseState,
+            apiKeyService,
+            serviceAccountService,
+            documentSubsetBitsetCache,
+            roleConsumer,
+            null
+        );
+    }
+
+    private CompositeRolesStore buildCompositeRolesStore(
+        Settings settings,
+        @Nullable FileRolesStore fileRolesStore,
+        @Nullable NativeRolesStore nativeRolesStore,
+        @Nullable ReservedRolesStore reservedRolesStore,
+        @Nullable Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders,
+        @Nullable NativePrivilegeStore privilegeStore,
+        @Nullable XPackLicenseState licenseState,
+        @Nullable ApiKeyService apiKeyService,
+        @Nullable ServiceAccountService serviceAccountService,
+        @Nullable DocumentSubsetBitsetCache documentSubsetBitsetCache,
+        @Nullable Consumer<Collection<RoleDescriptor>> roleConsumer,
+        @Nullable Consumer<CompositeRolesStore> onInvalidation) {
+
+        if (licenseState == null) {
+            licenseState = new XPackLicenseState(settings, () -> 0);
+        }
+
+        final RoleProviders roleProviders = buildRolesProvider(
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            customRoleProviders,
+            licenseState
+        );
+
+        if (privilegeStore == null) {
+            privilegeStore = mock(NativePrivilegeStore.class);
+            doAnswer((invocationOnMock) -> {
+                @SuppressWarnings("unchecked")
+                ActionListener<Collection<ApplicationPrivilegeDescriptor>> callback =
+                    (ActionListener<Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
+                callback.onResponse(Collections.emptyList());
+                return null;
+            }).when(privilegeStore).getPrivileges(isASet(), isASet(), anyActionListener());
+        }
+        if (apiKeyService == null) {
+            apiKeyService = mock(ApiKeyService.class);
+        }
+        if (serviceAccountService == null) {
+            serviceAccountService = mock(ServiceAccountService.class);
+        }
+        if (documentSubsetBitsetCache == null) {
+            documentSubsetBitsetCache = buildBitsetCache();
+        }
+        if (roleConsumer == null) {
+            roleConsumer = rds -> { };
+        }
+
+        return new CompositeRolesStore(
+            settings,
+            roleProviders,
+            privilegeStore,
+            new ThreadContext(settings),
+            licenseState,
+            cache,
+            apiKeyService,
+            serviceAccountService,
+            documentSubsetBitsetCache,
+            roleConsumer
+        ) {
+            @Override
+            public void invalidateAll() {
+                if (onInvalidation == null) {
+                    super.invalidateAll();
+                } else {
+                    onInvalidation.accept(this);
+                }
+            }
+        };
+    }
+
+    private RoleProviders buildRolesProvider(
+        @Nullable FileRolesStore fileRolesStore,
+        @Nullable NativeRolesStore nativeRolesStore,
+        @Nullable ReservedRolesStore reservedRolesStore,
+        @Nullable Map<String, List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>>> customRoleProviders,
+        @Nullable XPackLicenseState licenseState
+    ) {
         if (fileRolesStore == null) {
             fileRolesStore = mock(FileRolesStore.class);
             doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
@@ -1404,39 +1569,25 @@ public class CompositeRolesStoreTests extends ESTestCase {
             reservedRolesStore = mock(ReservedRolesStore.class);
             doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
         }
-        if (privilegeStore == null) {
-            privilegeStore = mock(NativePrivilegeStore.class);
-            doAnswer((invocationOnMock) -> {
-                @SuppressWarnings("unchecked")
-                ActionListener<Collection<ApplicationPrivilegeDescriptor>> callback =
-                    (ActionListener<Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
-                callback.onResponse(Collections.emptyList());
-                return null;
-            }).when(privilegeStore).getPrivileges(isASet(), isASet(), anyActionListener());
-        }
         if (licenseState == null) {
-            licenseState = new XPackLicenseState(settings, () -> 0);
+            licenseState = new XPackLicenseState(SECURITY_ENABLED_SETTINGS, () -> 0);
         }
-        if (apiKeyService == null) {
-            apiKeyService = mock(ApiKeyService.class);
+        if (customRoleProviders == null) {
+            customRoleProviders = Collections.emptyMap();
         }
-        if (serviceAccountService == null) {
-            serviceAccountService = mock(ServiceAccountService.class);
-        }
-        if (documentSubsetBitsetCache == null) {
-            documentSubsetBitsetCache = buildBitsetCache();
-        }
-        if (roleConsumer == null) {
-            roleConsumer = rds -> { };
-        }
-        return new CompositeRolesStore(settings, fileRolesStore, nativeRolesStore, reservedRolesStore, privilegeStore,
-            Collections.emptyList(), new ThreadContext(settings), licenseState, cache, apiKeyService,
-            serviceAccountService, documentSubsetBitsetCache, roleConsumer);
+        return new RoleProviders(
+            reservedRolesStore,
+            fileRolesStore,
+            nativeRolesStore,
+            customRoleProviders,
+            licenseState
+        );
     }
 
     private DocumentSubsetBitsetCache buildBitsetCache() {
         return new DocumentSubsetBitsetCache(Settings.EMPTY, mock(ThreadPool.class));
     }
+
     private static class InMemoryRolesProvider implements BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>> {
         private final Function<Set<String>, RoleRetrievalResult> roleDescriptorsFunc;
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/RoleProvidersTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/RoleProvidersTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.store;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.license.LicenseStateListener;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
+import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
+import org.elasticsearch.xpack.security.Security;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RoleProvidersTests extends ESTestCase {
+
+    public void testFileRoleInvalidationListener() {
+        final MockLicenseState licenseState = MockLicenseState.createMock();
+
+        final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
+        AtomicReference<Consumer<Set<String>>> fileChangeListener = new AtomicReference<>(null);
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            final Consumer<Set<String>> consumer = (Consumer<Set<String>>) inv.getArguments()[0];
+            fileChangeListener.set(consumer);
+            return null;
+        }).when(fileRolesStore).addListener(any());
+
+        final RoleProviders roleProviders = new RoleProviders(
+            mock(ReservedRolesStore.class),
+            fileRolesStore,
+            mock(NativeRolesStore.class),
+            Collections.emptyMap(),
+            licenseState
+        );
+        assertThat(fileChangeListener.get(), notNullValue());
+
+        final AtomicInteger roleChangeCount = new AtomicInteger(0);
+        final AtomicReference<Set<String>> lastRolesChange = new AtomicReference<>(Collections.emptySet());
+
+        roleProviders.addChangeListener(new RoleProviders.ChangeListener() {
+            @Override
+            public void rolesChanged(Set<String> roles) {
+                roleChangeCount.incrementAndGet();
+                lastRolesChange.set(roles);
+            }
+
+            @Override
+            public void providersChanged() {
+                // ignore
+            }
+        });
+
+        assertThat(roleProviders.getProviders(), hasSize(3));
+        assertThat(roleChangeCount.get(), is(0));
+
+        assertThat(roleProviders.getProviders(), hasSize(3));
+        assertThat(roleChangeCount.get(), is(0));
+
+        Set<String> roleNames = Sets.newHashSet(generateRandomStringArray(5, 8, false, false));
+        fileChangeListener.get().accept(roleNames);
+        assertThat(roleProviders.getProviders(), hasSize(3));
+        assertThat(roleChangeCount.get(), is(1));
+        assertThat(lastRolesChange.get(), is(roleNames));
+
+        roleNames = Sets.newHashSet(generateRandomStringArray(5, 4, false, false));
+        fileChangeListener.get().accept(roleNames);
+        assertThat(roleProviders.getProviders(), hasSize(3));
+        assertThat(roleChangeCount.get(), is(2));
+        assertThat(lastRolesChange.get(), is(roleNames));
+    }
+
+    public void testLicenseChange() {
+        final MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(true);
+
+        final AtomicReference<LicenseStateListener> licenseListener = new AtomicReference<>(null);
+        MockLicenseState.acceptListeners(licenseState, licenseListener::set);
+
+        List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> customProviders = Collections.singletonList(
+            (names, listener) -> {}
+        );
+        final String extensionName = randomAlphaOfLengthBetween(3, 12);
+        final RoleProviders roleProviders = new RoleProviders(
+            mock(ReservedRolesStore.class),
+            mock(FileRolesStore.class),
+            mock(NativeRolesStore.class),
+            Collections.singletonMap(extensionName, customProviders),
+            licenseState
+        );
+        assertThat(licenseListener.get(), notNullValue());
+
+        final AtomicInteger providerChangeCount = new AtomicInteger(0);
+        roleProviders.addChangeListener(new RoleProviders.ChangeListener() {
+            @Override
+            public void rolesChanged(Set<String> roles) {
+                // ignore
+            }
+
+            @Override
+            public void providersChanged() {
+                providerChangeCount.incrementAndGet();
+            }
+        });
+
+        assertThat(roleProviders.getProviders(), hasSize(4));
+        assertThat(providerChangeCount.get(), is(0));
+        verify(licenseState, times(1)).enableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+
+        licenseListener.get().licenseStateChanged();
+        assertThat(roleProviders.getProviders(), hasSize(4));
+        assertThat(providerChangeCount.get(), is(0)); // no relevant change in license
+        verify(licenseState, times(2)).enableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+
+        when(licenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(false);
+        licenseListener.get().licenseStateChanged();
+        assertThat(roleProviders.getProviders(), hasSize(3));
+        assertThat(providerChangeCount.get(), is(1));
+        verify(licenseState, times(2)).enableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+        verify(licenseState, times(1)).disableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+
+        when(licenseState.isAllowed(Security.CUSTOM_ROLE_PROVIDERS_FEATURE)).thenReturn(true);
+        licenseListener.get().licenseStateChanged();
+        assertThat(roleProviders.getProviders(), hasSize(4));
+        assertThat(providerChangeCount.get(), is(2));
+        verify(licenseState, times(3)).enableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+        verify(licenseState, times(1)).disableUsageTracking(Security.CUSTOM_ROLE_PROVIDERS_FEATURE, extensionName);
+    }
+
+}


### PR DESCRIPTION
This changes the license checking for custom role providers to use the
new `LicensedFeature` model with feature tracking.

To support this, and reduce code complexity the logic for managing
role providers has been moved out of the `CompositeRolesStore` into a
new `RoleProviders` test.

Backport of: #79127
