### PR TITLE
[ML] Fix and re-enable MlHiddenIndicesFullClusterRestartIT

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -42,8 +42,8 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractFullClusterRest
     private static final String JOB_ID = "ml-hidden-indices-old-cluster-job";
     private static final List<Tuple<List<String>, String>> EXPECTED_INDEX_ALIAS_PAIRS =
         List.of(
-            Tuple.tuple(List.of(".ml-annotations-6"), ".ml-annotations-read"),
-            Tuple.tuple(List.of(".ml-annotations-6"), ".ml-annotations-write"),
+            Tuple.tuple(List.of(".ml-annotations-000001"), ".ml-annotations-read"),
+            Tuple.tuple(List.of(".ml-annotations-000001"), ".ml-annotations-write"),
             Tuple.tuple(List.of(".ml-state", ".ml-state-000001"), ".ml-state-write"),
             Tuple.tuple(List.of(".ml-anomalies-shared"), ".ml-anomalies-" + JOB_ID),
             Tuple.tuple(List.of(".ml-anomalies-shared"), ".ml-anomalies-.write-" + JOB_ID)
@@ -67,7 +67,6 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractFullClusterRest
         XPackRestTestHelper.waitForTemplates(client(), templatesToWaitFor, clusterUnderstandsComposableTemplates);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78913")
     public void testMlIndicesBecomeHidden() throws Exception {
         if (isRunningAgainstOldCluster()) {
             // trigger ML indices creation


### PR DESCRIPTION
This PR removes the assertion (in `MlConfigIndexMappingsFullClusterRestartIT` test) that verifies that `.ml-config` index does not exist before creating the first ML job.
Since the full cluster restart tests can run in parallel, we cannot make an assumption that this is the case as another test (`MlHiddenIndicesFullClusterRestartIT`) could have already triggered `.ml-config` index creation.
This, as well as fixing annotations index name lets us re-enable `MlHiddenIndicesFullClusterRestartIT` test.

Fixes https://github.com/elastic/elasticsearch/issues/78913