### PR TITLE
Optimize `significant_text` aggregation to only parse the field it requires from _source

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -363,7 +363,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
          * Extract values from {@code _source}.
          */
         protected List<Object> extractRawValues(String field) {
-            return sourceLookup.extractRawValues(field);
+            return sourceLookup.extractRawValuesWithoutCaching(field);
         }
 
         @Override


### PR DESCRIPTION
Previously created optimizations:

 - Enabling XContentParser filtering for specific fields: https://github.com/elastic/elasticsearch/pull/77154
 - Retrieving only specific fields from _source: https://github.com/elastic/elasticsearch/pull/79099

Allow significant_text to only parse out the specific field it requires from `_source`. This allows for a minor optimization when `_source` is small, but can be significant (pun intended) when `_source` contains many fields, or other larger fields that `significant_text` doesn't care about.

Since `significant_text` does not allow sub-aggs, not caching the parsed `_source` is reasonable. 