### PR TITLE
[7.x] Optimistic concurrency control for updating ingest pipelines

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/290_versioned_update.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/290_versioned_update.yml
@@ -1,8 +1,8 @@
 ---
 "Test pipeline versioned updates":
   - skip:
-      version: " - 7.99.99"
-      reason: "re-enable in 7.16+ when backported"
+      version: " - 7.15.99"
+      reason: "added versioned updates in 7.16.0"
 
   - do:
       ingest.put_pipeline:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/290_versioned_update.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/290_versioned_update.yml
@@ -1,0 +1,177 @@
+---
+"Test pipeline versioned updates":
+  - skip:
+      version: " - 7.99.99"
+      reason: "re-enable in 7.16+ when backported"
+
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  # conditional update fails because of missing version
+  - do:
+      catch: bad_request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        if_version: 1
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "version": 1,
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.version: 1 }
+
+  # required version does not match specified version
+  - do:
+      catch: bad_request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        if_version: 99
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+
+  # may not update to same version
+  - do:
+      catch: bad_request
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        if_version: 1
+        body:  >
+          {
+            "version": 1,
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+
+  # cannot conditionally update non-existent pipeline
+  - do:
+      catch: bad_request
+      ingest.put_pipeline:
+        id: "my_pipeline2"
+        if_version: 1
+        body:  >
+          {
+            "version": 1,
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+
+  # conditionally update to specified version
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        if_version: 1
+        body:  >
+          {
+            "version": 99,
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.version: 99 }
+
+  # conditionally update without specified version
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        if_version: 99
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.version: 100 }
+
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+  - match: { acknowledged: true }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -27,6 +27,10 @@
       ]
     },
     "params":{
+      "if_version":{
+        "type":"int",
+        "description":"Required version for optimistic concurrency control for pipeline updates"
+      },
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
@@ -47,7 +47,7 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
         id = in.readString();
         source = in.readBytesReference();
         xContentType = in.readEnum(XContentType.class);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             version = in.readOptionalInt();
         } else {
             version = null;
@@ -85,7 +85,7 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
         out.writeString(id);
         out.writeBytesReference(source);
         out.writeEnum(xContentType);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeOptionalInt(version);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.ingest;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -22,17 +23,23 @@ import java.util.Objects;
 
 public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> implements ToXContentObject {
 
-    private String id;
-    private BytesReference source;
-    private XContentType xContentType;
+    private final String id;
+    private final BytesReference source;
+    private final XContentType xContentType;
+    private final Integer version;
 
     /**
      * Create a new pipeline request with the id and source along with the content type of the source
      */
-    public PutPipelineRequest(String id, BytesReference source, XContentType xContentType) {
+    public PutPipelineRequest(String id, BytesReference source, XContentType xContentType, Integer version) {
         this.id = Objects.requireNonNull(id);
         this.source = Objects.requireNonNull(source);
         this.xContentType = Objects.requireNonNull(xContentType);
+        this.version = version;
+    }
+
+    public PutPipelineRequest(String id, BytesReference source, XContentType xContentType) {
+        this(id, source, xContentType, null);
     }
 
     public PutPipelineRequest(StreamInput in) throws IOException {
@@ -40,9 +47,15 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
         id = in.readString();
         source = in.readBytesReference();
         xContentType = in.readEnum(XContentType.class);
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            version = in.readOptionalInt();
+        } else {
+            version = null;
+        }
     }
 
     PutPipelineRequest() {
+        this(null, null, null, null);
     }
 
     @Override
@@ -62,12 +75,19 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
         return xContentType;
     }
 
+    public Integer getVersion() {
+        return version;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(id);
         out.writeBytesReference(source);
         out.writeEnum(xContentType);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeOptionalInt(version);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +56,9 @@ import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -394,7 +397,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         Map<String, Object> pipelineConfig = null;
         IngestMetadata currentIngestMetadata = state.metadata().custom(IngestMetadata.TYPE);
-        if (currentIngestMetadata != null && currentIngestMetadata.getPipelines().containsKey(request.getId())) {
+        if (request.getVersion() == null &&
+            currentIngestMetadata != null &&
+            currentIngestMetadata.getPipelines().containsKey(request.getId())) {
             pipelineConfig = XContentHelper.convertToMap(request.getSource(), false, request.getXContentType()).v2();
             PipelineConfiguration currentPipeline = currentIngestMetadata.getPipelines().get(request.getId());
             if (currentPipeline.getConfigAsMap().equals(pipelineConfig)) {
@@ -494,8 +499,56 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return processorMetrics;
     }
 
-    public static ClusterState innerPut(PutPipelineRequest request, ClusterState currentState) {
+    // visible for testing
+    static ClusterState innerPut(PutPipelineRequest request, ClusterState currentState) {
         IngestMetadata currentIngestMetadata = currentState.metadata().custom(IngestMetadata.TYPE);
+
+        BytesReference pipelineSource = request.getSource();
+        if (request.getVersion() != null) {
+            var currentPipeline = currentIngestMetadata != null ? currentIngestMetadata.getPipelines().get(request.getId()) : null;
+            if (currentPipeline == null) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ROOT,
+                    "version conflict, required version [%s] for pipeline [%s] but no pipeline was found",
+                    request.getVersion(),
+                    request.getId()
+                ));
+            }
+
+            final Integer currentVersion = currentPipeline.getVersion();
+            if (Objects.equals(request.getVersion(), currentVersion) == false) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ROOT,
+                    "version conflict, required version [%s] for pipeline [%s] but current version is [%s]",
+                    request.getVersion(),
+                    request.getId(),
+                    currentVersion
+                ));
+            }
+
+            var pipelineConfig = XContentHelper.convertToMap(request.getSource(), false, request.getXContentType()).v2();
+            final Integer specifiedVersion = (Integer) pipelineConfig.get("version");
+            if (pipelineConfig.containsKey("version") && Objects.equals(specifiedVersion, currentVersion)) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ROOT,
+                    "cannot update pipeline [%s] with the same version [%s]",
+                    request.getId(),
+                    request.getVersion()
+                ));
+            }
+
+            // if no version specified in the pipeline definition, inject a version of [request.getVersion() + 1]
+            if (specifiedVersion == null) {
+                pipelineConfig.put("version", request.getVersion() == null ? 1 : request.getVersion() + 1);
+                try {
+                    var builder = XContentBuilder.builder(request.getXContentType().xContent()).map(pipelineConfig);
+                    pipelineSource = BytesReference.bytes(builder);
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+
         Map<String, PipelineConfiguration> pipelines;
         if (currentIngestMetadata != null) {
             pipelines = new HashMap<>(currentIngestMetadata.getPipelines());
@@ -503,7 +556,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             pipelines = new HashMap<>();
         }
 
-        pipelines.put(request.getId(), new PipelineConfiguration(request.getId(), request.getSource(), request.getXContentType()));
+        pipelines.put(request.getId(), new PipelineConfiguration(request.getId(), pipelineSource, request.getXContentType()));
         ClusterState.Builder newState = ClusterState.builder(currentState);
         newState.metadata(Metadata.builder(currentState.getMetadata())
             .putCustom(IngestMetadata.TYPE, new IngestMetadata(pipelines))

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -96,6 +96,22 @@ public final class PipelineConfiguration extends AbstractDiffable<PipelineConfig
         return config;
     }
 
+    public Integer getVersion() {
+        var configMap = getConfigAsMap();
+        if (configMap.containsKey("version")) {
+            Object o = configMap.get("version");
+            if (o == null) {
+                return null;
+            } else if (o instanceof Number) {
+                return ((Number) o).intValue();
+            } else {
+                throw new IllegalStateException("unexpected version type [" + o.getClass().getName() + "]");
+            }
+        } else {
+            return null;
+        }
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -97,7 +97,7 @@ public final class PipelineConfiguration extends AbstractDiffable<PipelineConfig
     }
 
     public Integer getVersion() {
-        var configMap = getConfigAsMap();
+        Map<String, Object> configMap = getConfigAsMap();
         if (configMap.containsKey("version")) {
             Object o = configMap.get("version");
             if (o == null) {

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -38,11 +39,24 @@ public class RestPutPipelineAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        Integer ifVersion = null;
+        if (restRequest.hasParam("if_version")) {
+            String versionString = restRequest.param("if_version");
+            try {
+                ifVersion = Integer.parseInt(versionString);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ROOT,
+                    "invalid value [%s] specified for [if_version]. must be an integer value",
+                    versionString
+                ));
+            }
+        }
+
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
-        PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), sourceTuple.v2(), sourceTuple.v1());
+        PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), sourceTuple.v2(), sourceTuple.v1(), ifVersion);
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         return channel -> client.admin().cluster().putPipeline(request, new RestToXContentListener<>(channel));
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -43,10 +43,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.cbor.CborXContent;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
@@ -60,6 +57,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.cbor.CborXContent;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.Before;
 import org.mockito.ArgumentMatcher;
@@ -88,8 +88,8 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.hamcrest.Matchers.containsString;
 import static org.elasticsearch.core.Tuple.tuple;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -1673,12 +1673,12 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     public void testPutPipelineWithVersionedUpdateWithoutExistingPipeline() throws Exception {
-        var pipelineId = randomAlphaOfLength(5);
-        var clusterState = ClusterState.EMPTY_STATE;
+        String pipelineId = randomAlphaOfLength(5);
+        ClusterState clusterState = ClusterState.EMPTY_STATE;
 
         final Integer version = randomInt();
-        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
-        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
+        String pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        PutPipelineRequest request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
         assertThat(
             e.getMessage(),
@@ -1692,19 +1692,20 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     public void testPutPipelineWithVersionedUpdateDoesNotMatchExistingPipeline() {
-        var pipelineId = randomAlphaOfLength(5);
+        String pipelineId = randomAlphaOfLength(5);
         final Integer version = randomInt();
-        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
-        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
-        var clusterState = ClusterState.builder(new ClusterName("test"))
+        String pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        PipelineConfiguration existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
             .metadata(Metadata.builder().putCustom(
                     IngestMetadata.TYPE,
-                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                    new IngestMetadata(org.elasticsearch.core.Map.of(pipelineId, existingPipeline))
                 ).build()
             ).build();
 
         final Integer requestedVersion = randomValueOtherThan(version, ESTestCase::randomInt);
-        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, requestedVersion);
+        PutPipelineRequest request =
+            new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, requestedVersion);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
         assertThat(
             e.getMessage(),
@@ -1719,18 +1720,18 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     public void testPutPipelineWithVersionedUpdateSpecifiesSameVersion() throws Exception {
-        var pipelineId = randomAlphaOfLength(5);
+        String pipelineId = randomAlphaOfLength(5);
         final Integer version = randomInt();
-        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
-        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
-        var clusterState = ClusterState.builder(new ClusterName("test"))
+        String pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        PipelineConfiguration existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
             .metadata(Metadata.builder().putCustom(
                     IngestMetadata.TYPE,
-                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                    new IngestMetadata(org.elasticsearch.core.Map.of(pipelineId, existingPipeline))
                 ).build()
             ).build();
 
-        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
+        PutPipelineRequest request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
         assertThat(
             e.getMessage(),
@@ -1744,44 +1745,47 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     public void testPutPipelineWithVersionedUpdateSpecifiesValidVersion() throws Exception {
-        var pipelineId = randomAlphaOfLength(5);
+        String pipelineId = randomAlphaOfLength(5);
         final Integer existingVersion = randomInt();
-        var pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
-        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
-        var clusterState = ClusterState.builder(new ClusterName("test"))
+        String pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
+        PipelineConfiguration existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
             .metadata(Metadata.builder().putCustom(
                     IngestMetadata.TYPE,
-                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                    new IngestMetadata(org.elasticsearch.core.Map.of(pipelineId, existingPipeline))
                 ).build()
             ).build();
 
         final int specifiedVersion = randomValueOtherThan(existingVersion, ESTestCase::randomInt);
-        var updatedPipelineString = "{\"version\": " + specifiedVersion + ", \"processors\": []}";
-        var request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
-        var updatedState = IngestService.innerPut(request, clusterState);
+        String updatedPipelineString = "{\"version\": " + specifiedVersion + ", \"processors\": []}";
+        PutPipelineRequest request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
+        ClusterState updatedState = IngestService.innerPut(request, clusterState);
 
-        var updatedConfig = ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
+        PipelineConfiguration updatedConfig =
+            ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
         assertThat(updatedConfig, notNullValue());
         assertThat(updatedConfig.getVersion(), equalTo(specifiedVersion));
     }
 
     public void testPutPipelineWithVersionedUpdateIncrementsVersion() throws Exception {
-        var pipelineId = randomAlphaOfLength(5);
+        String pipelineId = randomAlphaOfLength(5);
         final Integer existingVersion = randomInt();
-        var pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
-        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
-        var clusterState = ClusterState.builder(new ClusterName("test"))
+        String pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
+        PipelineConfiguration existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
             .metadata(Metadata.builder().putCustom(
                     IngestMetadata.TYPE,
-                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                    new IngestMetadata(org.elasticsearch.core.Map.of(pipelineId, existingPipeline))
                 ).build()
             ).build();
 
-        var updatedPipelineString = "{\"processors\": []}";
-        var request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
-        var updatedState = IngestService.innerPut(request, clusterState);
+        String updatedPipelineString = "{\"processors\": []}";
+        PutPipelineRequest request =
+            new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
+        ClusterState updatedState = IngestService.innerPut(request, clusterState);
 
-        var updatedConfig = ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
+        PipelineConfiguration updatedConfig =
+            ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
         assertThat(updatedConfig, notNullValue());
         assertThat(updatedConfig.getVersion(), equalTo(existingVersion + 1));
     }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1672,6 +1672,120 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(listener.getFailureCount(), equalTo(0L));
     }
 
+    public void testPutPipelineWithVersionedUpdateWithoutExistingPipeline() throws Exception {
+        var pipelineId = randomAlphaOfLength(5);
+        var clusterState = ClusterState.EMPTY_STATE;
+
+        final Integer version = randomInt();
+        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
+        assertThat(
+            e.getMessage(),
+            equalTo(String.format(
+                Locale.ROOT,
+                "version conflict, required version [%s] for pipeline [%s] but no pipeline was found",
+                version,
+                pipelineId
+            ))
+        );
+    }
+
+    public void testPutPipelineWithVersionedUpdateDoesNotMatchExistingPipeline() {
+        var pipelineId = randomAlphaOfLength(5);
+        final Integer version = randomInt();
+        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        var clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().putCustom(
+                    IngestMetadata.TYPE,
+                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                ).build()
+            ).build();
+
+        final Integer requestedVersion = randomValueOtherThan(version, ESTestCase::randomInt);
+        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, requestedVersion);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
+        assertThat(
+            e.getMessage(),
+            equalTo(String.format(
+                Locale.ROOT,
+                "version conflict, required version [%s] for pipeline [%s] but current version is [%s]",
+                requestedVersion,
+                pipelineId,
+                version
+            ))
+        );
+    }
+
+    public void testPutPipelineWithVersionedUpdateSpecifiesSameVersion() throws Exception {
+        var pipelineId = randomAlphaOfLength(5);
+        final Integer version = randomInt();
+        var pipelineString = "{\"version\": " + version + ", \"processors\": []}";
+        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        var clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().putCustom(
+                    IngestMetadata.TYPE,
+                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                ).build()
+            ).build();
+
+        var request = new PutPipelineRequest(pipelineId, new BytesArray(pipelineString), XContentType.JSON, version);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IngestService.innerPut(request, clusterState));
+        assertThat(
+            e.getMessage(),
+            equalTo(String.format(
+                Locale.ROOT,
+                "cannot update pipeline [%s] with the same version [%s]",
+                pipelineId,
+                version
+            ))
+        );
+    }
+
+    public void testPutPipelineWithVersionedUpdateSpecifiesValidVersion() throws Exception {
+        var pipelineId = randomAlphaOfLength(5);
+        final Integer existingVersion = randomInt();
+        var pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
+        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        var clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().putCustom(
+                    IngestMetadata.TYPE,
+                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                ).build()
+            ).build();
+
+        final int specifiedVersion = randomValueOtherThan(existingVersion, ESTestCase::randomInt);
+        var updatedPipelineString = "{\"version\": " + specifiedVersion + ", \"processors\": []}";
+        var request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
+        var updatedState = IngestService.innerPut(request, clusterState);
+
+        var updatedConfig = ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
+        assertThat(updatedConfig, notNullValue());
+        assertThat(updatedConfig.getVersion(), equalTo(specifiedVersion));
+    }
+
+    public void testPutPipelineWithVersionedUpdateIncrementsVersion() throws Exception {
+        var pipelineId = randomAlphaOfLength(5);
+        final Integer existingVersion = randomInt();
+        var pipelineString = "{\"version\": " + existingVersion + ", \"processors\": []}";
+        var existingPipeline = new PipelineConfiguration(pipelineId, new BytesArray(pipelineString), XContentType.JSON);
+        var clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().putCustom(
+                    IngestMetadata.TYPE,
+                    new IngestMetadata(Map.of(pipelineId, existingPipeline))
+                ).build()
+            ).build();
+
+        var updatedPipelineString = "{\"processors\": []}";
+        var request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
+        var updatedState = IngestService.innerPut(request, clusterState);
+
+        var updatedConfig = ((IngestMetadata) updatedState.metadata().custom(IngestMetadata.TYPE)).getPipelines().get(pipelineId);
+        assertThat(updatedConfig, notNullValue());
+        assertThat(updatedConfig.getVersion(), equalTo(existingVersion + 1));
+    }
+
     private static Tuple<String, Object> randomMapEntry() {
         return tuple(randomAlphaOfLength(5), randomObject());
     }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1758,7 +1758,8 @@ public class IngestServiceTests extends ESTestCase {
 
         final int specifiedVersion = randomValueOtherThan(existingVersion, ESTestCase::randomInt);
         String updatedPipelineString = "{\"version\": " + specifiedVersion + ", \"processors\": []}";
-        PutPipelineRequest request = new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
+        PutPipelineRequest request =
+            new PutPipelineRequest(pipelineId, new BytesArray(updatedPipelineString), XContentType.JSON, existingVersion);
         ClusterState updatedState = IngestService.innerPut(request, clusterState);
 
         PipelineConfiguration updatedConfig =

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Predicate;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class PipelineConfigurationTests extends AbstractXContentTestCase<PipelineConfiguration> {
 
     public void testSerialization() throws IOException {
@@ -70,6 +72,24 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
         assertEquals(xContentType, parsed.getXContentType());
         assertEquals("{}", XContentHelper.convertToJson(parsed.getConfig(), false, parsed.getXContentType()));
         assertEquals("1", parsed.getId());
+    }
+
+    public void testGetVersion() {
+        {
+            // missing version
+            String configJson = "{\"description\": \"blah\", \"_meta\" : {\"foo\": \"bar\"}}";
+            PipelineConfiguration configuration = new PipelineConfiguration("1",
+                new BytesArray(configJson.getBytes(StandardCharsets.UTF_8)), XContentType.JSON);
+            assertNull(configuration.getVersion());
+        }
+        {
+            // null version
+            int version = randomInt();
+            String configJson = "{\"version\": " + version + ", \"description\": \"blah\", \"_meta\" : {\"foo\": \"bar\"}}";
+            PipelineConfiguration configuration = new PipelineConfiguration("1",
+                new BytesArray(configJson.getBytes(StandardCharsets.UTF_8)), XContentType.JSON);
+            assertThat(configuration.getVersion(), equalTo(version));
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action.ingest;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RestPutPipelineActionTests extends RestActionTestCase {
+
+    private RestPutPipelineAction action;
+
+    @Before
+    public void setUpAction() {
+        action = new RestPutPipelineAction();
+        controller().registerHandler(action);
+        verifyingClient.setExecuteVerifier((actionType, request) -> Mockito.mock(AcknowledgedResponse.class));
+        verifyingClient.setExecuteLocallyVerifier((actionType, request) -> Mockito.mock(AcknowledgedResponse.class));
+    }
+
+    public void testInvalidIfVersionValue() {
+        Map<String, String> params = new HashMap<>();
+        final String invalidValue = randomAlphaOfLength(5);
+        params.put("if_version", invalidValue);
+        params.put("id", "my_pipeline");
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.PUT)
+            .withPath("/_ingest/pipeline/my_pipeline")
+            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withParams(params)
+            .build();
+
+        Exception ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, verifyingClient));
+        assertEquals(
+            "invalid value [" + invalidValue + "] specified for [if_version]. must be an integer value",
+            ex.getMessage()
+        );
+    }
+
+    public void testMissingIfVersionValue() {
+        Map<String, String> params = new HashMap<>();
+        params.put("id", "my_pipeline");
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.PUT)
+            .withPath("/_ingest/pipeline/my_pipeline")
+            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withParams(params)
+            .build();
+
+        var verifier = new BiFunction<ActionType<AcknowledgedResponse>, ActionRequest, AcknowledgedResponse>() {
+            boolean wasInvoked = false;
+
+            @Override
+            public AcknowledgedResponse apply(ActionType<AcknowledgedResponse> actionType, ActionRequest actionRequest) {
+                wasInvoked  = true;
+                assertThat(actionRequest.getClass(), equalTo(PutPipelineRequest.class));
+                PutPipelineRequest req = (PutPipelineRequest) actionRequest;
+                assertThat(req.getId(), equalTo("my_pipeline"));
+                return null;
+            }
+
+            public boolean wasInvoked() {
+                return wasInvoked;
+            }
+        };
+        verifyingClient.setExecuteVerifier(verifier);
+
+        dispatchRequest(request);
+        assertThat(verifier.wasInvoked(), equalTo(true));
+    }
+
+    public void testNumericIfVersionValue() {
+        Map<String, String> params = new HashMap<>();
+        final int numericValue = randomInt();
+        params.put("id", "my_pipeline");
+        params.put("if_version", Integer.toString(numericValue));
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.PUT)
+            .withPath("/_ingest/pipeline/my_pipeline")
+            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withParams(params)
+            .build();
+
+        var verifier = new BiFunction<ActionType<AcknowledgedResponse>, ActionRequest, AcknowledgedResponse>() {
+            boolean wasInvoked = false;
+
+            @Override
+            public AcknowledgedResponse apply(ActionType<AcknowledgedResponse> actionType, ActionRequest actionRequest) {
+                wasInvoked  = true;
+                assertThat(actionRequest.getClass(), equalTo(PutPipelineRequest.class));
+                PutPipelineRequest req = (PutPipelineRequest) actionRequest;
+                assertThat(req.getId(), equalTo("my_pipeline"));
+                assertThat(req.getVersion(), equalTo(numericValue));
+                return null;
+            }
+
+            public boolean wasInvoked() {
+                return wasInvoked;
+            }
+        };
+        verifyingClient.setExecuteVerifier(verifier);
+
+        dispatchRequest(request);
+        assertThat(verifier.wasInvoked(), equalTo(true));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
@@ -101,7 +101,7 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
         boolean wasInvoked = false;
         final Integer expectedVersion;
 
-        public RequestVerifier(Integer expectedVersion) {
+        RequestVerifier(Integer expectedVersion) {
             this.expectedVersion = expectedVersion;
         }
 

--- a/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
@@ -69,22 +69,7 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
             .withParams(params)
             .build();
 
-        var verifier = new BiFunction<ActionType<AcknowledgedResponse>, ActionRequest, AcknowledgedResponse>() {
-            boolean wasInvoked = false;
-
-            @Override
-            public AcknowledgedResponse apply(ActionType<AcknowledgedResponse> actionType, ActionRequest actionRequest) {
-                wasInvoked  = true;
-                assertThat(actionRequest.getClass(), equalTo(PutPipelineRequest.class));
-                PutPipelineRequest req = (PutPipelineRequest) actionRequest;
-                assertThat(req.getId(), equalTo("my_pipeline"));
-                return null;
-            }
-
-            public boolean wasInvoked() {
-                return wasInvoked;
-            }
-        };
+        RequestVerifier verifier = new RequestVerifier(null);
         verifyingClient.setExecuteVerifier(verifier);
 
         dispatchRequest(request);
@@ -104,26 +89,36 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
             .withParams(params)
             .build();
 
-        var verifier = new BiFunction<ActionType<AcknowledgedResponse>, ActionRequest, AcknowledgedResponse>() {
-            boolean wasInvoked = false;
-
-            @Override
-            public AcknowledgedResponse apply(ActionType<AcknowledgedResponse> actionType, ActionRequest actionRequest) {
-                wasInvoked  = true;
-                assertThat(actionRequest.getClass(), equalTo(PutPipelineRequest.class));
-                PutPipelineRequest req = (PutPipelineRequest) actionRequest;
-                assertThat(req.getId(), equalTo("my_pipeline"));
-                assertThat(req.getVersion(), equalTo(numericValue));
-                return null;
-            }
-
-            public boolean wasInvoked() {
-                return wasInvoked;
-            }
-        };
+        RequestVerifier verifier = new RequestVerifier(numericValue);
         verifyingClient.setExecuteVerifier(verifier);
 
         dispatchRequest(request);
         assertThat(verifier.wasInvoked(), equalTo(true));
+    }
+
+    private static class RequestVerifier implements BiFunction<ActionType<AcknowledgedResponse>, ActionRequest, AcknowledgedResponse> {
+
+        boolean wasInvoked = false;
+        final Integer expectedVersion;
+
+        public RequestVerifier(Integer expectedVersion) {
+            this.expectedVersion = expectedVersion;
+        }
+
+        @Override
+        public AcknowledgedResponse apply(ActionType<AcknowledgedResponse> actionType, ActionRequest actionRequest) {
+            wasInvoked = true;
+            assertThat(actionRequest.getClass(), equalTo(PutPipelineRequest.class));
+            PutPipelineRequest req = (PutPipelineRequest) actionRequest;
+            assertThat(req.getId(), equalTo("my_pipeline"));
+            if (expectedVersion != null) {
+                assertThat(req.getVersion(), equalTo(expectedVersion));
+            }
+            return null;
+        }
+
+        public boolean wasInvoked() {
+            return wasInvoked;
+        }
     }
 }


### PR DESCRIPTION
This commit adds optional optimistic concurrency control to the [API for updating ingest pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html). This is achieved through the addition of an `if_version` query parameter similar to the `if_seq_no` and `if_primary_term` parameters used for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html) in Elasticsearch.  When this parameter is specified, the pipeline update succeeds only if there is an existing pipeline with a version that matches the specified version. 

```
PUT /_ingest/pipeline/my_pipeline?if_version=5
{
  "version": 9,
  "processors": [
    ...
  ]
}
```

In the example above, the update succeeds only if "my_pipeline" exists with a version of 5. Any version can be specified in the body of the update so long as it is _not_ the existing version. If no version is specified in the body of the update, the version is automatically set to `<currentVersion> + 1`. Pipelines that do not have a `version` attribute with a numeric value cannot be updated with the `if_version` parameter because checking for a null or missing version is not a meaningful guard against concurrent updates.

Note that any pipeline updates that do not include an `if_version` parameter will be processed unconditionally. Note also that there are no [optimizations possible for no-op pipeline updates](https://github.com/elastic/elasticsearch/pull/78196) when the `if_version` parameter is specified because such an update will always change, at the very least, the version attribute of the pipeline and will therefore never be a no-op update.

Fixes #77031

Backport of #78551 
