### PR TITLE
[7.15] [DOCS] Remove logic for permanently unreleased branches (#79575)

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -55,16 +55,6 @@ endif::[]
 :javadoc-watcher: {rest-high-level-client-javadoc}/org/elasticsearch/protocol/xpack/watcher
 
 ///////
-Permanently unreleased branches (master, n.X)
-///////
-ifeval::["{source_branch}"=="master"]
-:permanently-unreleased-branch:
-endif::[]
-ifeval::["{source_branch}"=="{major-version}"]
-:permanently-unreleased-branch:
-endif::[]
-
-///////
 Shared attribute values are pulled from elastic/docs
 ///////
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Remove logic for permanently unreleased branches (#79575)