### PR TITLE
[7.x] Fix CCSDuelIT for skipped shards (#79490)

### DIFF
--- a/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
@@ -103,6 +103,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 
 /**
@@ -438,7 +439,6 @@ public class CCSDuelIT extends ESRestTestCase {
         assumeMultiClusterSetup();
         SearchRequest searchRequest = initSearchRequest();
         // set to a value greater than the number of shards to avoid differences due to the skipping of shards
-        searchRequest.setPreFilterShardSize(128);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         boolean onlyRemote = randomBoolean();
         sourceBuilder.query(new TermQueryBuilder("_index", onlyRemote ? REMOTE_INDEX_NAME : INDEX_NAME));
@@ -461,7 +461,6 @@ public class CCSDuelIT extends ESRestTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79365")
     public void testFieldCollapsingOneClusterHasNoResults() throws Exception {
         assumeMultiClusterSetup();
         SearchRequest searchRequest = initSearchRequest();
@@ -771,6 +770,7 @@ public class CCSDuelIT extends ESRestTestCase {
                 message.compareMaps(minimizeRoundtripsResponseMap, fanOutResponseMap);
                 throw new AssertionError("Didn't match expected value:\n" + message);
             }
+            assertThat(minimizeRoundtripsSearchResponse.getSkippedShards(), lessThanOrEqualTo(fanOutSearchResponse.getSkippedShards()));
         }
     }
 
@@ -834,6 +834,10 @@ public class CCSDuelIT extends ESRestTestCase {
                  */
                 shard.remove("fetch");
             }
+        }
+        Map<String, Object> shards = (Map<String, Object>)responseMap.get("_shards");
+        if (shards != null) {
+            shards.remove("skipped");
         }
         return responseMap;
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix CCSDuelIT for skipped shards (#79490)