### PR TITLE
[7.9] [DOCS] Update Fleet link in 7.9 migration guide (#79660)

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -27,7 +27,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 *Details* +
 In 7.9, {es} added built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{fleet-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams.
 
 *Impact* +


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Update Fleet link in 7.9 migration guide (#79660)