### PR TITLE
Enable tsdb feature flag in server tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.optional-base'
 apply plugin: 'elasticsearch.publish'
@@ -125,6 +127,12 @@ def generatePluginsList = tasks.register("generatePluginsList") {
 
 tasks.named("processResources").configure {
     dependsOn generateModulesList, generatePluginsList
+}
+
+if (BuildParams.isSnapshotBuild() == false) {
+    tasks.named("test").configure {
+        systemProperty 'es.index_mode_feature_flag_registered', 'true'
+    }
 }
 
 tasks.named("thirdPartyAudit").configure {


### PR DESCRIPTION
We now have tests in the server that rely on tsdb settings. Usually we
build a snapshot version of Elasticsearch and the feature flag is
enabled by default. But nightly we run the tests outside of snapshot
mode which disables the feature flag. So the tests fail! This manually
reenables the feature flag when we a running in non-snapshot mode.

Closes #79339
