### PR TITLE
Skip Expensive InternalSnapshotInfoService Application in some Cases

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -127,6 +127,12 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.localNodeMaster()) {
+            if (event.previousState().nodes().isLocalNodeElectedMaster()
+                && event.routingTableChanged() == false
+                && event.nodesChanged() == false) {
+                // we neither just became master nor did the routing table change, nothing to update
+                return;
+            }
             final Set<SnapshotShard> onGoingSnapshotRecoveries = listOfSnapshotShards(event.state());
 
             int unknownShards = 0;


### PR DESCRIPTION
If nothing about the routing changed, no need to run this thing which can be expensive because it builds the routing nodes

relates #77466 