### PR TITLE
Ensure indexing_data CCR requests are compressed

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -98,7 +98,7 @@ public final class TransportActionProxy {
         }
     }
 
-    static class ProxyRequest<T extends TransportRequest> extends TransportRequest {
+    static class ProxyRequest<T extends TransportRequest> extends TransportRequest implements RawIndexingDataTransportRequest {
         final T wrapped;
         final DiscoveryNode targetNode;
 
@@ -119,6 +119,14 @@ public final class TransportActionProxy {
             super.writeTo(out);
             targetNode.writeTo(out);
             wrapped.writeTo(out);
+        }
+
+        @Override
+        public boolean isRawIndexingData() {
+            if (wrapped instanceof RawIndexingDataTransportRequest) {
+                return ((RawIndexingDataTransportRequest) wrapped).isRawIndexingData();
+            }
+            return false;
         }
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsRequest.java
@@ -11,11 +11,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 
 import java.io.IOException;
 import java.util.List;
 
-public final class BulkShardOperationsRequest extends ReplicatedWriteRequest<BulkShardOperationsRequest> {
+public final class BulkShardOperationsRequest extends ReplicatedWriteRequest<BulkShardOperationsRequest>
+    implements RawIndexingDataTransportRequest {
 
     private final String historyUUID;
     private final List<Translog.Operation> operations;


### PR DESCRIPTION
Currently, CCR requests are not compressed if they are indexing data.
This is because the `BulkShardOperationsRequest` does not 
implement the indexing data interface.

Additionally, the fact that the request can be wrapped in proxy request
also requires special logic. This commit implements the same logic that
we do for shard indexing actions to ensure that the data is compressed
if the underlying request is indexing data.