### PR TITLE
[7.16] Notify stubbable transport behaviors on clear (#77774)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -170,7 +170,6 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
      * sure that the node is removed form the cluster, that the node start pinging and that
      * the cluster reforms when healed.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77751")
     public void testNodeNotReachableFromMaster() throws Exception {
         startCluster(3);
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -281,7 +281,8 @@ public final class MockTransportService extends TransportService {
             listener.onFailure(new ConnectTransportException(discoveryNode, "UNRESPONSIVE: simulated")));
 
         transport().addSendBehavior(transportAddress, new StubbableTransport.SendRequestBehavior() {
-            private Set<Transport.Connection> toClose = ConcurrentHashMap.newKeySet();
+            private final Set<Transport.Connection> toClose = ConcurrentHashMap.newKeySet();
+
             @Override
             public void sendRequest(Transport.Connection connection, long requestId, String action,
                                     TransportRequest request, TransportRequestOptions options) {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -29,9 +29,12 @@ import org.elasticsearch.transport.TransportStats;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static junit.framework.TestCase.assertTrue;
 
 public class StubbableTransport implements Transport {
 
@@ -94,9 +97,22 @@ public class StubbableTransport implements Transport {
 
     void clearOutboundBehaviors() {
         this.defaultSendRequest = null;
-        sendBehaviors.clear();
+        final Iterator<SendRequestBehavior> sendBehaviorIterator = sendBehaviors.values().iterator();
+        while (sendBehaviorIterator.hasNext()) {
+            final SendRequestBehavior behavior = sendBehaviorIterator.next();
+            sendBehaviorIterator.remove();
+            behavior.clearCallback();
+        }
+        assertTrue(sendBehaviors.isEmpty());
+
         this.defaultConnectBehavior = null;
-        connectBehaviors.clear();
+        final Iterator<OpenConnectionBehavior> connectBehaviorIterator = connectBehaviors.values().iterator();
+        while (connectBehaviorIterator.hasNext()) {
+            final OpenConnectionBehavior behavior = connectBehaviorIterator.next();
+            connectBehaviorIterator.remove();
+            behavior.clearCallback();
+        }
+        assertTrue(connectBehaviors.isEmpty());
     }
 
     void clearOutboundBehaviors(TransportAddress transportAddress) {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Notify stubbable transport behaviors on clear (#77774)