### PR TITLE
[DOCS] Fixes broken link to 7.x

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -6,7 +6,7 @@
 [partintro]
 --
 
-deprecated[7.15.0, The High Level REST Client is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.x/index.html[Java API Client].]
+deprecated[7.15.0, The High Level REST Client is deprecated in favour of the {java-api-client}/index.html[Java API Client].]
 
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as


### PR DESCRIPTION
This PR fixes the following broken link:

> 13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-rest/7.15/java-rest-high.html contains broken links to:
13:55:46 INFO:build_docs:   - en/elasticsearch/client/java-api-client/7.x/index.html