### PR TITLE
[DOCS] Update Fleet link in 7.9 migration guide

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -27,7 +27,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 *Details* +
 In 7.9, {es} added built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns, each with a priority of `100`.
-{ingest-guide}/fleet.html[{agent}] uses these templates to
+{fleet-guide}/fleet.html[{agent}] uses these templates to
 create data streams.
 
 *Impact* +

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -27,7 +27,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 *Details* +
 In 7.9, {es} added built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns, each with a priority of `100`.
-{fleet-guide}/fleet.html[{agent}] uses these templates to
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to
 create data streams.
 
 *Impact* +

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -27,7 +27,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 *Details* +
 In 7.9, {es} added built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{ingest-guide}/fleet.html[{agent}] uses these templates to
 create data streams.
 
 *Impact* +


### PR DESCRIPTION
Fixes old link that uses incorrect filename. This needs to be backported to 7.9, too, to fix the error in https://github.com/elastic/docs/pull/2255.

