### PR TITLE
Revert "Deprecate resolution loss on date field (#78921) backport(#79355)"

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -88,7 +88,7 @@ logging>>.
 ====
 *Details* +
 In SAML, Identity Providers (IdPs) can either be explicitly configured to
-release a `NameID` with a specific format, or configured to attempt to conform
+release a `NameID` with a specific format, or configured to attempt to conform 
 with the requirements of a Service Provider (SP). The SP declares its
 requirements in the `NameIDPolicy` element of a SAML Authentication Request.
 In {es}, the `nameid_format` SAML realm setting controls the `NameIDPolicy`
@@ -103,9 +103,9 @@ IdP. If you want to retain the previous behavior, set `nameid_format` to
 
 *Impact* +
 If you currently don't configure `nameid_format` explicitly, it's possible
-that your IdP will reject authentication requests from {es} because the requests
+that your IdP will reject authentication requests from {es} because the requests 
 do not specify a `NameID` format (and your IdP is configured to expect one).
-This mismatch can result in a broken SAML configuration. If you're unsure whether
+This mismatch can result in a broken SAML configuration. If you're unsure whether 
 your IdP is explicitly configured to use a certain `NameID` format and you want to retain current behavior
 , try setting `nameid_format` to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` explicitly.
 ====
@@ -347,19 +347,4 @@ cache do not expire.
 To override the defaults, configure the `script.cache.max_size`,
 `script.max_compilations_rate`, and `script.cache.expire` settings.
 ====
-
-.Attempting to store nanosecond resolution in a `date` field is deprecated.
-[%collapsible]
-====
-*Details* +
-Attempting to store a nanosecond resolution in a {ref}/date.html[`date`] field is deprecated.
-While previously allowed, these attempts always resulted in resolution loss.
-A `date` field can only store up to millisecond resolutions.
-
-*Impact* +
-If you attempt to store a nanosecond resolution in a `date` type field, {es} will
-emit a deprecation warning. To avoid deprecation warnings, use a
-{ref}/date_nanos.html[`date_nanos`] field instead.
-====
-
 // end::notable-breaking-changes[]

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -219,7 +219,7 @@ public class IndexingIT extends AbstractRollingTestCase {
                 Request index = new Request("POST", "/" + indexName + "/_doc/");
                 XContentBuilder doc = XContentBuilder.builder(XContentType.JSON.xContent())
                     .startObject()
-                        .field("date", "2015-01-01T12:10:30.123Z")
+                        .field("date", "2015-01-01T12:10:30.123456789Z")
                         .field("date_nanos", "2015-01-01T12:10:30.123456789Z")
                     .endObject();
                 index.addParameter("refresh", "true");

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yml
@@ -9,7 +9,7 @@
         index: timetest
         body:
           mappings:
-            "properties": { "my_time": {"type": "date_nanos", "format": "strict_date_optional_time_nanos"}}
+            "properties": { "my_time": {"type": "date", "format": "strict_date_optional_time_nanos"}}
 
   - do:
       ingest.put_pipeline:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
@@ -8,7 +8,7 @@ setup:
                 mappings:
                     properties:
                         mydate:
-                            type: date_nanos
+                            type: date
                             format: "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSZZZZZ"
 
     - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -300,8 +300,7 @@ final class DynamicFieldsBuilder {
             Settings settings = context.indexSettings().getSettings();
             boolean ignoreMalformed = FieldMapper.IGNORE_MALFORMED_SETTING.get(settings);
             createDynamicField(new DateFieldMapper.Builder(name, DateFieldMapper.Resolution.MILLISECONDS,
-                dateTimeFormatter, ScriptCompiler.NONE, ignoreMalformed, context.indexSettings().getIndexVersionCreated(),
-                context.indexSettings().getIndex().getName()), context);
+                dateTimeFormatter, ScriptCompiler.NONE, ignoreMalformed, context.indexSettings().getIndexVersionCreated()), context);
         }
 
         void newDynamicBinaryField(DocumentParserContext context, String name) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -106,7 +106,8 @@ public final class MappingParser {
         }
 
         MappingParserContext parserContext = parserContextSupplier.get();
-        RootObjectMapper rootObjectMapper = rootObjectTypeParser.parse(type, mapping, parserContext).build(MapperBuilderContext.ROOT);
+        RootObjectMapper rootObjectMapper
+            = rootObjectTypeParser.parse(type, mapping, parserContext).build(MapperBuilderContext.ROOT);
 
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersFunction.apply(type);
         Map<String, Object> meta = null;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -565,7 +565,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
                 null,
                 ScriptCompiler.NONE,
                 false,
-                Version.CURRENT, "indexName").build(MapperBuilderContext.ROOT);
+                Version.CURRENT).build(MapperBuilderContext.ROOT);
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);
             when(env.sharedDataFile()).thenReturn(null);
@@ -573,7 +573,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             when(allocationService.reroute(any(ClusterState.class), any(String.class))).then(i -> i.getArguments()[0]);
             RootObjectMapper.Builder root = new RootObjectMapper.Builder("_doc");
             root.add(new DateFieldMapper.Builder(dataStream.getTimeStampField().getName(), DateFieldMapper.Resolution.MILLISECONDS,
-                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ScriptCompiler.NONE, true, Version.CURRENT, "indexName"));
+                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ScriptCompiler.NONE, true, Version.CURRENT));
             MetadataFieldMapper dtfm = getDataStreamTimestampFieldMapper();
             Mapping mapping = new Mapping(
                 root.build(MapperBuilderContext.ROOT),

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.logging.log4j.Level;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.time.DateFormatter;
@@ -147,17 +146,6 @@ public class DateFieldMapperTests extends MapperTestCase {
             "failed to parse date field [-2147483648] with format [strict_date_optional_time||epoch_millis]",
             "strict_date_optional_time||epoch_millis");
         testIgnoreMalformedForValue("-522000000", "long overflow", "date_optional_time");
-    }
-
-    public void testResolutionLossDeprecation() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b
-            .field("type", "date")));
-
-        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2018-10-03T14:42:44.123456+0000")));
-
-        assertWarnings(true, new DeprecationWarning(Level.WARN, "You are attempting to store a nanosecond resolution " +
-            "on a field [field] of type date on index [index]. " +
-            "The nanosecond part was lost. Use date_nanos field type."));
     }
 
     private void testIgnoreMalformedForValue(String value, String expectedCause, String dateFormat) throws IOException {
@@ -415,11 +403,11 @@ public class DateFieldMapperTests extends MapperTestCase {
     }
 
     public void testFetchMillisFromIso8601Nanos() throws IOException {
-        assertFetch(dateNanosMapperService(), "field", randomIs8601Nanos(MAX_NANOS), null);
+        assertFetch(dateMapperService(), "field", randomIs8601Nanos(MAX_ISO_DATE), null);
     }
 
     public void testFetchMillisFromIso8601NanosFormatted() throws IOException {
-        assertFetch(dateNanosMapperService(), "field", randomIs8601Nanos(MAX_NANOS), "strict_date_optional_time_nanos");
+        assertFetch(dateMapperService(), "field", randomIs8601Nanos(MAX_ISO_DATE), "strict_date_optional_time_nanos");
     }
 
     /**
@@ -430,8 +418,7 @@ public class DateFieldMapperTests extends MapperTestCase {
      * way.
      */
     public void testFetchMillisFromRoundedNanos() throws IOException {
-        assertFetch(dateMapperService(), "field", randomDecimalMillis(MAX_ISO_DATE), null);
-        assertFetch(dateNanosMapperService(), "field", randomDecimalNanos(MAX_NANOS), null);
+        assertFetch(dateMapperService(), "field", randomDecimalNanos(MAX_ISO_DATE), null);
     }
 
     /**
@@ -544,7 +531,7 @@ public class DateFieldMapperTests extends MapperTestCase {
         switch (((DateFieldType) ft).resolution()) {
             case MILLISECONDS:
                 if (randomBoolean()) {
-                    return randomDecimalMillis(MAX_ISO_DATE);
+                    return randomIs8601Nanos(MAX_ISO_DATE);
                 }
                 return randomLongBetween(0, Long.MAX_VALUE);
             case NANOSECONDS:
@@ -575,10 +562,6 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     private String randomDecimalNanos(long maxMillis) {
         return Long.toString(randomLongBetween(0, maxMillis)) + "." + between(0, 999999);
-    }
-
-    private String randomDecimalMillis(long maxMillis) {
-        return Long.toString(randomLongBetween(0, maxMillis));
     }
 
     public void testScriptAndPrecludedParameters() {

--- a/x-pack/plugin/data-streams/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/datastreams/AutoCreateDataStreamIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/datastreams/AutoCreateDataStreamIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -102,9 +101,7 @@ public class AutoCreateDataStreamIT extends ESRestTestCase {
 
     private Response indexDocument() throws IOException {
         final Request indexDocumentRequest = new Request("POST", "recipe_kr/_doc");
-        final Instant now = Instant.now();
-        final String time = DateFormatter.forPattern("strict_date_optional_time").format(now);
-        indexDocumentRequest.setJsonEntity("{ \"@timestamp\": \"" + time + "\", \"name\": \"Kimchi\" }");
+        indexDocumentRequest.setJsonEntity("{ \"@timestamp\": \"" + Instant.now() + "\", \"name\": \"Kimchi\" }");
         return client().performRequest(indexDocumentRequest);
     }
 }

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
@@ -12,8 +12,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.time.ZoneOffset;
@@ -282,7 +280,7 @@ public class PainlessDomainSplitIT extends ESRestTestCase {
 
         for (int i = 1; i <= 100; i++) {
             ZonedDateTime time = baseTime.plusHours(i);
-            String formattedTime = DateFormatter.forPattern("strict_date_optional_time").format(time);
+            String formattedTime = time.format(DateTimeFormatter.ISO_DATE_TIME);
             if (i % 50 == 0) {
                 // Anomaly has 100 docs, but we don't care about the value
                 for (int j = 0; j < 100; j++) {

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -210,8 +210,8 @@ teardown:
             test_alias: {}
           mappings:
             properties:
-              date:
-                type: date_nanos
+              time:
+                type: date
               user:
                 type: keyword
               stars:

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
@@ -48,8 +48,8 @@ teardown:
             test_alias: {}
           mappings:
             properties:
-              date:
-                type: date_nanos
+              time:
+                type: date
               user:
                 type: keyword
               stars:
@@ -107,8 +107,8 @@ teardown:
             test_alias: {}
           mappings:
             properties:
-              date:
-                type: date_nanos
+              time:
+                type: date
               user:
                 type: keyword
               stars:

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -34,7 +34,6 @@ import org.elasticsearch.client.transform.transforms.TransformStats;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -53,7 +52,6 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -190,7 +188,7 @@ public class TransformContinuousIT extends ESRestTestCase {
         for (int i = 0; i < 100; i++) {
             dates.add(
                 // create a random date between 1/1/2001 and 1/1/2006
-                formatTimestmap(dateType)
+                ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
                     .format(Instant.ofEpochMilli(randomLongBetween(978307200000L, 1136073600000L)))
             );
         }
@@ -245,18 +243,16 @@ public class TransformContinuousIT extends ESRestTestCase {
                 }
 
                 // simulate a different timestamp that is off from the timestamp used for sync, so it can fall into the previous bucket
-                String metricDateString = formatTimestmap(dateType)
+                String metricDateString = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
                     .format(runDate.minusSeconds(randomIntBetween(0, 2)).plusNanos(randomIntBetween(0, 999999)));
                 source.append("\"metric-timestamp\":\"").append(metricDateString).append("\",");
 
-                final Instant timestamp = runDate.plusNanos(randomIntBetween(0, 999999));
-                String dateString = formatTimestmap(dateType)
-                    .format(timestamp);
+                String dateString = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
+                    .format(runDate.plusNanos(randomIntBetween(0, 999999)));
 
                 source.append("\"timestamp\":\"").append(dateString).append("\",");
                 // for data streams
-                //dynamic field results in a date type
-                source.append("\"@timestamp\":\"").append(formatTimestmap("date").format(timestamp)).append("\",");
+                source.append("\"@timestamp\":\"").append(dateString).append("\",");
                 source.append("\"run\":").append(run);
                 source.append("}");
 
@@ -296,14 +292,6 @@ public class TransformContinuousIT extends ESRestTestCase {
                     );
                 }
             }
-        }
-    }
-
-    private DateFormatter formatTimestmap(String dateType) {
-        if(dateType == "date_nanos"){
-            return DateFormatter.forPattern("strict_date_optional_time_nanos").withZone(ZoneId.of("UTC"));
-        } else {
-            return DateFormatter.forPattern("strict_date_optional_time").withZone(ZoneId.of("UTC"));
         }
     }
 


### PR DESCRIPTION
This reverts commit ff6e589.
and
docs commit 69cf4a31547ff5450cec43b1a5d2f6b35e5c1a09.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
