### PR TITLE
[ML] this adds support for the `human` flag for byte size values in the deployment stats API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
@@ -312,7 +312,7 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
                 builder.startObject();
                 builder.field("model_id", modelId);
                 if (modelSize != null) {
-                    builder.field("model_size", modelSize);
+                    builder.humanReadableField("model_size_bytes", "model_size", modelSize);
                 }
                 if (inferenceThreads != null) {
                     builder.field(StartTrainedModelDeploymentAction.TaskParams.INFERENCE_THREADS.getPreferredName(), inferenceThreads);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -268,7 +268,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         List<Map<String, Object>> stats = (List<Map<String, Object>>)entityAsMap(response).get("deployment_stats");
         assertThat(stats, hasSize(1));
         assertThat(stats.get(0).get("model_id"), equalTo(modelA));
-        assertThat(stats.get(0).get("model_size"), equalTo("1.5kb"));
+        assertThat(stats.get(0).get("model_size_bytes"), equalTo((int)RAW_MODEL_SIZE));
         List<Map<String, Object>> nodes = (List<Map<String, Object>>)stats.get(0).get("nodes");
         // 2 of the 3 nodes in the cluster are ML nodes
         assertThat(nodes, hasSize(2));


### PR DESCRIPTION
We should allow the raw bytes and the human readable size given the `human` flag.