### PR TITLE
[DOCS] Add docs for kibana_system reset tool

### DIFF
--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -14,6 +14,7 @@ tasks from the command line:
 * <<elasticsearch-keystore>>
 * <<node-tool>>
 * <<reset-elastic-password>>
+* <<reset-kibana-system-password>>
 * <<saml-metadata>>
 * <<setup-passwords>>
 * <<shard-tool>>
@@ -29,6 +30,7 @@ include::croneval.asciidoc[]
 include::keystore.asciidoc[]
 include::node-tool.asciidoc[]
 include::reset-elastic-password.asciidoc[]
+include::reset-kibana-system-password.asciidoc[]
 include::saml-metadata.asciidoc[]
 include::service-tokens-command.asciidoc[]
 include::setup-passwords.asciidoc[]

--- a/docs/reference/commands/reset-elastic-password.asciidoc
+++ b/docs/reference/commands/reset-elastic-password.asciidoc
@@ -13,6 +13,7 @@ The `elasticsearch-reset-elastic-password` command resets the password for the
 bin/elasticsearch-reset-elastic-password
 [-a, --auto] [-b, --batch] [-E <KeyValuePair]
 [-f, --force] [-h, --help] [-i, --interactive]
+[-s, --silent] [-v, --verbose]
 ----
 
 [discrete]
@@ -23,7 +24,9 @@ strong password is generated for you. To explicitly set a password, run the
 tool in interactive mode with `-i`. The command generates (and subsequently
 removes) a temporary user in the <<file-realm,file realm>> to run the request
 that changes the `elastic` user password.
-IMPORTANT: You cannot use this tool if the file realm is disabled in your `elasticsearch.yml` file.
+
+IMPORTANT: You cannot use this tool if the file realm is disabled in your
+`elasticsearch.yml` file.
 
 This command uses an HTTP connection to connect to the cluster and run the user
 management requests. The command automatically attempts to establish the connection
@@ -50,6 +53,10 @@ option. For more information about debugging connection failures, see
 `-h, --help`:: Returns all of the command parameters.
 
 `-i, --interactive`:: Prompts the user for the password of the `elastic` user. Use this option to explicitly set a password.
+
+`-s --silent`:: Shows minimal output in the console.
+
+`-v --verbose`:: Shows verbose output in the console.
 
 [discrete]
 === Examples

--- a/docs/reference/commands/reset-kibana-system-password.asciidoc
+++ b/docs/reference/commands/reset-kibana-system-password.asciidoc
@@ -1,0 +1,74 @@
+[roles="xpack"]
+[[reset-kibana-system-password]]
+== elasticsearch-reset-kibana-system-password
+
+The `elasticsearch-reset-kibana-system-password` command resets the password for
+the `kibana_system` <<built-in-users,built-in user>>.
+
+[discrete]
+=== Synopsis
+
+[source,shell]
+----
+bin/elasticsearch-reset-kibana-system-password
+[-a, --auto] [-b, --batch] [-E <KeyValuePair]
+[-f, --force] [-h, --help] [-i, --interactive]
+[-s, --silent] [-v, --verbose]
+----
+
+[discrete]
+=== Description
+
+Use this command to reset the password of the `kibana_system` user. This is the
+user that {kib} uses to communicat with {es}. By default,
+a strong password is generated for you. To explicitly set a password, run the
+tool in interactive mode with `-i`. The command generates (and subsequently
+removes) a temporary user in the <<file-realm,file realm>> to run the request
+that changes the `kibana_system` user password.
+
+IMPORTANT: You cannot use this tool if the file realm is disabled in your
+`elasticsearch.yml` file.
+
+This command uses an HTTP connection to connect to the cluster and run the user
+management requests. The command automatically attempts to establish the
+connection over HTTPS by using the `xpack.security.http.ssl` settings in
+the `elasticsearch.yml` file. If you do not use the default configuration
+directory location, ensure that the `ES_PATH_CONF` environment variable returns
+the correct path before you run the `elasticsearch-reset-elastic-password`
+command. You can override settings in your `elasticsearch.yml` file by using the
+`-E` command option. For more information about debugging connection failures,
+see <<trb-security-setup>>.
+
+[discrete]
+[[reset-kibana-system-password-parameters]]
+=== Parameters
+
+`-a, --auto`:: Resets the password of the `kibana_system` user to an
+auto-generated strong password. (Default)
+
+`-b, --batch`:: Runs the reset password process without prompting for
+verification.
+
+`-E <KeyValuePair>`:: Configures a standard {es} or {xpack} setting.
+
+`-f, --force`:: Forces the command to run against an unhealthy cluster.
+
+`-h, --help`:: Returns all of the command parameters.
+
+`-i, --interactive`:: Prompts the user for the password of the `kibana_system`
+user. Use this option to explicitly set a password.
+
+`-s --silent`:: Shows minimal output in the console.
+
+`-v --verbose`:: Shows verbose output in the console.
+
+[discrete]
+=== Examples
+
+The following example resets the password of the `kibana_system` user to an
+auto-generated value and prints the new password in the console.
+
+[source,shell]
+----
+bin/elasticsearch-reset-kibana-system-password
+----


### PR DESCRIPTION
Adds documentation for the `elasticsearch-reset-kibana-system-password` command. Also fixes some issues in the documentation for the `elasticsearch-reset-elastic-password` command.

Preview link: https://elasticsearch_79506.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/reset-kibana-system-password.html

Closes #78226