### PR TITLE
Only remove active peer on connection failure

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -410,7 +410,9 @@ public abstract class PeerFinder {
                     synchronized (mutex) {
                         assert probeConnectionResult.get() == null
                             : "discoveryNode unexpectedly already set to " + probeConnectionResult.get();
-                        peersByAddress.remove(transportAddress);
+                        if (isActive()) {
+                            peersByAddress.remove(transportAddress);
+                        } // else this Peer has been superseded by a different instance which should be left in place
                     }
                 }
             });


### PR DESCRIPTION
Today if the `PeerFinder` experiences a connection failure then it
removes the `Peer` with the corresponding transport address. However the
removed `Peer` might be a different instance which is actually fine and
holds a connection reference which therefore leaks.

With this commit we only remove ourselves from the tracked set of peers.

Relates #77295
Closes #79550