### PR TITLE
Use 'migration' instead of 'upgrade' in GET system feature migration status responses (#79302)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/GetFeatureUpgradeStatusResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/GetFeatureUpgradeStatusResponse.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class GetFeatureUpgradeStatusResponse {
 
     private static final ParseField FEATURE_UPGRADE_STATUSES = new ParseField("features");
-    private static final ParseField UPGRADE_STATUS = new ParseField("upgrade_status");
+    private static final ParseField UPGRADE_STATUS = new ParseField("migration_status");
 
     private final List<FeatureUpgradeStatus> featureUpgradeStatuses;
     private final String upgradeStatus;
@@ -76,7 +76,7 @@ public class GetFeatureUpgradeStatusResponse {
 
         private static final ParseField FEATURE_NAME = new ParseField("feature_name");
         private static final ParseField MINIMUM_INDEX_VERSION = new ParseField("minimum_index_version");
-        private static final ParseField UPGRADE_STATUS = new ParseField("upgrade_status");
+        private static final ParseField UPGRADE_STATUS = new ParseField("migration_status");
         private static final ParseField INDEX_VERSIONS = new ParseField("indices");
 
         @SuppressWarnings("unchecked")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
@@ -55,7 +55,7 @@ public class MigrationIT extends ESRestHighLevelClientTestCase {
     public void testGetFeatureUpgradeStatus() throws IOException {
         GetFeatureUpgradeStatusRequest request = new GetFeatureUpgradeStatusRequest();
         GetFeatureUpgradeStatusResponse response = highLevelClient().migration().getFeatureUpgradeStatus(request, RequestOptions.DEFAULT);
-        assertThat(response.getUpgradeStatus(), equalTo("NO_UPGRADE_NEEDED"));
+        assertThat(response.getUpgradeStatus(), equalTo("NO_MIGRATION_NEEDED"));
         assertThat(response.getFeatureUpgradeStatuses().size(), greaterThanOrEqualTo(1));
         Optional<GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus> optionalTasksStatus = response.getFeatureUpgradeStatuses().stream()
             .filter(status -> "tasks".equals(status.getFeatureName()))
@@ -65,7 +65,7 @@ public class MigrationIT extends ESRestHighLevelClientTestCase {
 
         GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus tasksStatus = optionalTasksStatus.get();
 
-        assertThat(tasksStatus.getUpgradeStatus(), equalTo("NO_UPGRADE_NEEDED"));
+        assertThat(tasksStatus.getUpgradeStatus(), equalTo("NO_MIGRATION_NEEDED"));
         assertThat(tasksStatus.getMinimumIndexVersion(), equalTo(Version.CURRENT.toString()));
         assertThat(tasksStatus.getFeatureName(), equalTo("tasks"));
     }

--- a/docs/reference/migration/apis/feature_upgrade.asciidoc
+++ b/docs/reference/migration/apis/feature_upgrade.asciidoc
@@ -46,77 +46,77 @@ Example response:
     {
       "feature_name" : "async_search",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "enrich",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "fleet",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "geoip",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "kibana",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "logstash_management",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "machine_learning",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "searchable_snapshots",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "security",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "tasks",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "transform",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     },
     {
       "feature_name" : "watcher",
       "minimum_index_version" : "7.0.0",
-      "upgrade_status" : "NO_UPGRADE_NEEDED",
+      "migration_status" : "NO_MIGRATION_NEEDED",
       "indices" : [ ]
     }
   ],
-  "upgrade_status" : "NO_UPGRADE_NEEDED"
+  "migration_status" : "NO_MIGRATION_NEEDED"
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"minimum_index_version" : "7.0.0"/"minimum_index_version" : $body.$_path/]

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
@@ -104,9 +104,9 @@ public class FeatureUpgradeIT extends AbstractRollingTestCase {
                 assertThat(feature.size(), equalTo(4));
                 assertThat(feature.get("minimum_index_version"), equalTo(UPGRADE_FROM_VERSION.toString()));
                 if (UPGRADE_FROM_VERSION.before(TransportGetFeatureUpgradeStatusAction.NO_UPGRADE_REQUIRED_VERSION)) {
-                    assertThat(feature.get("upgrade_status"), equalTo("UPGRADE_NEEDED"));
+                    assertThat(feature.get("migration_status"), equalTo("MIGRATION_NEEDED"));
                 } else {
-                    assertThat(feature.get("upgrade_status"), equalTo("NO_UPGRADE_NEEDED"));
+                    assertThat(feature.get("migration_status"), equalTo("NO_MIGRATION_NEEDED"));
                 }
             });
         }

--- a/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/FeatureUpgradeApiIT.java
+++ b/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/FeatureUpgradeApiIT.java
@@ -52,8 +52,8 @@ public class FeatureUpgradeApiIT extends ESRestTestCase {
         Response response = client().performRequest(new Request("GET", "/_migration/system_features"));
         assertThat(response.getStatusLine().getStatusCode(), is(200));
         XContentTestUtils.JsonMapView view = XContentTestUtils.createJsonMapView(response.getEntity().getContent());
-        String upgradeStatus = view.get("upgrade_status");
-        assertThat(upgradeStatus, equalTo("NO_UPGRADE_NEEDED"));
+        String upgradeStatus = view.get("migration_status");
+        assertThat(upgradeStatus, equalTo("NO_MIGRATION_NEEDED"));
         List<Map<String, Object>> features = view.get("features");
         Map<String, Object> testFeature = features.stream()
             .filter(feature -> "system indices qa".equals(feature.get("feature_name")))
@@ -62,7 +62,7 @@ public class FeatureUpgradeApiIT extends ESRestTestCase {
 
         assertThat(testFeature.size(), equalTo(4));
         assertThat(testFeature.get("minimum_index_version"), equalTo(Version.CURRENT.toString()));
-        assertThat(testFeature.get("upgrade_status"), equalTo("NO_UPGRADE_NEEDED"));
+        assertThat(testFeature.get("migration_status"), equalTo("NO_MIGRATION_NEEDED"));
         assertThat(testFeature.get("indices"), instanceOf(List.class));
 
         assertThat((List<Object>) testFeature.get("indices"), hasSize(1));

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,5 +1,5 @@
 
-   
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/10_get_feature_upgrade_status.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/10_get_feature_upgrade_status.yml
@@ -7,5 +7,5 @@
   - do:
       migration.get_feature_upgrade_status: {}
 
-  - is_true: upgrade_status
+  - is_true: migration_status
   - is_true: features

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
@@ -57,7 +57,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
             builder.value(featureUpgradeStatus);
         }
         builder.endArray();
-        builder.field("upgrade_status", upgradeStatus);
+        builder.field("migration_status", upgradeStatus);
         builder.endObject();
         return builder;
     }
@@ -98,8 +98,8 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
     }
 
     public enum UpgradeStatus {
-        UPGRADE_NEEDED,
-        NO_UPGRADE_NEEDED,
+        MIGRATION_NEEDED,
+        NO_MIGRATION_NEEDED,
         IN_PROGRESS
     }
 
@@ -167,7 +167,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
             builder.startObject();
             builder.field("feature_name", this.featureName);
             builder.field("minimum_index_version", this.minimumIndexVersion.toString());
-            builder.field("upgrade_status", this.upgradeStatus);
+            builder.field("migration_status", this.upgradeStatus);
             builder.startArray("indices");
             for (IndexVersion version : this.indexVersions) {
                 builder.value(version);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_UPGRADE_NEEDED;
-import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.UPGRADE_NEEDED;
+import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED;
+import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.MIGRATION_NEEDED;
 
 /**
  * Transport class for the get feature upgrade status action
@@ -80,7 +80,7 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
                 .orElse(Version.CURRENT)
                 .before(Version.V_7_0_0);
 
-        listener.onResponse(new GetFeatureUpgradeStatusResponse(features, isUpgradeNeeded ? UPGRADE_NEEDED : NO_UPGRADE_NEEDED));
+        listener.onResponse(new GetFeatureUpgradeStatusResponse(features, isUpgradeNeeded ? MIGRATION_NEEDED : NO_MIGRATION_NEEDED));
     }
 
     // visible for testing
@@ -97,7 +97,7 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
         return new GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus(
             featureName,
             minimumVersion,
-            minimumVersion.before(Version.V_7_0_0) ? UPGRADE_NEEDED : NO_UPGRADE_NEEDED,
+            minimumVersion.before(Version.V_7_0_0) ? MIGRATION_NEEDED : NO_MIGRATION_NEEDED,
             indexVersions
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponseTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.UPGRADE_NEEDED;
+import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.MIGRATION_NEEDED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -50,7 +50,7 @@ public class GetFeatureUpgradeStatusResponseTests extends AbstractWireSerializin
 
     /** If constructor is called with null for a list, we just use an empty list */
     public void testConstructorHandlesNullLists() {
-        GetFeatureUpgradeStatusResponse response = new GetFeatureUpgradeStatusResponse(null, UPGRADE_NEEDED);
+        GetFeatureUpgradeStatusResponse response = new GetFeatureUpgradeStatusResponse(null, MIGRATION_NEEDED);
         assertThat(response.getFeatureUpgradeStatuses(), notNullValue());
         assertThat(response.getFeatureUpgradeStatuses(), equalTo(Collections.emptyList()));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusActionTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_UPGRADE_NEEDED;
+import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TransportGetFeatureUpgradeStatusActionTests extends ESTestCase {
@@ -35,7 +35,7 @@ public class TransportGetFeatureUpgradeStatusActionTests extends ESTestCase {
             TransportGetFeatureUpgradeStatusAction.getFeatureUpgradeStatus(
                 CLUSTER_STATE, "test-feature", FEATURE);
 
-        assertThat(status.getUpgradeStatus(), equalTo(NO_UPGRADE_NEEDED));
+        assertThat(status.getUpgradeStatus(), equalTo(NO_MIGRATION_NEEDED));
         assertThat(status.getFeatureName(), equalTo("test-feature"));
         assertThat(status.getMinimumIndexVersion(), equalTo(Version.V_7_0_0));
         assertThat(status.getIndexVersions().size(), equalTo(2)); // additional testing below


### PR DESCRIPTION
* Change 'upgrade' to 'migration' in System Index Migration responses

backport of #79302