### PR TITLE
[7.x] Optimize allocations for `List.copyOf` and `Set.copyOf`

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/List.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/List.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.core;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,8 +76,14 @@ public class List {
      * @param coll a {@code Collection} from which elements are drawn, must be non-null
      * @return a {@code List} containing the elements of the given {@code Collection}
      */
-    @SuppressWarnings("unchecked")
     public static <T> java.util.List<T> copyOf(Collection<? extends T> coll) {
-        return (java.util.List<T>) List.of(coll.toArray());
+        switch (coll.size()) {
+            case 0:
+                return List.of();
+            case 1:
+                return List.of(coll.iterator().next());
+            default:
+                return Collections.unmodifiableList(new ArrayList<>(coll));
+        }
     }
 }

--- a/libs/core/src/main/java/org/elasticsearch/core/List.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/List.java
@@ -79,9 +79,9 @@ public class List {
     public static <T> java.util.List<T> copyOf(Collection<? extends T> coll) {
         switch (coll.size()) {
             case 0:
-                return List.of();
+                return Collections.emptyList();
             case 1:
-                return List.of(coll.iterator().next());
+                return Collections.singletonList(coll.iterator().next());
             default:
                 return Collections.unmodifiableList(new ArrayList<>(coll));
         }

--- a/libs/core/src/main/java/org/elasticsearch/core/Set.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Set.java
@@ -61,9 +61,9 @@ public class Set {
     public static <T> java.util.Set<T> of(T... entries) {
         switch (entries.length) {
             case 0:
-                return Set.of();
+                return of();
             case 1:
-                return Set.of(entries[0]);
+                return of(entries[0]);
             default:
                 return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(entries)));
         }
@@ -81,9 +81,9 @@ public class Set {
     public static <T> java.util.Set<T> copyOf(Collection<? extends T> coll) {
         switch (coll.size()) {
             case 0:
-                return Set.of();
+                return Collections.emptySet();
             case 1:
-                return Set.of(coll.iterator().next());
+                return Collections.singleton(coll.iterator().next());
             default:
                 return Collections.unmodifiableSet(new HashSet<>(coll));
         }

--- a/libs/core/src/main/java/org/elasticsearch/core/Set.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Set.java
@@ -78,8 +78,14 @@ public class Set {
      * @throws NullPointerException if coll is null, or if it contains any nulls
      * @since 10
      */
-    @SuppressWarnings("unchecked")
     public static <T> java.util.Set<T> copyOf(Collection<? extends T> coll) {
-        return (java.util.Set<T>) Set.of(new HashSet<>(coll).toArray());
+        switch (coll.size()) {
+            case 0:
+                return Set.of();
+            case 1:
+                return Set.of(coll.iterator().next());
+            default:
+                return Collections.unmodifiableSet(new HashSet<>(coll));
+        }
     }
 }


### PR DESCRIPTION
We can remove the array allocation which required only to call  `List.of/Set.of` and instead create copies directly
based the supplied collection.