### PR TITLE
[ML] Remove redundant constructor argument from MachineLearning

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -412,7 +412,6 @@ import org.elasticsearch.xpack.ml.rest.validate.RestValidateJobConfigAction;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -611,7 +610,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     private final SetOnce<DeploymentManager> deploymentManager = new SetOnce<>();
     private final SetOnce<TrainedModelAllocationClusterService> trainedModelAllocationClusterServiceSetOnce = new SetOnce<>();
 
-    public MachineLearning(Settings settings, Path configPath) {
+    public MachineLearning(Settings settings) {
         this.settings = settings;
         this.enabled = XPackSettings.MACHINE_LEARNING_ENABLED.get(settings);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
@@ -43,7 +43,7 @@ public class LocalStateMachineLearning extends LocalStateCompositeXPackPlugin {
     public LocalStateMachineLearning(final Settings settings, final Path configPath) {
         super(settings, configPath);
         LocalStateMachineLearning thisVar = this;
-        mlPlugin = new MachineLearning(settings, configPath){
+        mlPlugin = new MachineLearning(settings){
             @Override
             protected XPackLicenseState getLicenseState() {
                 return thisVar.getLicenseState();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -175,7 +175,7 @@ public class MachineLearningTests extends ESTestCase {
     private MachineLearning createMachineLearning(Settings settings) {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
 
-        return new MachineLearning(settings, null){
+        return new MachineLearning(settings) {
             @Override
             protected XPackLicenseState getLicenseState() {
                 return licenseState;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
@@ -45,13 +45,13 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             TestEnvironment.newEnvironment(
                 Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
             ),
-            List.of(new MachineLearning(Settings.EMPTY, null))
+            List.of(new MachineLearning(Settings.EMPTY))
         );
     }
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
-        return List.of(new MachineLearning(Settings.EMPTY, null));
+        return List.of(new MachineLearning(Settings.EMPTY));
     }
 
     private static final String TEXT_FIELD_NAME = "text";

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
@@ -33,7 +33,7 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
 
     @Override
     protected SearchPlugin registerPlugin() {
-        return new MachineLearning(Settings.EMPTY, null);
+        return new MachineLearning(Settings.EMPTY);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregationBuilderTests.java
@@ -31,7 +31,7 @@ public class BucketCorrelationAggregationBuilderTests extends BasePipelineAggreg
 
     @Override
     protected List<SearchPlugin> plugins() {
-        return Collections.singletonList(new MachineLearning(Settings.EMPTY, null));
+        return Collections.singletonList(new MachineLearning(Settings.EMPTY));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.search.aggregations.bucket.AbstractNXYSignificanceHeuri
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.allOf;
@@ -56,14 +56,14 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
     @Override
     protected NamedXContentRegistry xContentRegistry() {
         return new NamedXContentRegistry(
-            new SearchModule(Settings.EMPTY, Arrays.asList(new MachineLearning(Settings.EMPTY, null))).getNamedXContents()
+            new SearchModule(Settings.EMPTY, List.of(new MachineLearning(Settings.EMPTY))).getNamedXContents()
         );
     }
 
     @Override
     protected NamedWriteableRegistry writableRegistry() {
         return new NamedWriteableRegistry(
-            new SearchModule(Settings.EMPTY, Arrays.asList(new MachineLearning(Settings.EMPTY, null))).getNamedWriteables()
+            new SearchModule(Settings.EMPTY, List.of(new MachineLearning(Settings.EMPTY))).getNamedWriteables()
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilderTests.java
@@ -43,7 +43,7 @@ public class InferencePipelineAggregationBuilderTests extends BasePipelineAggreg
 
     @Override
     protected List<SearchPlugin> plugins() {
-        return Collections.singletonList(new MachineLearning(Settings.EMPTY, null));
+        return Collections.singletonList(new MachineLearning(Settings.EMPTY));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InternalInferenceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InternalInferenceAggregationTests.java
@@ -40,7 +40,7 @@ public class InternalInferenceAggregationTests extends InternalAggregationTestCa
 
     @Override
     protected SearchPlugin registerPlugin() {
-        return new MachineLearning(Settings.EMPTY, null);
+        return new MachineLearning(Settings.EMPTY);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregationBuilderTests.java
@@ -32,7 +32,7 @@ public class BucketCountKSTestAggregationBuilderTests extends BasePipelineAggreg
 
     @Override
     protected List<SearchPlugin> plugins() {
-        return Collections.singletonList(new MachineLearning(Settings.EMPTY, null));
+        return Collections.singletonList(new MachineLearning(Settings.EMPTY));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
@@ -28,7 +28,7 @@ public class InternalKSTestAggregationTests extends InternalAggregationTestCase<
 
     @Override
     protected SearchPlugin registerPlugin() {
-        return new MachineLearning(Settings.EMPTY, null);
+        return new MachineLearning(Settings.EMPTY);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/CategorizationAnalyzerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/CategorizationAnalyzerTests.java
@@ -52,7 +52,7 @@ public class CategorizationAnalyzerTests extends ESTestCase {
 
     public static AnalysisRegistry buildTestAnalysisRegistry(Environment environment) throws Exception {
         CommonAnalysisPlugin commonAnalysisPlugin = new CommonAnalysisPlugin();
-        MachineLearning ml = new MachineLearning(environment.settings(), environment.configFile());
+        MachineLearning ml = new MachineLearning(environment.settings());
         return new AnalysisModule(environment, Arrays.asList(commonAnalysisPlugin, ml)).getAnalysisRegistry();
     }
 


### PR DESCRIPTION
The MachineLearning plugin still takes a configPath argument
but doesn't use it. I think this used to be an argument used
by all plugins, but isn't any longer, and it's been removed
from most plugins. This change removes it from MachineLearning
too.