### PR TITLE
SQL: Improve testCatalogDependentCommands() reliability

### DIFF
--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
@@ -71,7 +71,8 @@ public class JdbcCatalogIT extends JdbcIntegrationTestCase {
     }
 
     public void testCatalogDependentCommands() throws Exception {
-        for (String query : List.of("SHOW TABLES", "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"", "DESCRIBE \"" + INDEX_NAME + "\"")) {
+        for (String query : List.of("SHOW TABLES \"" + INDEX_NAME + "\"", "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"",
+            "DESCRIBE \"" + INDEX_NAME + "\"")) {
             try (Connection es = esJdbc()) {
                 PreparedStatement ps = es.prepareStatement(query);
                 ResultSet rs = ps.executeQuery();

--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
@@ -70,7 +70,6 @@ public class JdbcCatalogIT extends JdbcIntegrationTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79548")
     public void testCatalogDependentCommands() throws Exception {
         for (String query : List.of("SHOW TABLES \"" + INDEX_NAME + "\"", "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"",
             "DESCRIBE \"" + INDEX_NAME + "\"")) {

--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
@@ -71,8 +71,11 @@ public class JdbcCatalogIT extends JdbcIntegrationTestCase {
     }
 
     public void testCatalogDependentCommands() throws Exception {
-        for (String query : List.of("SHOW TABLES \"" + INDEX_NAME + "\"", "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"",
-            "DESCRIBE \"" + INDEX_NAME + "\"")) {
+        for (String query : List.of(
+            "SHOW TABLES \"" + INDEX_NAME + "\"",
+            "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"",
+            "DESCRIBE \"" + INDEX_NAME + "\""
+        )) {
             try (Connection es = esJdbc()) {
                 PreparedStatement ps = es.prepareStatement(query);
                 ResultSet rs = ps.executeQuery();


### PR DESCRIPTION
`SHOW TABLES` by itself will list all tables available in the cluster.
If async events produce any ".some_system_index" test, the newly
available index will interfere with test's assumptions.

Fixes #79548.