### PR TITLE
Replace eager gradle task creation with task avoidance api

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rewrite/RewritePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rewrite/RewritePlugin.java
@@ -16,6 +16,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
 
@@ -47,14 +48,20 @@ public class RewritePlugin implements Plugin<Project> {
                 details.useVersion(extension.getRewriteVersion());
             }
         });
-        RewriteTask rewriteTask = project.getTasks().create(REWRITE_TASKNAME, RewriteTask.class, rewriteConf, extension);
-        rewriteTask.getActiveRecipes().convention(providerFactory.provider(() -> extension.getActiveRecipes()));
-        rewriteTask.getConfigFile().convention(projectLayout.file(providerFactory.provider(() -> extension.getConfigFile())));
+        TaskProvider<RewriteTask> rewriteTaskProvider = project.getTasks()
+            .register(REWRITE_TASKNAME, RewriteTask.class, rewriteConf, extension);
+        rewriteTaskProvider.configure((rewriteTask) -> {
+            rewriteTask.getActiveRecipes().convention(providerFactory.provider(() -> extension.getActiveRecipes()));
+            rewriteTask.getConfigFile().convention(projectLayout.file(providerFactory.provider(() -> extension.getConfigFile())));
+        });
+
         project.getPlugins().withType(JavaBasePlugin.class, javaBasePlugin -> {
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             javaPluginExtension.getSourceSets().all(sourceSet -> {
-                rewriteTask.getSourceFiles().from(sourceSet.getAllSource());
-                rewriteTask.getDependencyFiles().from(sourceSet.getCompileClasspath());
+                rewriteTaskProvider.configure(r -> {
+                    r.getSourceFiles().from(sourceSet.getAllSource());
+                    r.getDependencyFiles().from(sourceSet.getCompileClasspath());
+                });
             });
         });
     }

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -23,13 +23,13 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
-forbiddenApisTest {
+tasks.named("forbiddenApisTest").configure {
   // we don't use the core test-framework, no lucene classes present so we don't want the es-test-signatures to
   // be pulled in
   replaceSignatureFiles 'jdk-signatures', 'es-all-signatures'
 }
 
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     Tests {

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -31,19 +31,19 @@ if (!isEclipse) {
     java11Implementation sourceSets.main.output
   }
 
-  compileJava11Java {
+  tasks.named("compileJava11Java").configure {
     sourceCompatibility = 11
     targetCompatibility = 11
   }
 
-  forbiddenApisJava11 {
+  tasks.named("forbiddenApisJava11").configure {
     if (BuildParams.runtimeJavaVersion < JavaVersion.VERSION_11) {
       targetCompatibility = JavaVersion.VERSION_11.getMajorVersion()
     }
     replaceSignatureFiles 'jdk-signatures'
   }
 
-  jar {
+  tasks.named("jar").configure {
     metaInf {
       into 'versions/11'
       from sourceSets.java11.output

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -76,13 +76,16 @@ tasks.named("bundlePlugin").configure {
   }
 }
 
-task testRepositoryCreds(type: Test) {
+def testRepositoryCreds = tasks.register("testRepositoryCreds", Test) {
   include '**/RepositoryCredentialsTests.class'
   systemProperty 'es.allow_insecure_settings', 'true'
 }
-check.dependsOn(testRepositoryCreds)
 
-test {
+tasks.named('check').configure {
+  dependsOn(testRepositoryCreds)
+}
+
+tasks.named('test').configure {
   // this is tested explicitly in separate test tasks
   exclude '**/RepositoryCredentialsTests.class'
   exclude '**/S3RepositoryThirdPartyTests.class'

--- a/qa/smoke-test-client/build.gradle
+++ b/qa/smoke-test-client/build.gradle
@@ -25,12 +25,12 @@ testClusters.matching { it.name == "singleNodeIntegTest" }.configureEach {
   setting 'discovery.type', 'single-node'
 }
 
-def integTest = tasks.named("integTest").configure {
+tasks.named("integTest").configure {
   dependsOn singleNodeIntegTest
 }
 
 tasks.named("check").configure {
-  dependsOn(integTest)
+  dependsOn("integTest")
 }
 
 tasks.named("testingConventions").configure {

--- a/qa/smoke-test-client/build.gradle
+++ b/qa/smoke-test-client/build.gradle
@@ -17,22 +17,23 @@ dependencies {
   testImplementation project(':client:transport') // randomly swapped in as a transport
 }
 
-task singleNodeIntegTest(type: RestIntegTestTask) {
-  mustRunAfter(precommit)
+def singleNodeIntegTest = tasks.register("singleNodeIntegTest", RestIntegTestTask) {
+  mustRunAfter("precommit")
 }
 
-testClusters.singleNodeIntegTest {
+testClusters.matching { it.name == "singleNodeIntegTest" }.configureEach {
   setting 'discovery.type', 'single-node'
 }
 
-integTest {
+def integTest = tasks.named("integTest").configure {
   dependsOn singleNodeIntegTest
 }
 
-check.dependsOn(integTest)
+tasks.named("check").configure {
+  dependsOn(integTest)
+}
 
-
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     IT {

--- a/qa/translog-policy/build.gradle
+++ b/qa/translog-policy/build.gradle
@@ -85,7 +85,7 @@ configurations {
   testArtifacts.extendsFrom testRuntime
 }
 
-task testJar(type: Jar) {
+def testJar = tasks.register("testJar", Jar) {
   archiveAppendix.set('test')
   from sourceSets.test.output
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,7 +41,7 @@ if (!isEclipse) {
     java11Implementation sourceSets.main.output
   }
 
-  compileJava11Java {
+  tasks.named("compileJava11Java").configure {
     sourceCompatibility = 11
     targetCompatibility = 11
   }
@@ -54,7 +54,7 @@ if (!isEclipse) {
     }
   }
 
-  jar {
+  tasks.named("jar").configure {
     metaInf {
       into 'versions/11'
       from sourceSets.java11.output

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -29,7 +29,7 @@ subprojects {
       project.dependencies.add('featureAwarePlugin', project.sourceSets.main.output.getClassesDirs())
 
       File successMarker = file("$buildDir/markers/featureAware")
-      task featureAwareCheck(type: LoggedExec) {
+      def featureAwareCheck = tasks.register("featureAwareCheck", LoggedExec) {
         description = "Runs FeatureAwareCheck on main classes."
         dependsOn project.configurations.featureAwarePlugin
         outputs.file(successMarker)
@@ -40,7 +40,7 @@ subprojects {
         final List files = []
         if (project.sourceSets.findByName("main")) {
           files.add(project.sourceSets.main.output.classesDirs)
-          dependsOn project.tasks.classes
+          dependsOn project.tasks.named('classes')
         }
         // filter out non-existent classes directories from empty source sets
         final FileCollection classDirectories = project.files(files).filter { it.exists() }
@@ -55,7 +55,9 @@ subprojects {
         }
       }
 
-      project.precommit.dependsOn featureAwareCheck
+      project.tasks.named("precommit").configure {
+        dependsOn featureAwareCheck
+      }
     }
   }
 }

--- a/x-pack/qa/security-client-tests/build.gradle
+++ b/x-pack/qa/security-client-tests/build.gradle
@@ -7,18 +7,19 @@ dependencies {
 }
 
 String outputDir = "${buildDir}/generated-resources/${project.name}"
-task copyXPackPluginProps(type: Copy) {
+def copyXPackPluginProps = tasks.register("copyXPackPluginProps", Copy) {
   from project(xpackModule('core')).file('src/main/plugin-metadata')
+  // TODO revisit resolving other modules plugin properties
   from project(xpackModule('core')).tasks.pluginProperties
   into outputDir
 }
 project.sourceSets.test.output.dir(outputDir, builtBy: copyXPackPluginProps)
 
-integTest {
+tasks.named("integTest").configure {
   systemProperty 'tests.security.manager', 'false'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = "default"
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/security-migrate-tests/build.gradle
+++ b/x-pack/qa/security-migrate-tests/build.gradle
@@ -27,7 +27,7 @@ tasks.matching { it.name.equals('integTest')}.configureEach {integTestTask ->
   nonInputProperties.systemProperty 'tests.config.dir', "${-> testClusters.integTest.singleNode().getConfigDir()}"
 }
 
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     IT {

--- a/x-pack/qa/transport-client-tests/build.gradle
+++ b/x-pack/qa/transport-client-tests/build.gradle
@@ -12,8 +12,7 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
 }
 
-
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     IT {

--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -68,7 +68,7 @@ dependencies {
   api 'javax.xml.bind:jaxb-api:2.2.2'
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /aws-java-sdk-.*/, to: 'aws-java-sdk'
   mapping from: /jmespath-java.*/, to: 'aws-java-sdk'
   mapping from: /jackson-.*/, to: 'jackson'
@@ -85,8 +85,12 @@ dependencyLicenses {
 
 // TODO: Investigate using the new Gradle test-fixture plugin here after the upgrade to 5.6
 // There is only AbstractCleanupTests class in test directory and it's abstract
-test.enabled = false
-testingConventions.enabled = false
+tasks.named("test").configure {
+  it.enabled = false
+}
+tasks.named("testingConventions").configure {
+  it.enabled = false
+}
 
 tasks.register("unpackArchive", Copy) {
   dependsOn "assemble"

--- a/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
+++ b/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
@@ -16,10 +16,12 @@ dependencies {
   testImplementation files(project(':x-pack:snapshot-tool').sourceSets.test.output)
 }
 
-test.enabled = false
+tasks.named('test').configure {
+  enabled = false
+}
 
-task gcsThirdPartyTests {
-  dependsOn check
+tasks.register("gcsThirdPartyTests") {
+  dependsOn "check"
 }
 
 boolean useGCSFixture = false
@@ -43,7 +45,7 @@ def encodedCredentials = {
   Base64.encoder.encodeToString(Files.readAllBytes(file(gcsServiceAccount).toPath()))
 }
 
-task gcsThirdPartyTest(type: Test) {
+def gcsThirdPartyTest = tasks.register("gcsThirdPartyTest", Test) {
   include '**/GCSCleanupTests.class'
 
   systemProperty 'tests.security.manager', false
@@ -54,8 +56,12 @@ task gcsThirdPartyTest(type: Test) {
 }
 
 if (useGCSFixture) {
-  gcsThirdPartyTest.enabled = false;
-  testingConventions.enabled = false;
+  gcsThirdPartyTest.configure {
+    enabled = false
+  }
+  tasks.named('testingConventions').configure {
+    enabled = false
+  }
   /*
 
   See: https://github.com/elastic/elasticsearch/issues/46813 Fails with --parallel
@@ -87,4 +93,6 @@ if (useGCSFixture) {
   */
 }
 
-check.dependsOn(gcsThirdPartyTest)
+tasks.named("check").configure {
+  dependsOn(gcsThirdPartyTest)
+}

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -15,8 +15,9 @@ dependencies {
   testImplementation files(project(':x-pack:snapshot-tool').sourceSets.test.output)
 }
 
-test.enabled = false
-
+tasks.named("test").configure {
+  it.enabled = false
+}
 boolean useS3Fixture = false
 
 String s3PermanentAccessKey = System.getenv("amazon_s3_access_key")
@@ -35,7 +36,7 @@ if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3P
   throw new IllegalArgumentException("not all options specified to run against external S3 service as permanent credentials are present")
 }
 
-task s3ThirdPartyTest(type: Test) {
+def s3ThirdPartyTest = tasks.register("s3ThirdPartyTest", Test) {
   include '**/*.class'
 
   systemProperty 'tests.security.manager', false
@@ -48,7 +49,9 @@ task s3ThirdPartyTest(type: Test) {
 
 if (useS3Fixture) {
   apply plugin: 'elasticsearch.test.fixtures'
-  testingConventions.enabled = false;
+  tasks.named("testingConventions").configure {
+    it.enabled = false
+  }
   testFixtures.useFixture(':test:fixtures:minio-fixture', "minio-fixture-for-snapshot-tool")
 
   def minioAddress = {
@@ -57,9 +60,11 @@ if (useS3Fixture) {
     'http://127.0.0.1:' + minioPort
   }
 
-  s3ThirdPartyTest {
-    dependsOn project(':test:fixtures:minio-fixture').postProcessFixture
+  s3ThirdPartyTest.configure {
+    dependsOn ':test:fixtures:minio-fixture:postProcessFixture'
     nonInputProperties.systemProperty 'test.s3.endpoint', "${-> minioAddress.call()}"
   }
 }
-check.dependsOn(s3ThirdPartyTest)
+tasks.named("check").configure {
+  dependsOn(s3ThirdPartyTest)
+}

--- a/x-pack/test/feature-aware/build.gradle
+++ b/x-pack/test/feature-aware/build.gradle
@@ -7,11 +7,22 @@ dependencies {
   testImplementation project(':test:framework')
 }
 
-forbiddenApisMain.enabled = true
+tasks.named("forbiddenApisMain").configure {
+  enabled = true
+}
 
-dependencyLicenses.enabled = false
-dependenciesInfo.enabled = false
+tasks.named("dependencyLicenses").configure {
+  enabled = false
+}
 
-jarHell.enabled = false
+tasks.named("dependenciesInfo").configure {
+  enabled = false
+}
 
-thirdPartyAudit.enabled = false
+tasks.named("jarHell").configure {
+  enabled = false
+}
+
+tasks.named("thirdPartyAudit").configure {
+  enabled = false
+}

--- a/x-pack/transport-client/build.gradle
+++ b/x-pack/transport-client/build.gradle
@@ -12,15 +12,17 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure {
+  enabled = false
+}
 
-forbiddenApisTest {
+tasks.named("forbiddenApisTest").configure {
   // we don't use the core test-framework, no lucene classes present so we don't want the es-test-signatures to
   // be pulled in
   replaceSignatureFiles 'jdk-signatures', 'es-all-signatures'
 }
 
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     Tests {


### PR DESCRIPTION
Fixing some eagerly created gradle tasks sneaked into the 7.x branch lately
