### PR TITLE
[DOCS] Fix cluster update settings refs

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -514,7 +514,7 @@ index doesn’t grow too large while waiting for the rollover check. By default,
 {ilm-init} checks rollover conditions every 10 minutes.
 +
 --
-The following <<cluster-update-settings,update cluster settings API>> request
+The following <<cluster-update-settings,cluster update settings API>> request
 lowers the `indices.lifecycle.poll_interval` setting to `1m` (one minute).
 
 [source,console]
@@ -651,8 +651,8 @@ original value when reindexing is complete. This prevents unnecessary load on
 the master node.
 +
 --
-The following update cluster settings API request resets the
-`indices.lifecycle.poll_interval` setting to its default value, 10 minutes.
+The following cluster update settings API request resets the
+`indices.lifecycle.poll_interval` setting to its default value.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -802,7 +802,7 @@ The EQL search API supports <<modules-cross-cluster-search,cross-cluster
 search>>. However, the local and <<remote-clusters,remote clusters>>
 must use the same {es} version.
 
-The following <<cluster-update-settings,update cluster settings>> request
+The following <<cluster-update-settings,cluster update settings>> request
 adds two remote clusters: `cluster_one` and `cluster_two`.
 
 [source,console]

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -504,7 +504,7 @@ GET _cluster/settings?flat_settings=true&include_defaults=true
 // TEST[s/^/PUT my-index\n/]
 
 You can change the settings using the <<indices-update-settings,update index
-settings>> and <<cluster-update-settings,update cluster settings>> APIs.
+settings>> and <<cluster-update-settings,cluster update settings>> APIs.
 
 **Allocate or reduce replicas**
 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -322,8 +322,8 @@ setting limits the maximum number of open shards for a cluster. This error
 indicates an action would exceed this limit.
 
 If you're confident your changes won't destabilize the cluster, you can
-temporarily increase the limit using the <<cluster-update-settings,update
-cluster settings API>> and retry the action.
+temporarily increase the limit using the <<cluster-update-settings,cluster
+update settings API>> and retry the action.
 
 [source,console]
 ----

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -358,14 +358,14 @@ docker run -v my/source/dir:/usr/share/nginx/html:ro nginx
 of each node’s `elasticsearch.yml` file.
 +
 By default, {es} checks the endpoint for updates every three days. To use
-another polling interval, use the <<cluster-update-settings,update cluster
+another polling interval, use the <<cluster-update-settings,cluster update
 settings API>> to set
 <<ingest-geoip-downloader-poll-interval,`ingest.geoip.downloader.poll.interval`>>.
 
 [[manually-update-geoip-databases]]
 **Manually update your GeoIP2 databases**
 
-. Use the <<cluster-update-settings,update cluster settings API>> to set
+. Use the <<cluster-update-settings,cluster update settings API>> to set
 `ingest.geoip.downloader.enabled` to `false`. This disables automatic updates
 that may overwrite your database changes. This also deletes all downloaded
 databases.

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -311,7 +311,7 @@ For example, the following command creates a user named `restore_user`.
 Use this file realm user to authenticate requests until the restore operation is
 complete.
 
-. Use the <<cluster-update-settings,update cluster settings API>> to set
+. Use the <<cluster-update-settings,cluster update settings API>> to set
 <<action-destructive-requires-name,`action.destructive_requires_name`>> to
 `false`. This lets you delete indices and data streams using wildcards.
 +

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -22,7 +22,7 @@ GET _cluster/settings?flat_settings=true&filter_path=persistent.archived*
 ----
 
 You can remove archived cluster settings using the
-<<cluster-update-settings,update cluster settings API>>.
+<<cluster-update-settings,cluster update settings API>>.
 
 [source,console]
 ----


### PR DESCRIPTION
The [API ](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html)is named 'cluster update settings,' not 'update cluster settings.'