### PR TITLE
Simplify some Mapping Construction and Parsing

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
@@ -15,23 +15,19 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.INDEX_NAME;
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.PRIMARY_INDEX_NAME;
-import static org.elasticsearch.test.XContentTestUtils.convertToXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -106,7 +102,7 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
      * Fetch the mappings and settings for {@link TestSystemIndexDescriptor#INDEX_NAME} and verify that they match the expected values.
      * Note that in the case of the mappings, this is just a dumb string comparison, so order of keys matters.
      */
-    private void assertMappingsAndSettings(String expectedMappings) {
+    private void assertMappingsAndSettings(CompressedXContent expectedMappings) {
         final GetMappingsResponse getMappingsResponse = client().admin()
             .indices()
             .getMappings(new GetMappingsRequest().indices(INDEX_NAME))
@@ -118,13 +114,7 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
             mappings.containsKey(PRIMARY_INDEX_NAME),
             equalTo(true)
         );
-        final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).getSourceAsMap();
-
-        try {
-            assertThat(convertToXContent(sourceAsMap, XContentType.JSON).utf8ToString(), equalTo(expectedMappings));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        assertThat(mappings.get(PRIMARY_INDEX_NAME).source(), equalTo(expectedMappings));
 
         final GetSettingsResponse getSettingsResponse = client().admin()
             .indices()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
@@ -10,16 +10,14 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 /**
  * A special kind of {@link SystemIndexDescriptor} that can toggle what kind of mappings it
@@ -39,8 +37,8 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
         .build();
 
     TestSystemIndexDescriptor() {
-        super(INDEX_NAME + "*", PRIMARY_INDEX_NAME, "Test system index", getOldMappings(), SETTINGS, INDEX_NAME, 0, "version", "stack",
-            Version.CURRENT.minimumCompatibilityVersion(), Type.INTERNAL_MANAGED, List.of(), List.of(), null, false);
+        super(INDEX_NAME + "*", PRIMARY_INDEX_NAME, "Test system index", getOldMappings().string(), SETTINGS, INDEX_NAME, 0, "version",
+            "stack", Version.CURRENT.minimumCompatibilityVersion(), Type.INTERNAL_MANAGED, List.of(), List.of(), null, false);
     }
 
     @Override
@@ -49,16 +47,14 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
     }
 
     @Override
-    public String getMappings() {
+    public CompressedXContent getMappings() {
         return useNewMappings.get() ? getNewMappings() : getOldMappings();
     }
 
-    public static String getOldMappings() {
+    public static CompressedXContent getOldMappings() {
         try {
-            final XContentBuilder builder = jsonBuilder();
-
-            builder.startObject();
-            {
+            return new CompressedXContent((builder, params) -> {
+                builder.startObject(MapperService.SINGLE_MAPPING_NAME);
                 builder.startObject("_meta");
                 builder.field("version", Version.CURRENT.previousMajor().toString());
                 builder.endObject();
@@ -69,22 +65,18 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
                     builder.field("type", "text");
                     builder.endObject();
                 }
-                builder.endObject();
-            }
-
-            builder.endObject();
-            return Strings.toString(builder);
+                builder.endObject().endObject();
+                return builder;
+            });
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to build .test-index-1 index mappings", e);
         }
     }
 
-    public static String getNewMappings() {
+    public static CompressedXContent getNewMappings() {
         try {
-            final XContentBuilder builder = jsonBuilder();
-
-            builder.startObject();
-            {
+            return new CompressedXContent((builder, params) -> {
+                builder.startObject(MapperService.SINGLE_MAPPING_NAME);
                 builder.startObject("_meta");
                 builder.field("version", Version.CURRENT.toString());
                 builder.endObject();
@@ -98,11 +90,8 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
                     builder.field("type", "text");
                     builder.endObject();
                 }
-                builder.endObject();
-            }
-
-            builder.endObject();
-            return Strings.toString(builder);
+                return builder.endObject().endObject();
+            });
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to build .test-index-1 index mappings", e);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -187,9 +188,9 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     return updateRequest;
                 }
 
-                private CreateIndexClusterStateUpdateRequest buildSystemIndexUpdateRequest(
-                    String indexName, SystemIndexDescriptor descriptor) {
-                    String mappings = descriptor.getMappings();
+                private CreateIndexClusterStateUpdateRequest buildSystemIndexUpdateRequest(String indexName,
+                                                                                           SystemIndexDescriptor descriptor) {
+                    CompressedXContent mappings = descriptor.getMappings();
                     Settings settings = descriptor.getSettings();
                     String aliasName = descriptor.getAliasName();
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
@@ -38,7 +39,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     private Settings settings = Settings.EMPTY;
 
-    private String mappings = "{}";
+    private CompressedXContent mappings = CompressedXContent.EMPTY_JSON;
 
     private final Set<Alias> aliases = new HashSet<>();
 
@@ -57,7 +58,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
         return this;
     }
 
-    public CreateIndexClusterStateUpdateRequest mappings(String mappings) {
+    public CreateIndexClusterStateUpdateRequest mappings(CompressedXContent mappings) {
         this.mappings = mappings;
         return this;
     }
@@ -112,7 +113,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
         return settings;
     }
 
-    public String mappings() {
+    public CompressedXContent mappings() {
         return mappings;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -252,6 +253,10 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      */
     public CreateIndexRequest mapping(Map<String, ?> source) {
         return mapping(MapperService.SINGLE_MAPPING_NAME, source);
+    }
+
+    public CreateIndexRequest mapping(CompressedXContent source) {
+        return mapping(source.compressedReference(), XContentType.JSON);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataMappingService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -158,10 +159,10 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
         for (Index index : concreteIndices) {
             final SystemIndexDescriptor descriptor = systemIndices.findMatchingDescriptor(index.getName());
             if (descriptor != null && descriptor.isAutomaticallyManaged() && descriptor.hasDynamicMappings() == false) {
-                final String descriptorMappings = descriptor.getMappings();
+                final CompressedXContent descriptorMappings = descriptor.getMappings();
                 // Technically we could trip over a difference in whitespace here, but then again nobody should be trying to manually
                 // update a descriptor's mappings.
-                if (descriptorMappings.equals(requestMappings) == false) {
+                if (descriptorMappings.string().equals(requestMappings) == false) {
                     violations.add(index.getName());
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -181,7 +181,7 @@ public class TransportSimulateIndexTemplateAction
 
         // empty request mapping as the user can't specify any explicit mappings via the simulate api
         List<Map<String, Object>> mappings = MetadataCreateIndexService.collectV2Mappings(
-            "{}", simulatedState, matchingTemplate, xContentRegistry, indexName);
+            CompressedXContent.EMPTY_JSON, simulatedState, matchingTemplate, xContentRegistry, indexName);
 
         CompressedXContent mergedMapping = indicesService.<CompressedXContent, Exception>withTempIndexService(indexMetadata,
             tempIndexService -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -21,12 +21,15 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
 
 /**
  * Put index template action.
@@ -56,7 +59,7 @@ public class TransportPutIndexTemplateAction extends AcknowledgedTransportMaster
 
     @Override
     protected void masterOperation(Task task, final PutIndexTemplateRequest request, final ClusterState state,
-                                   final ActionListener<AcknowledgedResponse> listener) {
+                                   final ActionListener<AcknowledgedResponse> listener) throws IOException {
         String cause = request.cause();
         if (cause.length() == 0) {
             cause = "api";
@@ -68,7 +71,7 @@ public class TransportPutIndexTemplateAction extends AcknowledgedTransportMaster
                 .patterns(request.patterns())
                 .order(request.order())
                 .settings(templateSettingsBuilder.build())
-                .mappings(request.mappings())
+                .mappings(request.mappings() == null ? null : new CompressedXContent(request.mappings()))
                 .aliases(request.aliases())
                 .create(request.create())
                 .masterTimeout(request.masterNodeTimeout())

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.IndexingPressure;
@@ -283,7 +282,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
 
             try {
                 primary.mapperService().merge(MapperService.SINGLE_MAPPING_NAME,
-                    new CompressedXContent(result.getRequiredMappingUpdate(), XContentType.JSON, ToXContent.EMPTY_PARAMS),
+                    new CompressedXContent(result.getRequiredMappingUpdate()),
                     MapperService.MergeReason.MAPPING_UPDATE_PREFLIGHT);
             } catch (Exception e) {
                 logger.info(() -> new ParameterizedMessage("{} mapping update rejected by primary", primary.shardId()), e);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -16,9 +16,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 
@@ -64,8 +62,7 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
     public MappingMetadata(String type, Map<String, Object> mapping) {
         this.type = type;
         try {
-            this.source = new CompressedXContent(
-                    (builder, params) -> builder.mapContents(mapping), XContentType.JSON, ToXContent.EMPTY_PARAMS);
+            this.source = new CompressedXContent((builder, params) -> builder.mapContents(mapping));
         } catch (IOException e) {
             throw new UncheckedIOException(e);  // XContent exception, should never happen
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -155,7 +155,7 @@ public class MetadataMappingService {
                 // update mapping metadata on all types
                 DocumentMapper mapper = mapperService.documentMapper();
                 if (mapper != null) {
-                    indexMetadataBuilder.putMapping(new MappingMetadata(mapper.mappingSource()));
+                    indexMetadataBuilder.putMapping(new MappingMetadata(mapper));
                 }
                 if (updatedMapping) {
                     indexMetadataBuilder.mappingVersion(1 + indexMetadataBuilder.mappingVersion());

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -34,6 +34,16 @@ import java.util.zip.CheckedOutputStream;
  */
 public final class CompressedXContent {
 
+    public static final CompressedXContent EMPTY_JSON;
+
+    static {
+        try {
+            EMPTY_JSON = new CompressedXContent("{}");
+        } catch (IOException e) {
+            throw new AssertionError();
+        }
+    }
+
     private static int crc32(BytesReference data) {
         CRC32 crc32 = new CRC32();
         try {
@@ -53,6 +63,10 @@ public final class CompressedXContent {
         this.bytes = compressed;
         this.crc32 = crc32;
         assertConsistent();
+    }
+
+    public CompressedXContent(ToXContent xcontent) throws IOException {
+        this(xcontent, XContentType.JSON, ToXContent.EMPTY_PARAMS);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 
 import java.io.IOException;
@@ -73,7 +72,7 @@ public final class Mapping implements ToXContentFragment {
      */
     public CompressedXContent toCompressedXContent() {
         try {
-            return new CompressedXContent(this, XContentType.JSON, ToXContent.EMPTY_PARAMS);
+            return new CompressedXContent(this);
         } catch (Exception e) {
             throw new ElasticsearchGenerationException("failed to serialize source for type [" + root.name() + "]", e);
         }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -182,7 +182,7 @@ public class SystemIndexManager implements ClusterStateListener {
     private void upgradeIndexMetadata(SystemIndexDescriptor descriptor, ActionListener<AcknowledgedResponse> listener) {
         final String indexName = descriptor.getPrimaryIndex();
 
-        PutMappingRequest request = new PutMappingRequest(indexName).source(descriptor.getMappings(), XContentType.JSON);
+        PutMappingRequest request = new PutMappingRequest(indexName).source(descriptor.getMappings().string(), XContentType.JSON);
 
         final OriginSettingClient originSettingClient = new OriginSettingClient(this.client, descriptor.getOrigin());
 

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -41,7 +42,7 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
     private final IndexMetadata currentIndex;
     private final String featureName;
     private final Settings settings;
-    private final String mapping;
+    private final CompressedXContent mapping;
     private final String origin;
     private final SystemIndices.Feature owningFeature;
 
@@ -53,7 +54,7 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
         IndexMetadata currentIndex,
         String featureName,
         Settings settings,
-        String mapping,
+        CompressedXContent mapping,
         String origin,
         SystemIndices.Feature owningFeature
     ) {
@@ -96,7 +97,7 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
     /**
      * Gets the mappings to be used for the post-migration index.
      */
-    String getMappings() {
+    CompressedXContent getMappings() {
         return mapping;
     }
 
@@ -191,13 +192,13 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
         }
         Settings settings = settingsBuilder.build();
 
-        String mapping = descriptor.getMappings();
+        CompressedXContent mapping = descriptor.getMappings();
         if (descriptor.isAutomaticallyManaged() == false) {
             // Get Settings from old index
             settings = copySettingsForNewIndex(currentIndex.getSettings(), indexScopedSettings);
 
             // Copy mapping from the old index
-            mapping = currentIndex.mapping().source().string();
+            mapping = currentIndex.mapping().source();
         }
         return new SystemIndexMigrationInfo(
             currentIndex,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -299,7 +299,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             indexNameExpressionResolver));
     }
 
-    public void testCreateIndexRequest() {
+    public void testCreateIndexRequest() throws IOException {
         String alias = randomAlphaOfLength(10);
         String rolloverIndex = randomAlphaOfLength(10);
         final RolloverRequest rolloverRequest = new RolloverRequest(alias, randomAlphaOfLength(10));
@@ -319,7 +319,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         assertThat(createIndexRequest.cause(), equalTo("rollover_index"));
     }
 
-    public void testCreateIndexRequestForDataStream() {
+    public void testCreateIndexRequestForDataStream() throws IOException {
         DataStream dataStream = DataStreamTestHelper.randomInstance();
         final String newWriteIndexName = DataStream.getDefaultBackingIndexName(dataStream.getName(), dataStream.getGeneration() + 1);
         final RolloverRequest rolloverRequest = new RolloverRequest(dataStream.getName(), randomAlphaOfLength(10));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -553,7 +553,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             templateBuilder.putAlias(AliasMetadata.builder("alias1"));
             templateBuilder.putMapping("_doc", createMapping("mapping_from_template", "text"));
         });
-        request.mappings(createMapping("mapping_from_request", "text").string());
+        request.mappings(createMapping("mapping_from_request", "text"));
 
         Map<String, Object> parsedMappings = MetadataCreateIndexService.parseV1Mappings(request.mappings(),
             List.of(templateMetadata.getMappings()), NamedXContentRegistry.EMPTY);
@@ -621,7 +621,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             .settings(Settings.builder().put("key1", "templateValue"))
         );
 
-        request.mappings(reqMapping.string());
+        request.mappings(reqMapping);
         request.aliases(Set.of(new Alias("alias").searchRouting("fromRequest")));
         request.settings(Settings.builder().put("key1", "requestValue").build());
 
@@ -832,7 +832,8 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             }
         });
 
-        Map<String, Object> mappings = parseV1Mappings("{\"_doc\":{}}", List.of(templateMetadata.mappings()), xContentRegistry());
+        Map<String, Object> mappings =
+            parseV1Mappings(new CompressedXContent("{\"_doc\":{}}"), List.of(templateMetadata.mappings()), xContentRegistry());
         assertThat(mappings, Matchers.hasKey(MapperService.SINGLE_MAPPING_NAME));
     }
 
@@ -845,7 +846,8 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 ExceptionsHelper.reThrowIfNotNull(e);
             }
         });
-        Map<String, Object> mappings = parseV1Mappings("", List.of(templateMetadata.mappings()), xContentRegistry());
+        Map<String, Object> mappings =
+            parseV1Mappings(CompressedXContent.EMPTY_JSON, List.of(templateMetadata.mappings()), xContentRegistry());
         assertThat(mappings, Matchers.hasKey(MapperService.SINGLE_MAPPING_NAME));
     }
 
@@ -857,7 +859,8 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 ExceptionsHelper.reThrowIfNotNull(e);
             }
         });
-        Map<String, Object> mappings = parseV1Mappings("", List.of(templateMetadata.mappings()), xContentRegistry());
+        Map<String, Object> mappings =
+            parseV1Mappings(CompressedXContent.EMPTY_JSON, List.of(templateMetadata.mappings()), xContentRegistry());
         assertThat(mappings, Matchers.hasKey(MapperService.SINGLE_MAPPING_NAME));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
@@ -11,10 +11,8 @@ package org.elasticsearch.common.compress;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Assert;
 
@@ -97,13 +95,13 @@ public class DeflateCompressedXContentTests extends ESTestCase {
             builder.endObject();
             return builder;
         };
-        CompressedXContent compressedXContent = new CompressedXContent(toXContentObject, XContentType.JSON, ToXContent.EMPTY_PARAMS);
+        CompressedXContent compressedXContent = new CompressedXContent(toXContentObject);
         assertEquals("{}", compressedXContent.string());
     }
 
     public void testToXContentFragment() throws IOException {
         ToXContentFragment toXContentFragment = (builder, params) -> builder.field("field", "value");
-        CompressedXContent compressedXContent = new CompressedXContent(toXContentFragment, XContentType.JSON, ToXContent.EMPTY_PARAMS);
+        CompressedXContent compressedXContent = new CompressedXContent(toXContentFragment);
         assertEquals("{\"field\":\"value\"}", compressedXContent.string());
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -107,7 +107,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
             Metadata.builder()
                 .put(getIndexMetadata(d1, null, 6, IndexMetadata.State.OPEN))
-                .put(getIndexMetadata(d2, d2.getMappings(), 6, IndexMetadata.State.OPEN))
+                .put(getIndexMetadata(d2, d2.getMappings().string(), 6, IndexMetadata.State.OPEN))
                 .build()
         );
 
@@ -143,7 +143,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
-            Metadata.builder().put(getIndexMetadata(d2, d2.getMappings(), 6, IndexMetadata.State.OPEN)).build()
+            Metadata.builder().put(getIndexMetadata(d2, d2.getMappings().string(), 6, IndexMetadata.State.OPEN)).build()
         );
 
         assertThat(eligibleDescriptors, hasSize(1));
@@ -245,7 +245,7 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static ClusterState.Builder createClusterState() {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings());
+        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings().string());
     }
 
     private static ClusterState.Builder createClusterState(String mappings) {
@@ -253,7 +253,7 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static ClusterState.Builder createClusterState(IndexMetadata.State state) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), 6, state);
+        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings().string(), 6, state);
     }
 
     private static ClusterState.Builder createClusterState(String mappings, IndexMetadata.State state) {
@@ -261,7 +261,7 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static ClusterState.Builder createClusterState(int format) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), format, IndexMetadata.State.OPEN);
+        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings().string(), format, IndexMetadata.State.OPEN);
     }
 
     private static ClusterState.Builder createClusterState(String mappings, int format, IndexMetadata.State state) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/AutoFollowStatsMonitoringDocTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/AutoFollowStatsMonitoringDocTests.java
@@ -146,9 +146,8 @@ public class AutoFollowStatsMonitoringDocTests extends BaseMonitoringDocTestCase
         builder.value(status);
         Map<String, Object> serializedStatus = XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(builder), false);
 
-        byte[] loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
-        Map<String, Object> template =
-            XContentHelper.convertToMap(XContentType.JSON.xContent(), loadedTemplate, 0, loadedTemplate.length, false);
+        BytesReference loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
+        Map<String, Object> template = XContentHelper.convertToMap(loadedTemplate, false, XContentType.JSON).v2();
         Map<?, ?> autoFollowStatsMapping =
             (Map<?, ?>) XContentMapValues.extractValue("mappings._doc.properties.ccr_auto_follow_stats.properties", template);
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/FollowStatsMonitoringDocTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/FollowStatsMonitoringDocTests.java
@@ -240,9 +240,8 @@ public class FollowStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Fol
         builder.value(status);
         Map<String, Object> serializedStatus = XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(builder), false);
 
-        byte[] loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
-        Map<String, Object> template =
-            XContentHelper.convertToMap(XContentType.JSON.xContent(), loadedTemplate, 0, loadedTemplate.length, false);
+        BytesReference loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
+        Map<String, Object> template = XContentHelper.convertToMap(loadedTemplate, false, XContentType.JSON).v2();
         Map<?, ?> followStatsMapping = (Map<?, ?>) XContentMapValues
             .extractValue("mappings._doc.properties.ccr_stats.properties", template);
         assertThat(serializedStatus.size(), equalTo(followStatsMapping.size()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -69,7 +69,7 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
                 try {
                     return new PutComposableIndexTemplateAction.Request(templateConfig.getTemplateName())
                         .indexTemplate(ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                            DeprecationHandler.THROW_UNSUPPORTED_OPERATION, templateConfig.loadBytes())))
+                            DeprecationHandler.THROW_UNSUPPORTED_OPERATION, templateConfig.loadBytes().streamInput())))
                         .masterNodeTimeout(MASTER_TIMEOUT);
                 } catch (IOException e) {
                     throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -324,7 +324,7 @@ public final class MlIndexAndAlias {
         try {
             request = new PutComposableIndexTemplateAction.Request(templateConfig.getTemplateName())
                 .indexTemplate(ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, templateConfig.loadBytes())))
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, templateConfig.loadBytes().streamInput())))
                 .masterNodeTimeout(masterTimeout);
         } catch (IOException e) {
             throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -288,7 +288,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         final ComposableIndexTemplate indexTemplate;
         try {
             indexTemplate = ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, composableTemplate.loadBytes()));
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, composableTemplate.loadBytes().streamInput()));
         } catch (Exception e) {
             throw new ElasticsearchParseException("unable to parse composable template " + composableTemplate.getTemplateName(), e);
         }
@@ -331,7 +331,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
             PutComponentTemplateAction.Request request = new PutComponentTemplateAction.Request(templateName);
             try {
                 request.componentTemplate(ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, config.loadBytes())));
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, config.loadBytes().streamInput())));
             } catch (Exception e) {
                 throw new ElasticsearchParseException("unable to parse component template " + config.getTemplateName(), e);
             }
@@ -364,7 +364,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
             PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request(templateName);
             try {
                 request.indexTemplate(ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, config.loadBytes())));
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, config.loadBytes().streamInput())));
             } catch (Exception e) {
                 throw new ElasticsearchParseException("unable to parse composable template " + config.getTemplateName(), e);
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryStoreTests.java
@@ -57,7 +57,7 @@ public class SnapshotHistoryStoreTests extends ESTestCase {
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         ComposableIndexTemplate template =
             ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, TEMPLATE_SLM_HISTORY.loadBytes()));
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, TEMPLATE_SLM_HISTORY.loadBytes().streamInput()));
         ClusterState state = clusterService.state();
         Metadata.Builder metadataBuilder =
             Metadata.builder(state.getMetadata()).indexTemplates(Map.of(TEMPLATE_SLM_HISTORY.getTemplateName(), template));

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichCoordinatorDocTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichCoordinatorDocTests.java
@@ -129,14 +129,9 @@ public class EnrichCoordinatorDocTests extends BaseMonitoringDocTestCase<EnrichC
         builder.endObject();
         Map<String, Object> serializedStatus = XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(builder), false);
 
-        byte[] loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
-        Map<String, Object> template = XContentHelper.convertToMap(
-            XContentType.JSON.xContent(),
-            loadedTemplate,
-            0,
-            loadedTemplate.length,
-            false
-        );
+        final BytesReference loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES)
+            .loadBytes();
+        Map<String, Object> template = XContentHelper.convertToMap(loadedTemplate, false, XContentType.JSON).v2();
         Map<?, ?> followStatsMapping = (Map<?, ?>) XContentMapValues.extractValue(
             "mappings._doc.properties.enrich_coordinator_stats.properties",
             template

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/ExecutingPolicyDocTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/ExecutingPolicyDocTests.java
@@ -142,14 +142,9 @@ public class ExecutingPolicyDocTests extends BaseMonitoringDocTestCase<Executing
         builder.endObject();
         Map<String, Object> serializedStatus = XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(builder), false);
 
-        byte[] loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES).loadBytes();
-        Map<String, Object> template = XContentHelper.convertToMap(
-            XContentType.JSON.xContent(),
-            loadedTemplate,
-            0,
-            loadedTemplate.length,
-            false
-        );
+        final BytesReference loadedTemplate = MonitoringTemplateRegistry.getTemplateConfigForMonitoredSystem(MonitoredSystem.ES)
+            .loadBytes();
+        Map<String, Object> template = XContentHelper.convertToMap(XContentType.JSON.xContent(), loadedTemplate.streamInput(), false);
         Map<?, ?> followStatsMapping = (Map<?, ?>) XContentMapValues.extractValue(
             "mappings._doc.properties.enrich_executing_policy_stats.properties",
             template

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -81,7 +81,7 @@ public class ILMHistoryStoreTests extends ESTestCase {
     private ComposableIndexTemplate parseIndexTemplate(IndexTemplateConfig c) {
         try {
             return ComposableIndexTemplate.parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, c.loadBytes()));
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, c.loadBytes().streamInput()));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -399,7 +399,7 @@ public class SecurityIndexManager implements ClusterStateListener {
                         descriptorForVersion.getAliasName()
                     );
                     PutMappingRequest request = new PutMappingRequest(state.concreteIndexName).source(
-                        descriptorForVersion.getMappings(),
+                        descriptorForVersion.getMappings().uncompressed(),
                         XContentType.JSON
                     ).origin(descriptorForVersion.getOrigin());
                     executeAsyncWithOrigin(client.threadPool().getThreadContext(), descriptorForVersion.getOrigin(), request,


### PR DESCRIPTION
Move away from parsing `String` in a couple of places and remove a number of redundant
serialization round trips and byte copying. This sets up follow-ups that will try to
deduplicate pieces of mappings and settings in the `Metadata` and gives us a bit of a
speedup in isolation already.

relates #77466 

Follow-ups to this would be:

* Move the requests like the create-index or put-mapping request to using `CompressedXContent` as well to save computation and make deduplication with existing metadata cheaper
* Cache not just the system template bytes but the outright template instances on heap and deduplicate from that
* Make use of these changes to deduplicate mapping sources in computation and on-heap representation of the cluster state