### PR TITLE
[7.12] [doc] Remove external herokuapp website link (#79537)

### DIFF
--- a/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
+++ b/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
@@ -231,8 +231,6 @@ In java time, `z` outputs 'Z' for Zulu when given a UTC timezone.
 We strongly recommend you test any date format changes using real data before
 deploying in production.
 
-For help with date debugging, consider using
-https://esddd.herokuapp.com/[https://esddd.herokuapp.com/.]
 
 [[java-time-migrate-update-mappings]]
 ==== Update index mappings


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [doc] Remove external herokuapp website link (#79537)