### PR TITLE
[DOCS] Adds missing query params to GET category and GET influencer APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -49,6 +49,18 @@ information about all categories. If you specify only the
 `partition_field_value`, it returns information about all categories for the
 specified partition.
 
+[[ml-get-category-query-parms]]
+== {api-query-parms-title}
+
+`from`::
+    (Optional, integer) Skips the specified number of categories. Defaults to 
+    `0`.
+
+`size`::
+    (Optional, integer) Specifies the maximum number of categories to obtain.
+    Defaults to `100`.
+
+
 [[ml-get-category-request-body]]
 == {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -53,12 +53,14 @@ specified partition.
 == {api-query-parms-title}
 
 `from`::
-    (Optional, integer) Skips the specified number of categories. Defaults to 
-    `0`.
+(Optional, integer) Skips the specified number of categories. Defaults to `0`.
+
+`partition_field_value`::
+(Optional, string) Only return categories for the specified partition.
 
 `size`::
-    (Optional, integer) Specifies the maximum number of categories to obtain.
-    Defaults to `100`.
+(Optional, integer) Specifies the maximum number of categories to obtain. 
+Defaults to `100`.
 
 
 [[ml-get-category-request-body]]

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -33,6 +33,19 @@ the anomalies. Influencer results are available only if an
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+
+[[ml-get-influencer-query-parms]]
+== {api-query-parms-title}
+
+`from`::
+    (Optional, integer) Skips the specified number of influencers. Defaults to 
+    `0`.
+
+`size`::
+    (Optional, integer) Specifies the maximum number of influencers to obtain.
+    Defaults to `100`.
+
+
 [[ml-get-influencer-request-body]]
 == {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -37,13 +37,34 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 [[ml-get-influencer-query-parms]]
 == {api-query-parms-title}
 
+`desc`::
+(Optional, Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
+
+`exclude_interim`::
+(Optional, Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
+
 `from`::
-    (Optional, integer) Skips the specified number of influencers. Defaults to 
-    `0`.
+(Optional, integer)
+Skips the specified number of influencers. Defaults to `0`.
+
+`influencer_score`::
+(Optional, double) Returns influencers with anomaly scores greater than or
+equal to this value. Defaults to `0.0`.
 
 `size`::
-    (Optional, integer) Specifies the maximum number of influencers to obtain.
-    Defaults to `100`.
+(Optional, integer)
+Specifies the maximum number of influencers to obtain. Defaults to `100`.
+
+`sort`::
+(Optional, string) Specifies the sort field for the requested influencers. By
+default, the influencers are sorted by the `influencer_score` value.
+
+`start`::
+(Optional, string) Returns influencers with timestamps after this time. Defaults 
+to `-1`, which means it is unset and results are not limited to specific 
+timestamps.
 
 
 [[ml-get-influencer-request-body]]


### PR DESCRIPTION
## Overview

This PR adds the missing `from` and `size` query parameters to the GET Category and the GET Influencer APIs.

### Preview

* [GET Category](https://elasticsearch_79448.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-category.html)
* [GET Influencer](https://elasticsearch_79448.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html)