### PR TITLE
Use short URLs for transform deprecation messages

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
@@ -15,9 +15,9 @@ public class TransformDeprecations {
     public static final String BREAKING_CHANGES_BASE_URL =
         "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html";
 
-    public static final String QUERY_BREAKING_CHANGES_URL = BREAKING_CHANGES_BASE_URL + "#breaking_80_search_changes";
+    public static final String QUERY_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-query-options";
 
-    public static final String AGGS_BREAKING_CHANGES_URL = BREAKING_CHANGES_BASE_URL + "#breaking_80_aggregations_changes";
+    public static final String AGGS_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-aggregation-options";
 
     public static final String ACTION_UPGRADE_TRANSFORMS_API = "Use the upgrade transforms API to fix your transforms.";
 


### PR DESCRIPTION
This PR replaces hard-coded URLs in transform deprecation messages with short URLs, which can be maintained outside the code.

In particular, it uses https://links.elastic.dev/alias/es-deprecation-8-transform-aggregation-options and https://links.elastic.dev/alias/es-deprecation-8-transform-query-options 
