### PR TITLE
[DOCS] Adds deprecation details for max_page_search_size

### DIFF
--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -211,4 +211,19 @@ Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
 
+[discrete]
+[[breaking_78_transform_changes]]
+=== Transforms changes
+
+.The `max_page_search_size` property is deprecated in the `pivot` {transform} configuration object
+[%collapsible]
+====
+*Details* +
+The `max_page_search_size` property within `pivot` is deprecated in the
+<<put-transform,create {transform}>> and <<preview-transform,preview {transform}>>
+APIs.
+
+*Impact* +
+Use the `max_page_search_size` property within `settings` instead.
+====
 //end::notable-breaking-changes[]

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -130,6 +130,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 `group_by`:::
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
+
+`max_page_search_size`:::
+(Optional, integer)
+deprecated:[7.8.0,Moved to `settings`.]
 ====
 //End pivot
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -149,6 +149,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 
+`max_page_search_size`:::
+(Optional, integer)
+deprecated:[7.8.0,Moved to `settings`.]
 ====
 //End pivot
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
@@ -11,10 +11,6 @@ public class TransformDeprecations {
 
     public static final String UPGRADE_TRANSFORM_URL = "https://ela.st/es-7-upgrade-transforms";
 
-    // breaking changes base url for the _next_ major release
-    public static final String BREAKING_CHANGES_BASE_URL =
-        "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html";
-
     public static final String QUERY_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-query-options";
 
     public static final String AGGS_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-aggregation-options";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
@@ -24,5 +24,6 @@ public class TransformDeprecations {
     public static final String ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED =
         "[max_page_search_size] is deprecated inside pivot. Use settings instead.";
 
+    public static final String MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-7-transform-max-page-search-size";
     private TransformDeprecations() {}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
@@ -186,7 +186,7 @@ public class PivotConfig implements Writeable, ToXContentObject {
                 new DeprecationIssue(
                     Level.WARNING,
                     "Transform [" + id + "] uses deprecated max_page_search_size",
-                    TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                    TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                     TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                     false,
                     null

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -724,7 +724,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             assertThat(serializedGroups, equalTo(originalGroups));
 
             // Now test xcontent serialization and parsing on wire serialized object
-            XContentType xContentType = randomFrom(XContentType.values());
+            XContentType xContentType = randomFrom(XContentType.values()).canonical();
             BytesReference ref = XContentHelper.toXContent(serialized, xContentType, getToXContentParams(), false);
             XContentParser parser = this.createParser(XContentFactory.xContent(xContentType), ref);
             TransformConfig parsed = doParseInstance(parser);
@@ -768,7 +768,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(
             deprecatedConfig.checkForDeprecations(xContentRegistry()),
             equalTo(
-                org.elasticsearch.core.List.of(
+                List.of(
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
@@ -790,7 +790,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(
             deprecatedConfig.checkForDeprecations(xContentRegistry()),
             equalTo(
-                org.elasticsearch.core.List.of(
+                List.of(
                     new DeprecationIssue(
                         Level.CRITICAL,
                         "Transform [" + id + "] is too old",
@@ -841,14 +841,12 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
 
         // Read TransformConfig from JSON and verify that metadata keys are in the same order as in JSON
         TransformConfig transformConfig = createTransformConfigFromString(json, transformId, true);
-        assertThat(
-            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
+        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
 
         // Write TransformConfig to JSON, read it again and verify that metadata keys are still in the same order
         json = XContentHelper.toXContent(transformConfig, XContentType.JSON, TO_XCONTENT_PARAMS, false).utf8ToString();
         transformConfig = createTransformConfigFromString(json, transformId, true);
-        assertThat(
-            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
+        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
 
         // Write TransformConfig to wire, read it again and verify that metadata keys are still in the same order
         try (BytesStreamOutput output = new BytesStreamOutput()) {
@@ -857,8 +855,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                 transformConfig = new TransformConfig(in);
             }
         }
-        assertThat(
-            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
+        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
     }
 
     private TransformConfig createTransformConfigFromString(String json, String id) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -724,7 +724,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             assertThat(serializedGroups, equalTo(originalGroups));
 
             // Now test xcontent serialization and parsing on wire serialized object
-            XContentType xContentType = randomFrom(XContentType.values()).canonical();
+            XContentType xContentType = randomFrom(XContentType.values());
             BytesReference ref = XContentHelper.toXContent(serialized, xContentType, getToXContentParams(), false);
             XContentParser parser = this.createParser(XContentFactory.xContent(xContentType), ref);
             TransformConfig parsed = doParseInstance(parser);
@@ -768,7 +768,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(
             deprecatedConfig.checkForDeprecations(xContentRegistry()),
             equalTo(
-                List.of(
+                org.elasticsearch.core.List.of(
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
@@ -790,7 +790,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(
             deprecatedConfig.checkForDeprecations(xContentRegistry()),
             equalTo(
-                List.of(
+                org.elasticsearch.core.List.of(
                     new DeprecationIssue(
                         Level.CRITICAL,
                         "Transform [" + id + "] is too old",
@@ -841,12 +841,14 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
 
         // Read TransformConfig from JSON and verify that metadata keys are in the same order as in JSON
         TransformConfig transformConfig = createTransformConfigFromString(json, transformId, true);
-        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
+        assertThat(
+            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
 
         // Write TransformConfig to JSON, read it again and verify that metadata keys are still in the same order
         json = XContentHelper.toXContent(transformConfig, XContentType.JSON, TO_XCONTENT_PARAMS, false).utf8ToString();
         transformConfig = createTransformConfigFromString(json, transformId, true);
-        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
+        assertThat(
+            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
 
         // Write TransformConfig to wire, read it again and verify that metadata keys are still in the same order
         try (BytesStreamOutput output = new BytesStreamOutput()) {
@@ -855,7 +857,8 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                 transformConfig = new TransformConfig(in);
             }
         }
-        assertThat(new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(List.of("d", "a", "c", "e", "b"))));
+        assertThat(
+            new ArrayList<>(transformConfig.getMetadata().keySet()), is(equalTo(org.elasticsearch.core.List.of("d", "a", "c", "e", "b"))));
     }
 
     private TransformConfig createTransformConfigFromString(String json, String id) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -750,7 +750,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null
@@ -772,7 +772,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null
@@ -802,7 +802,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null


### PR DESCRIPTION
When the `pivot`.`max_page_search_size` property was deprecated, it was removed from the docs (via https://github.com/elastic/elasticsearch/pull/56178). However, we ought to have marked it as deprecated and added a breaking change.  This PR rectifies that problem.

It also updates the URL that is used in the deprecation message to (1) point to the new breaking change content and (2) use a [short URL](https://links.elastic.dev/alias/es-deprecation-7-transform-max-page-search-size) which is easier to manage when/if our URLs change.

If this property is removed in 8.0, we'll need to make note of this discontinuation there too.

### Preview

- https://elasticsearch_79664.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/breaking-changes-7.8.html#breaking_78_transform_changes
- https://elasticsearch_79664.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/put-transform.html
- https://elasticsearch_79664.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/preview-transform.html