### PR TITLE
[ML] add new truncate parameter tokenization

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenization.java
@@ -25,7 +25,12 @@ public class BertTokenization extends Tokenization {
         ConstructingObjectParser<BertTokenization, Void> parser = new ConstructingObjectParser<>(
             "bert_tokenization",
             ignoreUnknownFields,
-            a -> new BertTokenization((Boolean) a[0], (Boolean) a[1], (Integer) a[2])
+            a -> new BertTokenization(
+                (Boolean) a[0],
+                (Boolean) a[1],
+                (Integer) a[2],
+                a[3] == null ? null : Truncate.fromString((String)a[3])
+            )
         );
         Tokenization.declareCommonFields(parser);
         return parser;
@@ -38,8 +43,13 @@ public class BertTokenization extends Tokenization {
         return lenient ? LENIENT_PARSER.apply(parser, null) : STRICT_PARSER.apply(parser, null);
     }
 
-    public BertTokenization(@Nullable Boolean doLowerCase, @Nullable Boolean withSpecialTokens, @Nullable Integer maxSequenceLength) {
-        super(doLowerCase, withSpecialTokens, maxSequenceLength);
+    public BertTokenization(
+        @Nullable Boolean doLowerCase,
+        @Nullable Boolean withSpecialTokens,
+        @Nullable Integer maxSequenceLength,
+        @Nullable Truncate truncate
+    ) {
+        super(doLowerCase, withSpecialTokens, maxSequenceLength, truncate);
     }
 
     public BertTokenization(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
@@ -17,47 +17,74 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
 public abstract class Tokenization implements NamedXContentObject, NamedWriteable {
 
+    public enum Truncate {
+        FIRST,
+        SECOND,
+        NONE;
+
+        public static Truncate fromString(String value) {
+            return valueOf(value.toUpperCase(Locale.ROOT));
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
     //TODO add global params like never_split, bos_token, eos_token, mask_token, tokenize_chinese_chars, strip_accents, etc.
     public static final ParseField DO_LOWER_CASE = new ParseField("do_lower_case");
     public static final ParseField WITH_SPECIAL_TOKENS = new ParseField("with_special_tokens");
     public static final ParseField MAX_SEQUENCE_LENGTH = new ParseField("max_sequence_length");
+    public static final ParseField TRUNCATE = new ParseField("truncate");
 
     private static final int DEFAULT_MAX_SEQUENCE_LENGTH = 512;
     private static final boolean DEFAULT_DO_LOWER_CASE = false;
     private static final boolean DEFAULT_WITH_SPECIAL_TOKENS = true;
+    private static final Truncate DEFAULT_TRUNCATION = Truncate.FIRST;
 
     static <T extends Tokenization> void declareCommonFields(ConstructingObjectParser<T, ?> parser) {
         parser.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), DO_LOWER_CASE);
         parser.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), WITH_SPECIAL_TOKENS);
         parser.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_SEQUENCE_LENGTH);
+        parser.declareString(ConstructingObjectParser.optionalConstructorArg(), TRUNCATE);
     }
 
     public static BertTokenization createDefault() {
-        return new BertTokenization(null, null, null);
+        return new BertTokenization(null, null, null, Truncate.FIRST);
     }
 
     protected final boolean doLowerCase;
     protected final boolean withSpecialTokens;
     protected final int maxSequenceLength;
+    protected final Truncate truncate;
 
-    Tokenization(@Nullable Boolean doLowerCase, @Nullable Boolean withSpecialTokens, @Nullable Integer maxSequenceLength) {
+    Tokenization(
+        @Nullable Boolean doLowerCase,
+        @Nullable Boolean withSpecialTokens,
+        @Nullable Integer maxSequenceLength,
+        @Nullable Truncate truncate
+    ) {
         if (maxSequenceLength != null && maxSequenceLength <= 0) {
             throw new IllegalArgumentException("[" + MAX_SEQUENCE_LENGTH.getPreferredName() + "] must be positive");
         }
         this.doLowerCase = Optional.ofNullable(doLowerCase).orElse(DEFAULT_DO_LOWER_CASE);
         this.withSpecialTokens = Optional.ofNullable(withSpecialTokens).orElse(DEFAULT_WITH_SPECIAL_TOKENS);
         this.maxSequenceLength = Optional.ofNullable(maxSequenceLength).orElse(DEFAULT_MAX_SEQUENCE_LENGTH);
+        this.truncate = Optional.ofNullable(truncate).orElse(DEFAULT_TRUNCATION);
     }
 
     public Tokenization(StreamInput in) throws IOException {
         this.doLowerCase = in.readBoolean();
         this.withSpecialTokens = in.readBoolean();
         this.maxSequenceLength = in.readVInt();
+        this.truncate = in.readEnum(Truncate.class);
     }
 
     @Override
@@ -65,6 +92,7 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         out.writeBoolean(doLowerCase);
         out.writeBoolean(withSpecialTokens);
         out.writeVInt(maxSequenceLength);
+        out.writeEnum(truncate);
     }
 
     abstract XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException;
@@ -75,6 +103,7 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         builder.field(DO_LOWER_CASE.getPreferredName(), doLowerCase);
         builder.field(WITH_SPECIAL_TOKENS.getPreferredName(), withSpecialTokens);
         builder.field(MAX_SEQUENCE_LENGTH.getPreferredName(), maxSequenceLength);
+        builder.field(TRUNCATE.getPreferredName(), truncate.toString());
         builder = doXContentBody(builder, params);
         builder.endObject();
         return builder;
@@ -87,12 +116,13 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         Tokenization that = (Tokenization) o;
         return doLowerCase == that.doLowerCase
             && withSpecialTokens == that.withSpecialTokens
+            && truncate == that.truncate
             && maxSequenceLength == that.maxSequenceLength;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doLowerCase, withSpecialTokens, maxSequenceLength);
+        return Objects.hash(doLowerCase, truncate, withSpecialTokens, maxSequenceLength);
     }
 
     public boolean doLowerCase() {
@@ -105,5 +135,9 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
 
     public int maxSequenceLength() {
         return maxSequenceLength;
+    }
+
+    public Truncate getTruncate() {
+        return truncate;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
@@ -48,7 +48,8 @@ public class BertTokenizationTests extends AbstractBWCSerializationTestCase<Bert
         return new BertTokenization(
             randomBoolean() ? null : randomBoolean(),
             randomBoolean() ? null : randomBoolean(),
-            randomBoolean() ? null : randomIntBetween(1, 1024)
+            randomBoolean() ? null : randomIntBetween(1, 1024),
+            randomBoolean() ? null : randomFrom(Tokenization.Truncate.values())
         );
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelType;
 import org.elasticsearch.xpack.core.ml.inference.allocation.AllocationStatus;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -276,7 +277,9 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
             new PutTrainedModelAction.Request(
                 TrainedModelConfig.builder()
                     .setModelType(TrainedModelType.PYTORCH)
-                    .setInferenceConfig(new PassThroughConfig(null, new BertTokenization(null, false, null), null))
+                    .setInferenceConfig(
+                        new PassThroughConfig(null, new BertTokenization(null, false, null, Tokenization.Truncate.NONE), null)
+                    )
                     .setModelId(modelId)
                     .build(),
                 false

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.ingest.DeletePipelineAction;
 import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineAction;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
-import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.xcontent.XContentType;
@@ -31,10 +30,9 @@ import org.elasticsearch.xpack.core.ml.dataframe.analyses.BoostedTreeParams;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Classification;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelType;
-import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
@@ -200,7 +198,7 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
                     .setInferenceConfig(
                         new PassThroughConfig(
                             null,
-                            new BertTokenization(null, false, null),
+                            new BertTokenization(null, false, null, Tokenization.Truncate.NONE),
                             null
                         )
                     )

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelCRUDIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConst
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.junit.Before;
@@ -72,7 +73,7 @@ public class TrainedModelCRUDIT extends MlSingleNodeTestCase {
                             new VocabularyConfig(
                                 InferenceIndexConstants.nativeDefinitionStore()
                             ),
-                            new BertTokenization(null, false, null),
+                            new BertTokenization(null, false, null, Tokenization.Truncate.NONE),
                             null
                         )
                     )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/BertRequestBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/BertRequestBuilderTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ public class BertRequestBuilderTests extends ESTestCase {
     public void testBuildRequest() throws IOException {
         BertTokenizer tokenizer = BertTokenizer.builder(
             Arrays.asList("Elastic", "##search", "fun", BertTokenizer.CLASS_TOKEN, BertTokenizer.SEPARATOR_TOKEN, BertTokenizer.PAD_TOKEN),
-            new BertTokenization(null, null, 512)
+            new BertTokenization(null, null, 512, Tokenization.Truncate.NONE)
         ).build();
 
         BertRequestBuilder requestBuilder = new BertRequestBuilder(tokenizer);
@@ -56,7 +57,7 @@ public class BertRequestBuilderTests extends ESTestCase {
     public void testInputTooLarge() throws IOException {
         BertTokenizer tokenizer = BertTokenizer.builder(
             Arrays.asList("Elastic", "##search", "fun", BertTokenizer.CLASS_TOKEN, BertTokenizer.SEPARATOR_TOKEN, BertTokenizer.PAD_TOKEN),
-            new BertTokenization(null, null, 5)
+            new BertTokenization(null, null, 5, Tokenization.Truncate.NONE)
         ).build();
         {
             BertRequestBuilder requestBuilder = new BertRequestBuilder(tokenizer);
@@ -84,7 +85,7 @@ public class BertRequestBuilderTests extends ESTestCase {
                 "my", "little", "red", "car",
                 "God", "##zilla"
                 ),
-            new BertTokenization(null, null, 512)
+            new BertTokenization(null, null, 512, Tokenization.Truncate.NONE)
         ).build();
 
         BertRequestBuilder requestBuilder = new BertRequestBuilder(tokenizer);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.NerResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
@@ -277,7 +278,7 @@ public class NerProcessorTests extends ESTestCase {
     }
 
     private static TokenizationResult tokenize(List<String> vocab, String input) {
-        BertTokenizer tokenizer = BertTokenizer.builder(vocab, new BertTokenization(true, false, null))
+        BertTokenizer tokenizer = BertTokenizer.builder(vocab, new BertTokenization(true, false, null, Tokenization.Truncate.NONE))
             .setDoLowerCase(true)
             .setWithSpecialTokens(false)
             .build();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
@@ -67,7 +68,7 @@ public class TextClassificationProcessorTests extends ESTestCase {
                     BertTokenizer.CLASS_TOKEN, BertTokenizer.SEPARATOR_TOKEN, BertTokenizer.PAD_TOKEN),
                 randomAlphaOfLength(10)
             ),
-            new BertTokenization(null, null, 512));
+            new BertTokenization(null, null, 512, Tokenization.Truncate.NONE));
 
         TextClassificationConfig config = new TextClassificationConfig(
             new VocabularyConfig("test-index"), null, List.of("a", "b"), null, null);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdate;
@@ -35,7 +36,7 @@ public class ZeroShotClassificationProcessorTests extends ESTestCase {
                     BertTokenizer.CLASS_TOKEN, BertTokenizer.SEPARATOR_TOKEN, BertTokenizer.PAD_TOKEN),
                 randomAlphaOfLength(10)
             ),
-            new BertTokenization(null, true, 512));
+            new BertTokenization(null, true, 512, Tokenization.Truncate.NONE));
 
         ZeroShotClassificationConfig config = new ZeroShotClassificationConfig(
             List.of("entailment", "neutral", "contradiction"),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
@@ -16,47 +17,102 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class BertTokenizerTests extends ESTestCase {
 
+    private static final List<String> TEST_CASED_VOCAB = List.of(
+        "Elastic",
+        "##search",
+        "is",
+        "fun",
+        "my",
+        "little",
+        "red",
+        "car",
+        "God",
+        "##zilla",
+        ".",
+        ",",
+        BertTokenizer.CLASS_TOKEN,
+        BertTokenizer.SEPARATOR_TOKEN,
+        BertTokenizer.MASK_TOKEN,
+        BertTokenizer.UNKNOWN_TOKEN,
+        "day",
+        "Pancake",
+        "with"
+    );
+
     public void testTokenize() {
         BertTokenizer tokenizer = BertTokenizer.builder(
-            Arrays.asList("Elastic", "##search", "fun"),
-            new BertTokenization(null, false, null)
+            TEST_CASED_VOCAB,
+            new BertTokenization(null, false, null, Tokenization.Truncate.NONE)
         ).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun");
         assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", "fun"));
-        assertArrayEquals(new int[] {0, 1, 2}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 0, 1, 3 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1}, tokenization.getTokenMap());
+    }
+
+    public void testTokenizeLargeInputNoTruncation() {
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, false, 5, Tokenization.Truncate.NONE))
+            .build();
+
+        ElasticsearchStatusException ex = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> tokenizer.tokenize("Elasticsearch fun with Pancake and Godzilla")
+        );
+        assertThat(ex.getMessage(), equalTo("Input too large. The tokenized input length [8] exceeds the maximum sequence length [5]"));
+
+        BertTokenizer specialCharTokenizer = BertTokenizer.builder(
+            TEST_CASED_VOCAB,
+            new BertTokenization(null, true, 5, Tokenization.Truncate.NONE)
+        ).build();
+
+        // Shouldn't throw
+        tokenizer.tokenize("Elasticsearch fun with Pancake");
+
+        // Should throw as special chars add two tokens
+        expectThrows(ElasticsearchStatusException.class, () -> specialCharTokenizer.tokenize("Elasticsearch fun with Pancake"));
+    }
+
+    public void testTokenizeLargeInputTruncation() {
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, false, 5, Tokenization.Truncate.FIRST))
+            .build();
+
+        TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun with Pancake and Godzilla");
+        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", "fun", "with", "Pancake"));
+
+        tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 5, Tokenization.Truncate.FIRST)).build();
+        tokenization = tokenizer.tokenize("Elasticsearch fun with Pancake and Godzilla");
+        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "Elastic", "##search", "fun", "[SEP]"));
     }
 
     public void testTokenizeAppendSpecialTokens() {
         BertTokenizer tokenizer = BertTokenizer.builder(
-            Arrays.asList( "elastic", "##search", "fun", BertTokenizer.CLASS_TOKEN, BertTokenizer.SEPARATOR_TOKEN),
+            TEST_CASED_VOCAB,
             Tokenization.createDefault()
         ).build();
 
-        TokenizationResult.Tokenization tokenization = tokenizer.tokenize("elasticsearch fun");
-        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "elastic", "##search", "fun", "[SEP]"));
-        assertArrayEquals(new int[] {3, 0, 1, 2, 4}, tokenization.getTokenIds());
+        TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun");
+        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "Elastic", "##search", "fun", "[SEP]"));
+        assertArrayEquals(new int[] { 12, 0, 1, 3, 13 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {-1, 0, 0, 1, -1}, tokenization.getTokenMap());
     }
 
     public void testNeverSplitTokens() {
         final String specialToken = "SP001";
 
-        BertTokenizer tokenizer = BertTokenizer.builder(
-            Arrays.asList("Elastic", "##search", "fun", specialToken, BertTokenizer.UNKNOWN_TOKEN),
-            Tokenization.createDefault()
-        ).setNeverSplit(Collections.singleton(specialToken))
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, Tokenization.createDefault())
+            .setNeverSplit(Collections.singleton(specialToken))
          .setWithSpecialTokens(false)
          .build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch " + specialToken + " fun");
         assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", specialToken, "fun"));
-        assertArrayEquals(new int[] {0, 1, 3, 2}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 0, 1, 15, 3 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1, 2}, tokenization.getTokenMap());
     }
 
@@ -91,29 +147,25 @@ public class BertTokenizerTests extends ESTestCase {
 
     public void testPunctuation() {
         BertTokenizer tokenizer = BertTokenizer.builder(
-            Arrays.asList("Elastic", "##search", "fun", ".", ",", BertTokenizer.MASK_TOKEN, BertTokenizer.UNKNOWN_TOKEN),
+            TEST_CASED_VOCAB,
             Tokenization.createDefault()
         ).setWithSpecialTokens(false).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch, fun.");
         assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", ",", "fun", "."));
-        assertArrayEquals(new int[] {0, 1, 4, 2, 3}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 0, 1, 11, 3, 10 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1, 2, 3}, tokenization.getTokenMap());
 
         tokenization = tokenizer.tokenize("Elasticsearch, fun [MASK].");
         assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", ",", "fun", "[MASK]", "."));
-        assertArrayEquals(new int[] {0, 1, 4, 2, 5, 3}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 0, 1, 11, 3, 14, 10 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1, 2, 3, 4}, tokenization.getTokenMap());
     }
 
     public void testBatchInput() {
         BertTokenizer tokenizer = BertTokenizer.builder(
-            Arrays.asList("Elastic", "##search", "fun",
-                "Pancake", "day",
-                "my", "little", "red", "car",
-                "God", "##zilla"
-                ),
-            new BertTokenization(null, false, null)
+            TEST_CASED_VOCAB,
+            new BertTokenization(null, false, null, Tokenization.Truncate.NONE)
         ).build();
 
         TokenizationResult tr = tokenizer.buildTokenizationResult(
@@ -133,36 +185,22 @@ public class BertTokenizerTests extends ESTestCase {
 
         tokenization = tr.getTokenizations().get(1);
         assertThat(tokenization.getTokens(), arrayContaining("my", "little", "red", "car"));
-        assertArrayEquals(new int[] {5, 6, 7, 8}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 4, 5, 6, 7 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 1, 2, 3}, tokenization.getTokenMap());
 
         tokenization = tr.getTokenizations().get(2);
         assertThat(tokenization.getTokens(), arrayContaining("God", "##zilla", "day"));
-        assertArrayEquals(new int[] {9, 10, 4}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 8, 9, 16 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1}, tokenization.getTokenMap());
 
         tokenization = tr.getTokenizations().get(3);
         assertThat(tokenization.getTokens(), arrayContaining("God", "##zilla", "Pancake", "red", "car", "day"));
-        assertArrayEquals(new int[] {9, 10, 3, 7, 8, 4}, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 8, 9, 17, 6, 7, 16 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] {0, 0, 1, 2, 3, 4}, tokenization.getTokenMap());
     }
 
     public void testMultiSeqTokenization() {
-        List<String> vocab = List.of(
-            "Elastic",
-            "##search",
-            "is",
-            "fun",
-            "my",
-            "little",
-            "red",
-            "car",
-            "God",
-            "##zilla",
-            BertTokenizer.CLASS_TOKEN,
-            BertTokenizer.SEPARATOR_TOKEN
-        );
-        BertTokenizer tokenizer = BertTokenizer.builder(vocab, Tokenization.createDefault())
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, Tokenization.createDefault())
             .setDoLowerCase(false)
             .setWithSpecialTokens(true)
             .build();
@@ -185,7 +223,56 @@ public class BertTokenizerTests extends ESTestCase {
                 BertTokenizer.SEPARATOR_TOKEN
             )
         );
-        assertArrayEquals(new int[] { 10, 0, 1, 2, 3, 11, 8, 9, 4, 5, 6, 7, 11 }, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { 12, 0, 1, 2, 3, 13, 8, 9, 4, 5, 6, 7, 13 }, tokenization.getTokenIds());
+    }
+
+    public void testTokenizeLargeInputMultiSequenceTruncation() {
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 10, Tokenization.Truncate.FIRST))
+            .build();
+
+        TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch is fun", "Godzilla my little red car");
+        assertThat(
+            tokenization.getTokens(),
+            arrayContaining(
+                BertTokenizer.CLASS_TOKEN,
+                "Elastic",
+                BertTokenizer.SEPARATOR_TOKEN,
+                "God",
+                "##zilla",
+                "my",
+                "little",
+                "red",
+                "car",
+                BertTokenizer.SEPARATOR_TOKEN
+            )
+        );
+
+        expectThrows(
+            ElasticsearchStatusException.class,
+            () -> BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 8, Tokenization.Truncate.NONE))
+                .build()
+                .tokenize("Elasticsearch is fun", "Godzilla my little red car")
+        );
+
+        tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 10, Tokenization.Truncate.SECOND)).build();
+
+        tokenization = tokenizer.tokenize("Elasticsearch is fun", "Godzilla my little red car");
+        assertThat(
+            tokenization.getTokens(),
+            arrayContaining(
+                BertTokenizer.CLASS_TOKEN,
+                "Elastic",
+                "##search",
+                "is",
+                "fun",
+                BertTokenizer.SEPARATOR_TOKEN,
+                "God",
+                "##zilla",
+                "my",
+                BertTokenizer.SEPARATOR_TOKEN
+            )
+        );
+
     }
 
     public void testMultiSeqRequiresSpecialTokens() {


### PR DESCRIPTION
This commit adds a new `truncate` parameter to tokenization.

Valid values are:
first : truncate only the first sequence (if two are provided)
second: truncate only the second sequence (if two are provided)
none: do no truncation, which means we throw an error when sequences are too long
