### PR TITLE
[DOCS] Add docs for restoring to new cluster

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -53,6 +53,10 @@ POST /index_4/_close
 [source,console]
 ----
 POST /_snapshot/my_repository/my_snapshot/_restore
+{
+  "indices": "*,-.*",
+  "feature_states": [ "geoip" ]
+}
 ----
 // TEST[s/_restore/_restore?wait_for_completion=true/]
 

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -59,7 +59,7 @@ POST /_snapshot/my_repository/my_snapshot/_restore
 }
 ----
 // TEST[s/_restore/_restore?wait_for_completion=true/]
-// TEST[s/"\*\,\-\.\*",/"*,-.*"/]
+// TEST[s/",/"/]
 // TEST[s/"feature_states": \[ "geoip" \]//]
 
 [[restore-snapshot-api-request]]

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -59,6 +59,8 @@ POST /_snapshot/my_repository/my_snapshot/_restore
 }
 ----
 // TEST[s/_restore/_restore?wait_for_completion=true/]
+// TEST[s/"\*\,\-\.\*",/"*,-.*"/]
+// TEST[s/"feature_states": \[ "geoip" \]//]
 
 [[restore-snapshot-api-request]]
 ==== {api-request-title}

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -242,10 +242,8 @@ state is the preferred way to restore system indices and system data streams.
 If you restore a snapshot's cluster state, the operation restores all feature
 states in the snapshot by default. Similarly, if you don't restore a snapshot's
 cluster state, the operation doesn't restore any feature states by default. You
-can also restore only specific feature states from a snapshot, regardless of the
-cluster state.
-
-NOTE: You can't restore specific feature states in {kib}.
+can also choose to restore only specific feature states from a snapshot,
+regardless of the cluster state.
 
 To view a snapshot's feature states, use the get snapshot API.
 

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -81,9 +81,9 @@ You can restore a snapshot using {kib}'s *Snapshot and Restore* feature or the
 <<restore-snapshot-api,restore snapshot API>>.
 
 By default, a restore request attempts to restore all indices and data streams
-in a snapshot, including <<system-indices,system indices>>. In most cases, you
-only need to restore a specific index or data stream from a snapshot. However,
-you can't restore an existing open index.
+in a snapshot, including <<system-indices,system indices and system data
+streams>>. In most cases, you only need to restore a specific index or data
+stream from a snapshot. However, you can't restore an existing open index.
 
 If you're restoring data to a pre-existing cluster, use one of the
 following methods to avoid conflicts with existing indices and data streams:
@@ -235,9 +235,9 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 [[restore-feature-state]]
 === Restore a feature state
 
-You can restore a feature state to recover system indices and other
-configuration data for a feature from a snapshot. Restoring a feature state is
-the preferred way to restore system indices.
+You can restore a feature state to recover system indices, system data streams,
+and other configuration data for a feature from a snapshot. Restoring a feature
+state is the preferred way to restore system indices and system data streams.
 
 If you restore a snapshot's cluster state, the operation restores all feature
 states in the snapshot by default. Similarly, if you don't restore a snapshot's
@@ -270,8 +270,8 @@ Console before restoring the `security` feature state. If you run {es} on your
 own hardware, <<restore-create-file-realm-user,create a superuser in the file
 realm>> to ensure you'll still be able to access your cluster.
 
-To avoid accidentally restoring other dot indices, append the `-.*` wildcard
-pattern to the `indices` value.
+To avoid accidentally restoring system indices, system data streams, and other
+dot indices, append the `-.*` wildcard pattern to the `indices` value.
 
 [source,console]
 ----
@@ -292,12 +292,12 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 === Restore an entire cluster
 
 In some cases, you need to restore an entire cluster from a snapshot, including
-the cluster state and all system indices. These cases should be rare, such as in
+the cluster state and all feature states. These cases should be rare, such as in
 the event of a catastrophic failure.
 
-Restoring an entire cluster involves deleting important system indices, including
-those used for authentication. Consider whether you can restore specific indices
-or data streams instead.
+Restoring an entire cluster involves deleting important system indices,
+including those used for authentication. Consider whether you can restore
+specific indices or data streams instead.
 
 If you're restoring to a different cluster, see <<restore-different-cluster>>
 before you start.
@@ -439,8 +439,8 @@ DELETE *?expand_wildcards=all
 ----
 // TEST[continued]
 
-. Restore the entire snapshot, including the cluster state. This also restores
-any feature states and system indices in the snapshot.
+. Restore the entire snapshot, including the cluster state. By default,
+restoring the cluster state also restores any feature states in the snapshot.
 +
 [source,console]
 ----

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -81,8 +81,9 @@ You can restore a snapshot using {kib}'s *Snapshot and Restore* feature or the
 <<restore-snapshot-api,restore snapshot API>>.
 
 By default, a restore request attempts to restore all indices and data streams
-in a snapshot, including <<system-indices,system indices>>. However, you can't
-restore an existing open index.
+in a snapshot, including <<system-indices,system indices>>. In most cases, you
+only need to restore a specific index or data stream from a snapshot. However,
+you can't restore an existing open index.
 
 If you're restoring data to a pre-existing cluster, use one of the
 following methods to avoid conflicts with existing indices and data streams:

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -79,14 +79,19 @@ GET _snapshot/my_repository/*?verbose=false
 You can restore a snapshot using {kib}'s *Snapshot and Restore* feature or the
 <<restore-snapshot-api,restore snapshot API>>.
 
-In most cases, you only need to restore a specific index or data stream from a
-snapshot. However, you can't restore an existing open index.
+By default, a restore request attempts to restore all indices and data streams
+in a snapshot, including system indices. However, you can't restore an
+existing open index.
 
-To avoid conflicts with existing indices and data streams, use one of the
-following methods:
+If you're restoring data to a pre-existing cluster, use one of the
+following methods to avoid conflicts with existing indices and data streams:
 
 * <<delete-restore>>
 * <<rename-on-restore>>
+
+Some {es} features automatically create system indices on cluster startup. To
+avoid conflicts with these system indices when restoring data to a new cluster,
+see <<restore-new-cluster>>.
 
 [discrete]
 [[delete-restore]]
@@ -115,14 +120,8 @@ DELETE _data_stream/logs-my_app-default
 ----
 // TEST[setup:setup-snapshots]
 
-By default, a restore request attempts to restore all indices and data
-streams in the snapshot, including system indices. If your cluster already
-contains one or more of these system indices, the request will return an error.
-
-To avoid this error, specify the indices and data streams to restore. To exclude
-system indices and other index names that begin with a dot (`.`), append the
-`-.*` wildcard pattern. To restore all indices and data streams except dot
-indices, use `*,-.*`.
+In the restore request, explicitly specify any indices and data streams to
+restore.
 
 [source,console]
 ----
@@ -206,6 +205,74 @@ POST _reindex
 }
 ----
 // TEST[continued]
+
+[discrete]
+[[restore-new-cluster]]
+==== Restore to a new cluster
+
+Some {es} features, such as the <<geoip-processor,GeoIP processor>>,
+automatically create system indices at startup. To avoid naming conflicts with
+these indices, use the `*,-.*` wildcard pattern in your restore request. This
+pattern excludes system indices and other indices that begin with a dot (`.`).
+
+////
+[source,console]
+----
+# Delete an index
+DELETE my-index
+
+# Delete a data stream
+DELETE _data_stream/logs-my_app-default
+----
+// TEST[setup:setup-snapshots]
+////
+
+[source,console]
+----
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+{
+  "indices": "*,-.*"
+}
+----
+// TEST[continued]
+// TEST[s/_restore/_restore?wait_for_completion=true/]
+
+If your snapshot includes the related feature state, you can also restore the
+system indices and other configuration data for a specific feature.
+
+NOTE: You can't restore specific feature states in {kib}.
+
+To view a snapshot's feature states, use the get snapshot API.
+
+[source,console]
+----
+GET _snapshot/my_repository/my_snapshot_2099.05.06
+----
+// TEST[setup:setup-snapshots]
+
+To restore a feature state, specify the `feature_name` from the response in the
+restore snapshot API's <<restore-snapshot-api-feature-states,`feature_states`>>
+parameter. When you restore a feature state, {es} closes and overwrites any
+existing indices that are part of the feature state.
+
+WARNING: Restoring the `security` feature state can overwrite system indices
+used for authentication. If you use {ess}, ensure you have access to the {ess}
+Console before restoring the `security` feature state. If you run {es} on your
+own hardware, <<restore-create-file-realm-user,create a superuser in the file
+realm>> to ensure you'll still be able to access your cluster.
+
+[source,console]
+----
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+{
+  "indices": "*,-.*",
+  "feature_states": [ "geoip" ]
+}
+----
+// TEST[setup:setup-snapshots]
+// TEST[s/_restore/_restore?wait_for_completion=true/]
+// TEST[s/"\*\,\-\.\*",/"-*"/]
+// TEST[s/"feature_states": \[ "geoip" \]//]
 
 [discrete]
 [[restore-entire-cluster]]
@@ -297,19 +364,25 @@ POST _watcher/_start
 ////
 --
 
-. If you use {es} security features, log in to a node host, navigate to the {es}
+
+. {blank}
++
+--
+[[restore-create-file-realm-user]]
+If you use {es} security features, log in to a node host, navigate to the {es}
 installation directory, and add a user with the `superuser` role to the file
 realm using the <<users-command,`elasticsearch-users`>> tool.
-+
+
 For example, the following command creates a user named `restore_user`.
-+
+
 [source,sh]
 ----
 ./bin/elasticsearch-users useradd restore_user -p my_password -r superuser
 ----
-+
+
 Use this file realm user to authenticate requests until the restore operation is
 complete.
+--
 
 . Use the <<cluster-update-settings,cluster update settings API>> to set
 <<action-destructive-requires-name,`action.destructive_requires_name`>> to

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -34,7 +34,7 @@ When restoring data from a snapshot, keep the following in mind:
 * If you restore a data stream, you also restore its backing indices.
 
 * You can only restore an existing index if it's <<indices-close,closed>> and
-the index in the snapshot has the same number of primary shards. 
+the index in the snapshot has the same number of primary shards.
 
 * You can't restore an existing open index. This includes
 backing indices for a data stream.
@@ -127,7 +127,7 @@ restore.
 
 [source,console]
 ----
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 {
   "indices": "my-index,logs-my_app-default"
 }
@@ -152,7 +152,7 @@ any restored index or data stream.
 
 [source,console]
 ----
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 {
   "indices": "my-index,logs-my_app-default",
   "rename_pattern": "(.+)",
@@ -222,7 +222,7 @@ all indices and data streams except dot indices.
 
 [source,console]
 ----
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 {
   "indices": "*,-.*"
 }
@@ -236,9 +236,14 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 === Restore a feature state
 
 You can restore a feature state to recover system indices and other
-configuration data for a feature from a snapshot.
+configuration data for a feature from a snapshot. Restoring a feature state is
+the preferred way to restore system indices.
 
-NOTE: You can't restore specific feature states in {kib}.
+If you restore a snapshot's cluster state, the operation restores all feature
+states in the snapshot by default. Similarly, if you don't restore a snapshot's
+cluster state, the operation doesn't restore any feature states by default. You
+can also restore only specific feature states from a snapshot, regardless of the
+cluster state.
 
 To view a snapshot's feature states, use the get snapshot API.
 
@@ -251,10 +256,13 @@ GET _snapshot/my_repository/my_snapshot_2099.05.06
 The response's `feature_states` property contains a list of features in the
 snapshot as well as each feature's indices.
 
-To restore a feature state, specify the `feature_name` from the response in the
-restore snapshot API's <<restore-snapshot-api-feature-states,`feature_states`>>
-parameter. When you restore a feature state, {es} closes and overwrites the
-feature's existing indices.
+To restore a specific feature state from the snapshot, specify the
+`feature_name` from the response in the restore snapshot API's
+<<restore-snapshot-api-feature-states,`feature_states`>> parameter. When you
+restore a feature state, {es} closes and overwrites the feature's existing
+indices.
+
+NOTE: You can't restore specific feature states in {kib}.
 
 WARNING: Restoring the `security` feature state overwrites system indices
 used for authentication. If you use {ess}, ensure you have access to the {ess}
@@ -267,7 +275,7 @@ pattern to the `indices` value.
 
 [source,console]
 ----
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 {
   "indices": "*,-.*",
   "feature_states": [ "geoip" ]
@@ -436,7 +444,7 @@ any feature states and system indices in the snapshot.
 +
 [source,console]
 ----
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
+POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 {
   "indices": "*",
   "include_global_state": true

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -245,6 +245,8 @@ cluster state, the operation doesn't restore any feature states by default. You
 can also restore only specific feature states from a snapshot, regardless of the
 cluster state.
 
+NOTE: You can't restore specific feature states in {kib}.
+
 To view a snapshot's feature states, use the get snapshot API.
 
 [source,console]
@@ -261,8 +263,6 @@ To restore a specific feature state from the snapshot, specify the
 <<restore-snapshot-api-feature-states,`feature_states`>> parameter. When you
 restore a feature state, {es} closes and overwrites the feature's existing
 indices.
-
-NOTE: You can't restore specific feature states in {kib}.
 
 WARNING: Restoring the `security` feature state overwrites system indices
 used for authentication. If you use {ess}, ensure you have access to the {ess}

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -266,7 +266,7 @@ Specify the `feature_name` from the response in the restore snapshot API's
 restore a feature state, {es} closes and overwrites any existing indices for the
 feature with indices from the snapshot.
 
-WARNING: Restoring the `security` feature state can overwrite system indices
+WARNING: Restoring the `security` feature state overwrites system indices
 used for authentication. If you use {ess}, ensure you have access to the {ess}
 Console before restoring the `security` feature state. If you run {es} on your
 own hardware, <<restore-create-file-realm-user,create a superuser in the file
@@ -426,7 +426,7 @@ DELETE _data_stream/*
 // TEST[continued]
 
 . Restore the entire snapshot, including the cluster state. This also restores
-any system indices in the snapshot.
+any feature states and system indices in the snapshot.
 +
 [source,console]
 ----

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -208,7 +208,7 @@ POST _reindex
 
 [discrete]
 [[restore-new-cluster]]
-==== Restore to a new cluster
+=== Restore to a new cluster
 
 Some {es} features, such as the <<geoip-processor,GeoIP processor>>,
 automatically create system indices at startup. To avoid naming conflicts with

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -258,13 +258,13 @@ GET _snapshot/my_repository/my_snapshot_2099.05.06
 ----
 // TEST[setup:setup-snapshots]
 
-The response's `feature_states` property includes a list of features in the
+The response's `feature_states` property contains a list of features in the
 snapshot as well as each feature's indices.
 
-Specify the `feature_name` from the response in the restore snapshot API's
-<<restore-snapshot-api-feature-states,`feature_states`>> parameter. When you
-restore a feature state, {es} closes and overwrites any existing indices for the
-feature with indices from the snapshot.
+To restore a feature state, specify the `feature_name` from the response in the
+restore snapshot API's <<restore-snapshot-api-feature-states,`feature_states`>>
+parameter. When you restore a feature state, {es} closes and overwrites the
+feature's existing indices.
 
 WARNING: Restoring the `security` feature state overwrites system indices
 used for authentication. If you use {ess}, ensure you have access to the {ess}

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -216,18 +216,6 @@ automatically create system indices at startup. To avoid naming conflicts with
 these indices, use the `-.*` wildcard pattern to exclude system indices and
 other dot (`.`) indices from your restore request.
 
-////
-[source,console]
-----
-# Delete an index
-DELETE my-index
-
-# Delete a data stream
-DELETE _data_stream/logs-my_app-default
-----
-// TEST[setup:setup-snapshots]
-////
-
 For example, the following request uses the `*,-.*` wildcard pattern to restore
 all indices and data streams except dot indices.
 
@@ -238,7 +226,8 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
   "indices": "*,-.*"
 }
 ----
-// TEST[continued]
+// TEST[setup:setup-snapshots]
+// TEST[s/^/DELETE my-index\nDELETE _data_stream\/logs-my_app-default\n/]
 // TEST[s/_restore/_restore?wait_for_completion=true/]
 
 [discrete]
@@ -284,8 +273,9 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 }
 ----
 // TEST[setup:setup-snapshots]
+// TEST[s/^/DELETE my-index\nDELETE _data_stream\/logs-my_app-default\n/]
 // TEST[s/_restore/_restore?wait_for_completion=true/]
-// TEST[s/"\*\,\-\.\*",/"-*"/]
+// TEST[s/",/"/]
 // TEST[s/"feature_states": \[ "geoip" \]//]
 
 [discrete]
@@ -318,6 +308,18 @@ the cluster.
 . Temporarily stop indexing and turn off the following features:
 +
 --
+* GeoIP database downloader
++
+[source,console]
+----
+PUT _cluster/settings
+{
+  "persistent": {
+    "ingest.geoip.downloader.enabled": false
+  }
+}
+----
+
 * ILM
 +
 [source,console]
@@ -348,19 +350,18 @@ POST _ml/set_upgrade_mode?enabled=false
 // TEST[continued]
 ////
 
-////
+* Monitoring
++
 [source,console]
 ----
 PUT _cluster/settings
 {
   "persistent": {
-    "xpack.monitoring.collection.enabled": true
+    "xpack.monitoring.collection.enabled": false
   }
 }
 ----
 // TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
-// TEST[continued]
-////
 
 * Watcher
 +
@@ -400,7 +401,7 @@ complete.
 
 . Use the <<cluster-update-settings,cluster update settings API>> to set
 <<action-destructive-requires-name,`action.destructive_requires_name`>> to
-`false`. This lets you delete indices and data streams using wildcards.
+`false`. This lets you delete data streams and indices using wildcards.
 +
 [source,console]
 ----
@@ -413,15 +414,19 @@ PUT _cluster/settings
 ----
 // TEST[setup:setup-snapshots]
 
-. Delete existing indices and data streams on the cluster.
+. Delete all existing data streams on the cluster.
 +
 [source,console]
 ----
-# Delete all indices
-DELETE *
+DELETE _data_stream/*?expand_wildcards=all
+----
+// TEST[continued]
 
-# Delete all data streams
-DELETE _data_stream/*
+. Delete all existing indices on the cluster.
++
+[source,console]
+----
+DELETE *?expand_wildcards=all
 ----
 // TEST[continued]
 
@@ -443,6 +448,19 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 features you stopped:
 +
 --
+* GeoIP database downloader
++
+[source,console]
+----
+PUT _cluster/settings
+{
+  "persistent": {
+    "ingest.geoip.downloader.enabled": true
+  }
+}
+----
+//TEST[s/true/false/]
+
 * ILM
 +
 [source,console]
@@ -456,6 +474,20 @@ POST _ilm/start
 ----
 POST _ml/set_upgrade_mode?enabled=false
 ----
+
+* Monitoring
++
+[source,console]
+----
+PUT _cluster/settings
+{
+  "persistent": {
+    "xpack.monitoring.collection.enabled": true
+  }
+}
+----
+// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[s/true/false/]
 
 * Watcher
 +

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -10,6 +10,7 @@ In this guide, you'll learn how to:
 
 * Get a list of available snapshots
 * Restore an index or data stream from a snapshot
+* Restore a feature state
 * Restore an entire cluster
 * Monitor the restore operation
 * Cancel an ongoing restore
@@ -80,8 +81,8 @@ You can restore a snapshot using {kib}'s *Snapshot and Restore* feature or the
 <<restore-snapshot-api,restore snapshot API>>.
 
 By default, a restore request attempts to restore all indices and data streams
-in a snapshot, including system indices. However, you can't restore an
-existing open index.
+in a snapshot, including <<system-indices,system indices>>. However, you can't
+restore an existing open index.
 
 If you're restoring data to a pre-existing cluster, use one of the
 following methods to avoid conflicts with existing indices and data streams:
@@ -91,7 +92,7 @@ following methods to avoid conflicts with existing indices and data streams:
 
 Some {es} features automatically create system indices on cluster startup. To
 avoid conflicts with these system indices when restoring data to a new cluster,
-see <<restore-new-cluster>>.
+see <<restore-exclude-system-indices>>.
 
 [discrete]
 [[delete-restore]]
@@ -207,13 +208,13 @@ POST _reindex
 // TEST[continued]
 
 [discrete]
-[[restore-new-cluster]]
-=== Restore to a new cluster
+[[restore-exclude-system-indices]]
+==== Exclude system indices
 
 Some {es} features, such as the <<geoip-processor,GeoIP processor>>,
 automatically create system indices at startup. To avoid naming conflicts with
-these indices, use the `*,-.*` wildcard pattern in your restore request. This
-pattern excludes system indices and other indices that begin with a dot (`.`).
+these indices, use the `-.*` wildcard pattern to exclude system indices and
+other dot (`.`) indices from your restore request.
 
 ////
 [source,console]
@@ -227,6 +228,9 @@ DELETE _data_stream/logs-my_app-default
 // TEST[setup:setup-snapshots]
 ////
 
+For example, the following request uses the `*,-.*` wildcard pattern to restore
+all indices and data streams except dot indices.
+
 [source,console]
 ----
 POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore 
@@ -237,8 +241,12 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 // TEST[continued]
 // TEST[s/_restore/_restore?wait_for_completion=true/]
 
-If your snapshot includes the related feature state, you can also restore the
-system indices and other configuration data for a specific feature.
+[discrete]
+[[restore-feature-state]]
+=== Restore a feature state
+
+You can restore a feature state to recover system indices and other
+configuration data for a feature from a snapshot.
 
 NOTE: You can't restore specific feature states in {kib}.
 
@@ -250,16 +258,22 @@ GET _snapshot/my_repository/my_snapshot_2099.05.06
 ----
 // TEST[setup:setup-snapshots]
 
-To restore a feature state, specify the `feature_name` from the response in the
-restore snapshot API's <<restore-snapshot-api-feature-states,`feature_states`>>
-parameter. When you restore a feature state, {es} closes and overwrites any
-existing indices that are part of the feature state.
+The response's `feature_states` property includes a list of features in the
+snapshot as well as each feature's indices.
+
+Specify the `feature_name` from the response in the restore snapshot API's
+<<restore-snapshot-api-feature-states,`feature_states`>> parameter. When you
+restore a feature state, {es} closes and overwrites any existing indices for the
+feature with indices from the snapshot.
 
 WARNING: Restoring the `security` feature state can overwrite system indices
 used for authentication. If you use {ess}, ensure you have access to the {ess}
 Console before restoring the `security` feature state. If you run {es} on your
 own hardware, <<restore-create-file-realm-user,create a superuser in the file
 realm>> to ensure you'll still be able to access your cluster.
+
+To avoid accidentally restoring other dot indices, append the `-.*` wildcard
+pattern to the `indices` value.
 
 [source,console]
 ----


### PR DESCRIPTION
When restoring a snapshot to a new cluster, users may expect the cluster
to not contain any conflicting indices or data streams. However, some
features, such as the GeoIP processor, automatically create indices at
startup.

This adds and updates related procedures in the restore a snapshot tutorial.
I plan to improve other documentation related to feature states in snapshots
in a separate PR(s).

This PR also updates the restore snapshot API's example to include
the `indices` and `feature_states` parameters.

Relates to #79675

### Preview
https://elasticsearch_79683.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshots-restore-snapshot.html