### PR TITLE
Fix repository-azure for empty settings on reload

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.repositories.azure;
 
 import com.azure.core.util.serializer.JacksonAdapter;
+
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -16,10 +17,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsException;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -33,6 +32,7 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -132,9 +132,6 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
     public void reload(Settings settings) {
         // secure settings should be readable
         final Map<String, AzureStorageSettings> clientsSettings = AzureStorageSettings.load(settings);
-        if (clientsSettings.isEmpty()) {
-            throw new SettingsException("If you want to use an azure repository, you need to define a client configuration.");
-        }
         AzureStorageService storageService = azureStoreService.get();
         assert storageService != null;
         storageService.refreshSettings(clientsSettings);

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -168,7 +168,7 @@ public class AzureStorageServiceTests extends ESTestCase {
             plugin.reload(Settings.EMPTY);
             // existing client untouched
             assertThat(client11.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
-            // new client also untouched
+            // client is no longer registered
             final SettingsException e =
                 expectThrows(SettingsException.class, () -> azureStorageService.client("azure1", LocationMode.PRIMARY_ONLY));
             assertThat(e.getMessage(), equalTo("Unable to find client with name [azure1]"));

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.repositories.azure;
 
 import com.azure.storage.common.policy.RequestRetryOptions;
+
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
@@ -163,14 +164,14 @@ public class AzureStorageServiceTests extends ESTestCase {
             final AzureStorageService azureStorageService = plugin.azureStoreService.get();
             AzureBlobServiceClient client11 = azureStorageService.client("azure1", LocationMode.PRIMARY_ONLY);
             assertThat(client11.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
-            // reinit with empty settings
-            final SettingsException e = expectThrows(SettingsException.class, () -> plugin.reload(Settings.EMPTY));
-            assertThat(e.getMessage(), is("If you want to use an azure repository, you need to define a client configuration."));
+            // reinit with empty settings is okay
+            plugin.reload(Settings.EMPTY);
             // existing client untouched
             assertThat(client11.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
             // new client also untouched
-            AzureBlobServiceClient client21 = azureStorageService.client("azure1", LocationMode.PRIMARY_ONLY);
-            assertThat(client21.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
+            final SettingsException e =
+                expectThrows(SettingsException.class, () -> azureStorageService.client("azure1", LocationMode.PRIMARY_ONLY));
+            assertThat(e.getMessage(), equalTo("Unable to find client with name [azure1]"));
         }
     }
 


### PR DESCRIPTION
Today when reloading settings, if the repository-azure plugin is installed and no repositories of type "azure" are defined, the repository-azure plugin will throw an exception that no client configurations are specified, and it will not process the update (thus, leaving the definition of existing repositories). This behavior has the impact that if the repository-azure plugin is installed, but no repositories of type "azure" are defined, then any attempt to reload settings will receive an exception. This behavior appears to be legacy, and is not mirrored in the other cloud service provider repository plugins. This commit removes that behavior. This enables installing the repository-azure plugin by default, without requiring that a repository of type "azure" be configured.

