### PR TITLE
[7.16] Add jdk internal package for mocking (#79715)

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -13,6 +13,7 @@
 grant codeBase "${codebase.mockito-core}" {
   // needed to access ReflectionFactory (see below)
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
   // needed for reflection in ibm jdk
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
   // needed to support creation of mocks
@@ -29,6 +30,7 @@ grant codeBase "${codebase.byte-buddy}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "net.bytebuddy.createJavaDispatcher";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.utility";
   permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.dynamic.loading";
@@ -39,6 +41,7 @@ grant codeBase "${codebase.byte-buddy}" {
 grant codeBase "${codebase.objenesis}" {
   permission java.lang.RuntimePermission "reflectionFactoryAccess";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ql.tree;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.PathUtils;
@@ -89,7 +88,6 @@ import static org.mockito.Mockito.mock;
  * node of that type is called for.
  * </ul>
  */
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79704")
 public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCase {
 
     private static final List<Class<?>> CLASSES_WITH_MIN_TWO_CHILDREN = asList(In.class, InPipe.class);


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Add jdk internal package for mocking (#79715)