### PR TITLE
Fixed index name pattern

### DIFF
--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -165,8 +165,7 @@ requests.
 
 [source,console]
 ----
-# PUT <my-index-{now/d}-000001>
-PUT %3Cmy-index-%7Bnow%2Fd%7D-000001%3E
+PUT <my-index-{now/d}-000001>
 {
   "aliases": {
     "my-alias": {}


### PR DESCRIPTION
The index name in the documentation is with some characters which is not the best usage scenario and also non-standard used elsewhere.