### PR TITLE
Expand warning about modifying data path contents

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -460,14 +460,16 @@ directory, so that the home directory can be deleted without deleting your data!
 The RPM and Debian distributions do this for you already.
 
 // tag::modules-node-data-path-warning-tag[]
-WARNING: Don't modify anything within the data directory or
-run processes that might interfere with its contents. If
-something other than {es} modifies the contents of the data directory, then {es}
-may fail, reporting corruption or other data inconsistencies, or may appear
-to work correctly having silently lost some of your data. Do not attempt to
-take filesystem backups of the data directory; there is no supported way to restore
-such a backup. Instead, use <<snapshot-restore>> to take backups safely.
-Don't run virus scanners on the data directory. A virus scanner can prevent {es}
+WARNING: Don't modify anything within the data directory or run processes that
+might interfere with its contents. If something other than {es} modifies the
+contents of the data directory, then {es} may fail, reporting corruption or
+other data inconsistencies, or may appear to work correctly having silently
+lost some of your data. Don't attempt to take filesystem backups of the data
+directory; there is no supported way to restore such a backup. Instead, use
+<<snapshot-restore>> to take backups safely. Don't run virus scanners on the
+data directory. A virus scanner can prevent {es} from working correctly and may
+modify the contents of the data directory. The data directory contains no
+executables so a virus scan will only find false positives.
 // end::modules-node-data-path-warning-tag[]
 
 [discrete]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -460,17 +460,14 @@ directory, so that the home directory can be deleted without deleting your data!
 The RPM and Debian distributions do this for you already.
 
 // tag::modules-node-data-path-warning-tag[]
-WARNING: You must not modify anything within the data directory and you must
-not run any other processes that might interfere with its contents. If
-something other than {es} modifies the contents of the data directory then {es}
-may fail, reporting corruption or other data inconsistencies, or it may appear
+WARNING: Don't modify anything within the data directory or
+run processes that might interfere with its contents. If
+something other than {es} modifies the contents of the data directory, then {es}
+may fail, reporting corruption or other data inconsistencies, or may appear
 to work correctly having silently lost some of your data. Do not attempt to
-take backups of the data directory because there is no supported way to restore
-from such a backup. Instead, use <<snapshot-restore>> to take backups safely.
-Do not run virus scanners on the data directory because they can prevent {es}
-from working correctly and may modify the directory's contents. The data
-directory contains no executables so a virus scan will only find false
-positives.
+take filesystem backups of the data directory; there is no supported way to restore
+such a backup. Instead, use <<snapshot-restore>> to take backups safely.
+Don't run virus scanners on the data directory. A virus scanner can prevent {es}
 // end::modules-node-data-path-warning-tag[]
 
 [discrete]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -459,6 +459,20 @@ should be configured to locate the data directory outside the {es} home
 directory, so that the home directory can be deleted without deleting your data!
 The RPM and Debian distributions do this for you already.
 
+// tag::modules-node-data-path-warning-tag[]
+WARNING: You must not modify anything within the data directory and you must
+not run any other processes that might interfere with its contents. If
+something other than {es} modifies the contents of the data directory then {es}
+may fail, reporting corruption or other data inconsistencies, or it may appear
+to work correctly having silently lost some of your data. Do not attempt to
+take backups of the data directory because there is no supported way to restore
+from such a backup. Instead, use <<snapshot-restore>> to take backups safely.
+Do not run virus scanners on the data directory because they can prevent {es}
+from working correctly and may modify the directory's contents. The data
+directory contains no executables so a virus scan will only find false
+positives.
+// end::modules-node-data-path-warning-tag[]
+
 [discrete]
 [[other-node-settings]]
 === Other node settings

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -17,15 +17,13 @@ In production, we strongly recommend you set the `path.data` and `path.logs` in
 `.msi`>> installations write data and log to locations outside of `$ES_HOME` by
 default.
 
-IMPORTANT: To avoid errors, only {es} should open files in the `path.data`
-directory. Exclude the `path.data` directory from other services that may open
-and lock its files, such as antivirus or backup programs.
-
 Supported `path.data` and `path.logs` values vary by platform:
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/customize-data-log-path-widget.asciidoc[]
+
+include::{es-repo-dir}/modules/node.asciidoc[tag=modules-node-data-path-warning-tag]
 
 [discrete]
 ==== Multiple data paths


### PR DESCRIPTION
Today we have a short note in one place in the docs saying not to touch
the contents of the data path. This commit expands the warning to
describe more precisely what is forbidden, and to give some more detail
of the consequences, and also duplicates the warning to the other
location that documents the `path.data` setting.