### PR TITLE
Search bug fix - _terms_enum API index_filter doesn’t work with _tier field on upgraded cluster

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
@@ -91,7 +91,10 @@ public class DataTierFieldMapper extends MetadataFieldMapper {
             String value = DataTier.TIER_PREFERENCE_SETTING.get(settings);
 
             if (Strings.hasText(value) == false) {
-                return null;
+                // Starting in 8.0 we should always have a default preference of data_content
+                // but in 7.x it is possible to have null so we default here to make terms_enum
+                // api work. See https://github.com/elastic/elasticsearch/issues/79200
+                return DataTier.DATA_CONTENT;
             }
 
             // Tier preference can be a comma-delimited list of tiers, ordered by preference

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -48,8 +48,8 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("Data_Warm", null, false, createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("noSuchRole", null, createContext()));
 
-        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("data_*", null, createContextWithoutSetting()));
-        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("*", null, createContextWithoutSetting()));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("data_*", null, createContextWithoutSetting()));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("*", null, createContextWithoutSetting()));
     }
 
     public void testTermQuery() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -74,7 +74,7 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
     public void testExistsQuery() {
         MappedFieldType ft = DataTierFieldMapper.DataTierFieldType.INSTANCE;
         assertEquals(new MatchAllDocsQuery(), ft.existsQuery(createContext()));
-        assertEquals(new MatchNoDocsQuery(), ft.existsQuery(createContextWithoutSetting()));
+        assertEquals(new MatchAllDocsQuery(), ft.existsQuery(createContextWithoutSetting()));
     }
 
     public void testRegexpQuery() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -95,7 +95,7 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
         assertEquals(singletonList("data_warm"), valueFetcher.fetchValues(lookup, ignoredValues));
 
         ValueFetcher emptyValueFetcher = ft.valueFetcher(createContextWithoutSetting(), null);
-        assertTrue(emptyValueFetcher.fetchValues(lookup, ignoredValues).isEmpty());
+        assertEquals(singletonList("data_content"), emptyValueFetcher.fetchValues(lookup, ignoredValues));
     }
 
     private SearchExecutionContext createContext() {


### PR DESCRIPTION
Upgraded indices cannot be relied on to have a data tier preference set and hence are ignored by Kibana auto-complete style requests that filter based on data tier.
This PR changes _tier field behaviour to default to having the value “data_content” when an index's preference is not set. This index setting will be the default behaviour in 8.0 but we can’t rely on non-null values in 7.x.

Closes #79200
