### PR TITLE
SQL: Improve testCatalogDependentCommands() reliability (backport of #79555)

### DIFF
--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCatalogIT.java
@@ -71,7 +71,11 @@ public class JdbcCatalogIT extends JdbcIntegrationTestCase {
     }
 
     public void testCatalogDependentCommands() throws Exception {
-        for (String query : Arrays.asList("SHOW TABLES", "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"", "DESCRIBE \"" + INDEX_NAME + "\"")) {
+        for (String query : Arrays.asList(
+            "SHOW TABLES \"" + INDEX_NAME + "\"",
+            "SHOW COLUMNS FROM \"" + INDEX_NAME + "\"",
+            "DESCRIBE \"" + INDEX_NAME + "\""
+        )) {
             try (Connection es = esJdbc()) {
                 PreparedStatement ps = es.prepareStatement(query);
                 ResultSet rs = ps.executeQuery();


### PR DESCRIPTION
`SHOW TABLES` by itself will list all tables available in the cluster.
If async events produce any ".some_system_index" test, the newly
available index will interfere with test's assumptions. Fixes #79548.

(cherry picked from commit 0b1e11874f7ecd498054d0416eefdf18cc3ef1ab)
