### PR TITLE
[7.16] Fix formatting bwc project excludes (#79743)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -117,7 +117,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
         ":client:transport",
         ":distribution:archives:integ-test-zip",
         ":distribution:bwc:bugfix",
-        ":distribution:bwc:bugfix",
+        ":distribution:bwc:maintenance",
         ":distribution:bwc:minor",
         ":distribution:bwc:staged",
         ":distribution:docker",


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Fix formatting bwc project excludes (#79743)