### PR TITLE
[7.x] TEST Ensure password 14 chars length on Kerberos FIPS tests (#79496)

### DIFF
--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
@@ -5,7 +5,7 @@ set -e
 addprinc.sh elasticsearch
 addprinc.sh HTTP/localhost
 addprinc.sh peppa
-addprinc.sh george          dino
+addprinc.sh george          dino_but_longer_than_14_chars
 
 # Use this as a signal that setup is complete
 python3 -m http.server 4444 &

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -53,7 +53,7 @@ tasks.named("integTest").configure {
   nonInputProperties.systemProperty 'test.userkt', "peppa@${realm}"
   nonInputProperties.systemProperty 'test.userkt.keytab', "${peppaKeytab}"
   nonInputProperties.systemProperty 'test.userpwd', "george@${realm}"
-  systemProperty 'test.userpwd.password', "dino"
+  systemProperty 'test.userpwd.password', "dino_but_longer_than_14_chars"
   systemProperty 'tests.security.manager', 'true'
   jvmArgs([
     "-Djava.security.krb5.conf=${project(':test:fixtures:krb5kdc-fixture').ext.krb5Conf("peppa")}",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - TEST Ensure password 14 chars length on Kerberos FIPS tests (#79496)