### PR TITLE
Fix line separator in hot threads log assertion

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
@@ -1847,15 +1848,17 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     "node [" + brokenNode + "] is lagging at cluster state version [*], " +
                         "although publication of cluster state version [*] completed [*] ago"));
 
-                mockLogAppender.addExpectation(new MockLogAppender.SeenEventExpectation(
-                    "hot threads from lagging node",
-                    LagDetector.class.getCanonicalName(),
-                    Level.DEBUG,
-                    "hot threads from node [" +
-                        brokenNode.getLocalNode().descriptionWithoutAttributes() +
-                        "] lagging at version [*] despite commit of cluster state version [*]:" +
-                        System.lineSeparator() +
-                        "Hot threads at*"));
+                if (Constants.WINDOWS == false) {
+                    // log messages containing control characters are hidden from the log assertions framework, and this includes the
+                    // `\r` that Windows uses in its line endings, so we only see this message on systems with `\n` line endings:
+                    mockLogAppender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                        "hot threads from lagging node",
+                        LagDetector.class.getCanonicalName(),
+                        Level.DEBUG,
+                        "hot threads from node [" +
+                            brokenNode.getLocalNode().descriptionWithoutAttributes() +
+                            "] lagging at version [*] despite commit of cluster state version [*]:\nHot threads at*"));
+                }
 
                 // drop the publication messages to one node, but then restore connectivity so it remains in the cluster and does not fail
                 // health checks

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1853,7 +1853,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     Level.DEBUG,
                     "hot threads from node [" +
                         brokenNode.getLocalNode().descriptionWithoutAttributes() +
-                        "] lagging at version [*] despite commit of cluster state version [*]:\nHot threads at*"));
+                        "] lagging at version [*] despite commit of cluster state version [*]:" +
+                        System.lineSeparator() +
+                        "Hot threads at*"));
 
                 // drop the publication messages to one node, but then restore connectivity so it remains in the cluster and does not fail
                 // health checks


### PR DESCRIPTION
`CoordinatorTests#testLogsMessagesIfPublicationDelayed` fails on Windows
at an assertion about a log message which includes a `\n` character.
This commit replaces that character with `System.lineSeparator()` to fix
this assertion.

Closes #79359