### PR TITLE
[Docs] Clarify ignore_above behaviour

### DIFF
--- a/docs/reference/mapping/fields/ignored-field.asciidoc
+++ b/docs/reference/mapping/fields/ignored-field.asciidoc
@@ -2,8 +2,10 @@
 === `_ignored` field
 
 The `_ignored` field indexes and stores the names of every field in a document
-that has been ignored because it was malformed and
-<<ignore-malformed,`ignore_malformed`>> was turned on.
+that has been ignored when the document was indexed. This can, for example,
+be the case when the field was malformed and <<ignore-malformed,`ignore_malformed`>>
+was turned on, or when a `keyword` fields value exceeds its optional
+<<ignore-above,`ignore_above`>> setting.
 
 This field is searchable with <<query-dsl-term-query,`term`>>,
 <<query-dsl-terms-query,`terms`>> and <<query-dsl-exists-query,`exists`>>


### PR DESCRIPTION
Clarify that `keyword` fields that exceed the optional `ignore_above` setting
are inlcuded in the `_ignored` fields since 7.14.

Closes #79605