### PR TITLE
Vector tiles: Add key bucket value to the aggs layer

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -250,7 +250,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
@@ -261,7 +261,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         // 33 points, 1 polygon and two from geometry collection
         assertLayer(tile, HITS_LAYER, 4096, 36, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
@@ -271,7 +271,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 256, 33, 2);
-        assertLayer(tile, AGGS_LAYER, 256, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 256, 1, 2);
         assertLayer(tile, META_LAYER, 256, 1, 13);
     }
 
@@ -284,7 +284,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 512, 33, 2);
-        assertLayer(tile, AGGS_LAYER, 512, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 512, 1, 2);
         assertLayer(tile, META_LAYER, 512, 1, 13);
     }
 
@@ -340,7 +340,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
         }
         {
@@ -358,7 +358,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
         }
@@ -413,7 +413,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_type\": \"centroid\",  \"grid_precision\": 2}");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, AGGS_LAYER, 4096, 4 * 4, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 4 * 4, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
     }
@@ -427,7 +427,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 4);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "eq");
             assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 33);
@@ -452,7 +452,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "eq");
             assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 33);
@@ -479,7 +479,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
     }
@@ -510,7 +510,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\": 0 }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
@@ -519,7 +519,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\": 100 }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
@@ -532,7 +532,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
-            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
         }
         {
@@ -626,7 +626,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POINTS);
     }
@@ -636,10 +636,17 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
         assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_id", "polygon");
+        // check we add right values to the aggs layer
+        final VectorTile.Tile.Layer aggsLayer = getLayer(tile, AGGS_LAYER);
+        for (int i = 0; i < 256 * 256; i++) {
+            final VectorTile.Tile.Feature feature = aggsLayer.getFeatures(i);
+            assertSintTag(aggsLayer, feature, "_count", 1);
+            assertBucketKeyTag(aggsLayer, feature);
+        }
     }
 
     public void testWithFields() throws Exception {
@@ -648,7 +655,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 4);
-        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
@@ -668,7 +675,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 3);
         assertLayer(tile, META_LAYER, 4096, 1, 18);
         // check pipeline aggregation values
         final VectorTile.Tile.Layer metaLayer = getLayer(tile, META_LAYER);
@@ -693,7 +700,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 4);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 5);
         assertLayer(tile, META_LAYER, 4096, 1, 28);
         // check pipeline aggregation values
         final VectorTile.Tile.Layer metaLayer = getLayer(tile, META_LAYER);
@@ -774,6 +781,19 @@ public class VectorTileRestIT extends ESRestTestCase {
             }
         }
         fail("Could not find tag [" + tag + "]");
+    }
+
+    private void assertBucketKeyTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature) {
+        for (int i = 0; i < feature.getTagsCount(); i += 2) {
+            String thisTag = layer.getKeys(feature.getTags(i));
+            if ("_key".equals(thisTag)) {
+                VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
+                // just make sure it can be parsed
+                GeoTileUtils.longEncode(thisValue.getStringValue());
+                return;
+            }
+        }
+        fail("Could not find tag [|_key]");
     }
 
     private VectorTile.Tile execute(Request mvtRequest) throws IOException {

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -368,7 +368,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
         }
@@ -378,7 +378,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
         }
@@ -427,7 +427,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 4);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "eq");
             assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 33);
@@ -438,7 +438,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 11);
         }
     }
@@ -463,7 +463,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 2);
-            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "gte");
             assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 1);
@@ -543,7 +543,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POINT));
-            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
             assertLayer(tile, META_LAYER, 4096, 1, 14);
         }
     }


### PR DESCRIPTION
Adds  to each feature on the aggs layer a tag called `_key` with the value of the bucket key. This allows to unique identify each feature.

closes https://github.com/elastic/elasticsearch/issues/79585