### PR TITLE
[7.x] EQL: Rename a test class for eclipse (#79254)

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/eql/EqlClientYamlIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/eql/EqlClientYamlIT.java
@@ -12,9 +12,9 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-public class EqlRestIT extends ESClientYamlSuiteTestCase {
+public class EqlClientYamlIT extends ESClientYamlSuiteTestCase {
 
-    public EqlRestIT(final ClientYamlTestCandidate testCandidate) {
+    public EqlClientYamlIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - EQL: Rename a test class for eclipse (#79254)