### PR TITLE
[7.6] [DOCS] Re-add several query params to search API docs (#79716)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -96,12 +96,18 @@ end::allow-no-match-transforms2[]
 tag::analyzer[]
 `analyzer`::
 (Optional, string) Analyzer to use for the query string.
++
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::analyzer[]
 
 tag::analyze_wildcard[]
 `analyze_wildcard`::
 (Optional, boolean) If `true`, wildcard and prefix queries are 
 analyzed. Defaults to `false`.
++
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::analyze_wildcard[]
 
 tag::bytes[]
@@ -148,6 +154,9 @@ tag::default_operator[]
 `default_operator`::
 (Optional, string) The default operator for query string query: AND or OR. 
 Defaults to `OR`.
++
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::default_operator[]
 
 tag::dest[]
@@ -172,8 +181,11 @@ end::detailed[]
 
 tag::df[]
 `df`::
-(Optional, string) Field to use as default where no field prefix is 
-given in the query string.
+(Optional, string) Field to use as default where no field prefix is given in the
+query string.
++
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::df[]
 
 tag::docs-count[]
@@ -487,8 +499,12 @@ end::index-template[]
 
 tag::lenient[]
 `lenient`::
-(Optional, boolean) If `true`, format-based query failures (such as 
-providing text to a numeric field) will be ignored. Defaults to `false`.
+(Optional, Boolean) If `true`, format-based query failures (such as providing
+text to a numeric field) in the query string will be ignored. Defaults to
+`false`.
++
+This parameter can only be used when the `q` query string parameter is
+specified.
 end::lenient[]
 
 tag::level[]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -54,6 +54,10 @@ no partial results. Defaults to `true`.
 To override the default for this field, set the 
 `search.default_allow_partial_results` cluster setting to `false`.
 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+
 `batched_reduce_size`::
   (Optional, integer) The number of shard results that should be reduced at once
   on the coordinating node. This value should be used as a protection mechanism
@@ -65,6 +69,10 @@ To override the default for this field, set the
 (Optional, boolean) If `true`, network round-trips between the 
 coordinating node and the remote clusters are minimized when executing 
 {ccs} (CCS) requests. See <<ccs-network-delays>>. Defaults to `true`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
 
 `docvalue_fields`::
   (Optional, string) A comma-separated list of fields to return as the docvalue
@@ -101,6 +109,8 @@ both parameters are specified, only the query parameter is used.
   ignored when throttled. Defaults to `false`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
 
 `max_concurrent_shard_requests`::
   (Optional, integer) Defines the number of concurrent shard requests per node
@@ -203,9 +213,32 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
 `suggest_field`::
   (Optional, string) Specifies which field to use for suggestions.
 
+`suggest_mode`::
+(Optional, string) Specifies the <<search-suggesters,suggest mode>>. Defaults to
+`missing`. Available options:
++
+--
+
+* `always`
+* `missing`
+* `popular`
+
+This parameter can only be used when the `suggest_field` and `suggest_text`
+query string parameters are specified.
+--
+
+`suggest_size`::
+(Optional, integer) Number of <<search-suggesters,suggestions>> to return.
++
+This parameter can only be used when the `suggest_field` and `suggest_text`
+query string parameters are specified.
+
 `suggest_text`::
-  (Optional, string) The source text for which the suggestions should be
-  returned.
+(Optional, string) The source text for which the suggestions should be
+returned.
++
+This parameter can only be used when the `suggest_field` query string parameter
+is specified.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [DOCS] Re-add several query params to search API docs (#79716)