### PR TITLE
Improve transient settings deprecation message

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -10,13 +10,18 @@ package org.elasticsearch.xpack.deprecation;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
+import java.util.Locale;
+import java.util.stream.Collectors;
+
 public class ClusterDeprecationChecks {
     static DeprecationIssue checkTransientSettingsExistence(ClusterState state) {
         if (state.metadata().transientSettings().isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Transient cluster settings are in the process of being removed.",
                 "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                "Use persistent settings to define your cluster settings instead.",
+                String.format(Locale.ROOT,
+                    "Use persistent settings instead of transient settings for the following: [%s]",
+                    state.metadata().transientSettings().names().stream().sorted().collect(Collectors.joining(", "))),
                 false,
                 null);
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -10,18 +10,13 @@ package org.elasticsearch.xpack.deprecation;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
-import java.util.Locale;
-import java.util.stream.Collectors;
-
 public class ClusterDeprecationChecks {
     static DeprecationIssue checkTransientSettingsExistence(ClusterState state) {
         if (state.metadata().transientSettings().isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
-                "Transient cluster settings are in the process of being removed.",
+                "Transient cluster settings are deprecated",
                 "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                String.format(Locale.ROOT,
-                    "Use persistent settings instead of transient settings for the following: [%s]",
-                    state.metadata().transientSettings().names().stream().sorted().collect(Collectors.joining(", "))),
+                "Use persistent settings to configure your cluster.",
                 false,
                 null);
         }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -13,8 +13,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
-import java.util.Locale;
-
 import static org.hamcrest.Matchers.equalTo;
 
 public class ClusterDeprecationChecksTests extends ESTestCase {
@@ -36,14 +34,11 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
 
         ClusterState badState = ClusterState.builder(new ClusterName("test")).metadata(metadataWithTransientSettings).build();
         DeprecationIssue issue = ClusterDeprecationChecks.checkTransientSettingsExistence(badState);
-        String expectedDetails = String.format(Locale.ROOT,
-            "Use persistent settings instead of transient settings for the following: [%s]",
-            String.join(", ", "action", "cluster", "indices"));
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
-                "Transient cluster settings are in the process of being removed.",
+                "Transient cluster settings are deprecated",
                 "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                expectedDetails,
+                "Use persistent settings to configure your cluster.",
                 false, null)
         ));
 


### PR DESCRIPTION
Add the supplied transient settings names as part of the deprecation response, to help people understand which settings they need to convert to persistent settings.
