### PR TITLE
[7.16] Fleet: Add action_response into .fleet-actions-results mapping (#79584)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
@@ -23,6 +23,10 @@
           "enabled": false,
           "type": "object"
         },
+        "action_response": {
+          "dynamic": true,
+          "type": "object"
+        },
         "data": {
           "enabled": false,
           "type": "object"


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Fleet: Add action_response into .fleet-actions-results mapping (#79584)