### PR TITLE
[7.16] Mute RefreshListenersTests.testDisallowAddListeners (#79702)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -437,6 +437,7 @@ public class RefreshListenersTests extends ESTestCase {
         refresher.cancel();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79689")
     public void testDisallowAddListeners() throws Exception {
         assertEquals(0, listeners.pendingCount());
         TestLocationListener listener = new TestLocationListener();


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Mute RefreshListenersTests.testDisallowAddListeners (#79702)