### PR TITLE
[7.16] Add deprecation headers to HLRC classes (#79754)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchClient.java
@@ -19,6 +19,13 @@ import java.io.IOException;
 
 import static java.util.Collections.emptySet;
 
+/**
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
+ */
+@Deprecated
+@SuppressWarnings("removal")
 public class AsyncSearchClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrClient.java
@@ -39,7 +39,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-apis.html">
  * X-Pack Rollup APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class CcrClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
@@ -34,7 +34,13 @@ import static java.util.Collections.singleton;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Cluster API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html">Cluster API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class ClusterClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichClient.java
@@ -27,7 +27,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-apis.html">
  * X-Pack Enrich Policy APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class EnrichClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/EqlClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/EqlClient.java
@@ -23,7 +23,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html">
  * EQL APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class EqlClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesClient.java
@@ -22,7 +22,13 @@ import static java.util.Collections.emptySet;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Snapshot API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/features-apis.html">Snapshot API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public class FeaturesClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphClient.java
@@ -16,7 +16,13 @@ import java.io.IOException;
 
 import static java.util.Collections.emptySet;
 
-
+/**
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
+ */
+@Deprecated
+@SuppressWarnings("removal")
 public class GraphClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -40,6 +40,13 @@ import java.io.IOException;
 
 import static java.util.Collections.emptySet;
 
+/**
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
+ */
+@Deprecated
+@SuppressWarnings("removal")
 public class IndexLifecycleClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
@@ -82,7 +82,13 @@ import static java.util.Collections.singleton;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Indices API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html">Indices API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class IndicesClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestClient.java
@@ -27,7 +27,13 @@ import static java.util.Collections.emptySet;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Ingest API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html">Ingest API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class IngestClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
@@ -45,7 +45,13 @@ import static java.util.Collections.singleton;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/licensing-apis.html">
  * X-Pack Licensing APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class LicenseClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
@@ -125,7 +125,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html">
  * X-Pack Machine Learning APIs </a> for additional information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class MachineLearningClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationClient.java
@@ -25,7 +25,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api.html">
  * X-Pack Migration APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class MigrationClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -250,7 +250,12 @@ import static java.util.stream.Collectors.toList;
  * {@link ResponseException}</li>
  * </ul>
  *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public class RestHighLevelClient implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(RestHighLevelClient.class);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClientBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClientBuilder.java
@@ -18,8 +18,12 @@ import java.util.List;
 /**
  * Helper to build a {@link RestHighLevelClient}, allowing setting the low-level client that
  * should be used as well as whether API compatibility should be used.
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
-
+@Deprecated
+@SuppressWarnings("removal")
 public class RestHighLevelClientBuilder {
     private final RestClient restClient;
     private CheckedConsumer<RestClient, IOException> closeHandler = RestClient::close;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupClient.java
@@ -34,7 +34,13 @@ import java.util.Collections;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/rollup-apis.html">
  * X-Pack Rollup APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public class RollupClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SearchableSnapshotsClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SearchableSnapshotsClient.java
@@ -23,7 +23,13 @@ import java.util.Objects;
  *
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html">Searchable Snapshots
  * APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public class SearchableSnapshotsClient {
 
     private RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityClient.java
@@ -88,7 +88,13 @@ import static java.util.Collections.singleton;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Security APIs.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api.html">Security APIs on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class SecurityClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotClient.java
@@ -37,7 +37,13 @@ import static java.util.Collections.emptySet;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Snapshot API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html">Snapshot API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class SnapshotClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksClient.java
@@ -25,7 +25,13 @@ import static java.util.Collections.emptySet;
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Tasks API.
  * <p>
  * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html">Task Management API on elastic.co</a>
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class TasksClient {
     private final RestHighLevelClient restHighLevelClient;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TextStructureClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TextStructureClient.java
@@ -7,12 +7,12 @@
  */
 package org.elasticsearch.client;
 
-import java.io.IOException;
-import java.util.Collections;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.textstructure.FindStructureRequest;
 import org.elasticsearch.client.textstructure.FindStructureResponse;
+
+import java.io.IOException;
+import java.util.Collections;
 
 
 /**
@@ -20,7 +20,13 @@ import org.elasticsearch.client.textstructure.FindStructureResponse;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/find-structure.html">
  * X-Pack Text Structure APIs </a> for additional information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class TextStructureClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformClient.java
@@ -28,6 +28,13 @@ import org.elasticsearch.client.transform.UpdateTransformResponse;
 import java.io.IOException;
 import java.util.Collections;
 
+/**
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
+ */
+@Deprecated
+@SuppressWarnings("removal")
 public final class TransformClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherClient.java
@@ -33,6 +33,13 @@ import java.io.IOException;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
+/**
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
+ */
+@Deprecated
+@SuppressWarnings("removal")
 public final class WatcherClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackClient.java
@@ -26,7 +26,13 @@ import static java.util.Collections.emptySet;
  * <p>
  * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html">
  * REST APIs on elastic.co</a> for more information.
+ *
+ * @deprecated The High Level Rest Client is deprecated in favor of the
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
+ * Elasticsearch Java API Client</a>
  */
+@Deprecated
+@SuppressWarnings("removal")
 public final class XPackClient {
 
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
@@ -60,6 +60,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class CCRIT extends ESRestHighLevelClientTestCase {
 
     @Before

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test and demonstrates how {@link RestHighLevelClient} can be extended to support custom endpoints.
  */
+@SuppressWarnings("removal")
 public class CustomRestHighLevelClientTests extends ESTestCase {
 
     private static final String ENDPOINT = "/_custom";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -61,6 +61,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings("removal")
 public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
 
     public static final String IGNORE_THROTTLED_DEPRECATION_WARNING = "[ignore_throttled] parameter is deprecated because frozen " +

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings("removal")
 public class EnrichIT extends ESRestHighLevelClientTestCase {
 
     public void testCRUD() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EqlIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EqlIT.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
+@SuppressWarnings("removal")
 public class EqlIT extends ESRestHighLevelClientTestCase {
 
     private static final String INDEX_NAME = "index";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings("removal")
 public class FeaturesIT extends ESRestHighLevelClientTestCase {
     public void testGetFeatures() throws IOException {
         GetFeaturesRequest request = new GetFeaturesRequest();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -147,6 +147,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
+@SuppressWarnings("removal")
 public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
     public static final RequestOptions LEGACY_TEMPLATE_OPTIONS = RequestOptions.DEFAULT.toBuilder()

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningGetResultsIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningGetResultsIT.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class MachineLearningGetResultsIT extends ESRestHighLevelClientTestCase {
 
     private static final String RESULTS_INDEX = ".ml-anomalies-shared";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -220,6 +220,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
     private static final RequestOptions POST_DATA_OPTIONS = RequestOptions.DEFAULT.toBuilder()

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MlTestStateCleaner.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MlTestStateCleaner.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 /**
  * Cleans up ML resources created during tests
  */
+@SuppressWarnings("removal")
 public class MlTestStateCleaner {
 
     private final Logger logger;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MockRestHighLevelTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MockRestHighLevelTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("removal")
 public class MockRestHighLevelTests extends ESTestCase {
     private RestHighLevelClient client;
     private static final List<String> WARNINGS = Collections.singletonList("Some Warning");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
  * This test works against a {@link RestHighLevelClient} subclass that simulates how custom response sections returned by
  * Elasticsearch plugins can be parsed using the high level client.
  */
+@SuppressWarnings("removal")
 public class RestHighLevelClientExtTests extends ESTestCase {
 
     private RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -160,6 +160,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("removal")
 public class RestHighLevelClientTests extends ESTestCase {
 
     private static final String SUBMIT_TASK_PREFIX = "submit_";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
@@ -71,6 +71,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 
+@SuppressWarnings("removal")
 public class RollupIT extends ESRestHighLevelClientTestCase {
 
     double sum = 0.0d;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchableSnapshotsIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchableSnapshotsIT.java
@@ -49,6 +49,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings("removal")
 public class SearchableSnapshotsIT extends ESRestHighLevelClientTestCase {
 
     @Before

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class SecurityIT extends ESRestHighLevelClientTestCase {
 
     public void testPutUser() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TextStructureIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TextStructureIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.textstructure.FindStructureRequest;
 import org.elasticsearch.client.textstructure.FindStructureResponse;
 import org.elasticsearch.client.textstructure.structurefinder.TextStructure;
 
+@SuppressWarnings("removal")
 public class TextStructureIT extends ESRestHighLevelClientTestCase {
 
     public void testFindFileStructure() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformIT.java
@@ -75,6 +75,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
+@SuppressWarnings("removal")
 public class TransformIT extends ESRestHighLevelClientTestCase {
 
     private List<String> transformsToClean = new ArrayList<>();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/AsyncSearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/AsyncSearchDocumentationIT.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
  * Documentation for Async Search APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class AsyncSearchDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @Before void setUpIndex() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CCRDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CCRDocumentationIT.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class CCRDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @Before

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -95,6 +95,7 @@ import static org.hamcrest.Matchers.not;
  * Documentation for CRUD APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @SuppressWarnings("unused")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ClusterClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ClusterClientDocumentationIT.java
@@ -62,6 +62,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * Documentation for Cluster APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class ClusterClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testClusterPutSettings() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/EnrichDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/EnrichDocumentationIT.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonMap;
 
+@SuppressWarnings("removal")
 public class EnrichDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @After

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/GraphDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/GraphDocumentationIT.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Collection;
 
+@SuppressWarnings("removal")
 public class GraphDocumentationIT extends ESRestHighLevelClientTestCase {
 
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -85,6 +85,7 @@ import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+@SuppressWarnings("removal")
 public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testPutLifecyclePolicy() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -138,6 +138,7 @@ import static org.hamcrest.Matchers.nullValue;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testIndicesExist() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IngestClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IngestClientDocumentationIT.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class IngestClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testPutPipeline() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
@@ -49,6 +49,7 @@ import static org.hamcrest.core.Is.is;
  * Documentation for Licensing APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @BeforeClass

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationClientDocumentationIT.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class MigrationClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testGetDeprecationInfo() throws IOException, InterruptedException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
@@ -44,6 +44,7 @@ import java.util.Map;
  * include-tagged::{doc-tests}/MigrationDocumentationIT.java[example]
  * --------------------------------------------------
  */
+@SuppressWarnings("removal")
 public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
     public void testClusterHealth() throws IOException {
         RestHighLevelClient client = highLevelClient();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MiscellaneousDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MiscellaneousDocumentationIT.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.is;
  * Documentation for miscellaneous APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class MiscellaneousDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testMain() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -236,6 +236,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
+@SuppressWarnings("removal")
 public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     private static final RequestOptions POST_DATA_OPTIONS = RequestOptions.DEFAULT.toBuilder()

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
@@ -71,6 +71,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
+@SuppressWarnings("removal")
 public class RollupDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @Before

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -122,6 +122,7 @@ import static org.hamcrest.Matchers.greaterThan;
  * Documentation for search APIs in the high level java client.
  * Code wrapped in {@code tag} and {@code end} tags is included in the docs.
  */
+@SuppressWarnings("removal")
 public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @SuppressWarnings({"unused", "unchecked"})

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class SearchableSnapshotsDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testMountSnapshot() throws IOException, InterruptedException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -157,6 +157,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
@@ -80,6 +80,7 @@ import static org.hamcrest.Matchers.equalTo;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class SnapshotClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     private static final String repositoryName = "test_repository";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/StoredScriptsDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/StoredScriptsDocumentationIT.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.equalTo;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class StoredScriptsDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @SuppressWarnings("unused")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TasksClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TasksClientDocumentationIT.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * than 84, the line will be cut and a horizontal scroll bar will be displayed.
  * (the code indentation of the tag is not included in the width)
  */
+@SuppressWarnings("removal")
 public class TasksClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     @SuppressWarnings("unused")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TextStructureClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TextStructureClientDocumentationIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.textstructure.FindStructureRequest;
 import org.elasticsearch.client.textstructure.FindStructureResponse;
 import org.elasticsearch.client.textstructure.structurefinder.TextStructure;
 
+@SuppressWarnings("removal")
 public class TextStructureClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testFindStructure() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
@@ -66,6 +66,7 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+@SuppressWarnings("removal")
 public class TransformDocumentationIT extends ESRestHighLevelClientTestCase {
 
     private List<String> transformsToClean = new ArrayList<>();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/WatcherDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/WatcherDocumentationIT.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class WatcherDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testStartStopWatchService() throws Exception {

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -61,6 +61,7 @@ import static org.hamcrest.Matchers.hasSize;
  * This test ensure that we keep the search states of a CCS request correctly when the local and remote clusters
  * have different but compatible versions. See SearchService#createAndPutReaderContext
  */
+@SuppressWarnings("removal")
 public class SearchStatesIT extends AbstractCCSRestTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(SearchStatesIT.class);

--- a/qa/ccs-unavailable-clusters/src/test/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/test/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
+@SuppressWarnings("removal")
 public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
 
     private static RestHighLevelClient restHighLevelClient;

--- a/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
@@ -115,6 +115,7 @@ import static org.hamcrest.Matchers.not;
  * such parameter, hence we want to verify that results are the same in both scenarios.
  */
 @TimeoutSuite(millis = 5 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@SuppressWarnings("removal")
 public class CCSDuelIT extends ESRestTestCase {
 
     private static final String INDEX_NAME = "ccs_duel_index";

--- a/qa/remote-clusters/src/test/java/org/elasticsearch/cluster/remote/test/AbstractMultiClusterRemoteTestCase.java
+++ b/qa/remote-clusters/src/test/java/org/elasticsearch/cluster/remote/test/AbstractMultiClusterRemoteTestCase.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
+@SuppressWarnings("removal")
 public abstract class AbstractMultiClusterRemoteTestCase extends ESRestTestCase {
 
     private static final String USER = "x_pack_rest_user";

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.is;
  *     <li>Run against the current version cluster from the second step: {@link TestStep#STEP4_NEW_CLUSTER}</li>
  * </ul>
  */
+@SuppressWarnings("removal")
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {

--- a/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientEmployeeResource.java
+++ b/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientEmployeeResource.java
@@ -36,6 +36,7 @@ import javax.ws.rs.core.Response;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 @Path("/employees")
+@SuppressWarnings("removal")
 public class RestHighLevelClientEmployeeResource {
 
     @Inject

--- a/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientProducer.java
+++ b/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientProducer.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.Produces;
 public final class RestHighLevelClientProducer {
 
     @Produces
+    @SuppressWarnings("removal")
     public RestHighLevelClient createRestHighLevelClient() {
         String httpUri = System.getProperty("elasticsearch.uri");
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+@SuppressWarnings("removal")
 public class MlDeprecationIT extends ESRestTestCase {
 
     private static final RequestOptions REQUEST_OPTIONS = RequestOptions.DEFAULT.toBuilder()

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
@@ -34,6 +34,7 @@ import java.util.StringJoiner;
 
 import static java.util.stream.Collectors.toList;
 
+@SuppressWarnings("removal")
 public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestCase {
 
     protected static final String PARAM_FORMATTING = "%2$s";

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xpack.ql.TestUtils;
  *
  * While the loader could be made generic, the queries are bound to each index and generalizing that would make things way too complicated.
  */
+@SuppressWarnings("removal")
 public class DataLoader {
     public static final String TEST_INDEX = "endgame-140";
     public static final String TEST_EXTRA_INDEX = "extra";

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 
 import static org.elasticsearch.common.Strings.hasText;
 
+@SuppressWarnings("removal")
 public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
 
     private static final long CLIENT_TIMEOUT = 40L; // upped from 10s to accomodate for max measured throughput decline

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/EqlUsageRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/EqlUsageRestTestCase.java
@@ -34,6 +34,7 @@ import static java.util.Collections.unmodifiableSet;
 /**
  * Tests a random number of queries that increase various (most of the times, one query will "touch" multiple metrics values) metrics.
  */
+@SuppressWarnings("removal")
 public abstract class EqlUsageRestTestCase extends ESRestTestCase {
 
     private RestHighLevelClient highLevelClient;

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDataLoader.java
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDataLoader.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import static org.elasticsearch.test.ESTestCase.assertEquals;
 
+@SuppressWarnings("removal")
 public class EqlDataLoader {
 
     private static final String PROPERTIES_FILENAME = "config.properties";

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
@@ -43,6 +43,7 @@ import static org.elasticsearch.xpack.ql.TestUtils.assertNoSearchContexts;
 
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
 @TestLogging(value = "org.elasticsearch.xpack.eql.EsEQLCorrectnessIT:INFO", reason = "Log query execution time")
+@SuppressWarnings("removal")
 public class EsEQLCorrectnessIT extends ESRestTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
@@ -47,6 +47,7 @@ import static org.elasticsearch.core.List.copyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+@SuppressWarnings("removal")
 public abstract class IdpRestTestCase extends ESRestTestCase {
 
     private RestHighLevelClient highLevelAdminClient;

--- a/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+@SuppressWarnings("removal")
 public class PermissionsIT extends ESRestTestCase {
 
     private static final String jsonDoc = "{ \"name\" : \"elasticsearch\", \"body\": \"foo bar\" }";

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityInBasicRestTestCase.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityInBasicRestTestCase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.util.Collections;
 
+@SuppressWarnings("removal")
 public abstract class SecurityInBasicRestTestCase extends ESRestTestCase {
     private RestHighLevelClient highLevelAdminClient;
 

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+@SuppressWarnings("removal")
 public abstract class SecurityOnTrialLicenseRestTestCase extends ESRestTestCase {
     private RestHighLevelClient highLevelAdminClient;
 

--- a/x-pack/plugin/security/qa/smoke-test-all-realms/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/SecurityRealmSmokeTestCase.java
+++ b/x-pack/plugin/security/qa/smoke-test-all-realms/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/SecurityRealmSmokeTestCase.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 
+@SuppressWarnings("removal")
 public abstract class SecurityRealmSmokeTestCase extends ESRestTestCase {
 
     private static Path httpCAPath;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRolesCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRolesCacheTests.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Test for the clear roles API
  */
+@SuppressWarnings("removal")
 public class ClearRolesCacheTests extends NativeRealmIntegTestCase {
 
     private static String[] roles;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
@@ -31,6 +31,7 @@ import java.util.List;
 /**
  * Test case with method to handle the starting and stopping the stores for native users and roles
  */
+@SuppressWarnings("removal")
 public abstract class NativeRealmIntegTestCase extends SecurityIntegTestCase {
 
     @Before

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -99,6 +99,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+@SuppressWarnings("removal")
 public class ApiKeyIntegTests extends SecurityIntegTestCase {
     private static final long DELETE_INTERVAL_MILLIS = 100L;
     private static final int CRYPTO_THREAD_POOL_QUEUE_SIZE = 10;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 
+@SuppressWarnings("removal")
 public class TokenAuthIntegTests extends SecurityIntegTestCase {
 
     @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmIntegTests.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Integration tests for the built in realm
  */
+@SuppressWarnings("removal")
 public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
 
     private static Hasher hasher;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.startsWith;
 
+@SuppressWarnings("removal")
 public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
 
     @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SnapshotUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SnapshotUserRoleIntegTests.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.elasticsearch.test.SecurityTestsUtils.assertThrowsAuthorizationException;
 
+@SuppressWarnings("removal")
 public class SnapshotUserRoleIntegTests extends NativeRealmIntegTestCase {
 
     private Client client;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -77,6 +77,7 @@ import static org.hamcrest.Matchers.is;
  *
  * @see SecuritySettingsSource
  */
+@SuppressWarnings("removal")
 public abstract class SecurityIntegTestCase extends ESIntegTestCase {
 
     private static SecuritySettingsSource SECURITY_DEFAULT_SETTINGS;

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/LatestIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/LatestIT.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class LatestIT extends TransformIntegTestCase {
 
     private static final String SOURCE_INDEX_NAME = "basic-crud-latest-reviews";

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.oneOf;
 
+@SuppressWarnings("removal")
 public class TransformIT extends TransformIntegTestCase {
 
     private static final int NUM_USERS = 28;

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -82,6 +82,7 @@ import java.util.function.Function;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.core.Is.is;
 
+@SuppressWarnings("removal")
 abstract class TransformIntegTestCase extends ESRestTestCase {
 
     private Map<String, TransformConfig> transformConfigs = new HashMap<>();

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+@SuppressWarnings("removal")
 public class TransformUsingSearchRuntimeFieldsIT extends TransformIntegTestCase {
 
     private static final String REVIEWS_INDEX_NAME = "basic-crud-reviews";

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -41,6 +41,7 @@ import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
+@SuppressWarnings("removal")
 public abstract class ContinuousTestCase extends ESRestTestCase {
 
     public static final TimeValue SYNC_DELAY = new TimeValue(1, TimeUnit.SECONDS);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -103,6 +103,7 @@ import static org.hamcrest.core.Is.is;
  *          to check that optimizations worked
  *      - repeat
  */
+@SuppressWarnings("removal")
 public class TransformContinuousIT extends ESRestTestCase {
 
     private List<ContinuousTestCase> transformTestCases = new ArrayList<>();

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
 
+@SuppressWarnings("removal")
 public class TransformGetAndGetStatsIT extends TransformRestTestCase {
 
     private static final String TEST_USER_NAME = "transform_user";

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformProgressIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformProgressIT.java
@@ -54,6 +54,7 @@ import static org.elasticsearch.xpack.transform.integration.TransformRestTestCas
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class TransformProgressIT extends ESRestTestCase {
     protected void createReviewsIndex(int userWithMissingBuckets) throws Exception {
         final int numDocs = 1000;

--- a/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.xpack.core.security.SecurityField;
 
 
+@SuppressWarnings("removal")
 public class ReindexWithSecurityIT extends SecurityIntegTestCase {
 
     @Override

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -60,6 +60,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+@SuppressWarnings("removal")
 public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-snapshots-upgrade-job";

--- a/x-pack/qa/runtime-fields/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/qa/runtime-fields/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+@SuppressWarnings("removal")
 public class PermissionsIT extends ESRestTestCase {
 
     private static HighLevelClient highLevelClient;


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Add deprecation headers to HLRC classes (#79754)