### PR TITLE
Scripting: Restore general cache

### DIFF
--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -126,11 +126,11 @@ within a period of time.
 See the "prefer-parameters" section of the <<modules-scripting-using,scripting>>
 documentation for more information.
 
-`script.context.$CONTEXT.max_compilations_rate`::
+`script.max_compilations_rate`::
     (<<dynamic-cluster-setting,Dynamic>>)
     Limit for the number of unique dynamic scripts within a certain interval
-    that are allowed to be compiled for a given context. Defaults to `75/5m`,
-    meaning 75 every 5 minutes.
+    that are allowed to be compiled. Defaults to `150/5m`,
+    meaning 150 every 5 minutes.
 
 [[regex-circuit-breaker]]
 [discrete]

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -120,12 +120,8 @@ the `multiplier` parameter without {es} recompiling the script.
 }
 ----
 
-For most contexts, you can compile up to 75 scripts per 5 minutes by default.
-For ingest contexts, the default script compilation rate is unlimited. You
-can change these settings dynamically by setting
-`script.context.$CONTEXT.max_compilations_rate`. For example, the following
-setting limits script compilation to 100 scripts every 10 minutes for the
-{painless}/painless-field-context.html[field context]:
+You can compile up to 150 scripts per 5 minutes by default.
+For ingest contexts, the default script compilation rate is unlimited.
 
 [source,js]
 ----
@@ -406,8 +402,8 @@ small.
 
 All scripts are cached by default so that they only need to be recompiled
 when updates occur. By default, scripts do not have a time-based expiration.
-You can change this behavior by using the `script.context.$CONTEXT.cache_expire` setting.
-Use the `script.context.$CONTEXT.cache_max_size` setting to configure the size of the cache.
+You can change this behavior by using the `script.cache.expire` setting.
+Use the `script.cache.max_size` setting to configure the size of the cache.
 
 NOTE: The size of scripts is limited to 65,535 bytes. Set the value of `script.max_size_in_bytes` to increase that soft limit. If your scripts are
 really large, then consider using a

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -27,6 +27,7 @@ import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.process.ProcessStats;
 import org.elasticsearch.node.AdaptiveSelectionStats;
+import org.elasticsearch.script.ScriptCacheStats;
 import org.elasticsearch.script.ScriptStats;
 import org.elasticsearch.threadpool.ThreadPoolStats;
 import org.elasticsearch.transport.TransportStats;
@@ -72,6 +73,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     private ScriptStats scriptStats;
 
     @Nullable
+    private ScriptCacheStats scriptCacheStats;
+
+    @Nullable
     private DiscoveryStats discoveryStats;
 
     @Nullable
@@ -98,6 +102,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         http = in.readOptionalWriteable(HttpStats::new);
         breaker = in.readOptionalWriteable(AllCircuitBreakerStats::new);
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
+        scriptCacheStats = scriptStats != null ? scriptStats.toScriptCacheStats() : null;
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
@@ -112,6 +117,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
                      @Nullable DiscoveryStats discoveryStats,
                      @Nullable IngestStats ingestStats,
                      @Nullable AdaptiveSelectionStats adaptiveSelectionStats,
+                     @Nullable ScriptCacheStats scriptCacheStats,
                      @Nullable IndexingPressureStats indexingPressureStats) {
         super(node);
         this.timestamp = timestamp;
@@ -128,6 +134,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         this.discoveryStats = discoveryStats;
         this.ingestStats = ingestStats;
         this.adaptiveSelectionStats = adaptiveSelectionStats;
+        this.scriptCacheStats = scriptCacheStats;
         this.indexingPressureStats = indexingPressureStats;
     }
 
@@ -224,6 +231,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     }
 
     @Nullable
+    public ScriptCacheStats getScriptCacheStats() {
+        return scriptCacheStats;
+    }
+
+    @Nullable
     public IndexingPressureStats getIndexingPressureStats() {
         return indexingPressureStats;
     }
@@ -313,6 +325,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (getAdaptiveSelectionStats() != null) {
             getAdaptiveSelectionStats().toXContent(builder, params);
+        }
+        if (getScriptCacheStats() != null) {
+            getScriptCacheStats().toXContent(builder, params);
         }
         if (getIndexingPressureStats() != null) {
             getIndexingPressureStats().toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -118,6 +118,7 @@ public class NodeService implements Closeable {
                 discoveryStats ? coordinator.stats() : null,
                 ingest ? ingestService.stats() : null,
                 adaptiveSelection ? responseCollectorService.getAdaptiveStats(searchTransportService.getPendingSearchRequests()) : null,
+                scriptCache ? scriptService.cacheStats() : null,
                 indexingPressure ? this.indexingPressure.stats() : null);
     }
 

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -19,8 +19,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.elasticsearch.core.TimeValue.timeValueMillis;
-
 /**
  * Abstract base for scripts to execute to build scripted fields. Inspired by
  * {@link AggregationScript} but hopefully with less historical baggage.
@@ -32,33 +30,21 @@ public abstract class AbstractFieldScript extends DocBasedScript {
     public static final int MAX_VALUES = 100;
 
     static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
-        return new ScriptContext<>(
-            name,
-            factoryClass,
-            /*
-             * We rely on the script cache in two ways:
-             * 1. It caches the "heavy" part of mappings generated at runtime.
-             * 2. Mapping updates tend to try to compile the script twice. Not
-             *    for any good reason. They just do.
-             * Thus we use the default 100.
-             */
-            100,
-            timeValueMillis(0),
-            /*
-             * Disable compilation rate limits for runtime fields so we
-             * don't prevent mapping updates because we've performed too
-             * many recently. That'd just be lame. We also compile these
-             * scripts during search requests so this could totally be a
-             * source of runaway script compilations. We think folks will
-             * mostly reuse scripts though.
-             */
-            ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(),
-            /*
-             * Disable runtime fields scripts from being allowed
-             * to be stored as part of the script meta data.
-             */
-            false
-        );
+        /*
+         * We rely on the script cache in two ways:
+         * 1. It caches the "heavy" part of mappings generated at runtime.
+         * 2. Mapping updates tend to try to compile the script twice. Not
+         *    for any good reason. They just do.
+         * Thus we use the default cache size.
+         *
+         * We also disable compilation rate limits for runtime fields so we
+         * don't prevent mapping updates because we've performed too
+         * many recently. That'd just be lame. We also compile these
+         * scripts during search requests so this could totally be a
+         * source of runaway script compilations. We think folks will
+         * mostly reuse scripts though.
+         */
+        return new ScriptContext<>(name, factoryClass, false);
     }
 
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = Map.of(

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -19,6 +19,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.elasticsearch.core.TimeValue.timeValueMillis;
+
 /**
  * Abstract base for scripts to execute to build scripted fields. Inspired by
  * {@link AggregationScript} but hopefully with less historical baggage.
@@ -30,21 +32,33 @@ public abstract class AbstractFieldScript extends DocBasedScript {
     public static final int MAX_VALUES = 100;
 
     static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
-        /*
-         * We rely on the script cache in two ways:
-         * 1. It caches the "heavy" part of mappings generated at runtime.
-         * 2. Mapping updates tend to try to compile the script twice. Not
-         *    for any good reason. They just do.
-         * Thus we use the default cache size.
-         *
-         * We also disable compilation rate limits for runtime fields so we
-         * don't prevent mapping updates because we've performed too
-         * many recently. That'd just be lame. We also compile these
-         * scripts during search requests so this could totally be a
-         * source of runaway script compilations. We think folks will
-         * mostly reuse scripts though.
-         */
-        return new ScriptContext<>(name, factoryClass, false);
+        return new ScriptContext<>(
+            name,
+            factoryClass,
+            /*
+             * We rely on the script cache in two ways:
+             * 1. It caches the "heavy" part of mappings generated at runtime.
+             * 2. Mapping updates tend to try to compile the script twice. Not
+             *    for any good reason. They just do.
+             * Thus we use the default 100.
+             */
+            100,
+            timeValueMillis(0),
+            /*
+             * Disable compilation rate limits for runtime fields so we
+             * don't prevent mapping updates because we've performed too
+             * many recently. That'd just be lame. We also compile these
+             * scripts during search requests so this could totally be a
+             * source of runaway script compilations. We think folks will
+             * mostly reuse scripts though.
+             */
+            false,
+            /*
+             * Disable runtime fields scripts from being allowed
+             * to be stored as part of the script meta data.
+             */
+            false
+        );
     }
 
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = Map.of(

--- a/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.core.TimeValue;
+
 import java.util.Map;
 
 /**
@@ -18,7 +20,8 @@ public abstract class IngestConditionalScript {
     public static final String[] PARAMETERS = { "ctx" };
 
     /** The context used to compile {@link IngestConditionalScript} factories. */
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("processor_conditional", Factory.class, true);
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("processor_conditional", Factory.class,
+        200, TimeValue.timeValueMillis(0), false, true);
 
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;

--- a/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.core.TimeValue;
-
 import java.util.Map;
 
 /**
@@ -20,8 +18,7 @@ public abstract class IngestConditionalScript {
     public static final String[] PARAMETERS = { "ctx" };
 
     /** The context used to compile {@link IngestConditionalScript} factories. */
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("processor_conditional", Factory.class,
-        200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("processor_conditional", Factory.class, true);
 
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;

--- a/server/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.core.TimeValue;
-
 import java.util.Map;
 
 /**
@@ -21,8 +19,7 @@ public abstract class IngestScript {
     public static final String[] PARAMETERS = { "ctx" };
 
     /** The context used to compile {@link IngestScript} factories. */
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ingest", Factory.class,
-        200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ingest", Factory.class, true);
 
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;

--- a/server/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.core.TimeValue;
+
 import java.util.Map;
 
 /**
@@ -19,7 +21,8 @@ public abstract class IngestScript {
     public static final String[] PARAMETERS = { "ctx" };
 
     /** The context used to compile {@link IngestScript} factories. */
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ingest", Factory.class, true);
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ingest", Factory.class,
+        200, TimeValue.timeValueMillis(0), false, true);
 
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -44,12 +44,7 @@ public class ScriptCache {
     private final double compilesAllowedPerNano;
     private final String contextRateSetting;
 
-    ScriptCache(
-            int cacheMaxSize,
-            TimeValue cacheExpire,
-            CompilationRate maxCompilationRate,
-            String contextRateSetting
-    ) {
+    ScriptCache(int cacheMaxSize, TimeValue cacheExpire, CompilationRate maxCompilationRate, String contextRateSetting) {
         this.cacheSize = cacheMaxSize;
         this.cacheExpire = cacheExpire;
         this.contextRateSetting = contextRateSetting;
@@ -94,8 +89,10 @@ public class ScriptCache {
                     logger.trace("context [{}]: compiling script, type: [{}], lang: [{}], options: [{}]", context.name, type,
                         lang, options);
                 }
-                // Check whether too many compilations have happened
-                checkCompilationLimit();
+                if (context.compilationRateLimited) {
+                    // Check whether too many compilations have happened
+                    checkCompilationLimit();
+                }
                 Object compiledScript = scriptEngine.compile(id, idOrCode, context, options);
                 // Since the cache key is the script content itself we don't need to
                 // invalidate/check the cache if an indexed script changes.

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -121,6 +121,10 @@ public class ScriptCache {
         throw (T) t;
     }
 
+    public ScriptStats stats() {
+        return scriptMetrics.stats();
+    }
+
     public ScriptContextStats stats(String context) {
         return scriptMetrics.stats(context);
     }

--- a/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-// This class is deprecated in favor of ScriptStats and ScriptContextStats.  It is removed in 8.
+// This class is deprecated in favor of ScriptStats and ScriptContextStats
 public class ScriptCacheStats implements Writeable, ToXContentFragment {
     private final Map<String, ScriptStats> context;
     private final ScriptStats general;

--- a/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+// This class is deprecated in favor of ScriptStats and ScriptContextStats.  It is removed in 8.
+public class ScriptCacheStats implements Writeable, ToXContentFragment {
+    private final Map<String, ScriptStats> context;
+    private final ScriptStats general;
+
+    public ScriptCacheStats(Map<String, ScriptStats> context) {
+        this.context = Collections.unmodifiableMap(context);
+        this.general = null;
+    }
+
+    public ScriptCacheStats(ScriptStats general) {
+        this.general = Objects.requireNonNull(general);
+        this.context = null;
+    }
+
+    public ScriptCacheStats(StreamInput in) throws IOException {
+        boolean isContext = in.readBoolean();
+        if (isContext == false) {
+            general = new ScriptStats(in);
+            context = null;
+            return;
+        }
+
+        general = null;
+        int size = in.readInt();
+        Map<String,ScriptStats> context = new HashMap<>(size);
+        for (int i=0; i < size; i++) {
+            String name = in.readString();
+            context.put(name, new ScriptStats(in));
+        }
+        this.context = Collections.unmodifiableMap(context);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (general != null) {
+            out.writeBoolean(false);
+            general.writeTo(out);
+            return;
+        }
+
+        out.writeBoolean(true);
+        out.writeInt(context.size());
+        for (String name: context.keySet().stream().sorted().collect(Collectors.toList())) {
+            out.writeString(name);
+            context.get(name).writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.SCRIPT_CACHE_STATS);
+        builder.startObject(Fields.SUM);
+        if (general != null) {
+            builder.field(ScriptStats.Fields.COMPILATIONS, general.getCompilations());
+            builder.field(ScriptStats.Fields.CACHE_EVICTIONS, general.getCacheEvictions());
+            builder.field(ScriptStats.Fields.COMPILATION_LIMIT_TRIGGERED, general.getCompilationLimitTriggered());
+            builder.endObject().endObject();
+            return builder;
+        }
+
+        ScriptStats sum = sum();
+        builder.field(ScriptStats.Fields.COMPILATIONS, sum.getCompilations());
+        builder.field(ScriptStats.Fields.CACHE_EVICTIONS, sum.getCacheEvictions());
+        builder.field(ScriptStats.Fields.COMPILATION_LIMIT_TRIGGERED, sum.getCompilationLimitTriggered());
+        builder.endObject();
+
+        builder.startArray(Fields.CONTEXTS);
+        for (String name: context.keySet().stream().sorted().collect(Collectors.toList())) {
+            ScriptStats stats = context.get(name);
+            builder.startObject();
+            builder.field(Fields.CONTEXT, name);
+            builder.field(ScriptStats.Fields.COMPILATIONS, stats.getCompilations());
+            builder.field(ScriptStats.Fields.CACHE_EVICTIONS, stats.getCacheEvictions());
+            builder.field(ScriptStats.Fields.COMPILATION_LIMIT_TRIGGERED, stats.getCompilationLimitTriggered());
+            builder.endObject();
+        }
+        builder.endArray();
+        builder.endObject();
+
+        return builder;
+    }
+
+    /**
+     * Get the context specific stats, null if using general cache
+     */
+    public Map<String, ScriptStats> getContextStats() {
+        return context;
+    }
+
+    /**
+     * Get the general stats, null if using context cache
+     */
+    public ScriptStats getGeneralStats() {
+        return general;
+    }
+
+    /**
+     * The sum of all script stats, either the general stats or the sum of all stats of the context stats.
+     */
+    public ScriptStats sum() {
+        if (general != null) {
+            return general;
+        }
+        long compilations = 0;
+        long cacheEvictions = 0;
+        long compilationLimitTriggered = 0;
+        for (ScriptStats stat: context.values()) {
+            compilations += stat.getCompilations();
+            cacheEvictions += stat.getCacheEvictions();
+            compilationLimitTriggered += stat.getCompilationLimitTriggered();
+        }
+        return new ScriptStats(
+            compilations,
+            cacheEvictions,
+            compilationLimitTriggered
+        );
+    }
+
+    static final class Fields {
+        static final String SCRIPT_CACHE_STATS = "script_cache";
+        static final String CONTEXT = "context";
+        static final String SUM = "sum";
+        static final String CONTEXTS = "contexts";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -75,8 +75,8 @@ public final class ScriptContext<FactoryType> {
     public final boolean allowStoredScript;
 
     /** Construct a context with the related instance and compiled classes with caller provided cache defaults */
-    ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
-                  boolean compilationRateLimited, boolean allowStoredScript) {
+    public ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
+                         boolean compilationRateLimited, boolean allowStoredScript) {
         this.name = name;
         this.factoryClazz = factoryClazz;
         Method newInstanceMethod = findMethod("FactoryType", factoryClazz, "newInstance");
@@ -105,20 +105,10 @@ public final class ScriptContext<FactoryType> {
     }
 
     /** Construct a context with the related instance and compiled classes with defaults for cacheSizeDefault, cacheExpireDefault and
-     *  maxCompilationRateDefault and allow scripts of this context to be stored scripts */
+     *  compilationRateLimited and allow scripts of this context to be stored scripts */
     public ScriptContext(String name, Class<FactoryType> factoryClazz) {
         // cache size default, cache expire default, max compilation rate are defaults from ScriptService.
         this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), true, true);
-    }
-
-    /**
-     * Construct a context for a system script usage, using the:
-     *  - default cache size (only relevant when context caching enabled): 200
-     *  - default cache expiration: no expiration
-     *  - unlimited compilation rate
-     */
-    public ScriptContext(String name, Class<FactoryType> factoryClazz, boolean allowStoredScript) {
-        this(name, factoryClazz, 200, TimeValue.timeValueMillis(0), false, allowStoredScript);
     }
 
     /** Returns a method with the given name, or throws an exception if multiple are found. */

--- a/server/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -111,7 +111,6 @@ public final class ScriptContext<FactoryType> {
         this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), true, true);
     }
 
-
     /**
      * Construct a context for a system script usage, using the:
      *  - default cache size (only relevant when context caching enabled): 200

--- a/server/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -47,6 +47,8 @@ import java.lang.reflect.Method;
  * be {@code boolean needs_score()}.
  */
 public final class ScriptContext<FactoryType> {
+    /** The default compilation rate limit for contexts with compilation rate limiting enabled */
+    public static final Tuple<Integer, TimeValue> DEFAULT_COMPILATION_RATE_LIMIT = new Tuple<>(150, TimeValue.timeValueMinutes(5));
 
     /** A unique identifier for this context. */
     public final String name;
@@ -66,15 +68,15 @@ public final class ScriptContext<FactoryType> {
     /** The default expiration of a script in the cache for the context, if not overridden */
     public final TimeValue cacheExpireDefault;
 
-    /** The default max compilation rate for scripts in this context.  Script compilation is throttled if this is exceeded */
-    public final Tuple<Integer, TimeValue> maxCompilationRateDefault;
+    /** Is compilation rate limiting enabled for this context? */
+    public final boolean compilationRateLimited;
 
     /** Determines if the script can be stored as part of the cluster state. */
     public final boolean allowStoredScript;
 
     /** Construct a context with the related instance and compiled classes with caller provided cache defaults */
-    public ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
-                        Tuple<Integer, TimeValue> maxCompilationRateDefault, boolean allowStoredScript) {
+    ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
+                  boolean compilationRateLimited, boolean allowStoredScript) {
         this.name = name;
         this.factoryClazz = factoryClazz;
         Method newInstanceMethod = findMethod("FactoryType", factoryClazz, "newInstance");
@@ -98,7 +100,7 @@ public final class ScriptContext<FactoryType> {
 
         this.cacheSizeDefault = cacheSizeDefault;
         this.cacheExpireDefault = cacheExpireDefault;
-        this.maxCompilationRateDefault = maxCompilationRateDefault;
+        this.compilationRateLimited = compilationRateLimited;
         this.allowStoredScript = allowStoredScript;
     }
 
@@ -106,7 +108,18 @@ public final class ScriptContext<FactoryType> {
      *  maxCompilationRateDefault and allow scripts of this context to be stored scripts */
     public ScriptContext(String name, Class<FactoryType> factoryClazz) {
         // cache size default, cache expire default, max compilation rate are defaults from ScriptService.
-        this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), new Tuple<>(75, TimeValue.timeValueMinutes(5)), true);
+        this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), true, true);
+    }
+
+
+    /**
+     * Construct a context for a system script usage, using the:
+     *  - default cache size (only relevant when context caching enabled): 200
+     *  - default cache expiration: no expiration
+     *  - unlimited compilation rate
+     */
+    public ScriptContext(String name, Class<FactoryType> factoryClazz, boolean allowStoredScript) {
+        this(name, factoryClazz, 200, TimeValue.timeValueMillis(0), false, allowStoredScript);
     }
 
     /** Returns a method with the given name, or throws an exception if multiple are found. */

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
@@ -27,6 +27,10 @@ public class ScriptMetrics {
         compilationLimitTriggered.inc();
     }
 
+    public ScriptStats stats() {
+        return new ScriptStats(compilationsMetric.count(), cacheEvictionsMetric.count(), compilationLimitTriggered.count());
+    }
+
     public ScriptContextStats stats(String context) {
         return new ScriptContextStats(
             context,
@@ -36,4 +40,5 @@ public class ScriptMetrics {
             new ScriptContextStats.TimeSeries(),
             new ScriptContextStats.TimeSeries()
         );
-    }}
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -23,6 +23,8 @@ import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -50,6 +52,7 @@ import java.util.stream.Collectors;
 public class ScriptService implements Closeable, ClusterStateApplier, ScriptCompiler {
 
     private static final Logger logger = LogManager.getLogger(ScriptService.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ScriptService.class);
 
     static final String DISABLE_DYNAMIC_SCRIPTING_SETTING = "script.disable_dynamic";
 
@@ -59,15 +62,21 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     static final String USE_CONTEXT_RATE_KEY = "use-context";
 
     public static final Setting<Integer> SCRIPT_GENERAL_CACHE_SIZE_SETTING =
-        Setting.intSetting("script.cache.max_size", 100, 0, Property.NodeScope);
+        Setting.intSetting("script.cache.max_size", 3000, 0, Property.Dynamic, Property.NodeScope);
     public static final Setting<TimeValue> SCRIPT_GENERAL_CACHE_EXPIRE_SETTING =
-        Setting.positiveTimeSetting("script.cache.expire", TimeValue.timeValueMillis(0), Property.NodeScope);
+        Setting.positiveTimeSetting("script.cache.expire", TimeValue.timeValueMillis(0), Property.Dynamic, Property.NodeScope);
     public static final Setting<Integer> SCRIPT_MAX_SIZE_IN_BYTES =
         Setting.intSetting("script.max_size_in_bytes", 65535, 0, Property.Dynamic, Property.NodeScope);
     public static final Setting<ScriptCache.CompilationRate> SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING =
-        new Setting<>("script.max_compilations_rate", USE_CONTEXT_RATE_KEY,
+        new Setting<>("script.max_compilations_rate", "150/5m",
             (String value) -> value.equals(USE_CONTEXT_RATE_KEY) ? USE_CONTEXT_RATE_VALUE: new ScriptCache.CompilationRate(value),
             Property.Dynamic, Property.NodeScope);
+
+    public static final String USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE = "[" + USE_CONTEXT_RATE_KEY + "] is deprecated for the setting [" +
+        SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey() + "] as system scripts are now exempt from the rate limit. " +
+        "Set to a value such as [150/5m] (a rate of 150 compilations per five minutes) to rate limit user scripts in case the " +
+        "script cache [" + SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey() + "] is undersized causing script compilation thrashing.";
+
 
     // Per-context settings
     static final String CONTEXT_PREFIX = "script.context.";
@@ -77,13 +86,14 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     public static final Setting.AffixSetting<Integer> SCRIPT_CACHE_SIZE_SETTING =
         Setting.affixKeySetting(CONTEXT_PREFIX,
             "cache_max_size",
-            key -> Setting.intSetting(key, SCRIPT_GENERAL_CACHE_SIZE_SETTING, 0, Property.NodeScope, Property.Dynamic));
+            key -> Setting.intSetting(key, SCRIPT_GENERAL_CACHE_SIZE_SETTING, 0,
+                                      Property.NodeScope, Property.Dynamic, Property.Deprecated));
 
     public static final Setting.AffixSetting<TimeValue> SCRIPT_CACHE_EXPIRE_SETTING =
         Setting.affixKeySetting(CONTEXT_PREFIX,
             "cache_expire",
             key -> Setting.positiveTimeSetting(key, SCRIPT_GENERAL_CACHE_EXPIRE_SETTING, TimeValue.timeValueMillis(0),
-                                               Property.NodeScope, Property.Dynamic));
+                                               Property.NodeScope, Property.Dynamic, Property.Deprecated));
 
     // Unlimited compilation rate for context-specific script caches
     static final String UNLIMITED_COMPILATION_RATE_KEY = "unlimited";
@@ -94,7 +104,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
             key -> new Setting<ScriptCache.CompilationRate>(key, "75/5m",
                 (String value) -> value.equals(UNLIMITED_COMPILATION_RATE_KEY) ? ScriptCache.UNLIMITED_COMPILATION_RATE:
                                                                                  new ScriptCache.CompilationRate(value),
-                Property.NodeScope, Property.Dynamic));
+                Property.NodeScope, Property.Dynamic, Property.Deprecated));
 
     private static final ScriptCache.CompilationRate SCRIPT_COMPILATION_RATE_ZERO = new ScriptCache.CompilationRate(0, TimeValue.ZERO);
 
@@ -205,6 +215,10 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
         this.setCacheHolder(settings);
     }
 
+    public static boolean isUseContextCacheSet(Settings settings) {
+        return SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(settings).equals(USE_CONTEXT_RATE_VALUE);
+    }
+
     /**
      * This is overridden in tests to disable compilation rate limiting.
      */
@@ -249,6 +263,10 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
      */
     void validateCacheSettings(Settings settings) {
         boolean useContext = SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(settings).equals(USE_CONTEXT_RATE_VALUE);
+        if (useContext) {
+            deprecationLogger.warn(DeprecationCategory.SCRIPTING, "scripting-context-cache",
+                    USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        }
         List<Setting.AffixSetting<?>> affixes = Arrays.asList(SCRIPT_MAX_COMPILATIONS_RATE_SETTING, SCRIPT_CACHE_EXPIRE_SETTING,
                                                               SCRIPT_CACHE_SIZE_SETTING);
         List<String> customRates = new ArrayList<>();
@@ -277,7 +295,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
                     String.join(", ", customRates) + "] if compile rates disabled via [" +
                     SCRIPT_DISABLE_MAX_COMPILATIONS_RATE_SETTING.getKey() + "]");
             }
-            if (useContext == false) {
+            if (useContext == false && SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.exists(settings)) {
                 throw new IllegalArgumentException("Cannot set custom general compilation rates [" +
                     SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey() + "] to [" +
                     SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(settings) + "] if compile rates disabled via [" +
@@ -568,6 +586,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
         } else if (current.general.rate.equals(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(settings)) == false ||
                    current.general.cacheExpire.equals(SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.get(settings)) == false ||
                    current.general.cacheSize != SCRIPT_GENERAL_CACHE_SIZE_SETTING.get(settings)) {
+            // General compilation rate, cache expiration or cache size changed
             cacheHolder.set(generalCacheHolder(settings));
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.core.TimeValue;
+
 import java.util.Map;
 
 /**
@@ -39,5 +41,6 @@ public abstract class TemplateScript {
     // Remove compilation rate limit for ingest.  Ingest pipelines may use many mustache templates, triggering compilation
     // rate limiting.  MustacheScriptEngine explicitly checks for TemplateScript.  Rather than complicating the implementation there by
     // creating a new Script class (as would be customary), this context is used to avoid the default rate limit.
-    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class, true);
+    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class,
+            200, TimeValue.timeValueMillis(0), false, true);
 }

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.core.TimeValue;
-
 import java.util.Map;
 
 /**
@@ -41,6 +39,5 @@ public abstract class TemplateScript {
     // Remove compilation rate limit for ingest.  Ingest pipelines may use many mustache templates, triggering compilation
     // rate limiting.  MustacheScriptEngine explicitly checks for TemplateScript.  Rather than complicating the implementation there by
     // creating a new Script class (as would be customary), this context is used to avoid the default rate limit.
-    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class,
-            200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class, true);
 }

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -151,11 +151,14 @@ public class DiskUsageTests extends ESTestCase {
         };
         List<NodeStats> nodeStats = Arrays.asList(
                 new NodeStats(new DiscoveryNode("node_1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null, null),
+                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null,
+                        null, null),
                 new NodeStats(new DiscoveryNode("node_2", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null, null),
+                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null,
+                        null, null),
                 new NodeStats(new DiscoveryNode("node_3", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null, null)
+                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null,
+                        null, null)
         );
         InternalClusterInfoService.fillDiskUsagePerNode(nodeStats, newLeastAvaiableUsages, newMostAvaiableUsages);
         DiskUsage leastNode_1 = newLeastAvaiableUsages.get("node_1");
@@ -192,11 +195,14 @@ public class DiskUsageTests extends ESTestCase {
         };
         List<NodeStats> nodeStats = Arrays.asList(
                 new NodeStats(new DiscoveryNode("node_1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null, null),
+                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null,
+                        null, null),
                 new NodeStats(new DiscoveryNode("node_2", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null, null),
+                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null,
+                        null, null),
                 new NodeStats(new DiscoveryNode("node_3", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null, null)
+                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null,
+                        null, null)
         );
         InternalClusterInfoService.fillDiskUsagePerNode(nodeStats, newLeastAvailableUsages, newMostAvailableUsages);
         DiskUsage leastNode_1 = newLeastAvailableUsages.get("node_1");

--- a/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
@@ -55,6 +55,33 @@ public class ScriptCacheTests extends ESTestCase {
         }
     }
 
+    public void testGeneralCompilationCircuitBreaking() throws Exception {
+        final TimeValue expire = ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.get(Settings.EMPTY);
+        final Integer size = ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING.get(Settings.EMPTY);
+        String settingName = ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey();
+        ScriptCache cache = new ScriptCache(size, expire, new ScriptCache.CompilationRate(1, TimeValue.timeValueMinutes(1)), settingName);
+        cache.checkCompilationLimit(); // should pass
+        expectThrows(CircuitBreakingException.class, cache::checkCompilationLimit);
+        cache = new ScriptCache(size, expire, new ScriptCache.CompilationRate(2, TimeValue.timeValueMinutes(1)), settingName);
+        cache.checkCompilationLimit(); // should pass
+        cache.checkCompilationLimit(); // should pass
+        expectThrows(CircuitBreakingException.class, cache::checkCompilationLimit);
+        int count = randomIntBetween(5, 50);
+        cache = new ScriptCache(size, expire, new ScriptCache.CompilationRate(count, TimeValue.timeValueMinutes(1)), settingName);
+        for (int i = 0; i < count; i++) {
+            cache.checkCompilationLimit(); // should pass
+        }
+        expectThrows(CircuitBreakingException.class, cache::checkCompilationLimit);
+        cache = new ScriptCache(size, expire, new ScriptCache.CompilationRate(0, TimeValue.timeValueMinutes(1)), settingName);
+        expectThrows(CircuitBreakingException.class, cache::checkCompilationLimit);
+        cache = new ScriptCache(size, expire,
+            new ScriptCache.CompilationRate(Integer.MAX_VALUE, TimeValue.timeValueMinutes(1)), settingName);
+        int largeLimit = randomIntBetween(1000, 10000);
+        for (int i = 0; i < largeLimit; i++) {
+            cache.checkCompilationLimit();
+        }
+    }
+
     public void testUnlimitedCompilationRate() {
         String context = randomFrom(
             ScriptModule.CORE_CONTEXTS.values().stream().filter(
@@ -64,6 +91,20 @@ public class ScriptCacheTests extends ESTestCase {
         final Integer size = ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(context).get(Settings.EMPTY);
         final TimeValue expire = ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(context).get(Settings.EMPTY);
         String settingName = ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(context).getKey();
+        ScriptCache cache = new ScriptCache(size, expire, ScriptCache.UNLIMITED_COMPILATION_RATE, settingName);
+        ScriptCache.TokenBucketState initialState = cache.tokenBucketState.get();
+        for(int i=0; i < 3000; i++) {
+            cache.checkCompilationLimit();
+            ScriptCache.TokenBucketState currentState = cache.tokenBucketState.get();
+            assertEquals(initialState.lastInlineCompileTime, currentState.lastInlineCompileTime);
+            assertEquals(initialState.availableTokens, currentState.availableTokens, 0.0); // delta of 0.0 because it should never change
+        }
+    }
+
+    public void testGeneralUnlimitedCompilationRate() {
+        final Integer size = ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING.get(Settings.EMPTY);
+        final TimeValue expire = ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.get(Settings.EMPTY);
+        String settingName = ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey();
         ScriptCache cache = new ScriptCache(size, expire, ScriptCache.UNLIMITED_COMPILATION_RATE, settingName);
         ScriptCache.TokenBucketState initialState = cache.tokenBucketState.get();
         for(int i=0; i < 3000; i++) {

--- a/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
@@ -21,7 +21,7 @@ public class ScriptCacheTests extends ESTestCase {
     public void testCompilationCircuitBreaking() throws Exception {
         String context = randomFrom(
             ScriptModule.CORE_CONTEXTS.values().stream().filter(
-                c -> c.maxCompilationRateDefault.equals(ScriptCache.UNLIMITED_COMPILATION_RATE) == false
+                c -> c.compilationRateLimited
             ).collect(Collectors.toList())
         ).name;
         final TimeValue expire = ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(context).get(Settings.EMPTY);
@@ -85,7 +85,7 @@ public class ScriptCacheTests extends ESTestCase {
     public void testUnlimitedCompilationRate() {
         String context = randomFrom(
             ScriptModule.CORE_CONTEXTS.values().stream().filter(
-                c -> c.maxCompilationRateDefault.equals(ScriptCache.UNLIMITED_COMPILATION_RATE) == false
+                c -> c.compilationRateLimited
             ).collect(Collectors.toList())
         ).name;
         final Integer size = ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(context).get(Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.script;
 
+// import org.apache.logging.log4j.Level; // TODO(stu)
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
 import org.elasticsearch.cluster.ClusterName;
@@ -16,6 +17,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -37,9 +39,10 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_EXPIRE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_SIZE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING;
-import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING;
+import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING;
+import static org.elasticsearch.script.ScriptService.USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE;
 import static org.elasticsearch.script.ScriptService.USE_CONTEXT_RATE_KEY;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -210,7 +213,6 @@ public class ScriptServiceTests extends ESTestCase {
         scriptService.compile(new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap()), randomFrom(contexts.values()));
         assertEquals(1L, scriptService.stats().getCompilations());
     }
-
     public void testMultipleCompilationsCountedInCompilationStats() throws IOException {
         buildScriptService(Settings.EMPTY);
         int numberOfCompilations = randomIntBetween(1, 20);
@@ -221,7 +223,36 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(numberOfCompilations, scriptService.stats().getCompilations());
     }
 
-    public void testCompilationStatsOnCacheHit() throws IOException {
+    public void testCompilationGeneralStatsOnCacheHit() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        Script script = new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap());
+        ScriptContext<?> context = randomFrom(contexts.values());
+        scriptService.compile(script, context);
+        scriptService.compile(script, context);
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    public void testIndexedScriptCountedInGeneralCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        ScriptContext<?> ctx = randomFrom(contexts.values());
+        scriptService.compile(new Script(ScriptType.STORED, null, "script", Collections.emptyMap()), ctx);
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    public void testContextCompilationStatsOnCacheHit() throws IOException {
+        buildScriptService(Settings.builder()
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+            .build());
+        Script script = new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap());
+        ScriptContext<?> context = randomFrom(contexts.values());
+        scriptService.compile(script, context);
+        scriptService.compile(script, context);
+        assertEquals(1L, scriptService.stats().getCompilations());
+        assertWarnings(true, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertWarnings(true, new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)); // TODO(stu)
+    }
+
+    public void testGeneralCompilationStatsOnCacheHit() throws IOException {
         Settings.Builder builder = Settings.builder()
             .put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), 1)
             .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "2/1m");
@@ -233,15 +264,44 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(1L, scriptService.stats().getCompilations());
     }
 
-    public void testIndexedScriptCountedInCompilationStats() throws IOException {
+    public void testGeneralIndexedScriptCountedInCompilationStats() throws IOException {
         buildScriptService(Settings.EMPTY);
         ScriptContext<?> ctx = randomFrom(contexts.values());
         scriptService.compile(new Script(ScriptType.STORED, null, "script", Collections.emptyMap()), ctx);
         assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    public void testContextIndexedScriptCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.builder()
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+            .build());
+        ScriptContext<?> ctx = randomFrom(contexts.values());
+        scriptService.compile(new Script(ScriptType.STORED, null, "script", Collections.emptyMap()), ctx);
+        assertEquals(1L, scriptService.stats().getCompilations());
         assertEquals(1L, scriptService.cacheStats().getContextStats().get(ctx.name).getCompilations());
+        assertWarnings(true, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertWarnings(true, new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));  // TODO(stu)
     }
 
     public void testCacheEvictionCountedInCacheEvictionsStats() throws IOException {
+        ScriptContext<?> context = randomFrom(contexts.values());
+        Setting<?> contextCacheSizeSetting = SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(context.name);
+        buildScriptService(Settings.builder()
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+            .put(contextCacheSizeSetting.getKey(), 1)
+            .build()
+        );
+        scriptService.compile(new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap()), context);
+        scriptService.compile(new Script(ScriptType.INLINE, "test", "2+2", Collections.emptyMap()), context);
+        assertEquals(2L, scriptService.stats().getCompilations());
+        assertEquals(1L, scriptService.stats().getCacheEvictions());
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{contextCacheSizeSetting},
+                USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{contextCacheSizeSetting}, // TODO(stu)
+        //         new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
+    }
+
+    public void testGeneralCacheEvictionCountedInCacheEvictionsStats() throws IOException {
         Settings.Builder builder = Settings.builder();
         builder.put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), 1);
         builder.put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "10/1m");
@@ -264,12 +324,18 @@ public class ScriptServiceTests extends ESTestCase {
             "]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.context." + ctx +
             ".max_compilations_rate] setting"
         );
+        Setting<?> cacheSizeA = SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(contextA.name);
+        Setting<?> compilationRateA = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(contextA.name);
+
+        Setting<?> cacheSizeB = SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(contextB.name);
+        Setting<?> compilationRateB = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(contextB.name);
+
         buildScriptService(Settings.builder()
             .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
-            .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(contextA.name).getKey(), 1)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(contextA.name).getKey(), aRate)
-            .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(contextB.name).getKey(), 2)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(contextB.name).getKey(), bRate)
+            .put(cacheSizeA.getKey(), 1)
+            .put(compilationRateA.getKey(), aRate)
+            .put(cacheSizeB.getKey(), 2)
+            .put(compilationRateB.getKey(), bRate)
             .build());
 
         // Context A
@@ -293,20 +359,24 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(CircuitBreakingException.class, gse.getRootCause().getClass());
 
         // Context specific
-        ScriptCacheStats stats = scriptService.cacheStats();
-        assertEquals(2L, stats.getContextStats().get(contextA.name).getCompilations());
-        assertEquals(1L, stats.getContextStats().get(contextA.name).getCacheEvictions());
-        assertEquals(1L, stats.getContextStats().get(contextA.name).getCompilationLimitTriggered());
+        ScriptStats stats = scriptService.stats();
+        assertEquals(2L, getByContext(stats, contextA.name).getCompilations());
+        assertEquals(1L, getByContext(stats, contextA.name).getCacheEvictions());
+        assertEquals(1L, getByContext(stats, contextA.name).getCompilationLimitTriggered());
 
-        assertEquals(3L, stats.getContextStats().get(contextB.name).getCompilations());
-        assertEquals(1L, stats.getContextStats().get(contextB.name).getCacheEvictions());
-        assertEquals(2L, stats.getContextStats().get(contextB.name).getCompilationLimitTriggered());
-        assertNull(scriptService.cacheStats().getGeneralStats());
+        assertEquals(3L, getByContext(stats, contextB.name).getCompilations());
+        assertEquals(1L, getByContext(stats, contextB.name).getCacheEvictions());
+        assertEquals(2L, getByContext(stats, contextB.name).getCompilationLimitTriggered());
 
         // Summed up
         assertEquals(5L, scriptService.stats().getCompilations());
         assertEquals(2L, scriptService.stats().getCacheEvictions());
         assertEquals(3L, scriptService.stats().getCompilationLimitTriggered());
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{cacheSizeA, compilationRateA, cacheSizeB, compilationRateB},
+            USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{cacheSizeA, compilationRateA, cacheSizeB, compilationRateB}, // TODO(stu)
+        //     new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     private ScriptContextStats getByContext(ScriptStats stats, String context) {
@@ -411,12 +481,21 @@ public class ScriptServiceTests extends ESTestCase {
             illegal.getMessage()
         );
 
+        Setting<?> ingestExpire = ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("ingest");
+        Setting<?> fieldSize = ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("field");
+        Setting<?> scoreCompilation = ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("score");
+
         buildScriptService(
             Settings.builder()
-                .put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("ingest").getKey(), "5m")
-                .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("field").getKey(), 123)
-                .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("score").getKey(), "50/5m")
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+                .put(ingestExpire.getKey(), "5m")
+                .put(fieldSize.getKey(), 123)
+                .put(scoreCompilation.getKey(), "50/5m")
                 .build());
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ingestExpire, fieldSize, scoreCompilation},
+                USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{ingestExpire, fieldSize, scoreCompilation}, // TODO(stu)
+        //         new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testFallbackContextSettings() {
@@ -428,11 +507,13 @@ public class ScriptServiceTests extends ESTestCase {
         String cacheExpireFoo = randomValueOtherThan(cacheExpireBackup, () -> randomTimeValue(1, 1000, "h"));
         TimeValue cacheExpireFooParsed = TimeValue.parseTimeValue(cacheExpireFoo, "");
 
+        Setting<?> cacheSizeSetting = ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("foo");
+        Setting<?> cacheExpireSetting = ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo");
         Settings s = Settings.builder()
             .put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), cacheSizeBackup)
-            .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("foo").getKey(), cacheSizeFoo)
+            .put(cacheSizeSetting.getKey(), cacheSizeFoo)
             .put(SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.getKey(), cacheExpireBackup)
-            .put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").getKey(), cacheExpireFoo)
+            .put(cacheExpireSetting.getKey(), cacheExpireFoo)
             .build();
 
         assertEquals(cacheSizeFoo, ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("foo").get(s).intValue());
@@ -440,12 +521,14 @@ public class ScriptServiceTests extends ESTestCase {
 
         assertEquals(cacheExpireFooParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").get(s));
         assertEquals(cacheExpireBackupParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("bar").get(s));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{cacheExpireSetting, cacheExpireSetting});
     }
 
     public void testUseContextSettingValue() {
+        Setting<?> contextMaxCompilationRate = ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("foo");
         Settings s = Settings.builder()
             .put(ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.USE_CONTEXT_RATE_KEY)
-            .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("foo").getKey(),
+            .put(contextMaxCompilationRate.getKey(),
                  ScriptService.USE_CONTEXT_RATE_KEY)
             .build();
 
@@ -456,6 +539,7 @@ public class ScriptServiceTests extends ESTestCase {
         });
 
         assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [use-context]", illegal.getMessage());
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{contextMaxCompilationRate});
     }
 
     public void testCacheHolderGeneralConstructor() throws IOException {
@@ -477,9 +561,12 @@ public class ScriptServiceTests extends ESTestCase {
         String aCompilationRate = "77/5m";
         String bCompilationRate = "78/6m";
 
+        Setting<?> aSetting = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a);
+        Setting<?> bSetting = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b);
         buildScriptService(Settings.builder()
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a).getKey(), aCompilationRate)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b).getKey(), bCompilationRate)
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+            .put(aSetting.getKey(), aCompilationRate)
+            .put(bSetting.getKey(), bCompilationRate)
             .build());
 
         assertNull(scriptService.cacheHolder.get().general);
@@ -490,6 +577,10 @@ public class ScriptServiceTests extends ESTestCase {
                      scriptService.cacheHolder.get().contextCache.get(a).get().rate);
         assertEquals(new ScriptCache.CompilationRate(bCompilationRate),
                      scriptService.cacheHolder.get().contextCache.get(b).get().rate);
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{aSetting, bSetting},
+                USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{aSetting, bSetting}, // TODO(stu)
+        //         new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testCompilationRateUnlimitedContextOnly() throws IOException {
@@ -500,19 +591,25 @@ public class ScriptServiceTests extends ESTestCase {
         });
         assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [unlimited]", illegal.getMessage());
 
+
+        Setting<?> field = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field");
+        Setting<?> ingest = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest");
         // Should not throw.
         buildScriptService(Settings.builder()
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest").getKey(),
-                 ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field").getKey(),
-                 ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+            .put(field.getKey(), ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+            .put(ingest.getKey(), ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
             .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.USE_CONTEXT_RATE_KEY)
             .build());
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{field, ingest},
+                USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{field, ingest}, // TODO(stu)
+        //         new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testDisableCompilationRateSetting() throws IOException {
         IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
             buildScriptService(Settings.builder()
+                .put("script.max_compilations_rate", "use-context")
                 .put("script.context.ingest.max_compilations_rate", "76/10m")
                 .put("script.context.field.max_compilations_rate", "77/10m")
                 .put("script.disable_max_compilations_rate", true)
@@ -536,11 +633,18 @@ public class ScriptServiceTests extends ESTestCase {
         buildScriptService(Settings.builder()
             .put("script.disable_max_compilations_rate", true)
             .build());
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{
+            SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field"),
+            SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest")},
+            USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{ // TODO(stu)
+        //     SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field"),
+        //     SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest")},
+        //     new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testCacheHolderChangeSettings() throws IOException {
-        Set<String> contextNames = contexts.entrySet().stream().filter(e -> e.getValue().compilationRateLimited)
-                .map(Map.Entry::getKey).collect(Collectors.toSet());
+        Set<String> contextNames = rateLimitedContexts.keySet();
         String a = randomFrom(contextNames);
         String aRate = "77/5m";
         String b = randomValueOtherThan(a, () -> randomFrom(contextNames));
@@ -561,11 +665,15 @@ public class ScriptServiceTests extends ESTestCase {
         assertNull(scriptService.cacheHolder.get().contextCache);
         assertEquals(generalRate, scriptService.cacheHolder.get().general.rate);
 
+        Setting<?> compilationRateA = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a);
+        Setting<?> compilationRateB = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b);
+        Setting<?> compilationRateC = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(c);
+
         scriptService.setCacheHolder(Settings.builder()
-                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a).getKey(), aRate)
-                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b).getKey(), bRate)
-                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(c).getKey(),
-                     ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+                .put(compilationRateA.getKey(), aRate)
+                .put(compilationRateB.getKey(), bRate)
+                .put(compilationRateC.getKey(), ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
                 .build()
         );
 
@@ -608,6 +716,8 @@ public class ScriptServiceTests extends ESTestCase {
             Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), bRate).build()
         );
         assertEquals(holder, scriptService.cacheHolder.get());
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{compilationRateA, compilationRateB, compilationRateC});
     }
 
     public void testFallbackToContextDefaults() throws IOException {
@@ -622,11 +732,15 @@ public class ScriptServiceTests extends ESTestCase {
 
         String name = "score";
 
+        Setting<?> cacheSizeContextSetting = SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(name);
+        Setting<?> cacheExpireContextSetting = SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(name);
+        Setting<?> compilationRateContextSetting = SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(name);
         // Use context specific
         scriptService.setCacheHolder(Settings.builder()
-                .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextCacheSize)
-                .put(SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextExpire)
-                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextRateStr)
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY)
+                .put(cacheSizeContextSetting.getKey(), contextCacheSize)
+                .put(cacheExpireContextSetting.getKey(), contextExpire)
+                .put(compilationRateContextSetting.getKey(), contextRateStr)
                 .build()
         );
 
@@ -641,7 +755,7 @@ public class ScriptServiceTests extends ESTestCase {
 
         ScriptContext<?> score = contexts.get(name);
         // Fallback to context defaults
-        buildScriptService(Settings.EMPTY);
+        buildScriptService(Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), USE_CONTEXT_RATE_KEY).build());
 
         holder = scriptService.cacheHolder.get();
         assertNotNull(holder.contextCache);
@@ -651,6 +765,11 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(ScriptContext.DEFAULT_COMPILATION_RATE_LIMIT, holder.contextCache.get(name).get().rate.asTuple());
         assertEquals(score.cacheSizeDefault, holder.contextCache.get(name).get().cacheSize);
         assertEquals(score.cacheExpireDefault, holder.contextCache.get(name).get().cacheExpire);
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{cacheSizeContextSetting, cacheExpireContextSetting,
+                compilationRateContextSetting}, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE);
+        // assertSettingDeprecationsAndWarnings(new Setting<?>[]{cacheSizeContextSetting, cacheExpireContextSetting, // TODO(stu)
+        //         compilationRateContextSetting}, new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     protected HashMap<String, ScriptContext<?>> compilationRateLimitedContexts() {

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_EXPIRE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_SIZE_SETTING;
+import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING;
+import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING;
+import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -216,7 +219,10 @@ public class ScriptServiceTests extends ESTestCase {
     }
 
     public void testCompilationStatsOnCacheHit() throws IOException {
-        buildScriptService(Settings.EMPTY);
+        Settings.Builder builder = Settings.builder()
+            .put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), 1)
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "2/1m");
+        buildScriptService(builder.build());
         Script script = new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap());
         ScriptContext<?> context = randomFrom(contexts.values());
         scriptService.compile(script, context);
@@ -229,19 +235,20 @@ public class ScriptServiceTests extends ESTestCase {
         ScriptContext<?> ctx = randomFrom(contexts.values());
         scriptService.compile(new Script(ScriptType.STORED, null, "script", Collections.emptyMap()), ctx);
         assertEquals(1L, scriptService.stats().getCompilations());
-        assertEquals(1L, getByContext(scriptService.stats(), ctx.name).getCompilations());
+        assertEquals(1L, scriptService.cacheStats().getContextStats().get(ctx.name).getCompilations());
     }
 
     public void testCacheEvictionCountedInCacheEvictionsStats() throws IOException {
-        ScriptContext<?> context = randomFrom(contexts.values());
-        buildScriptService(Settings.builder()
-            .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(context.name).getKey(), 1)
-            .build()
-        );
-        scriptService.compile(new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap()), context);
-        scriptService.compile(new Script(ScriptType.INLINE, "test", "2+2", Collections.emptyMap()), context);
+        Settings.Builder builder = Settings.builder();
+        builder.put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), 1);
+        builder.put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "10/1m");
+        buildScriptService(builder.build());
+        scriptService.compile(new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap()), randomFrom(contexts.values()));
+        scriptService.compile(new Script(ScriptType.INLINE, "test", "2+2", Collections.emptyMap()), randomFrom(contexts.values()));
         assertEquals(2L, scriptService.stats().getCompilations());
+        assertEquals(2L, scriptService.cacheStats().getGeneralStats().getCompilations());
         assertEquals(1L, scriptService.stats().getCacheEvictions());
+        assertEquals(1L, scriptService.cacheStats().getGeneralStats().getCacheEvictions());
     }
 
     public void testContextCacheStats() throws IOException {
@@ -282,14 +289,15 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(CircuitBreakingException.class, gse.getRootCause().getClass());
 
         // Context specific
-        ScriptStats stats = scriptService.stats();
-        assertEquals(2L, getByContext(stats, contextA.name).getCompilations());
-        assertEquals(1L, getByContext(stats, contextA.name).getCacheEvictions());
-        assertEquals(1L, getByContext(stats, contextA.name).getCompilationLimitTriggered());
+        ScriptCacheStats stats = scriptService.cacheStats();
+        assertEquals(2L, stats.getContextStats().get(contextA.name).getCompilations());
+        assertEquals(1L, stats.getContextStats().get(contextA.name).getCacheEvictions());
+        assertEquals(1L, stats.getContextStats().get(contextA.name).getCompilationLimitTriggered());
 
-        assertEquals(3L, getByContext(stats, contextB.name).getCompilations());
-        assertEquals(1L, getByContext(stats, contextB.name).getCacheEvictions());
-        assertEquals(2L, getByContext(stats, contextB.name).getCompilationLimitTriggered());
+        assertEquals(3L, stats.getContextStats().get(contextB.name).getCompilations());
+        assertEquals(1L, stats.getContextStats().get(contextB.name).getCacheEvictions());
+        assertEquals(2L, stats.getContextStats().get(contextB.name).getCompilationLimitTriggered());
+        assertNull(scriptService.cacheStats().getGeneralStats());
 
         // Summed up
         assertEquals(5L, scriptService.stats().getCompilations());
@@ -366,6 +374,99 @@ public class ScriptServiceTests extends ESTestCase {
                 iae.getMessage());
     }
 
+    public void testConflictContextSettings() throws IOException {
+        IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
+            buildScriptService(Settings.builder()
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "10/1m")
+                .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("field").getKey(), 123).build());
+        });
+        assertEquals("Context cache settings [script.context.field.cache_max_size] requires " +
+                     "[script.max_compilations_rate] to be [use-context]",
+            illegal.getMessage()
+        );
+
+        illegal = expectThrows(IllegalArgumentException.class, () -> {
+            buildScriptService(Settings.builder()
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "10/1m")
+                .put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("ingest").getKey(), "5m").build());
+        });
+
+        assertEquals("Context cache settings [script.context.ingest.cache_expire] requires " +
+                     "[script.max_compilations_rate] to be [use-context]",
+            illegal.getMessage()
+        );
+
+        illegal = expectThrows(IllegalArgumentException.class, () -> {
+            buildScriptService(Settings.builder()
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "10/1m")
+                .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("score").getKey(), "50/5m").build());
+        });
+
+        assertEquals("Context cache settings [script.context.score.max_compilations_rate] requires " +
+                     "[script.max_compilations_rate] to be [use-context]",
+            illegal.getMessage()
+        );
+
+        buildScriptService(
+            Settings.builder()
+                .put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("ingest").getKey(), "5m")
+                .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("field").getKey(), 123)
+                .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("score").getKey(), "50/5m")
+                .build());
+    }
+
+    public void testFallbackContextSettings() {
+        int cacheSizeBackup = randomIntBetween(0, 1024);
+        int cacheSizeFoo = randomValueOtherThan(cacheSizeBackup, () -> randomIntBetween(0, 1024));
+
+        String cacheExpireBackup = randomTimeValue(1, 1000, "h");
+        TimeValue cacheExpireBackupParsed = TimeValue.parseTimeValue(cacheExpireBackup, "");
+        String cacheExpireFoo = randomValueOtherThan(cacheExpireBackup, () -> randomTimeValue(1, 1000, "h"));
+        TimeValue cacheExpireFooParsed = TimeValue.parseTimeValue(cacheExpireFoo, "");
+
+        Settings s = Settings.builder()
+            .put(SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(), cacheSizeBackup)
+            .put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("foo").getKey(), cacheSizeFoo)
+            .put(SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.getKey(), cacheExpireBackup)
+            .put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").getKey(), cacheExpireFoo)
+            .build();
+
+        assertEquals(cacheSizeFoo, ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("foo").get(s).intValue());
+        assertEquals(cacheSizeBackup, ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace("bar").get(s).intValue());
+
+        assertEquals(cacheExpireFooParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("foo").get(s));
+        assertEquals(cacheExpireBackupParsed, ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace("bar").get(s));
+    }
+
+    public void testUseContextSettingValue() {
+        Settings s = Settings.builder()
+            .put(ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.USE_CONTEXT_RATE_KEY)
+            .put(ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("foo").getKey(),
+                 ScriptService.USE_CONTEXT_RATE_KEY)
+            .build();
+
+        assertEquals(ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(s), ScriptService.USE_CONTEXT_RATE_VALUE);
+
+        IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
+            ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getAsMap(s);
+        });
+
+        assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [use-context]", illegal.getMessage());
+    }
+
+    public void testCacheHolderGeneralConstructor() throws IOException {
+        String compilationRate = "77/5m";
+        buildScriptService(
+            Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), compilationRate).build()
+        );
+
+        ScriptService.CacheHolder holder = scriptService.cacheHolder.get();
+
+        assertNotNull(holder.general);
+        assertNull(holder.contextCache);
+        assertEquals(holder.general.rate, new ScriptCache.CompilationRate(compilationRate));
+    }
+
     public void testCacheHolderContextConstructor() throws IOException {
         String a = randomFrom(contexts.keySet());
         String b = randomValueOtherThan(a, () -> randomFrom(contexts.keySet()));
@@ -377,6 +478,7 @@ public class ScriptServiceTests extends ESTestCase {
             .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b).getKey(), bCompilationRate)
             .build());
 
+        assertNull(scriptService.cacheHolder.get().general);
         assertNotNull(scriptService.cacheHolder.get().contextCache);
         assertEquals(contexts.keySet(), scriptService.cacheHolder.get().contextCache.keySet());
 
@@ -384,6 +486,24 @@ public class ScriptServiceTests extends ESTestCase {
                      scriptService.cacheHolder.get().contextCache.get(a).get().rate);
         assertEquals(new ScriptCache.CompilationRate(bCompilationRate),
                      scriptService.cacheHolder.get().contextCache.get(b).get().rate);
+    }
+
+    public void testCompilationRateUnlimitedContextOnly() throws IOException {
+        IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
+            buildScriptService(Settings.builder()
+                .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+                .build());
+        });
+        assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [unlimited]", illegal.getMessage());
+
+        // Should not throw.
+        buildScriptService(Settings.builder()
+            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest").getKey(),
+                 ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field").getKey(),
+                 ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), ScriptService.USE_CONTEXT_RATE_KEY)
+            .build());
     }
 
     public void testDisableCompilationRateSetting() throws IOException {
@@ -399,6 +519,16 @@ public class ScriptServiceTests extends ESTestCase {
                 "[script.disable_max_compilations_rate]",
             illegal.getMessage());
 
+        illegal = expectThrows(IllegalArgumentException.class, () -> {
+            buildScriptService(Settings.builder()
+                .put("script.disable_max_compilations_rate", true)
+                .put("script.max_compilations_rate", "76/10m")
+                .build());
+        });
+        assertEquals("Cannot set custom general compilation rates [script.max_compilations_rate] " +
+                "to [76/10m] if compile rates disabled via [script.disable_max_compilations_rate]",
+                illegal.getMessage());
+
         buildScriptService(Settings.builder()
             .put("script.disable_max_compilations_rate", true)
             .build());
@@ -411,20 +541,31 @@ public class ScriptServiceTests extends ESTestCase {
         String b = randomValueOtherThan(a, () -> randomFrom(contextNames));
         String bRate = "78/6m";
         String c = randomValueOtherThanMany(s -> a.equals(s) || b.equals(s), () -> randomFrom(contextNames));
+        String compilationRate = "77/5m";
+        ScriptCache.CompilationRate generalRate = new ScriptCache.CompilationRate(compilationRate);
 
-        buildScriptService(Settings.EMPTY);
-
-        Settings settings = Settings.builder()
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a).getKey(), aRate)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b).getKey(), bRate)
-            .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(c).getKey(),
-                ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+        Settings s = Settings.builder()
+            .put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), compilationRate)
             .build();
 
+        buildScriptService(s);
+
+        assertNotNull(scriptService.cacheHolder.get().general);
+        // Set should not throw when using general cache
+        scriptService.cacheHolder.get().set(c, scriptService.contextCache(s, contexts.get(c)));
+        assertNull(scriptService.cacheHolder.get().contextCache);
+        assertEquals(generalRate, scriptService.cacheHolder.get().general.rate);
+
+        scriptService.setCacheHolder(Settings.builder()
+                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(a).getKey(), aRate)
+                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(b).getKey(), bRate)
+                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(c).getKey(),
+                     ScriptService.UNLIMITED_COMPILATION_RATE_KEY)
+                .build()
+        );
+
+        assertNull(scriptService.cacheHolder.get().general);
         assertNotNull(scriptService.cacheHolder.get().contextCache);
-        scriptService.cacheHolder.get().set(a, scriptService.contextCache(settings, contexts.get(a)));
-        scriptService.cacheHolder.get().set(b, scriptService.contextCache(settings, contexts.get(b)));
-        scriptService.cacheHolder.get().set(c, scriptService.contextCache(settings, contexts.get(c)));
         // get of missing context should be null
         assertNull(scriptService.cacheHolder.get().get(
             randomValueOtherThanMany(contexts.keySet()::contains, () -> randomAlphaOfLength(8)))
@@ -443,6 +584,25 @@ public class ScriptServiceTests extends ESTestCase {
             contexts.get(b)));
         assertEquals(new ScriptCache.CompilationRate(aRate),
                      scriptService.cacheHolder.get().contextCache.get(b).get().rate);
+
+        scriptService.setCacheHolder(s);
+        assertNotNull(scriptService.cacheHolder.get().general);
+        assertNull(scriptService.cacheHolder.get().contextCache);
+        assertEquals(generalRate, scriptService.cacheHolder.get().general.rate);
+
+        scriptService.setCacheHolder(
+            Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), bRate).build()
+        );
+
+        assertNotNull(scriptService.cacheHolder.get().general);
+        assertNull(scriptService.cacheHolder.get().contextCache);
+        assertEquals(new ScriptCache.CompilationRate(bRate), scriptService.cacheHolder.get().general.rate);
+
+        ScriptService.CacheHolder holder = scriptService.cacheHolder.get();
+        scriptService.setCacheHolder(
+            Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), bRate).build()
+        );
+        assertEquals(holder, scriptService.cacheHolder.get());
     }
 
     public void testFallbackToContextDefaults() throws IOException {
@@ -451,20 +611,19 @@ public class ScriptServiceTests extends ESTestCase {
         int contextCacheSize = randomIntBetween(1, 1024);
         TimeValue contextExpire = TimeValue.timeValueMinutes(randomIntBetween(10, 200));
 
-        buildScriptService(Settings.EMPTY);
+        buildScriptService(
+            Settings.builder().put(SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.getKey(), "75/5m").build()
+        );
 
         String name = "ingest";
 
         // Use context specific
-        scriptService.cacheHolder.get().set(
-            name,
-            scriptService.contextCache(Settings.builder()
-                    .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextCacheSize)
-                    .put(SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextExpire)
-                    .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextRateStr)
-                    .build(),
-                contexts.get(name)
-            ));
+        scriptService.setCacheHolder(Settings.builder()
+                .put(SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextCacheSize)
+                .put(SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextExpire)
+                .put(SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace(name).getKey(), contextRateStr)
+                .build()
+        );
 
         ScriptService.CacheHolder holder = scriptService.cacheHolder.get();
         assertNotNull(holder.contextCache);

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/server/src/test/java/org/elasticsearch/script/ScriptStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptStatsTests.java
@@ -40,6 +40,7 @@ public class ScriptStatsTests extends ESTestCase {
         stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
+        /* TODO(stu): master only
         String expected = "{\n" +
             "  \"script\" : {\n" +
             "    \"compilations\" : 1100,\n" +
@@ -69,6 +70,14 @@ public class ScriptStatsTests extends ESTestCase {
             "        \"compilation_limit_triggered\" : 302\n" +
             "      }\n" +
             "    ]\n" +
+            "  }\n" +
+            "}";
+         */
+        String expected = "{\n" +
+            "  \"script\" : {\n" +
+            "    \"compilations\" : 1100,\n" +
+            "    \"cache_evictions\" : 2211,\n" +
+            "    \"compilation_limit_triggered\" : 3322\n" +
             "  }\n" +
             "}";
         assertThat(Strings.toString(builder), equalTo(expected));

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -74,7 +74,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                     .map(fsInfoPath -> diskUsageFunction.apply(discoveryNode, fsInfoPath))
                     .toArray(FsInfo.Path[]::new)), nodeStats.getTransport(),
                 nodeStats.getHttp(), nodeStats.getBreaker(), nodeStats.getScriptStats(), nodeStats.getDiscoveryStats(),
-                nodeStats.getIngestStats(), nodeStats.getAdaptiveSelectionStats(), nodeStats.getIndexingPressureStats());
+                nodeStats.getIngestStats(), nodeStats.getAdaptiveSelectionStats(), nodeStats.getScriptCacheStats(),
+                nodeStats.getIndexingPressureStats());
         }).collect(Collectors.toList());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -93,7 +93,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeService;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.tasks.TaskManager;
@@ -521,16 +520,16 @@ public final class InternalTestCluster extends TestCluster {
             builder.put(TransportSettings.PING_SCHEDULE.getKey(), RandomNumbers.randomIntBetween(random, 100, 2000) + "ms");
         }
 
+
         if (random.nextBoolean()) {
-            String ctx = randomFrom(random, ScriptModule.CORE_CONTEXTS.keySet());
-            builder.put(ScriptService.SCRIPT_CACHE_SIZE_SETTING.getConcreteSettingForNamespace(ctx).getKey(),
+            builder.put(ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING.getKey(),
                         RandomNumbers.randomIntBetween(random, 0, 2000));
         }
         if (random.nextBoolean()) {
-            String ctx = randomFrom(random, ScriptModule.CORE_CONTEXTS.keySet());
-            builder.put(ScriptService.SCRIPT_CACHE_EXPIRE_SETTING.getConcreteSettingForNamespace(ctx).getKey(),
+            builder.put(ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.getKey(),
                         timeValueMillis(RandomNumbers.randomIntBetween(random, 750, 10000000)).getStringRep());
         }
+
         if (random.nextBoolean()) {
             int initialMillisBound = RandomNumbers.randomIntBetween(random,10, 100);
             builder.put(TransportReplicationAction.REPLICATION_INITIAL_RETRY_BACKOFF_BOUND.getKey(), timeValueMillis(initialMillisBound));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
@@ -367,6 +367,7 @@ public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -687,7 +687,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             IntStream.range(0, pipelineNames.size()).boxed().collect(Collectors.toMap(pipelineNames::get, processorStats::get)));
         return new NodeStats(mock(DiscoveryNode.class),
             Instant.now().toEpochMilli(), null, null, null, null, null, null, null, null,
-            null, null, null, ingestStats, null, null);
+            null, null, null, ingestStats, null, null, null);
 
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -299,7 +299,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
             IntStream.range(0, pipelineids.size()).boxed().collect(Collectors.toMap(pipelineids::get, processorStats::get)));
         return new NodeStats(mock(DiscoveryNode.class),
             Instant.now().toEpochMilli(), null, null, null, null, null, null, null, null,
-            null, null, null, ingestStats, null, null);
+            null, null, null, ingestStats, null, null, null);
 
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -378,6 +378,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
                                                                 emptySet(),
                                                                 Version.CURRENT);
 
-        return new NodeStats(discoveryNode, no, indices, os, process, jvm, threadPool, fs, null, null, null, null, null, null, null, null);
+        return new NodeStats(discoveryNode, no, indices, os, process, jvm, threadPool, fs, null, null, null, null, null, null, null, null,
+            null);
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -232,8 +232,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
             new ByteSizeValue(1, ByteSizeUnit.MB), new ByteSizeValue(10, ByteSizeUnit.MB), NodeScope);
 
     public static final ScriptContext<TemplateScript.Factory> SCRIPT_TEMPLATE_CONTEXT
-        = new ScriptContext<>("xpack_template", TemplateScript.Factory.class,
-        200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+        = new ScriptContext<>("xpack_template", TemplateScript.Factory.class, true);
 
     private static final Logger logger = LogManager.getLogger(Watcher.class);
     private WatcherIndexingListener listener;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -51,7 +51,6 @@ import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
-import org.elasticsearch.script.ScriptCache;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -231,7 +231,8 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
             new ByteSizeValue(1, ByteSizeUnit.MB), new ByteSizeValue(10, ByteSizeUnit.MB), NodeScope);
 
     public static final ScriptContext<TemplateScript.Factory> SCRIPT_TEMPLATE_CONTEXT
-        = new ScriptContext<>("xpack_template", TemplateScript.Factory.class, true);
+        = new ScriptContext<>("xpack_template", TemplateScript.Factory.class,
+        200, TimeValue.timeValueMillis(0), false, true);
 
     private static final Logger logger = LogManager.getLogger(Watcher.class);
     private WatcherIndexingListener listener;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.watcher.support.Variables;
@@ -42,5 +43,6 @@ public abstract class WatcherConditionScript {
         WatcherConditionScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext);
     }
 
-    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_condition", Factory.class, true);
+    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_condition", Factory.class,
+        200, TimeValue.timeValueMillis(0), false, true);
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.script.ScriptCache;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.watcher.support.Variables;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
@@ -44,6 +44,5 @@ public abstract class WatcherConditionScript {
         WatcherConditionScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext);
     }
 
-    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_condition", Factory.class,
-        200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_condition", Factory.class, true);
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.watcher.transform.script;
 
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.script.ScriptCache;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.watcher.transform.script;
 
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
@@ -43,5 +44,6 @@ public abstract class WatcherTransformScript {
         WatcherTransformScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext, Payload payload);
     }
 
-    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_transform", Factory.class, true);
+    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_transform", Factory.class,
+        200, TimeValue.timeValueMillis(0), false, true);
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
@@ -45,6 +45,5 @@ public abstract class WatcherTransformScript {
         WatcherTransformScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext, Payload payload);
     }
 
-    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_transform", Factory.class,
-        200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(), true);
+    public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("watcher_transform", Factory.class, true);
 }


### PR DESCRIPTION
Restore the scripting general cache in preparation for deprecation of the context cache, then removal of the context cache in master.

Brings back the general cache settings:
* `script.max_compilations_rate`
* `script.cache.expire`
* `script.cache.max_size`

`script.cache.max_size` and `script.cache.expire` are now dynamic settings. 

The context cache is still default, the switch to general cache as default will happen on context cache deprecation.

System script contexts can now opt-out of compilation rate limiting using a flag rather than a sentinel rate limit value.  Duplicated defaults for system contexts have been coalesced.

Other than that, this code is the same as what was in 7.x to make a `master`-first commit and backport strategy easy.

Refs: #62899