### PR TITLE
[DOCS] Re-add several query params to search API docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -68,7 +68,8 @@ tag::analyzer[]
 `analyzer`::
 (Optional, string) Analyzer to use for the query string.
 +
-To use this parameter, you must specify the `q` query string parameter.
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::analyzer[]
 
 tag::analyze_wildcard[]
@@ -76,7 +77,8 @@ tag::analyze_wildcard[]
 (Optional, Boolean) If `true`, wildcard and prefix queries are analyzed.
 Defaults to `false`.
 +
-To use this parameter, you must specify the `q` query string parameter.
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::analyze_wildcard[]
 
 tag::bytes[]
@@ -137,7 +139,8 @@ tag::default_operator[]
 (Optional, string) The default operator for query string query: AND or OR.
 Defaults to `OR`.
 +
-To use this parameter, you must specify the `q` query string parameter.
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::default_operator[]
 
 tag::dest[]
@@ -169,7 +172,8 @@ tag::df[]
 (Optional, string) Field to use as default where no field prefix is given in the
 query string.
 +
-To use this parameter, you must specify the `q` query string parameter.
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::df[]
 
 tag::docs-count[]
@@ -538,10 +542,12 @@ end::component-template[]
 
 tag::lenient[]
 `lenient`::
-(Optional, Boolean) If `true`, format-based query failures (such as
-providing text to a numeric field) will be ignored. Defaults to `false`.
+(Optional, Boolean) If `true`, format-based query failures (such as providing
+text to a numeric field) in the query string will be ignored. Defaults to
+`false`.
 +
-To use this parameter, you must specify the `q` query string parameter.
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::lenient[]
 
 tag::level[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -67,12 +67,16 @@ end::allow-no-match-transforms2[]
 tag::analyzer[]
 `analyzer`::
 (Optional, string) Analyzer to use for the query string.
++
+To use this parameter, you must specify the `q` query string parameter.
 end::analyzer[]
 
 tag::analyze_wildcard[]
 `analyze_wildcard`::
-(Optional, Boolean) If `true`, wildcard and prefix queries are
-analyzed. Defaults to `false`.
+(Optional, Boolean) If `true`, wildcard and prefix queries are analyzed.
+Defaults to `false`.
++
+To use this parameter, you must specify the `q` query string parameter.
 end::analyze_wildcard[]
 
 tag::bytes[]
@@ -132,6 +136,8 @@ tag::default_operator[]
 `default_operator`::
 (Optional, string) The default operator for query string query: AND or OR.
 Defaults to `OR`.
++
+To use this parameter, you must specify the `q` query string parameter.
 end::default_operator[]
 
 tag::dest[]
@@ -160,8 +166,10 @@ end::detailed[]
 
 tag::df[]
 `df`::
-(Optional, string) Field to use as default where no field prefix is
-given in the query string.
+(Optional, string) Field to use as default where no field prefix is given in the
+query string.
++
+To use this parameter, you must specify the `q` query string parameter.
 end::df[]
 
 tag::docs-count[]
@@ -532,6 +540,8 @@ tag::lenient[]
 `lenient`::
 (Optional, Boolean) If `true`, format-based query failures (such as
 providing text to a numeric field) will be ignored. Defaults to `false`.
++
+To use this parameter, you must specify the `q` query string parameter.
 end::lenient[]
 
 tag::level[]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -294,19 +294,22 @@ stored fields in the search response.
 * `missing`
 * `popular`
 
-To use this parameter, you must specify the `suggest_field` and `suggest_text`
-query parameters.
+This parameter can only be used when the `suggest_field` and `suggest_text`
+query string parameters are specified.
 --
 
 `suggest_size`::
 (Optional, integer) Number of <<search-suggesters,suggestions>> to return.
 +
-To use this parameter, you must specify the `suggest_field` and `suggest_text`
-query parameters.
+This parameter can only be used when the `suggest_field` and `suggest_text`
+query string parameters are specified.
 
 `suggest_text`::
 (Optional, string) The source text for which the suggestions should be
 returned.
++
+This parameter can only be used when the `suggest_field` query string parameter
+is specified.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -281,6 +281,9 @@ If this field is specified, the `_source` parameter defaults to `false`. You can
 pass `_source: true` to return both source fields and
 stored fields in the search response.
 
+`suggest_field`::
+(Optional, string) Specifies which field to use for suggestions.
+
 `suggest_mode`::
 (Optional, string) Specifies the <<search-suggesters,suggest mode>>. Defaults to
 `missing`. Available options:
@@ -300,9 +303,6 @@ query parameters.
 +
 To use this parameter, you must specify the `suggest_field` and `suggest_text`
 query parameters.
-
-`suggest_field`::
-(Optional, string) Specifies which field to use for suggestions.
 
 `suggest_text`::
 (Optional, string) The source text for which the suggestions should be

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -70,6 +70,10 @@ no partial results. Defaults to `true`.
 To override the default for this field, set the
 `search.default_allow_partial_results` cluster setting to `false`.
 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+
 `batched_reduce_size`::
 (Optional, integer) The number of shard results that should be reduced at once
 on the coordinating node. This value should be used as a protection mechanism
@@ -81,6 +85,10 @@ shards in the request can be large. Defaults to `512`.
 (Optional, Boolean) If `true`, network round-trips between the
 coordinating node and the remote clusters are minimized when executing
 {ccs} (CCS) requests. See <<ccs-network-delays>>. Defaults to `true`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
 
 `docvalue_fields`::
 (Optional, string) A comma-separated list of fields to return as the docvalue
@@ -105,6 +113,8 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 ignored when frozen. Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
 
 `max_concurrent_shard_requests`::
 (Optional, integer) Defines the number of concurrent shard requests per node
@@ -270,6 +280,26 @@ response.
 If this field is specified, the `_source` parameter defaults to `false`. You can
 pass `_source: true` to return both source fields and
 stored fields in the search response.
+
+`suggest_mode`::
+(Optional, string) Specifies the <<search-suggesters,suggest mode>>. Defaults to
+`missing`. Available options:
++
+--
+
+* `always`
+* `missing`
+* `popular`
+
+To use this parameter, you must specify the `suggest_field` and `suggest_text`
+query parameters.
+--
+
+`suggest_size`::
+(Optional, integer) Number of <<search-suggesters,suggestions>> to return.
++
+To use this parameter, you must specify the `suggest_field` and `suggest_text`
+query parameters.
 
 `suggest_field`::
 (Optional, string) Specifies which field to use for suggestions.


### PR DESCRIPTION
PR #55884 removed documentation for several query parameters from the search API
docs. During tests, I failed to notice that these are valid parameters but require other parameters to use.

Changes:

* Notes the following search API parameters require the `q` query string parameter:

  * `analyzer`
  * `analyze_wildcard`
  * `default_operator`
  * `df`
  * `lenient`

* Notes the following search API parameters require the `suggest_field` and `suggest_text` query parameters:

  * `suggest_mode`
  * `suggest_size`

* Re-adds the above parameters to the search API docs.

These changes also affect API documentation that reuses the search API parameters:

* Delete by query API
* Update by query API
* Count API
* Explain API
* Validate API

Closes #79674

### Preview
https://elasticsearch_79716.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-search.html#search-search-api-query-params