### PR TITLE
Small fixes in KnnVectorQueryBuilderTests

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilder.java
@@ -53,6 +53,14 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         return fieldName;
     }
 
+    public float[] queryVector() {
+        return queryVector;
+    }
+
+    public int numCands() {
+        return numCands;
+    }
+
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(fieldName);

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilderTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilderTests.java
@@ -31,7 +31,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQueryBuilder> {
     private static final String VECTOR_FIELD = "vector";
     private static final String VECTOR_ALIAS_FIELD = "vector_alias";
-    private static final String UNINDEXED_VECTOR_FIELD = "unindexed_vector";
     private static final int VECTOR_DIMENSION = 3;
 
     @Override
@@ -51,10 +50,6 @@ public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQ
                 .startObject(VECTOR_ALIAS_FIELD)
                     .field("type", "alias")
                     .field("path", VECTOR_FIELD)
-                .endObject()
-                .startObject(UNINDEXED_VECTOR_FIELD)
-                    .field("type", "dense_vector")
-                    .field("dims", VECTOR_DIMENSION)
                 .endObject()
             .endObject().endObject();
         mapperService.merge(MapperService.SINGLE_MAPPING_NAME,

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilderTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilderTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQueryBuilder> {
     private static final String VECTOR_FIELD = "vector";
@@ -74,8 +75,13 @@ public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQ
 
     @Override
     protected void doAssertLuceneQuery(KnnVectorQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
-        // TODO: expose getters on KnnVectorQuery and assert more here
         assertTrue(query instanceof KnnVectorQuery);
+        KnnVectorQuery knnVectorQuery = (KnnVectorQuery) query;
+
+        // The field should always be resolved to the concrete field
+        assertThat(knnVectorQuery, equalTo(new KnnVectorQuery(VECTOR_FIELD,
+            queryBuilder.queryVector(),
+            queryBuilder.numCands())));
     }
 
     public void testWrongDimension()  {


### PR DESCRIPTION
This PR fixes some issues in `KnnVectorQueryBuilderTests`:
* Improve the check on the Lucene query
* Remove an unused field mapping

Relates to #78473.
