### PR TITLE
[7.15] Expand warning about modifying data path contents (#79649)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -459,6 +459,19 @@ should be configured to locate the data directory outside the {es} home
 directory, so that the home directory can be deleted without deleting your data!
 The RPM and Debian distributions do this for you already.
 
+// tag::modules-node-data-path-warning-tag[]
+WARNING: Don't modify anything within the data directory or run processes that
+might interfere with its contents. If something other than {es} modifies the
+contents of the data directory, then {es} may fail, reporting corruption or
+other data inconsistencies, or may appear to work correctly having silently
+lost some of your data. Don't attempt to take filesystem backups of the data
+directory; there is no supported way to restore such a backup. Instead, use
+<<snapshot-restore>> to take backups safely. Don't run virus scanners on the
+data directory. A virus scanner can prevent {es} from working correctly and may
+modify the contents of the data directory. The data directory contains no
+executables so a virus scan will only find false positives.
+// end::modules-node-data-path-warning-tag[]
+
 [discrete]
 [[max-local-storage-nodes]]
 === `node.max_local_storage_nodes`

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -17,15 +17,13 @@ In production, we strongly recommend you set the `path.data` and `path.logs` in
 `.msi`>> installations write data and log to locations outside of `$ES_HOME` by
 default.
 
-IMPORTANT: To avoid errors, only {es} should open files in the `path.data`
-directory. Exclude the `path.data` directory from other services that may open
-and lock its files, such as antivirus or backup programs.
-
 Supported `path.data` and `path.logs` values vary by platform:
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/customize-data-log-path-widget.asciidoc[]
+
+include::{es-repo-dir}/modules/node.asciidoc[tag=modules-node-data-path-warning-tag]
 
 [discrete]
 ==== Multiple data paths


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Expand warning about modifying data path contents (#79649)