### PR TITLE
Script: Undeprecate general cache

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -59,15 +59,15 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     static final String USE_CONTEXT_RATE_KEY = "use-context";
 
     public static final Setting<Integer> SCRIPT_GENERAL_CACHE_SIZE_SETTING =
-        Setting.intSetting("script.cache.max_size", 100, 0, Property.NodeScope, Property.Deprecated);
+        Setting.intSetting("script.cache.max_size", 100, 0, Property.NodeScope);
     public static final Setting<TimeValue> SCRIPT_GENERAL_CACHE_EXPIRE_SETTING =
-        Setting.positiveTimeSetting("script.cache.expire", TimeValue.timeValueMillis(0), Property.NodeScope, Property.Deprecated);
+        Setting.positiveTimeSetting("script.cache.expire", TimeValue.timeValueMillis(0), Property.NodeScope);
     public static final Setting<Integer> SCRIPT_MAX_SIZE_IN_BYTES =
         Setting.intSetting("script.max_size_in_bytes", 65535, 0, Property.Dynamic, Property.NodeScope);
     public static final Setting<ScriptCache.CompilationRate> SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING =
         new Setting<>("script.max_compilations_rate", USE_CONTEXT_RATE_KEY,
             (String value) -> value.equals(USE_CONTEXT_RATE_KEY) ? USE_CONTEXT_RATE_VALUE: new ScriptCache.CompilationRate(value),
-            Property.Dynamic, Property.NodeScope, Property.Deprecated);
+            Property.Dynamic, Property.NodeScope);
 
     // Per-context settings
     static final String CONTEXT_PREFIX = "script.context.";

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -226,8 +225,6 @@ public class ScriptServiceTests extends ESTestCase {
         scriptService.compile(script, context);
         scriptService.compile(script, context);
         assertEquals(1L, scriptService.stats().getCompilations());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_CACHE_SIZE_SETTING,
-            SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testIndexedScriptCountedInCompilationStats() throws IOException {
@@ -249,8 +246,6 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(2L, scriptService.cacheStats().getGeneralStats().getCompilations());
         assertEquals(1L, scriptService.stats().getCacheEvictions());
         assertEquals(1L, scriptService.cacheStats().getGeneralStats().getCacheEvictions());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_CACHE_SIZE_SETTING,
-            SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testContextCacheStats() throws IOException {
@@ -408,7 +403,6 @@ public class ScriptServiceTests extends ESTestCase {
                 .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("field").getKey(), 123)
                 .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("score").getKey(), "50/5m")
                 .build());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testFallbackContextSettings() {
@@ -432,7 +426,6 @@ public class ScriptServiceTests extends ESTestCase {
 
         assertEquals(cacheExpireFooParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").get(s));
         assertEquals(cacheExpireBackupParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("bar").get(s));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_CACHE_SIZE_SETTING, SCRIPT_GENERAL_CACHE_EXPIRE_SETTING});
     }
 
     public void testUseContextSettingValue() {
@@ -449,7 +442,6 @@ public class ScriptServiceTests extends ESTestCase {
         });
 
         assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [use-context]", illegal.getMessage());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testCacheHolderGeneralConstructor() throws IOException {
@@ -463,7 +455,6 @@ public class ScriptServiceTests extends ESTestCase {
         assertNotNull(holder.general);
         assertNull(holder.contextCache);
         assertEquals(holder.general.rate, new ScriptCache.CompilationRate(compilationRate));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testCacheHolderContextConstructor() throws IOException {
@@ -503,7 +494,6 @@ public class ScriptServiceTests extends ESTestCase {
                  ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
             .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.USE_CONTEXT_RATE_KEY)
             .build());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testDisableCompilationRateSetting() throws IOException {
@@ -532,7 +522,6 @@ public class ScriptServiceTests extends ESTestCase {
         buildScriptService(Settings.builder()
             .put("script.disable_max_compilations_rate", true)
             .build());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testCacheHolderChangeSettings() throws IOException {
@@ -604,8 +593,6 @@ public class ScriptServiceTests extends ESTestCase {
             Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), bRate).build()
         );
         assertEquals(holder, scriptService.cacheHolder.get());
-
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     public void testFallbackToContextDefaults() throws IOException {
@@ -649,8 +636,6 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(ingest.maxCompilationRateDefault, holder.contextCache.get(name).get().rate.asTuple());
         assertEquals(ingest.cacheSizeDefault, holder.contextCache.get(name).get().cacheSize);
         assertEquals(ingest.cacheExpireDefault, holder.contextCache.get(name).get().cacheExpire);
-
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
 
     private void assertCompileRejected(String lang, String script, ScriptType scriptType, ScriptContext<?> scriptContext) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -82,9 +82,6 @@ public class DeprecationChecks {
                         NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
                     NodeDeprecationChecks::checkClusterRemoteConnectSetting,
                     NodeDeprecationChecks::checkNodeLocalStorageSetting,
-                    NodeDeprecationChecks::checkGeneralScriptSizeSetting,
-                    NodeDeprecationChecks::checkGeneralScriptExpireSetting,
-                    NodeDeprecationChecks::checkGeneralScriptCompileSettings,
                     (settings, pluginsAndModules, clusterState, licenseState) ->
                         NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.ENRICH_ENABLED_SETTING),
                     (settings, pluginsAndModules, clusterState, licenseState) ->

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -35,7 +35,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeRoleSettings;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.SniffConnectionStrategy;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -311,42 +311,6 @@ class NodeDeprecationChecks {
         );
     }
 
-    public static DeprecationIssue checkGeneralScriptSizeSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                 final ClusterState clusterState, final XPackLicenseState licenseState) {
-        return checkDeprecatedSetting(
-            settings,
-            pluginsAndModules,
-            ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING,
-            ScriptService.SCRIPT_CACHE_SIZE_SETTING,
-            "a script context",
-            "https://ela.st/es-deprecation-7-script-cache-size-setting"
-        );
-    }
-
-    public static DeprecationIssue checkGeneralScriptExpireSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                   final ClusterState clusterState, final XPackLicenseState licenseState) {
-        return checkDeprecatedSetting(
-            settings,
-            pluginsAndModules,
-            ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING,
-            ScriptService.SCRIPT_CACHE_EXPIRE_SETTING,
-            "a script context",
-            "https://ela.st/es-deprecation-7-script-cache-expire-setting"
-        );
-    }
-
-    public static DeprecationIssue checkGeneralScriptCompileSettings(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                    final ClusterState clusterState, final XPackLicenseState licenseState) {
-        return checkDeprecatedSetting(
-            settings,
-            pluginsAndModules,
-            ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING,
-            ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING,
-            "a script context",
-            "https://ela.st/es-deprecation-7-script-max-compilations-rate-setting"
-        );
-    }
-
     public static DeprecationIssue checkLegacyRoleSettings(
         final Setting<Boolean> legacyRoleSetting,
         final Settings settings,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -423,54 +423,6 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.size"});
     }
 
-    public void testGeneralScriptSizeSetting() {
-        final int size = randomIntBetween(1, 4);
-        final Settings settings = Settings.builder().put("script.cache.max_size", size).build();
-        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
-        final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
-        final List<DeprecationIssue> issues = getDeprecationIssues(settings, pluginsAndModules, licenseState);
-        final DeprecationIssue expected = new DeprecationIssue(
-            DeprecationIssue.Level.CRITICAL,
-            "setting [script.cache.max_size] is deprecated in favor of grouped setting [script.context.*.cache_max_size]",
-            "https://ela.st/es-deprecation-7-script-cache-size-setting",
-            "the setting [script.cache.max_size] is currently set to [" + size + "], instead set [script.context.*.cache_max_size] " +
-                "to [" + size + "] where * is a script context", false, null);
-        assertThat(issues, hasItem(expected));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING});
-    }
-
-    public void testGeneralScriptExpireSetting() {
-        final String expire = randomIntBetween(1, 4) + "m";
-        final Settings settings = Settings.builder().put("script.cache.expire", expire).build();
-        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
-        final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
-        final List<DeprecationIssue> issues = getDeprecationIssues(settings, pluginsAndModules, licenseState);
-        final DeprecationIssue expected = new DeprecationIssue(
-            DeprecationIssue.Level.CRITICAL,
-            "setting [script.cache.expire] is deprecated in favor of grouped setting [script.context.*.cache_expire]",
-            "https://ela.st/es-deprecation-7-script-cache-expire-setting",
-            "the setting [script.cache.expire] is currently set to [" + expire + "], instead set [script.context.*.cache_expire] to " +
-                "[" + expire + "] where * is a script context", false, null);
-        assertThat(issues, hasItem(expected));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING});
-    }
-
-    public void testGeneralScriptCompileSettings() {
-        final String rate = randomIntBetween(1, 100) + "/" + randomIntBetween(1, 200) + "m";
-        final Settings settings = Settings.builder().put("script.max_compilations_rate", rate).build();
-        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
-        final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
-        final List<DeprecationIssue> issues = getDeprecationIssues(settings, pluginsAndModules, licenseState);
-        final DeprecationIssue expected = new DeprecationIssue(
-            DeprecationIssue.Level.CRITICAL,
-            "setting [script.max_compilations_rate] is deprecated in favor of grouped setting [script.context.*.max_compilations_rate]",
-            "https://ela.st/es-deprecation-7-script-max-compilations-rate-setting",
-            "the setting [script.max_compilations_rate] is currently set to [" + rate +
-                "], instead set [script.context.*.max_compilations_rate] to [" + rate + "] where * is a script context", false, null);
-        assertThat(issues, hasItem(expected));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
-    }
-
     public void testClusterRemoteConnectSetting() {
         final boolean value = randomBoolean();
         final Settings settings = Settings.builder().put(RemoteClusterService.ENABLE_REMOTE_CLUSTERS.getKey(), value).build();

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;


### PR DESCRIPTION
General cache settings are no longer deprecated for 8.0
* `script.cache.max_size`
* `script.cache.expire`
* `script.max_compilations_rate`

Refs: #62899