### PR TITLE
[DOCS] ILM: Add ESS/ECE instructions for migrating to node roles

### DIFF
--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -26,9 +26,8 @@ higher, deploy a warm or cold data tier, or enable
 autoscaling.  This action automatically updates your configuration
 and {ilm-init} policies to use node roles.
 
-If you have created custom index template, then check those templates
-after the automated migration and remove <<shard-allocation-filtering,
-attribute-based allocation filters>> if any are specified.
+If you use custom index templates, check them after the automatic migration completes and remove any <<shard-allocation-filtering,
+attribute-based allocation filters>>.
 
 NOTE: You do not need to take any further action after the automatic migration. The following manual steps are only necessary if you do not allow the automatic migration or have a self-managed deployment.
 

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -20,12 +20,11 @@ control shard allocation for other purposes.
 
 [discrete]
 === Automatically migrating to node roles on {ess} or {ece}
-If you are using {ess} or {ece} and are using node attributes you will be
+If you are using node attributes on {ess} or {ece}, you will be
 prompted to switch to node roles when you upgrade to version 7.10 or
-higher, when you deploy a warm or cold data tier, or when you enable
-autoscaling.  Any of these actions will automatically update your
-deployment to use node roles and update your {ilm-init} policies to use the node
-roles instead of node annotations.
+higher, deploy a warm or cold data tier, or enable
+autoscaling.  This action automatically updates your configuration
+and {ilm-init} policies to use node roles.
 
 If you have created custom index template, then check those templates
 after the automated migration and remove <<shard-allocation-filtering,

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -21,7 +21,9 @@ deployments, you need to manually update your configuration, ILM policies, and
 indices to switch to node roles. 
 
 [discrete]
+[[cloud-migrate-to-node-roles]]
 === Automatically migrate to node roles on {ess} or {ece}
+
 If you are using node attributes on {ess} or {ece}, you will be
 prompted to switch to node roles when you:
 

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -23,9 +23,13 @@ indices to switch to node roles.
 [discrete]
 === Automatically migrate to node roles on {ess} or {ece}
 If you are using node attributes on {ess} or {ece}, you will be
-prompted to switch to node roles when you upgrade to version 7.10 through
-7.13, deploy a warm, cold, or frozen data tier, or enable
-autoscaling.  This action automatically updates your configuration
+prompted to switch to node roles when you:
+
+* Upgrade to {es} 7.10 or higher
+* Deploy a warm, cold, or frozen data tier
+* {cloud}/ec-autoscaling.html[Enable autoscaling]
+
+These actions automatically update your cluster configuration
 and {ilm-init} policies to use node roles. Additionally, upgrading to
 version 7.14 or higher will automatically update {ilm-init} policies
 when there is any new plan change applied to your deployment.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -21,7 +21,7 @@ deployments, you need to manually update your configuration, ILM policies, and
 indices to switch to node roles. 
 
 [discrete]
-=== Automatically migrating to node roles on {ess} or {ece}
+=== Automatically migrate to node roles on {ess} or {ece}
 If you are using node attributes on {ess} or {ece}, you will be
 prompted to switch to node roles when you upgrade to version 7.10 through
 7.13, deploy a warm, cold, or frozen data tier, or enable

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -44,7 +44,10 @@ The following manual steps are only necessary if you do not allow the automatic
 migration or have a self-managed deployment.
 
 [discrete]
-=== Manually migrating to node roles on self-managed deployments
+[[on-prem-migrate-to-node-roles]]
+=== Migrate to node roles on self-managed deployments
+
+To switch to using node roles:
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
 . <<remove-custom-allocation-settings, Remove the attribute-based allocation

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -35,7 +35,7 @@ By allowing the upgrade process to migrate your deployment you can skip
 the manual steps presented below. 
 
 [discrete]
-== Manual method to switch to using node roles for self-managed {es}:
+=== Manually migrating to node roles on self-managed deployments
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
 . <<remove-custom-allocation-settings, Remove the attribute-based allocation

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -38,7 +38,9 @@ when there is any new plan change applied to your deployment.
 If you use custom index templates, check them after the automatic migration completes and remove any <<shard-allocation-filtering,
 attribute-based allocation filters>>.
 
-NOTE: You do not need to take any further action after the automatic migration. The following manual steps are only necessary if you do not allow the automatic migration or have a self-managed deployment.
+NOTE: You do not need to take any further action after the automatic migration.
+The following manual steps are only necessary if you do not allow the automatic
+migration or have a self-managed deployment.
 
 [discrete]
 === Manually migrating to node roles on self-managed deployments

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -21,10 +21,13 @@ control shard allocation for other purposes.
 [discrete]
 === Automatically migrating to node roles on {ess} or {ece}
 If you are using node attributes on {ess} or {ece}, you will be
-prompted to switch to node roles when you upgrade to version 7.10 or
-higher, deploy a warm or cold data tier, or enable
+prompted to switch to node roles when you upgrade to version 7.10 through
+7.13, deploy a warm, cold, or frozen data tier, or enable
 autoscaling.  This action automatically updates your configuration
-and {ilm-init} policies to use node roles.
+and {ilm-init} policies to use node roles. Additionally, upgrading to
+version 7.14 or higher will automatically update {ilm-init} policies
+when there is any new plan change applied to your deployment.
+
 
 If you use custom index templates, check them after the automatic migration completes and remove any <<shard-allocation-filtering,
 attribute-based allocation filters>>.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -16,8 +16,7 @@ your data in a hot-warm-cold architecture,
 you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
-There are two methods to switch to using node roles, an automated method
-for {ess} or {ece}, and a manual method for self-managed {es}:
+{ess} and {ece} can perform the migration automatically. For self-managed deployements, you need to manually update your configuration, ILM policies, and indices to switch to using node roles. 
 
 [discrete]
 == Automated method for {ess} or {ece}

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -30,8 +30,7 @@ If you have created custom index template, then check those templates
 after the automated migration and remove <<shard-allocation-filtering,
 attribute-based allocation filters>> if any are specified.
 
-By allowing the upgrade process to migrate your deployment you can skip
-the manual steps presented below. 
+NOTE: You do not need to take any further action after the automatic migration. The following manual steps are only necessary if you do not allow the automatic migration or have a self-managed deployment.
 
 [discrete]
 === Manually migrating to node roles on self-managed deployments

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -32,7 +32,7 @@ prompted to switch to node roles when you:
 These actions automatically update your cluster configuration
 and {ilm-init} policies to use node roles. Additionally, upgrading to
 version 7.14 or higher automatically update {ilm-init} policies
-when there is any new plan change applied to your deployment.
+whenever any configuration change is applied to your deployment.
 
 
 If you use custom index templates, check them after the automatic migration

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -35,8 +35,9 @@ version 7.14 or higher will automatically update {ilm-init} policies
 when there is any new plan change applied to your deployment.
 
 
-If you use custom index templates, check them after the automatic migration completes and remove any <<shard-allocation-filtering,
-attribute-based allocation filters>>.
+If you use custom index templates, check them after the automatic migration
+completes and remove any <<shard-allocation-filtering, attribute-based
+allocation filters>>.
 
 NOTE: You do not need to take any further action after the automatic migration.
 The following manual steps are only necessary if you do not allow the automatic

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -31,7 +31,7 @@ prompted to switch to node roles when you:
 
 These actions automatically update your cluster configuration
 and {ilm-init} policies to use node roles. Additionally, upgrading to
-version 7.14 or higher will automatically update {ilm-init} policies
+version 7.14 or higher automatically update {ilm-init} policies
 when there is any new plan change applied to your deployment.
 
 

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -47,7 +47,7 @@ on new indices.
 
 [discrete]
 [[assign-data-tier]]
-=== Assign data nodes to a data tier
+==== Assign data nodes to a data tier
 
 Configure the appropriate roles for each data node to assign it to one or more
 data tiers: `data_hot`, `data_content`, `data_warm`, `data_cold`, or `data_frozen`.
@@ -85,7 +85,7 @@ node.roles [ data_hot, data_content ]
 
 [discrete]
 [[remove-custom-allocation-settings]]
-=== Remove custom allocation settings from existing {ilm-init} policies
+==== Remove custom allocation settings from existing {ilm-init} policies
 
 Update the allocate action for each lifecycle phase to remove the attribute-based
 allocation settings. {ilm-init} will inject a
@@ -104,7 +104,7 @@ your policy must include the hot, warm, and cold phases.
 
 [discrete]
 [[stop-setting-custom-hot-attribute]]
-=== Stop setting the custom hot attribute on new indices
+==== Stop setting the custom hot attribute on new indices
 
 When you create a data stream, its first backing index
 is now automatically assigned to `data_hot` nodes.
@@ -124,7 +124,7 @@ If you're using a custom index template, update it to remove the <<shard-allocat
 
 [discrete]
 [[set-tier-preference]]
-=== Set a tier preference for existing indices.
+==== Set a tier preference for existing indices.
 
 {ilm-init} automatically transitions managed indices through the available
 data tiers by automatically injecting a <<ilm-migrate,migrate action>>

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -119,8 +119,6 @@ DELETE _template/.cloud-hot-warm-allocation-0
 
 If you're using a custom index template, update it to remove the <<shard-allocation-filtering, attribute-based allocation filters>> you used to assign new indices to the hot tier.
 
-Check all of your custom index templates and update them to remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
-
 [discrete]
 [[set-tier-preference]]
 === Set a tier preference for existing indices.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -16,7 +16,9 @@ your data in a hot-warm-cold architecture,
 you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
-{ess} and {ece} can perform the migration automatically. For self-managed deployements, you need to manually update your configuration, ILM policies, and indices to switch to using node roles. 
+{ess} and {ece} can perform the migration automatically. For self-managed
+deployments, you need to manually update your configuration, ILM policies, and
+indices to switch to node roles. 
 
 [discrete]
 === Automatically migrating to node roles on {ess} or {ece}

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -19,7 +19,7 @@ control shard allocation for other purposes.
 {ess} and {ece} can perform the migration automatically. For self-managed deployements, you need to manually update your configuration, ILM policies, and indices to switch to using node roles. 
 
 [discrete]
-== Automated method for {ess} or {ece}
+=== Automatically migrating to node roles on {ess} or {ece}
 If you are using {ess} or {ece} and are using node attributes you will be
 prompted to switch to node roles when you upgrade to version 7.10 or
 higher, when you deploy a warm or cold data tier, or when you enable

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -16,17 +16,27 @@ your data in a hot-warm-cold architecture,
 you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
-NOTE: If you are using Elasticsearch Service or Elastic Cloud Enterprise and are 
+There are two methods to switch to using node roles, an automated method
+for Elasticsearch Service or Elastic Cloud Enterprise, and a manual method
+for self-managed Elasticsearch:
+
+[discrete]
+== Automated method for Elasticsearch Service or Elastic Cloud Enterprise
+If you are using Elasticsearch Service or Elastic Cloud Enterprise and are 
 using node attributes you will be prompted to switch to node roles when you
 upgrade to version 7.10 or higher, when you deploy a warm or cold data tier,
 or when you enable autoscaling.  Any of these actions will automatically
 update your deployment to use node roles and update your index lifecycle
 managment (ILM) policies to use the node roles instead of node annotations.
-Check all of your custom index templates and update them to remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
-By allowing the upgrade process to migrate your deployment you can skip the manual 
-steps presented below. 
 
-To switch to using node roles:
+If you have created custom index template, then check those templates after 
+the automated migration and remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
+
+By allowing the upgrade process to migrate your deployment you can skip
+the manual steps presented below. 
+
+[discrete]
+== Manual method to switch to using node roles for self-manageed Elasticsearch:
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
 . <<remove-custom-allocation-settings, Remove the attribute-based allocation

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -17,26 +17,26 @@ you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
 There are two methods to switch to using node roles, an automated method
-for Elasticsearch Service or Elastic Cloud Enterprise, and a manual method
-for self-managed Elasticsearch:
+for {ess} or {ece}, and a manual method for self-managed {es}:
 
 [discrete]
-== Automated method for Elasticsearch Service or Elastic Cloud Enterprise
-If you are using Elasticsearch Service or Elastic Cloud Enterprise and are 
-using node attributes you will be prompted to switch to node roles when you
-upgrade to version 7.10 or higher, when you deploy a warm or cold data tier,
-or when you enable autoscaling.  Any of these actions will automatically
-update your deployment to use node roles and update your index lifecycle
-managment (ILM) policies to use the node roles instead of node annotations.
+== Automated method for {ess} or {ece}
+If you are using {ess} or {ece} and are using node attributes you will be
+prompted to switch to node roles when you upgrade to version 7.10 or
+higher, when you deploy a warm or cold data tier, or when you enable
+autoscaling.  Any of these actions will automatically update your
+deployment to use node roles and update your {ilm-init} policies to use the node
+roles instead of node annotations.
 
-If you have created custom index template, then check those templates after 
-the automated migration and remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
+If you have created custom index template, then check those templates
+after the automated migration and remove <<shard-allocation-filtering,
+attribute-based allocation filters>> if any are specified.
 
 By allowing the upgrade process to migrate your deployment you can skip
 the manual steps presented below. 
 
 [discrete]
-== Manual method to switch to using node roles for self-manageed Elasticsearch:
+== Manual method to switch to using node roles for self-managed {es}:
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
 . <<remove-custom-allocation-settings, Remove the attribute-based allocation

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -16,6 +16,16 @@ your data in a hot-warm-cold architecture,
 you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
+NOTE: If you are using Elasticsearch Service or Elastic Cloud Enterprise and are 
+using node attributes you will be prompted to switch to node roles when you
+upgrade to version 7.10 or higher, when you deploy a warm or cold data tier,
+or when you enable autoscaling.  Any of these actions will automatically
+update your deployment to use node roles and update your index lifecycle
+managment (ILM) policies to use the node roles instead of node annotations.
+Check all of your custom index templates and update them to remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
+By allowing the upgrade process to migrate your deployment you can skip the manual 
+steps presented below. 
+
 To switch to using node roles:
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
@@ -102,6 +112,8 @@ DELETE _template/.cloud-hot-warm-allocation-0
 // TEST[skip:no cloud template]
 
 If you're using a custom index template, update it to remove the <<shard-allocation-filtering, attribute-based allocation filters>> you used to assign new indices to the hot tier.
+
+Check all of your custom index templates and update them to remove <<shard-allocation-filtering, attribute-based allocation filters>> if any are specified.
 
 [discrete]
 [[set-tier-preference]]


### PR DESCRIPTION
This PR adds documentation informing the reader about how the Elasticsearch Service / Elastic Cloud Enterprise upgrade process and autoscaling system automate the migration of the Elasticsearch nodes and ILM policies to using node.roles rather than filtering on node attributes.

Upgrading from Stack 7.7 to 7.15 in both Elasticsearch Service and Elastic Cloud Enterprise was tested, both with and without allowing the upgrade to automatically migrate to node roles.  Both environments were also tested with and without autoscaling.  Finally, a non-default index template which included the use of node attributes was tested with @stefnestor .  All of the test scenarios passed.

Here is a screenshot highlighting the changes (updated with feedback from Deb and Mario):
<img width="656" alt="image" src="https://user-images.githubusercontent.com/25182304/138967429-9b102b54-e2f8-4236-81a0-c9259a2e2e07.png">
