### PR TITLE
[ML] track inference model feature usage per node

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -406,13 +406,13 @@ public class XPackLicenseState {
         usage.put(new FeatureUsage(feature, null), epochMillisProvider.getAsLong());
     }
 
-    public void enableUsageTracking(LicensedFeature feature, String contextName) {
+    void enableUsageTracking(LicensedFeature feature, String contextName) {
         checkExpiry();
         Objects.requireNonNull(contextName, "Context name cannot be null");
         usage.put(new FeatureUsage(feature, contextName), -1L);
     }
 
-    public void disableUsageTracking(LicensedFeature feature, String contextName) {
+    void disableUsageTracking(LicensedFeature feature, String contextName) {
         Objects.requireNonNull(contextName, "Context name cannot be null");
         usage.replace(new FeatureUsage(feature, contextName), -1L, epochMillisProvider.getAsLong());
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -406,13 +406,13 @@ public class XPackLicenseState {
         usage.put(new FeatureUsage(feature, null), epochMillisProvider.getAsLong());
     }
 
-    void enableUsageTracking(LicensedFeature feature, String contextName) {
+    public void enableUsageTracking(LicensedFeature feature, String contextName) {
         checkExpiry();
         Objects.requireNonNull(contextName, "Context name cannot be null");
         usage.put(new FeatureUsage(feature, contextName), -1L);
     }
 
-    void disableUsageTracking(LicensedFeature feature, String contextName) {
+    public void disableUsageTracking(LicensedFeature feature, String contextName) {
         Objects.requireNonNull(contextName, "Context name cannot be null");
         usage.replace(new FeatureUsage(feature, contextName), -1L, epochMillisProvider.getAsLong());
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -468,6 +468,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         "model-inference",
         License.OperationMode.PLATINUM
     );
+    public static final LicensedFeature.Persistent ML_PYTORCH_MODEL_INFERENCE_FEATURE = LicensedFeature.persistent(
+        MachineLearningField.ML_FEATURE_FAMILY,
+        "pytorch-model-inference",
+        License.OperationMode.PLATINUM
+    );
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCreateTrainedModelAllocationAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCreateTrainedModelAllocationAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -40,7 +41,8 @@ public class TransportCreateTrainedModelAllocationAction extends TransportMaster
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        XPackLicenseState licenseState
     ) {
         super(
             CreateTrainedModelAllocationAction.NAME,
@@ -62,7 +64,8 @@ public class TransportCreateTrainedModelAllocationAction extends TransportMaster
                 clusterService,
                 deploymentManager,
                 transportService.getTaskManager(),
-                threadPool
+                threadPool,
+                licenseState
             )
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ALLOCATION_TASK_NAME_PREFIX;
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ALLOCATION_TASK_TYPE;
+import static org.elasticsearch.xpack.ml.MachineLearning.ML_PYTORCH_MODEL_INFERENCE_FEATURE;
 
 public class TrainedModelAllocationNodeService implements ClusterStateListener {
 
@@ -279,7 +280,8 @@ public class TrainedModelAllocationNodeService implements ClusterStateListener {
                     headers,
                     params,
                     trainedModelAllocationNodeService,
-                    licenseState
+                    licenseState,
+                    ML_PYTORCH_MODEL_INFERENCE_FEATURE
                 );
             }
         };

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -57,11 +57,11 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
             "trainedModelAllocationNodeService"
         );
         this.licenseState = licenseState;
-        ML_MODEL_INFERENCE_FEATURE.startTracking(licenseState, "model-" + taskParams.getModelId());
     }
 
     void init(InferenceConfig inferenceConfig) {
         this.inferenceConfig.set(inferenceConfig);
+        ML_MODEL_INFERENCE_FEATURE.startTracking(licenseState, "model-" + params.getModelId());
     }
 
     public String getModelId() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
@@ -507,7 +508,8 @@ public class TrainedModelAllocationNodeServiceTests extends ESTestCase {
             deploymentManager,
             taskManager,
             threadPool,
-            NODE_ID
+            NODE_ID,
+            mock(XPackLicenseState.class)
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
+import org.elasticsearch.xpack.ml.inference.allocation.TrainedModelAllocationNodeService;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ALLOCATION_TASK_NAME_PREFIX;
+import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ALLOCATION_TASK_TYPE;
+import static org.elasticsearch.xpack.ml.MachineLearning.ML_MODEL_INFERENCE_FEATURE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TrainedModelDeploymentTaskTests extends ESTestCase {
+
+    void assertTrackingComplete(Consumer<TrainedModelDeploymentTask> method, String modelId) {
+        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        TrainedModelDeploymentTask task = new TrainedModelDeploymentTask(
+            0,
+            TRAINED_MODEL_ALLOCATION_TASK_TYPE,
+            TRAINED_MODEL_ALLOCATION_TASK_NAME_PREFIX + modelId,
+            TaskId.EMPTY_TASK_ID,
+            Map.of(),
+            new StartTrainedModelDeploymentAction.TaskParams(
+                modelId,
+                randomLongBetween(1, Long.MAX_VALUE),
+                randomInt(5),
+                randomInt(5),
+                randomInt(5)
+            ),
+            mock(TrainedModelAllocationNodeService.class),
+            licenseState);
+
+        task.init(new PassThroughConfig(null, null, null));
+        verify(licenseState, times(1)).enableUsageTracking(ML_MODEL_INFERENCE_FEATURE, "model-" + modelId);
+        method.accept(task);
+        verify(licenseState, times(1)).disableUsageTracking(ML_MODEL_INFERENCE_FEATURE, "model-" + modelId);
+    }
+
+    public void testOnStopWithoutNotification() {
+        assertTrackingComplete(t -> t.stopWithoutNotification("foo"), randomAlphaOfLength(10));
+    }
+
+    public void testOnStop() {
+        assertTrackingComplete(t -> t.stop("foo"), randomAlphaOfLength(10));
+    }
+
+    public void testCancelled() {
+        assertTrackingComplete(TrainedModelDeploymentTask::onCancelled, randomAlphaOfLength(10));
+    }
+
+}


### PR DESCRIPTION
This adds feature usage tracking for deployed inference models. The models are tracked under the existing, inference feature and contain context related to the model ID.

I decided to track the feature via the allocation task to keep the logic similar between allocation tasks and licensed persistent tasks.

closes: https://github.com/elastic/elasticsearch/issues/76452