### PR TITLE
[DOCS] Remove logic for permanently unreleased branches

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -55,16 +55,6 @@ endif::[]
 :javadoc-watcher: {rest-high-level-client-javadoc}/org/elasticsearch/protocol/xpack/watcher
 
 ///////
-Permanently unreleased branches (master, n.X)
-///////
-ifeval::["{source_branch}"=="master"]
-:permanently-unreleased-branch:
-endif::[]
-ifeval::["{source_branch}"=="{major-version}"]
-:permanently-unreleased-branch:
-endif::[]
-
-///////
 Shared attribute values are pulled from elastic/docs
 ///////
 


### PR DESCRIPTION
These tags are no longer needed. We previously used them for docs behind a feature flag. You can now achieve the same effect with `"{release-state}"!="released"`.

No docs currently use this logic.