### PR TITLE
Adjust Multiple data paths deprecation to warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -320,7 +320,7 @@ public class Node implements Closeable {
             if (Environment.PATH_SHARED_DATA_SETTING.exists(tmpSettings)) {
                 // NOTE: this must be done with an explicit check here because the deprecation property on a path setting will
                 // cause ES to fail to start since logging is not yet initialized on first read of the setting
-                deprecationLogger.critical(
+                deprecationLogger.warn(
                     DeprecationCategory.SETTINGS,
                     "shared-data-path",
                     "setting [path.shared_data] is deprecated and will be removed in a future release"
@@ -329,13 +329,13 @@ public class Node implements Closeable {
 
             if (initialEnvironment.dataFiles().length > 1) {
                 // NOTE: we use initialEnvironment here, but assertEquivalent below ensures the data paths do not change
-                deprecationLogger.critical(DeprecationCategory.SETTINGS, "multiple-data-paths",
+                deprecationLogger.warn(DeprecationCategory.SETTINGS, "multiple-data-paths",
                     "Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
                         "multiple disks. This feature will be removed in a future release.");
             }
             if (Environment.dataPathUsesList(tmpSettings)) {
                 // already checked for multiple values above, so if this is a list it is a single valued list
-                deprecationLogger.critical(DeprecationCategory.SETTINGS, "multiple-data-paths-list",
+                deprecationLogger.warn(DeprecationCategory.SETTINGS, "multiple-data-paths-list",
                     "Configuring [path.data] with a list is deprecated. Instead specify as a string value.");
             }
 


### PR DESCRIPTION
Since Multiple Data Paths support has been added back to 8.0, the
deprecation is no longer critical, as the feature will not be
immediately removed after 7.16. This commit adjusts the deprecation
level to indicate it is a warning, intead of a critical deprecation that
would otherwise need to be addressed before upgrading.

relates #71205