### PR TITLE
Add tsdb feature flag to xpack restart tests

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -55,6 +55,9 @@ BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
         keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 
         setting 'xpack.security.authc.api_key.enabled', 'true'
+        if (BuildParams.isSnapshotBuild() == false) {
+            systemProperty 'es.index_mode_feature_flag_registered', 'true'
+        }
     }
 
     tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
These tests want to create a tsdb index as well so they need the feature
flag when run in non-snapshot mode.

Closes #79611