### PR TITLE
Addressing assertion failure, 'downgrading' to exception - enrich

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -127,11 +127,10 @@ public class EnrichPolicyRunner implements Runnable {
         client.admin().indices().getIndex(getIndexRequest, listener.delegateFailure((l, getIndexResponse) -> {
             try {
                 validateMappings(getIndexResponse);
+                prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
             } catch (Exception e) {
                 l.onFailure(e);
-                return;
             }
-            prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
         }));
     }
 


### PR DESCRIPTION
Addressing assertion failure, 'downgrading' to exception by moving call to try catch. Fixes "java.lang.AssertionError: java.lang.AssertionError: callback must handle its own exceptions"

Discovered in https://github.com/elastic/elasticsearch/pull/79607