### PR TITLE
Adjust Multiple data paths deprecation to warning (#79463)

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -349,7 +349,7 @@ public class Node implements Closeable {
                 // NOTE: we use initialEnvironment here, but assertEquivalent below ensures the data paths do not change
                 deprecationLogger.warn(DeprecationCategory.SETTINGS, "multiple-data-paths",
                     "Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
-                        "multiple disks. This feature will be in a future release.");
+                        "multiple disks. This feature will be removed in a future release.");
             }
             if (Environment.dataPathUsesList(tmpSettings)) {
                 // already checked for multiple values above, so if this is a list it is a single valued list

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -338,7 +338,7 @@ public class Node implements Closeable {
             if (Environment.PATH_SHARED_DATA_SETTING.exists(tmpSettings)) {
                 // NOTE: this must be done with an explicit check here because the deprecation property on a path setting will
                 // cause ES to fail to start since logging is not yet initialized on first read of the setting
-                deprecationLogger.critical(
+                deprecationLogger.warn(
                     DeprecationCategory.SETTINGS,
                     "shared-data-path",
                     "setting [path.shared_data] is deprecated and will be removed in a future release"
@@ -347,13 +347,13 @@ public class Node implements Closeable {
 
             if (initialEnvironment.dataFiles().length > 1) {
                 // NOTE: we use initialEnvironment here, but assertEquivalent below ensures the data paths do not change
-                deprecationLogger.critical(DeprecationCategory.SETTINGS, "multiple-data-paths",
+                deprecationLogger.warn(DeprecationCategory.SETTINGS, "multiple-data-paths",
                     "Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
-                        "multiple disks. This feature will be removed in 8.0.");
+                        "multiple disks. This feature will be in a future release.");
             }
             if (Environment.dataPathUsesList(tmpSettings)) {
                 // already checked for multiple values above, so if this is a list it is a single valued list
-                deprecationLogger.critical(DeprecationCategory.SETTINGS, "multiple-data-paths-list",
+                deprecationLogger.warn(DeprecationCategory.SETTINGS, "multiple-data-paths-list",
                     "Configuring [path.data] with a list is deprecated. Instead specify as a string value.");
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
@@ -110,7 +110,7 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
             Stream.of("setting [path.shared_data] is deprecated and will be removed in a future release",
             "Configuring [path.data] with a list is deprecated. Instead specify as a string value.",
             "Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
-                "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
+                "multiple disks. This feature will be removed in a future release.")).collect(Collectors.toList());
     }
 
     @After

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -65,7 +65,7 @@ public class InternalTestClusterTests extends ESTestCase {
     protected List<String> filteredWarnings() {
         return Stream.concat(super.filteredWarnings().stream(),
             Stream.of("Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
-            "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
+            "multiple disks. This feature will be removed in a future release.")).collect(Collectors.toList());
     }
 
     public void testInitializiationIsConsistent() {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -327,7 +327,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
     public List<String> filteredWarnings() {
         return Stream.concat(super.filteredWarnings().stream(),
             Stream.of("Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
-            "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
+            "multiple disks. This feature will be removed in a future release.")).collect(Collectors.toList());
     }
 
     @AfterClass


### PR DESCRIPTION
Since Multiple Data Paths support has been added back to 8.0, the
deprecation is no longer critical, as the feature will not be
immediately removed after 7.16. This commit adjusts the deprecation
level to indicate it is a warning, intead of a critical deprecation that
would otherwise need to be addressed before upgrading.

relates #71205