### PR TITLE
[DOCS] Remove ESS icon from `index.number_of_shards`

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -36,7 +36,7 @@ specific index module:
 
 [[index-number-of-shards]]
 // tag::index-number-of-shards-tag[]
-`index.number_of_shards` {ess-icon}::
+`index.number_of_shards`::
 The number of primary shards that an index should have. Defaults to `1`. This setting can only be set at index creation time. It cannot be changed on a closed index.
 +
 NOTE: The number of shards are limited to `1024` per index. This limitation is a safety limit to prevent accidental creation of indices that can destabilize a cluster due to resource allocation. The limit can be modified by specifying `export ES_JAVA_OPTS="-Des.index.max_number_of_shards=128"` system property on every node that is part of the cluster.


### PR DESCRIPTION
`index.number_of_shards` is an index setting and can't be configured
in `elasticsearch.yml` using Cloud's [edit user settings feature][0].

If you attempt it, ESS rejects the update and returns the following error.

<img width="467" alt="Screen Shot 2021-10-21 at 3 47 12 PM" src="https://user-images.githubusercontent.com/40268737/138347112-b884ae15-1e8c-4aa3-855b-d04bf498b409.PNG">

[0]: https://www.elastic.co/guide/en/cloud/current/ec-add-user-settings.html