### PR TITLE
Optimize XContent Object Parsers (#78813)

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/AbstractObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/AbstractObjectParser.java
@@ -156,7 +156,7 @@ public abstract class AbstractObjectParser<Value, Context> {
     }
 
     public <T> void declareObject(BiConsumer<Value, T> consumer, ContextParser<Context, T> objectParser, ParseField field) {
-        declareField(consumer, (p, c) -> objectParser.parse(p, c), field, ValueType.OBJECT);
+        declareField(consumer, objectParser, field, ValueType.OBJECT);
     }
 
     /**
@@ -240,7 +240,7 @@ public abstract class AbstractObjectParser<Value, Context> {
     }
 
     public <T> void declareObjectArray(BiConsumer<Value, List<T>> consumer, ContextParser<Context, T> objectParser, ParseField field) {
-        declareFieldArray(consumer, (p, c) -> objectParser.parse(p, c), field, ValueType.OBJECT_ARRAY);
+        declareFieldArray(consumer, objectParser, field, ValueType.OBJECT_ARRAY);
     }
 
     /**

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ConstructingObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ConstructingObjectParser.java
@@ -407,7 +407,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
         /**
          * The parse context that is used for this invocation. Stored here so that it can be passed to the {@link #builder}.
          */
-        private Context context;
+        private final Context context;
 
         /**
          * How many of the constructor parameters have we collected? We keep track of this so we don't have to count the

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
@@ -23,12 +23,11 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Represents set of {@link LifecycleAction}s which should be executed at a
@@ -42,8 +41,16 @@ public class Phase implements ToXContentObject, Writeable {
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<Phase, String> PARSER = new ConstructingObjectParser<>("phase", false,
-            (a, name) -> new Phase(name, (TimeValue) a[0], ((List<LifecycleAction>) a[1]).stream()
-                    .collect(Collectors.toMap(LifecycleAction::getWriteableName, Function.identity()))));
+            (a, name) -> {
+                final List<LifecycleAction> lifecycleActions = (List<LifecycleAction>) a[1];
+                Map<String, LifecycleAction> map = new HashMap<>(lifecycleActions.size());
+                for (LifecycleAction lifecycleAction : lifecycleActions) {
+                    if (map.put(lifecycleAction.getWriteableName(), lifecycleAction) != null) {
+                        throw new IllegalStateException("Duplicate key");
+                    }
+                }
+                return new Phase(name, (TimeValue) a[0], map);
+            });
     static {
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
             (ContextParser<String, Object>) (p, c) -> {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -30,6 +30,7 @@ import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.readStepKeys
 import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.refreshPhaseDefinition;
 import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
@@ -227,7 +228,7 @@ public class PhaseCacheManagementTests extends ESTestCase {
                 "        \"version\" : 1,\n" +
                 "        \"modified_date_in_millis\" : 1578521007076\n" +
                 "      }", "phase", null),
-            contains(new Step.StepKey("phase", "rollover", WaitForRolloverReadyStep.NAME),
+            containsInAnyOrder(new Step.StepKey("phase", "rollover", WaitForRolloverReadyStep.NAME),
                 new Step.StepKey("phase", "rollover", RolloverStep.NAME),
                 new Step.StepKey("phase", "rollover", WaitForActiveShardsStep.NAME),
                 new Step.StepKey("phase", "rollover", UpdateRolloverLifecycleDateStep.NAME),


### PR DESCRIPTION
Optimize object parsers a little by extracting cold paths, removing some unnecessary
lambda wrapping and some other small things.
Also, fixed a very expensive use of these APIs in Phase moving from a very hot stream
instantiation to a standard loop.

backport of #78813 