### PR TITLE
Adjust serialization versions for migration metadata & re-enable BWC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/78951"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
  */
 public class FeatureMigrationResults implements Metadata.Custom {
     public static final String TYPE = "system_index_migration";
-    private static final Version MIGRATION_ADDED_VERSION = Version.V_8_0_0;
+    public static final Version MIGRATION_ADDED_VERSION = Version.V_8_0_0;
 
     private static final ParseField RESULTS_FIELD = new ParseField("results");
 

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParams.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParams.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+import static org.elasticsearch.upgrades.FeatureMigrationResults.MIGRATION_ADDED_VERSION;
+
 /**
  * The params used to initialize {@link SystemIndexMigrator} when it's initially kicked off.
  *
@@ -62,7 +64,7 @@ public class SystemIndexMigrationTaskParams implements PersistentTaskParams {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0;
+        return MIGRATION_ADDED_VERSION;
     }
 
     @Override public boolean equals(Object obj) {


### PR DESCRIPTION
Also re-enables BWC following the backport of #78951.