### PR TITLE
[7.16] Addressing assertion failure, 'downgrading' to Exception - enrich (#79717)

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -127,11 +127,10 @@ public class EnrichPolicyRunner implements Runnable {
         client.admin().indices().getIndex(getIndexRequest, listener.delegateFailure((l, getIndexResponse) -> {
             try {
                 validateMappings(getIndexResponse);
+                prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
             } catch (Exception e) {
                 l.onFailure(e);
-                return;
             }
-            prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
         }));
     }
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Addressing assertion failure, 'downgrading' to Exception - enrich (#79717)