### PR TITLE
[DOCS] Add experimental label to TSDB mapping params and settings

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -331,6 +331,7 @@ pipeline attempts to change the `_index` field, the indexing request will fail.
 
 [[index-mapping-dimension-fields-limit]]
 `index.mapping.dimension_fields.limit`::
+experimental:[] 
 For internal use by Elastic only. Maximum number of time series dimensions for
 the index. Defaults to `16`.
 +

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -149,6 +149,7 @@ The following parameters are accepted by `keyword` fields:
 
 // tag::dimension[]
 `time_series_dimension`::
+experimental:[]
 (Optional, Boolean) For internal use by Elastic only. Marks the field as a time
 series dimension. Defaults to `false`.
 +

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -179,6 +179,7 @@ A numeric field can't be both a time series dimension and a time series metric.
 
 // tag::time_series_metric[]
 `time_series_metric`::
+experimental:[]
 (Optional, string) For internal use by Elastic only. Marks the field as a time
 series metric. The value is the metric type. Defaults to `null` (Not a time
 series metric).

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -112,10 +112,13 @@ field types are all described as the `keyword` type family.
   Whether this field can be aggregated on all indices.
 
 `time_series_dimension`::
-  Whether this field is used as a time series dimension.
+experimental:[]
+Whether this field is used as a time series dimension.
 
 `time_series_metric`::
-  Contains metric type if this fields is used as a time series metrics, absent if the field is not used as metric.
+experimental:[]
+Contains metric type if this fields is used as a time series metrics, absent if
+the field is not used as metric.
 
 `indices`::
   The list of indices where this field has the same type family, or null if all indices

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -117,8 +117,7 @@ Whether this field is used as a time series dimension.
 
 `time_series_metric`::
 experimental:[]
-Contains metric type if this fields is used as a time series metrics. If
-the field is not used as metric, this property isn't returned.
+Contains metric type if this fields is used as a time series metrics, absent if the field is not used as metric.
 
 `indices`::
   The list of indices where this field has the same type family, or null if all indices

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -112,12 +112,12 @@ field types are all described as the `keyword` type family.
   Whether this field can be aggregated on all indices.
 
 `time_series_dimension`::
-experimental:[]
-Whether this field is used as a time series dimension.
+  experimental:[]
+  Whether this field is used as a time series dimension.
 
 `time_series_metric`::
-experimental:[]
-Contains metric type if this fields is used as a time series metrics, absent if the field is not used as metric.
+  experimental:[]
+  Contains metric type if this fields is used as a time series metrics, absent if the field is not used as metric.
 
 `indices`::
   The list of indices where this field has the same type family, or null if all indices
@@ -132,14 +132,14 @@ Contains metric type if this fields is used as a time series metrics, absent if 
   indices have the same definition for the field.
 
 `non_dimension_indices`::
-experimental:[]
-If this list is present in response then some indices have the field marked as a dimension and other indices, the
-ones in this list, do not.
+  experimental:[]
+  If this list is present in response then some indices have the field marked as a dimension and other indices, the
+  ones in this list, do not.
 
 `metric_conflicts_indices`::
-experimental:[]
-The list of indices where this field is present if these indices don't have the same `time_series_metric` value for
-this field.
+  experimental:[]
+  The list of indices where this field is present if these indices don't have the same `time_series_metric` value for
+  this field.
 
 `meta`::
   Merged metadata across all indices as a map of string keys to arrays of values.

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -117,8 +117,8 @@ Whether this field is used as a time series dimension.
 
 `time_series_metric`::
 experimental:[]
-Contains metric type if this fields is used as a time series metrics, absent if
-the field is not used as metric.
+Contains metric type if this fields is used as a time series metrics. If
+the field is not used as metric, this property isn't returned.
 
 `indices`::
   The list of indices where this field has the same type family, or null if all indices
@@ -133,12 +133,14 @@ the field is not used as metric.
   indices have the same definition for the field.
 
 `non_dimension_indices`::
-  If this list is present in response then some indices have the field marked as a dimension and other indices, the
-  ones in this list, do not.
+experimental:[]
+If this list is present in response then some indices have the field marked as a dimension and other indices, the
+ones in this list, do not.
 
 `metric_conflicts_indices`::
-  The list of indices where this field is present if these indices don't have the same `time_series_metric` value for
-  this field.
+experimental:[]
+The list of indices where this field is present if these indices don't have the same `time_series_metric` value for
+this field.
 
 `meta`::
   Merged metadata across all indices as a map of string keys to arrays of values.


### PR DESCRIPTION
Adds an `experimental` annotation to the following:

* `time_series_metric` mapping parameter
* `time_series_dimension` mapping parameter
* `index.mapping.dimension_fields.limit` index setting
*  `time_series_dimension` and `time_series_metric` properties in the field caps API response

### Previews

* Aggregate metric field: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/aggregate-metric-double.html#aggregate-metric-double-params
* Histogram field: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/histogram.html#histogram-params
* IP field: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ip.html#ip-params
* Keyword field: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/keyword.html#keyword-params
* Numeric fields: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/number.html#number-params
* `index.mapping.dimension_fields.limit` index setting: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-modules.html#index-mapping-dimension-fields-limit
* Field caps response body: https://elasticsearch_79647.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-field-caps.html#search-field-caps-api-response-body