### PR TITLE
Fix internal link in migration guide

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -277,14 +277,14 @@ use only persistent settings.
 [%collapsible]
 ====
 *Details* +
-The {ref}/cluster-health.html[cluster health API] API includes options for
-waiting for certain health conditions to be satisfied. If the requested
-conditions are not satisfied within a timeout then {es} will send back a normal
-response including the field `"timed_out": true`. In earlier versions it would
-also use the HTTP response code `408 Request timeout` if the request timed out,
-and `200 OK` otherwise. The `408 Request timeout` response code is not
-appropriate for this situation and its use is deprecated. Future versions will
-use the response code `200 OK` for both cases.
+The {ref}/cluster-health.html[cluster health API] includes options for waiting
+for certain health conditions to be satisfied. If the requested conditions are
+not satisfied within a timeout then {es} will send back a normal response
+including the field `"timed_out": true`. In earlier versions it would also use
+the HTTP response code `408 Request timeout` if the request timed out, and `200
+OK` otherwise. The `408 Request timeout` response code is not appropriate for
+this situation and its use is deprecated. Future versions will use the response
+code `200 OK` for both cases.
 
 *Impact* +
 Update your application to read the `"timed_out"` field of the response instead

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -277,14 +277,14 @@ use only persistent settings.
 [%collapsible]
 ====
 *Details* +
-The <<cluster-health>> API includes options for waiting for certain health
-conditions to be satisfied. If the requested conditions are not satisfied
-within a timeout then {es} will send back a normal response including the field
-`"timed_out": true`. In earlier versions it would also use the HTTP response
-code `408 Request timeout` if the request timed out, and `200 OK` otherwise.
-The `408 Request timeout` response code is not appropriate for this situation
-and its use is deprecated. Future versions will use the response code `200 OK`
-for both cases.
+The {ref}/cluster-health.html[cluster health API] API includes options for
+waiting for certain health conditions to be satisfied. If the requested
+conditions are not satisfied within a timeout then {es} will send back a normal
+response including the field `"timed_out": true`. In earlier versions it would
+also use the HTTP response code `408 Request timeout` if the request timed out,
+and `200 OK` otherwise. The `408 Request timeout` response code is not
+appropriate for this situation and its use is deprecated. Future versions will
+use the response code `200 OK` for both cases.
 
 *Impact* +
 Update your application to read the `"timed_out"` field of the response instead


### PR DESCRIPTION
In #79451 we introduced an internal link in the migration guide, but
this has to be an external link so that these docs can be re-used in the
stack-wide guide too. This fixes that oversight.