### PR TITLE
[DOCS] Edits formatting in create trained models API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -373,19 +373,17 @@ An array of `trained_model` objects. Supported trained models are `tree` and
 (Optional, string)
 A human-readable description of the {infer} trained model.
 
-`estimated_heap_memory_usage_bytes`:::
+`estimated_heap_memory_usage_bytes`::
 (Optional, integer)
-The estimated heap usage in bytes to keep the trained model in memory.
-
-Can only be supplied if `defer_definition_decompression` is `true` or the
+The estimated heap usage in bytes to keep the trained model in memory. This
+property is supported only if `defer_definition_decompression` is `true` or the
 model definition is not supplied.
 
 `estimated_operations`:::
 (Optional, integer)
 The estimated number of operations to use the trained model during inference.
-
-Can only be supplied if `defer_definition_decompression` is `true` or the
-model definition is not supplied.
+This property is supported only if `defer_definition_decompression` is `true` or
+the model definition is not supplied.
 
 //Begin inference_config
 `inference_config`::

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -379,7 +379,7 @@ The estimated heap usage in bytes to keep the trained model in memory. This
 property is supported only if `defer_definition_decompression` is `true` or the
 model definition is not supplied.
 
-`estimated_operations`:::
+`estimated_operations`::
 (Optional, integer)
 The estimated number of operations to use the trained model during inference.
 This property is supported only if `defer_definition_decompression` is `true` or


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/78376

This PR fixes minor formatting issues in the [create trained models API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html)

In particular, it fixes the indentation and small wording changes here:
![image](https://user-images.githubusercontent.com/26471269/138771407-c3d54989-66a3-45ba-a657-cf453395a8b0.png)

### Preview

https://elasticsearch_79758.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models.html