### PR TITLE
[7.16] [ML] fail on poor configuration for categorize_text (#79586)

### DIFF
--- a/docs/reference/aggregations/bucket/categorize-text-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/categorize-text-aggregation.asciidoc
@@ -8,7 +8,8 @@ experimental::[]
 
 A multi-bucket aggregation that groups semi-structured text into buckets. Each `text` field is re-analyzed
 using a custom analyzer. The resulting tokens are then categorized creating buckets of similarly formatted
-text values. This aggregation works best with machine generated text like system logs.
+text values. This aggregation works best with machine generated text like system logs. Only the first 100 analyzed
+tokens are used to categorize the text.
 
 NOTE: If you have considerable memory allocated to your JVM but are receiving circuit breaker exceptions from this
       aggregation, you may be attempting to categorize text that is poorly formatted for categorization. Consider
@@ -27,11 +28,13 @@ The semi-structured text field to categorize.
 The maximum number of unique tokens at any position up to `max_matched_tokens`.
 Must be larger than 1. Smaller values use less memory and create fewer categories.
 Larger values will use more memory and create narrower categories.
+Max allowed value is `100`.
 
 `max_matched_tokens`::
 (Optional, integer, default: `5`)
 The maximum number of token positions to match on before attempting to merge categories.
 Larger values will use more memory and create narrower categories.
+Max allowed value is `100`.
 
 Example:
 `max_matched_tokens` of 2 would disallow merging of the categories
@@ -90,7 +93,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=tokenizer]
 (array of strings or objects)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter]
 =====
-end::categorization-analyzer[]
 
 `shard_size`::
 (Optional, integer)

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -36,6 +36,7 @@ tasks.named("yamlRestTest").configure {
     'ml/calendar_crud/Test delete job from non existing calendar',
     // These are searching tests with aggregations, and do not call any ML endpoints
     'ml/categorization_agg/Test categorization agg simple',
+    'ml/categorization_agg/Test categorization aggregation against unsupported field',
     'ml/categorization_agg/Test categorization aggregation with poor settings',
     'ml/custom_all_field/Test querying custom all field',
     'ml/datafeeds_crud/Test delete datafeed with missing id',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
@@ -123,9 +123,9 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
 
     public CategorizeTextAggregationBuilder setMaxUniqueTokens(int maxUniqueTokens) {
         this.maxUniqueTokens = maxUniqueTokens;
-        if (maxUniqueTokens <= 0) {
+        if (maxUniqueTokens <= 0 || maxUniqueTokens > MAX_MAX_UNIQUE_TOKENS) {
             throw ExceptionsHelper.badRequestException(
-                "[{}] must be greater than 0 and less than [{}]. Found [{}] in [{}]",
+                "[{}] must be greater than 0 and less than or equal [{}]. Found [{}] in [{}]",
                 MAX_UNIQUE_TOKENS.getPreferredName(),
                 MAX_MAX_UNIQUE_TOKENS,
                 maxUniqueTokens,
@@ -191,9 +191,9 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
 
     public CategorizeTextAggregationBuilder setMaxMatchedTokens(int maxMatchedTokens) {
         this.maxMatchedTokens = maxMatchedTokens;
-        if (maxMatchedTokens <= 0) {
+        if (maxMatchedTokens <= 0 || maxMatchedTokens > MAX_MAX_MATCHED_TOKENS) {
             throw ExceptionsHelper.badRequestException(
-                "[{}] must be greater than 0 and less than [{}]. Found [{}] in [{}]",
+                "[{}] must be greater than 0 and less than or equal [{}]. Found [{}] in [{}]",
                 MAX_MATCHED_TOKENS.getPreferredName(),
                 MAX_MAX_MATCHED_TOKENS,
                 maxMatchedTokens,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.aggs.categorization;
 
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -82,6 +83,19 @@ public class CategorizeTextAggregatorFactory extends AggregatorFactory {
         throws IOException {
         if (fieldType == null) {
             return createUnmapped(parent, metadata);
+        }
+        // TODO add support for Keyword && KeywordScriptFieldType
+        if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE
+            || fieldType.getTextSearchInfo() == TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS) {
+            throw new IllegalArgumentException(
+                "categorize_text agg ["
+                    + name
+                    + "] only works on analyzable text fields. Cannot aggregate field type ["
+                    + fieldType.name()
+                    + "] via ["
+                    + fieldType.getClass().getSimpleName()
+                    + "]"
+            );
         }
         TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(this.bucketCountThresholds);
         if (bucketCountThresholds.getShardSize() == CategorizeTextAggregationBuilder.DEFAULT_BUCKET_COUNT_THRESHOLDS.getShardSize()) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilderTests.java
@@ -17,6 +17,9 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.xpack.ml.aggs.categorization.CategorizeTextAggregationBuilder.MAX_MAX_MATCHED_TOKENS;
+import static org.elasticsearch.xpack.ml.aggs.categorization.CategorizeTextAggregationBuilder.MAX_MAX_UNIQUE_TOKENS;
+
 public class CategorizeTextAggregationBuilderTests extends BaseAggregationTestCase<CategorizeTextAggregationBuilder> {
 
     @Override
@@ -35,10 +38,10 @@ public class CategorizeTextAggregationBuilderTests extends BaseAggregationTestCa
             builder.setCategorizationAnalyzerConfig(CategorizationAnalyzerConfigTests.createRandomized().build());
         }
         if (randomBoolean()) {
-            builder.setMaxUniqueTokens(randomIntBetween(1, 500));
+            builder.setMaxUniqueTokens(randomIntBetween(1, MAX_MAX_UNIQUE_TOKENS));
         }
         if (randomBoolean()) {
-            builder.setMaxMatchedTokens(randomIntBetween(1, 10));
+            builder.setMaxMatchedTokens(randomIntBetween(1, MAX_MAX_MATCHED_TOKENS));
         }
         if (randomBoolean()) {
             builder.setSimilarityThreshold(randomIntBetween(1, 100));

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
@@ -13,6 +13,8 @@ setup:
                 type: keyword
               text:
                 type: text
+              value:
+                type: long
 
   - do:
       headers:
@@ -23,19 +25,19 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"product": "server","text": "Node 2 stopping"}
+          {"product": "server","text": "Node 2 stopping", "value": 1}
           {"index": {}}
-          {"product": "server", "text": "Node 2 starting"}
+          {"product": "server", "text": "Node 2 starting", "value": 1}
           {"index": {}}
-          {"product": "server", "text": "Node 4 stopping"}
+          {"product": "server", "text": "Node 4 stopping", "value": 1}
           {"index": {}}
-          {"product": "server", "text": "Node 5 stopping"}
+          {"product": "server", "text": "Node 5 stopping", "value": 1}
           {"index": {}}
-          {"product": "user", "text": "User Foo logging on"}
+          {"product": "user", "text": "User Foo logging on", "value": 1}
           {"index": {}}
-          {"product": "user", "text": "User Foo logging on"}
+          {"product": "user", "text": "User Foo logging on", "value": 1}
           {"index": {}}
-          {"product": "user", "text": "User Foo logging off"}
+          {"product": "user", "text": "User Foo logging off", "value": 1}
 
 ---
 "Test categorization agg simple":
@@ -83,10 +85,28 @@ setup:
   - match: { aggregations.categories.buckets.1.doc_count: 3 }
   - match: { aggregations.categories.buckets.1.key: "User Foo logging *" }
 ---
+"Test categorization aggregation against unsupported field":
+  - do:
+      catch: /categorize_text agg \[categories\] only works on analyzable text fields/
+      search:
+        index: to_categorize
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "categories": {
+                "categorize_text": {
+                  "field": "value"
+                }
+              }
+            }
+          }
+
+---
 "Test categorization aggregation with poor settings":
 
   - do:
-      catch: /\[max_unique_tokens\] must be greater than 0 and less than \[100\]/
+      catch: /\[max_unique_tokens\] must be greater than 0 and less than or equal \[100\]/
       search:
         index: to_categorize
         body: >
@@ -102,7 +122,23 @@ setup:
             }
           }
   - do:
-      catch: /\[max_matched_tokens\] must be greater than 0 and less than \[100\]/
+      catch: /\[max_unique_tokens\] must be greater than 0 and less than or equal \[100\]/
+      search:
+        index: to_categorize
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "categories": {
+                "categorize_text": {
+                  "field": "text",
+                  "max_unique_tokens": 101
+                }
+              }
+            }
+          }
+  - do:
+      catch: /\[max_matched_tokens\] must be greater than 0 and less than or equal \[100\]/
       search:
         index: to_categorize
         body: >
@@ -117,6 +153,23 @@ setup:
               }
             }
           }
+  - do:
+      catch: /\[max_matched_tokens\] must be greater than 0 and less than or equal \[100\]/
+      search:
+        index: to_categorize
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "categories": {
+                "categorize_text": {
+                  "field": "text",
+                  "max_matched_tokens": 101
+                }
+              }
+            }
+          }
+
   - do:
       catch: /\[similarity_threshold\] must be in the range \[1, 100\]/
       search:


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [ML] fail on poor configuration for categorize_text (#79586)