### PR TITLE
Reduce BWC version for transient settings

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "Test put and reset transient settings":
   - skip:
-      version: " - 7.99.99"
+      version: " - 7.15.99"
       reason:  "transient settings deprecation"
       features: "warnings"
 


### PR DESCRIPTION
We deprecated transient cluster settings in 7.16.0, however until
that was merged we had the 8.0.0 BWC for tests set to 7.99.99. This
change reduces the test compatibility to 7.15.99.
