### PR TITLE
Enable rate agg test for 7.16

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
@@ -39,8 +39,8 @@ setup:
 ---
 "rate with doc_count":
   - skip:
-      version: " - 7.99.99"
-      reason: bug fixed in 8.0.0
+      version: " - 7.15.99"
+      reason: bug fixed in 7.16.0
   - do:
       bulk:
         index: test2


### PR DESCRIPTION
Now that the rate agg fix (#79346) was backported to v7.16 (#79449), we change the minimum version
for the test