### PR TITLE
[7.16][Transform] respect timeout parameters in all API's (#79468)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -25,9 +25,14 @@ public abstract class AcknowledgedRequest<Request extends MasterNodeRequest<Requ
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
 
-    protected TimeValue timeout = DEFAULT_ACK_TIMEOUT;
+    protected TimeValue timeout;
 
     protected AcknowledgedRequest() {
+        this(DEFAULT_ACK_TIMEOUT);
+    }
+
+    protected AcknowledgedRequest(TimeValue timeout) {
+        this.timeout = timeout;
     }
 
     protected AcknowledgedRequest(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformAction.java
@@ -9,10 +9,11 @@ package org.elasticsearch.xpack.core.transform.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
 
@@ -28,11 +29,12 @@ public class DeleteTransformAction extends ActionType<AcknowledgedResponse> {
         super(NAME, AcknowledgedResponse::readFrom);
     }
 
-    public static class Request extends MasterNodeRequest<Request> {
+    public static class Request extends AcknowledgedRequest<Request> {
         private final String id;
         private final boolean force;
 
-        public Request(String id, boolean force) {
+        public Request(String id, boolean force, TimeValue timeout) {
+            super(timeout);
             this.id = ExceptionsHelper.requireNonNull(id, TransformField.ID.getPreferredName());
             this.force = force;
         }
@@ -71,7 +73,8 @@ public class DeleteTransformAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, force);
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(timeout(), id, force);
         }
 
         @Override
@@ -84,7 +87,8 @@ public class DeleteTransformAction extends ActionType<AcknowledgedResponse> {
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(id, other.id) && force == other.force;
+            // the base class does not implement equals, therefore we need to check timeout ourselves
+            return Objects.equals(id, other.id) && force == other.force && timeout().equals(other.timeout());
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -12,13 +12,14 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -54,7 +55,8 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
 
         private final TransformConfig config;
 
-        public Request(TransformConfig config) {
+        public Request(TransformConfig config, TimeValue timeout) {
+            super(timeout);
             this.config = config;
         }
 
@@ -63,7 +65,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
             this.config = new TransformConfig(in);
         }
 
-        public static Request fromXContent(final XContentParser parser) throws IOException {
+        public static Request fromXContent(final XContentParser parser, TimeValue timeout) throws IOException {
             Map<String, Object> content = parser.map();
             // dest.index is not required for _preview, so we just supply our own
             Map<String, String> tempDestination = new HashMap<>();
@@ -86,7 +88,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
                         BytesReference.bytes(xContentBuilder).streamInput()
                     )
             ) {
-                return new Request(TransformConfig.fromXContent(newParser, null, false));
+                return new Request(TransformConfig.fromXContent(newParser, null, false), timeout);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
@@ -44,7 +44,8 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
         private final TransformConfig config;
         private final boolean deferValidation;
 
-        public Request(TransformConfig config, boolean deferValidation) {
+        public Request(TransformConfig config, boolean deferValidation, TimeValue timeout) {
+            super(timeout);
             this.config = config;
             this.deferValidation = deferValidation;
         }
@@ -59,8 +60,13 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
             }
         }
 
-        public static Request fromXContent(final XContentParser parser, final String id, final boolean deferValidation) {
-            return new Request(TransformConfig.fromXContent(parser, id, false), deferValidation);
+        public static Request fromXContent(
+            final XContentParser parser,
+            final String id,
+            final boolean deferValidation,
+            final TimeValue timeout
+        ) {
+            return new Request(TransformConfig.fromXContent(parser, id, false), deferValidation, timeout);
         }
 
         /**
@@ -123,7 +129,8 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(config, deferValidation);
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(timeout(), config, deferValidation);
         }
 
         @Override
@@ -135,7 +142,11 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(config, other.config) && this.deferValidation == other.deferValidation;
+
+            // the base class does not implement equals, therefore we need to check timeout ourselves
+            return Objects.equals(config, other.config)
+                && this.deferValidation == other.deferValidation
+                && timeout().equals(other.timeout());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StartTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StartTransformAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -36,7 +37,8 @@ public class StartTransformAction extends ActionType<StartTransformAction.Respon
 
         private final String id;
 
-        public Request(String id) {
+        public Request(String id, TimeValue timeout) {
+            super(timeout);
             this.id = ExceptionsHelper.requireNonNull(id, TransformField.ID.getPreferredName());
         }
 
@@ -68,7 +70,8 @@ public class StartTransformAction extends ActionType<StartTransformAction.Respon
 
         @Override
         public int hashCode() {
-            return Objects.hash(id);
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(timeout(), id);
         }
 
         @Override
@@ -80,7 +83,8 @@ public class StartTransformAction extends ActionType<StartTransformAction.Respon
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(id, other.id);
+            // the base class does not implement equals, therefore we need to check timeout ourselves
+            return Objects.equals(id, other.id) && timeout().equals(other.timeout());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -49,10 +49,11 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
         private final boolean deferValidation;
         private TransformConfig config;
 
-        public Request(TransformConfigUpdate update, String id, boolean deferValidation) {
+        public Request(TransformConfigUpdate update, String id, boolean deferValidation, TimeValue timeout) {
             this.update = update;
             this.id = id;
             this.deferValidation = deferValidation;
+            this.setTimeout(timeout);
         }
 
         // use fromStreamWithBWC, this can be changed back to public after BWC is not required anymore
@@ -71,11 +72,16 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
                 return new Request(in);
             }
             UpdateTransformActionPre78.Request r = new UpdateTransformActionPre78.Request(in);
-            return new Request(r.getUpdate(), r.getId(), r.isDeferValidation());
+            return new Request(r.getUpdate(), r.getId(), r.isDeferValidation(), r.timeout());
         }
 
-        public static Request fromXContent(final XContentParser parser, final String id, final boolean deferValidation) {
-            return new Request(TransformConfigUpdate.fromXContent(parser), id, deferValidation);
+        public static Request fromXContent(
+            final XContentParser parser,
+            final String id,
+            final boolean deferValidation,
+            final TimeValue timeout
+        ) {
+            return new Request(TransformConfigUpdate.fromXContent(parser), id, deferValidation, timeout);
         }
 
         /**
@@ -151,7 +157,8 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
 
         @Override
         public int hashCode() {
-            return Objects.hash(update, id, deferValidation, config);
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(getTimeout(), update, id, deferValidation, config);
         }
 
         @Override
@@ -163,10 +170,13 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
                 return false;
             }
             Request other = (Request) obj;
+
+            // the base class does not implement equals, therefore we need to check timeout ourselves
             return Objects.equals(update, other.update)
                 && this.deferValidation == other.deferValidation
                 && this.id.equals(other.id)
-                && Objects.equals(config, other.config);
+                && Objects.equals(config, other.config)
+                && getTimeout().equals(other.getTimeout());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 
@@ -34,7 +35,8 @@ public class ValidateTransformAction extends ActionType<ValidateTransformAction.
         private final TransformConfig config;
         private final boolean deferValidation;
 
-        public Request(TransformConfig config, boolean deferValidation) {
+        public Request(TransformConfig config, boolean deferValidation, TimeValue timeout) {
+            super(timeout);
             this.config = config;
             this.deferValidation = deferValidation;
         }
@@ -82,13 +84,15 @@ public class ValidateTransformAction extends ActionType<ValidateTransformAction.
                 return false;
             }
             Request that = (Request) obj;
-            return Objects.equals(config, that.config)
-                && deferValidation == that.deferValidation;
+
+            // the base class does not implement equals, therefore we need to check timeout ourselves
+            return Objects.equals(config, that.config) && deferValidation == that.deferValidation && timeout().equals(that.timeout());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(config, deferValidation);
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(timeout(), config, deferValidation);
         }
     }
 
@@ -104,6 +108,7 @@ public class ValidateTransformAction extends ActionType<ValidateTransformAction.
             this.destIndexMappings = in.readMap(StreamInput::readString, StreamInput::readString);
         }
 
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(destIndexMappings, StreamOutput::writeString, StreamOutput::writeString);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformActionRequestTests.java
@@ -8,17 +8,43 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction.Request;
+
+import java.io.IOException;
 
 public class DeleteTransformActionRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override
     protected Request createTestInstance() {
-        return new Request(randomAlphaOfLengthBetween(1, 20), randomBoolean());
+        return new Request(randomAlphaOfLengthBetween(1, 20), randomBoolean(), TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
     }
 
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        String id = instance.getId();
+        boolean force = instance.isForce();
+        TimeValue timeout = instance.timeout();
+
+        switch (between(0, 2)) {
+            case 0:
+                id += randomAlphaOfLengthBetween(1, 5);
+                break;
+            case 1:
+                force ^= true;
+                break;
+            case 2:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(id, force, timeout);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformActionRequestTests.java
@@ -7,8 +7,10 @@
 
 package org.elasticsearch.xpack.core.transform.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -29,7 +31,7 @@ public class PreviewTransformActionRequestTests extends AbstractSerializingTrans
 
     @Override
     protected Request doParseInstance(XContentParser parser) throws IOException {
-        return Request.fromXContent(parser);
+        return Request.fromXContent(parser,  AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
     }
 
     @Override
@@ -60,7 +62,7 @@ public class PreviewTransformActionRequestTests extends AbstractSerializingTrans
             null,
             null
         );
-        return new Request(config);
+        return new Request(config, TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
     }
 
     public void testParsingOverwritesIdField() throws IOException {
@@ -137,7 +139,7 @@ public class PreviewTransformActionRequestTests extends AbstractSerializingTrans
             )
         ) {
 
-            Request request = Request.fromXContent(parser);
+            Request request = Request.fromXContent(parser,  AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
             assertThat(request.getConfig().getId(), is(equalTo(expectedTransformId)));
             assertThat(request.getConfig().getDestination().getIndex(), is(equalTo(expectedDestIndex)));
             assertThat(request.getConfig().getDestination().getPipeline(), is(equalTo(expectedDestPipeline)));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PutTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PutTransformActionRequestTests.java
@@ -8,10 +8,13 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
 import org.junit.Before;
+
+import java.io.IOException;
 
 public class PutTransformActionRequestTests extends AbstractWireSerializingTransformTestCase<Request> {
     private String transformId;
@@ -29,6 +32,29 @@ public class PutTransformActionRequestTests extends AbstractWireSerializingTrans
     @Override
     protected Request createTestInstance() {
         TransformConfig config = TransformConfigTests.randomTransformConfigWithoutHeaders(transformId);
-        return new Request(config, randomBoolean());
+        return new Request(config, randomBoolean(), TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        TransformConfig config = instance.getConfig();
+        boolean deferValidation = instance.isDeferValidation();
+        TimeValue timeout = instance.timeout();
+
+        switch (between(0, 2)) {
+            case 0:
+                config = new TransformConfig.Builder(config).setId(config.getId() + randomAlphaOfLengthBetween(1, 5)).build();
+                break;
+            case 1:
+                deferValidation ^= true;
+                break;
+            case 2:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(config, deferValidation, timeout);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/StartTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/StartTransformActionRequestTests.java
@@ -8,17 +8,39 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction.Request;
+
+import java.io.IOException;
 
 public class StartTransformActionRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override
     protected Request createTestInstance() {
-        return new Request(randomAlphaOfLengthBetween(1, 20));
+        return new Request(randomAlphaOfLengthBetween(1, 20), TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
     }
 
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        String id = instance.getId();
+        TimeValue timeout = instance.timeout();
+
+        switch (between(0, 1)) {
+            case 0:
+                id += randomAlphaOfLengthBetween(1, 5);
+                break;
+            case 1:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(id, timeout);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionPre78;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 
 import java.io.IOException;
 
@@ -29,11 +31,54 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
 
     @Override
     protected Request createTestInstance() {
-        Request request = new Request(randomTransformConfigUpdate(), randomAlphaOfLength(10), randomBoolean());
+        Request request = new Request(
+            randomTransformConfigUpdate(),
+            randomAlphaOfLength(10),
+            randomBoolean(),
+            TimeValue.parseTimeValue(randomTimeValue(), "timeout")
+        );
         if (randomBoolean()) {
             request.setConfig(TransformConfigTests.randomTransformConfig());
         }
         return request;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        String id = instance.getId();
+        TransformConfigUpdate update = instance.getUpdate();
+        boolean deferValidation = instance.isDeferValidation();
+        TimeValue timeout = instance.getTimeout();
+
+        switch (between(0, 3)) {
+            case 0:
+                id += randomAlphaOfLengthBetween(1, 5);
+                break;
+            case 1:
+                String description = update.getDescription() == null ? "" : update.getDescription();
+                description += randomAlphaOfLengthBetween(1, 5);
+                update = new TransformConfigUpdate(
+                    update.getSource(),
+                    update.getDestination(),
+                    update.getFrequency(),
+                    update.getSyncConfig(),
+                    description,
+                    update.getSettings(),
+                    update.getMetadata(),
+                    update.getRetentionPolicyConfig()
+                );
+                break;
+            case 2:
+                deferValidation ^= true;
+                break;
+            case 3:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(update, id, deferValidation, timeout);
     }
 
     public void testBWCPre78() throws IOException {
@@ -54,7 +99,8 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
             assertThat(oldRequest.getUpdate().getSource().getIndex(), is(equalTo(newRequest.getUpdate().getSource().getIndex())));
             assertThat(
                 oldRequest.getUpdate().getSource().getQueryConfig(),
-                is(equalTo(newRequest.getUpdate().getSource().getQueryConfig())));
+                is(equalTo(newRequest.getUpdate().getSource().getQueryConfig()))
+            );
             // runtime_mappings was added in 7.12 so it is always empty after deserializing from 7.7
             assertThat(oldRequest.getUpdate().getSource().getRuntimeMappings(), is(anEmptyMap()));
         }
@@ -76,7 +122,8 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
             assertThat(newRequestFromOld.getUpdate().getSource().getIndex(), is(equalTo(newRequest.getUpdate().getSource().getIndex())));
             assertThat(
                 newRequestFromOld.getUpdate().getSource().getQueryConfig(),
-                is(equalTo(newRequest.getUpdate().getSource().getQueryConfig())));
+                is(equalTo(newRequest.getUpdate().getSource().getQueryConfig()))
+            );
             // runtime_mappings was added in 7.12 so it is always empty after deserializing from 7.7
             assertThat(newRequestFromOld.getUpdate().getSource().getRuntimeMappings(), is(anEmptyMap()));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpgradeTransformsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpgradeTransformsActionRequestTests.java
@@ -8,8 +8,11 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.transform.action.UpgradeTransformsAction.Request;
+
+import java.io.IOException;
 
 public class UpgradeTransformsActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
@@ -20,7 +23,26 @@ public class UpgradeTransformsActionRequestTests extends AbstractWireSerializing
 
     @Override
     protected Request createTestInstance() {
-        return new Request(randomBoolean());
+        return new Request(randomBoolean(), TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        boolean dryRun = instance.isDryRun();
+        TimeValue timeout = instance.timeout();
+
+        switch (between(0, 1)) {
+            case 0:
+                dryRun ^= true;
+                break;
+            case 1:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(dryRun, timeout);
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformActionRequestTests.java
@@ -8,7 +8,11 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction.Request;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+
+import java.io.IOException;
 
 import static org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests.randomTransformConfig;
 
@@ -16,11 +20,34 @@ public class ValidateTransformActionRequestTests extends AbstractWireSerializing
 
     @Override
     protected Request createTestInstance() {
-        return new Request(randomTransformConfig(), randomBoolean());
+        return new Request(randomTransformConfig(), randomBoolean(), TimeValue.parseTimeValue(randomTimeValue(), "timeout"));
     }
 
     @Override
     protected Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+        TransformConfig config = instance.getConfig();
+        boolean deferValidation = instance.isDeferValidation();
+        TimeValue timeout = instance.timeout();
+
+        switch (between(0, 2)) {
+            case 0:
+                config = new TransformConfig.Builder(config).setId(config.getId() + randomAlphaOfLengthBetween(1, 5)).build();
+                break;
+            case 1:
+                deferValidation ^= true;
+                break;
+            case 2:
+                timeout = new TimeValue(timeout.duration() + randomLongBetween(1, 5), timeout.timeUnit());
+                break;
+            default:
+                throw new AssertionError("Illegal randomization branch");
+        }
+
+        return new Request(config, deferValidation, timeout);
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -86,7 +87,7 @@ public class TransformInternalIndexIT extends TransformSingleNodeTestCase {
 
         UpdateTransformAction.Request updateTransformActionRequest = new UpdateTransformAction.Request(
             new TransformConfigUpdate(null, null, null, null, "updated", null, null, null),
-            transformId, false);
+            transformId, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
         UpdateTransformAction.Response updateTransformActionResponse =
             client().execute(UpdateTransformAction.INSTANCE, updateTransformActionRequest).actionGet();
         assertThat(updateTransformActionResponse.getConfig().getId(), equalTo(transformId));

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoRemoteClusterClientNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoRemoteClusterClientNodeIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.integration;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
@@ -34,52 +35,69 @@ public class TransformNoRemoteClusterClientNodeIT extends TransformSingleNodeTes
     public void testPreviewTransformWithRemoteIndex() {
         String transformId = "transform-with-remote-index";
         TransformConfig config = randomConfig(transformId, "remote_cluster:my-index");
-        PreviewTransformAction.Request request = new PreviewTransformAction.Request(config);
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(PreviewTransformAction.INSTANCE, request).actionGet());
+        PreviewTransformAction.Request request = new PreviewTransformAction.Request(config, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(PreviewTransformAction.INSTANCE, request).actionGet()
+        );
         assertThat(
             e.getMessage(),
             allOf(
                 containsString("No appropriate node to run on"),
-                containsString("transform requires a remote connection but remote is disabled")));
+                containsString("transform requires a remote connection but remote is disabled")
+            )
+        );
     }
 
     public void testPutTransformWithRemoteIndex_DeferValidation() {
         String transformId = "transform-with-remote-index";
         TransformConfig config = randomConfig(transformId, "remote_cluster:my-index");
-        PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+        PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
         client().execute(PutTransformAction.INSTANCE, request).actionGet();
     }
 
     public void testPutTransformWithRemoteIndex_NoDeferValidation() {
         String transformId = "transform-with-remote-index";
         TransformConfig config = randomConfig(transformId, "remote_cluster:my-index");
-        PutTransformAction.Request request = new PutTransformAction.Request(config, false);
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(PutTransformAction.INSTANCE, request).actionGet());
+        PutTransformAction.Request request = new PutTransformAction.Request(config, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(PutTransformAction.INSTANCE, request).actionGet()
+        );
         assertThat(
             e.getMessage(),
             allOf(
                 containsString("No appropriate node to run on"),
-                containsString("transform requires a remote connection but remote is disabled")));
+                containsString("transform requires a remote connection but remote is disabled")
+            )
+        );
     }
 
     public void testUpdateTransformWithRemoteIndex_DeferValidation() {
         String transformId = "transform-with-local-index";
         {
             TransformConfig config = randomConfig(transformId, "my-index");
-            PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+            PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
             AcknowledgedResponse response = client().execute(PutTransformAction.INSTANCE, request).actionGet();
             assertThat(response.isAcknowledged(), is(true));
         }
 
-        TransformConfigUpdate update =
-            new TransformConfigUpdate(new SourceConfig("remote_cluster:my-index"), null, null, null, null, null, null, null);
-        UpdateTransformAction.Request request = new UpdateTransformAction.Request(update, transformId, true);
+        TransformConfigUpdate update = new TransformConfigUpdate(
+            new SourceConfig("remote_cluster:my-index"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UpdateTransformAction.Request request = new UpdateTransformAction.Request(
+            update,
+            transformId,
+            true,
+            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT
+        );
         client().execute(UpdateTransformAction.INSTANCE, request).actionGet();
     }
 
@@ -87,28 +105,42 @@ public class TransformNoRemoteClusterClientNodeIT extends TransformSingleNodeTes
         String transformId = "transform-with-local-index";
         {
             TransformConfig config = randomConfig(transformId, "my-index");
-            PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+            PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
             AcknowledgedResponse response = client().execute(PutTransformAction.INSTANCE, request).actionGet();
             assertThat(response.isAcknowledged(), is(true));
         }
 
-        TransformConfigUpdate update =
-            new TransformConfigUpdate(new SourceConfig("remote_cluster:my-index"), null, null, null, null, null, null, null);
-        UpdateTransformAction.Request request = new UpdateTransformAction.Request(update, transformId, false);
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(UpdateTransformAction.INSTANCE, request).actionGet());
+        TransformConfigUpdate update = new TransformConfigUpdate(
+            new SourceConfig("remote_cluster:my-index"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UpdateTransformAction.Request request = new UpdateTransformAction.Request(
+            update,
+            transformId,
+            false,
+            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT
+        );
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(UpdateTransformAction.INSTANCE, request).actionGet()
+        );
         assertThat(
             e.getMessage(),
             allOf(
                 containsString("No appropriate node to run on"),
-                containsString("transform requires a remote connection but remote is disabled")));
+                containsString("transform requires a remote connection but remote is disabled")
+            )
+        );
     }
 
     private static TransformConfig randomConfig(String transformId, String sourceIndex) {
-        return new TransformConfig.Builder()
-            .setId(transformId)
+        return new TransformConfig.Builder().setId(transformId)
             .setSource(new SourceConfig(sourceIndex))
             .setDest(new DestConfig("my-dest-index", null))
             .setPivotConfig(PivotConfigTests.randomPivotConfig())

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.integration;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
@@ -52,18 +53,18 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     public void testPreviewTransform() {
         String transformId = "transform-1";
         TransformConfig config = randomConfig(transformId);
-        PreviewTransformAction.Request request = new PreviewTransformAction.Request(config);
-        ElasticsearchStatusException e =
-            expectThrows(ElasticsearchStatusException.class, () -> client().execute(PreviewTransformAction.INSTANCE, request).actionGet());
-        assertThat(
-            e.getMessage(),
-            is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
+        PreviewTransformAction.Request request = new PreviewTransformAction.Request(config, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(PreviewTransformAction.INSTANCE, request).actionGet()
+        );
+        assertThat(e.getMessage(), is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
     }
 
     public void testPutTransform_DeferValidation() {
         String transformId = "transform-2";
         TransformConfig config = randomConfig(transformId);
-        PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+        PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
         AcknowledgedResponse response = client().execute(PutTransformAction.INSTANCE, request).actionGet();
         assertThat(response.isAcknowledged(), is(true));
 
@@ -73,28 +74,39 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     public void testPutTransform_NoDeferValidation() {
         String transformId = "transform-2";
         TransformConfig config = randomConfig(transformId);
-        PutTransformAction.Request request = new PutTransformAction.Request(config, false);
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(PutTransformAction.INSTANCE, request).actionGet());
-        assertThat(
-            e.getMessage(),
-            is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
+        PutTransformAction.Request request = new PutTransformAction.Request(config, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(PutTransformAction.INSTANCE, request).actionGet()
+        );
+        assertThat(e.getMessage(), is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
     }
 
     public void testUpdateTransform_DeferValidation() {
         String transformId = "transform-3";
         {
             TransformConfig config = randomConfig(transformId);
-            PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+            PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
             AcknowledgedResponse response = client().execute(PutTransformAction.INSTANCE, request).actionGet();
             assertThat(response.isAcknowledged(), is(true));
         }
 
-        TransformConfigUpdate update =
-            new TransformConfigUpdate(new SourceConfig("my-index", "my-index-2"), null, null, null, null, null, null, null);
-        UpdateTransformAction.Request request = new UpdateTransformAction.Request(update, transformId, true);
+        TransformConfigUpdate update = new TransformConfigUpdate(
+            new SourceConfig("my-index", "my-index-2"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UpdateTransformAction.Request request = new UpdateTransformAction.Request(
+            update,
+            transformId,
+            true,
+            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT
+        );
         client().execute(UpdateTransformAction.INSTANCE, request).actionGet();
 
         assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
@@ -104,27 +116,37 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
         String transformId = "transform-3";
         {
             TransformConfig config = randomConfig(transformId);
-            PutTransformAction.Request request = new PutTransformAction.Request(config, true);
+            PutTransformAction.Request request = new PutTransformAction.Request(config, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
             AcknowledgedResponse response = client().execute(PutTransformAction.INSTANCE, request).actionGet();
             assertThat(response.isAcknowledged(), is(true));
             assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
         }
 
-        TransformConfigUpdate update =
-            new TransformConfigUpdate(new SourceConfig("my-index", "my-index-2"), null, null, null, null, null, null, null);
-        UpdateTransformAction.Request request = new UpdateTransformAction.Request(update, transformId, false);
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(UpdateTransformAction.INSTANCE, request).actionGet());
-        assertThat(
-            e.getMessage(),
-            is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
+        TransformConfigUpdate update = new TransformConfigUpdate(
+            new SourceConfig("my-index", "my-index-2"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        UpdateTransformAction.Request request = new UpdateTransformAction.Request(
+            update,
+            transformId,
+            false,
+            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT
+        );
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(UpdateTransformAction.INSTANCE, request).actionGet()
+        );
+        assertThat(e.getMessage(), is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
     }
 
     private static TransformConfig randomConfig(String transformId) {
-        return new TransformConfig.Builder()
-            .setId(transformId)
+        return new TransformConfig.Builder().setId(transformId)
             .setSource(new SourceConfig("my-index"))
             .setDest(new DestConfig("my-dest-index", null))
             .setPivotConfig(PivotConfigTests.randomPivotConfig())

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -150,7 +150,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
             aVoid -> {
                 client.execute(
                     ValidateTransformAction.INSTANCE,
-                    new ValidateTransformAction.Request(config, request.isDeferValidation()),
+                    new ValidateTransformAction.Request(config, request.isDeferValidation(), request.timeout()),
                     validateTransformListener
                 );
             },

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -240,7 +240,11 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 )
             );
             transformConfigHolder.set(config);
-            client.execute(ValidateTransformAction.INSTANCE, new ValidateTransformAction.Request(config, false), validationListener);
+            client.execute(
+                ValidateTransformAction.INSTANCE,
+                new ValidateTransformAction.Request(config, false, request.timeout()),
+                validationListener
+            );
         }, listener::onFailure);
 
         // <1> Get the config to verify it exists and is valid

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -173,6 +173,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                 request.isDeferValidation(),
                 false, // dryRun
                 true, // checkAccess
+                request.getTimeout(),
                 ActionListener.wrap(updateResponse -> {
                     TransformConfig updatedConfig = updateResponse.getConfig();
                     auditor.info(updatedConfig.getId(), "Updated transform.");

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestDeleteTransformAction.java
@@ -6,8 +6,9 @@
  */
 package org.elasticsearch.xpack.transform.rest.action;
 
-
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -34,10 +35,11 @@ public class RestDeleteTransformAction extends BaseRestHandler {
 
         String id = restRequest.param(TransformField.ID.getPreferredName());
         boolean force = restRequest.paramAsBoolean(TransformField.FORCE.getPreferredName(), false);
-        DeleteTransformAction.Request request = new DeleteTransformAction.Request(id, force);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
 
-        return channel -> client.execute(DeleteTransformAction.INSTANCE, request,
-                new RestToXContentListener<>(channel));
+        DeleteTransformAction.Request request = new DeleteTransformAction.Request(id, force, timeout);
+
+        return channel -> client.execute(DeleteTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPreviewTransformAction.java
@@ -9,16 +9,18 @@ package org.elasticsearch.xpack.transform.rest.action;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
-import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -52,7 +54,8 @@ public class RestPreviewTransformAction extends BaseRestHandler {
         if (Strings.isNullOrEmpty(transformId) && restRequest.hasContentOrSourceParam() == false) {
             throw ExceptionsHelper.badRequestException(
                 "Please provide a transform [{}] or the config object",
-                TransformField.ID.getPreferredName());
+                TransformField.ID.getPreferredName()
+            );
         }
 
         if (Strings.isNullOrEmpty(transformId) == false && restRequest.hasContentOrSourceParam()) {
@@ -62,9 +65,12 @@ public class RestPreviewTransformAction extends BaseRestHandler {
             );
         }
 
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
         SetOnce<PreviewTransformAction.Request> previewRequestHolder = new SetOnce<>();
+
         if (Strings.isNullOrEmpty(transformId)) {
-            previewRequestHolder.set(PreviewTransformAction.Request.fromXContent(restRequest.contentOrSourceParamParser()));
+            previewRequestHolder.set(PreviewTransformAction.Request.fromXContent(restRequest.contentOrSourceParamParser(), timeout));
         }
 
         return channel -> {
@@ -86,7 +92,7 @@ public class RestPreviewTransformAction extends BaseRestHandler {
                             )
                         );
                     } else {
-                        PreviewTransformAction.Request previewRequest = new PreviewTransformAction.Request(transforms.get(0));
+                        PreviewTransformAction.Request previewRequest = new PreviewTransformAction.Request(transforms.get(0), timeout);
                         client.execute(PreviewTransformAction.INSTANCE, previewRequest, listener);
                     }
                 }, listener::onFailure));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPutTransformAction.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.transform.rest.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
@@ -48,14 +50,19 @@ public class RestPutTransformAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         if (restRequest.contentLength() > MAX_REQUEST_SIZE.getBytes()) {
             throw ExceptionsHelper.badRequestException(
-                "Request is too large: was [{}b], expected at most [{}]", restRequest.contentLength(), MAX_REQUEST_SIZE);
+                "Request is too large: was [{}b], expected at most [{}]",
+                restRequest.contentLength(),
+                MAX_REQUEST_SIZE
+            );
         }
 
         String id = restRequest.param(TransformField.ID.getPreferredName());
         XContentParser parser = restRequest.contentParser();
 
         boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
-        PutTransformAction.Request request = PutTransformAction.Request.fromXContent(parser, id, deferValidation);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        PutTransformAction.Request request = PutTransformAction.Request.fromXContent(parser, id, deferValidation, timeout);
 
         return channel -> client.execute(PutTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStartTransformAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.rest.action;
 
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -30,10 +31,10 @@ public class RestStartTransformAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         String id = restRequest.param(TransformField.ID.getPreferredName());
-        StartTransformAction.Request request = new StartTransformAction.Request(id);
-        request.timeout(restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT));
-        return channel -> client.execute(StartTransformAction.INSTANCE, request,
-                new RestToXContentListener<>(channel));
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        StartTransformAction.Request request = new StartTransformAction.Request(id, timeout);
+        return channel -> client.execute(StartTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpdateTransformAction.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.transform.rest.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
@@ -39,13 +41,18 @@ public class RestUpdateTransformAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         if (restRequest.contentLength() > MAX_REQUEST_SIZE.getBytes()) {
             throw ExceptionsHelper.badRequestException(
-                "Request is too large: was [{}b], expected at most [{}]", restRequest.contentLength(), MAX_REQUEST_SIZE);
+                "Request is too large: was [{}b], expected at most [{}]",
+                restRequest.contentLength(),
+                MAX_REQUEST_SIZE
+            );
         }
 
         String id = restRequest.param(TransformField.ID.getPreferredName());
         boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
         XContentParser parser = restRequest.contentParser();
-        UpdateTransformAction.Request request = UpdateTransformAction.Request.fromXContent(parser, id, deferValidation);
+        UpdateTransformAction.Request request = UpdateTransformAction.Request.fromXContent(parser, id, deferValidation, timeout);
 
         return channel -> client.execute(UpdateTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpgradeTransformsAction.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.transform.rest.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -39,10 +41,11 @@ public class RestUpgradeTransformsAction extends BaseRestHandler {
         }
 
         boolean dryRun = restRequest.paramAsBoolean(TransformField.DRY_RUN.getPreferredName(), false);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
 
         return channel -> client.execute(
             UpgradeTransformsAction.INSTANCE,
-            new UpgradeTransformsAction.Request(dryRun),
+            new UpgradeTransformsAction.Request(dryRun, timeout),
             new RestToXContentListener<>(channel)
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestDeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestDeleteTransformActionDeprecated.java
@@ -7,8 +7,10 @@
 package org.elasticsearch.xpack.transform.rest.action.compat;
 
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -39,7 +41,9 @@ public class RestDeleteTransformActionDeprecated extends BaseRestHandler {
 
         String id = restRequest.param(TransformField.ID.getPreferredName());
         boolean force = restRequest.paramAsBoolean(TransformField.FORCE.getPreferredName(), false);
-        DeleteTransformAction.Request request = new DeleteTransformAction.Request(id, force);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        DeleteTransformAction.Request request = new DeleteTransformAction.Request(id, force, timeout);
 
         return channel -> client.execute(DeleteTransformActionDeprecated.INSTANCE, request,
             new RestToXContentListener<>(channel));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPreviewTransformActionDeprecated.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.transform.rest.action.compat;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
@@ -41,8 +43,9 @@ public class RestPreviewTransformActionDeprecated extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         XContentParser parser = restRequest.contentParser();
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
 
-        PreviewTransformAction.Request request = PreviewTransformAction.Request.fromXContent(parser);
+        PreviewTransformAction.Request request = PreviewTransformAction.Request.fromXContent(parser, timeout);
         return channel -> client.execute(PreviewTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPutTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPutTransformActionDeprecated.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.transform.rest.action.compat;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
@@ -44,7 +46,9 @@ public class RestPutTransformActionDeprecated extends BaseRestHandler {
         XContentParser parser = restRequest.contentParser();
 
         boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
-        PutTransformAction.Request request = PutTransformAction.Request.fromXContent(parser, id, deferValidation);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        PutTransformAction.Request request = PutTransformAction.Request.fromXContent(parser, id, deferValidation, timeout);
 
         return channel -> client.execute(PutTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStartTransformActionDeprecated.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.rest.action.compat;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -35,8 +36,9 @@ public class RestStartTransformActionDeprecated extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         String id = restRequest.param(TransformField.ID.getPreferredName());
-        StartTransformAction.Request request = new StartTransformAction.Request(id);
-        request.timeout(restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT));
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        StartTransformAction.Request request = new StartTransformAction.Request(id, timeout);
         return channel -> client.execute(StartTransformActionDeprecated.INSTANCE, request,
             new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestUpdateTransformActionDeprecated.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.transform.rest.action.compat;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
@@ -42,8 +44,10 @@ public class RestUpdateTransformActionDeprecated extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String id = restRequest.param(TransformField.ID.getPreferredName());
         boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
         XContentParser parser = restRequest.contentParser();
-        UpdateTransformAction.Request request = UpdateTransformAction.Request.fromXContent(parser, id, deferValidation);
+        UpdateTransformAction.Request request = UpdateTransformAction.Request.fromXContent(parser, id, deferValidation, timeout);
 
         return channel -> client.execute(UpdateTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -131,6 +132,7 @@ public class TransformUpdaterTests extends ESTestCase {
                 true,
                 false,
                 false,
+                AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 listener
             ),
             updateResult -> {
@@ -164,6 +166,7 @@ public class TransformUpdaterTests extends ESTestCase {
                 true,
                 false,
                 false,
+                AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 listener
             ),
             updateResult -> {
@@ -233,6 +236,7 @@ public class TransformUpdaterTests extends ESTestCase {
                 true,
                 false,
                 false,
+                AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 listener
             ),
             updateResult -> {
@@ -294,6 +298,7 @@ public class TransformUpdaterTests extends ESTestCase {
                 true,
                 true,
                 false,
+                AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 listener
             ),
             updateResult -> {


### PR DESCRIPTION
make timeout parameter explicit in all transform actions and pass timeout values in sub-calls.

fixes #79268
backport #79468