### PR TITLE
[7.16] [DOCS] Updates transforms upgrade API docs (#79608)

### DIFF
--- a/docs/reference/transform/apis/transform-apis.asciidoc
+++ b/docs/reference/transform/apis/transform-apis.asciidoc
@@ -11,3 +11,4 @@
 * <<start-transform>>
 * <<stop-transform>>
 * <<update-transform>>
+* <<upgrade-transforms>>

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -38,11 +38,10 @@ If a {transform} upgrade step fails, the upgrade stops, and an error is returned
 about the underlying issue. Resolve the issue then re-run the process again. A 
 summary is returned when the upgrade is finished.
 
-For a major version update – for example, from 7.16 to 8.0 –, it is recommended 
-to have a recent cluster backup prior to performing a {transform} upgrade which 
-can be run either before or after an {es} upgrade. However, it is recommended to 
-perform it before upgrading {es} to the next major version to ensure 
-{ctransforms} remain running.
+To ensure {ctransforms} remain running during a major version upgrade of the 
+cluster – for example, from 7.16 to 8.0 – it is recommended to upgrade 
+{transforms} before upgrading the cluster. You may want to perform a recent 
+cluster backup prior to the upgrade.
 
 
 [IMPORTANT]
@@ -65,6 +64,20 @@ destination index remains unchanged.
   them. Defaults to `false`.
 
 
+[[upgrade-transforms-response-body]]
+== {api-response-body-title}
+
+`needs_update`::
+  (integer) The number of {transforms} that need to be upgraded.
+
+`no_action`::
+  (integer) The number of {transforms} that don't require upgrading.
+
+`updated`:: 
+  (integer) The number of {transforms} that have been upgraded.
+
+
+
 [[upgrade-transforms-example]]
 == {api-examples-title}
 
@@ -82,6 +95,7 @@ When all {transforms} are upgraded, you receive a summary:
 [source,console-result]
 ----
 {
+  "needs_update": 0,
   "updated": 2,
   "no_action": 1
 }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Updates transforms upgrade API docs (#79608)