### PR TITLE
Use short URL for transform deprecation message

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
@@ -11,10 +11,6 @@ public class TransformDeprecations {
 
     public static final String UPGRADE_TRANSFORM_URL = "https://ela.st/es-8-upgrade-transforms";
 
-    // breaking changes base url for the _next_ major release
-    public static final String BREAKING_CHANGES_BASE_URL =
-        "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html";
-
     public static final String QUERY_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-query-options";
 
     public static final String AGGS_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-aggregation-options";
@@ -23,6 +19,7 @@ public class TransformDeprecations {
 
     public static final String ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED =
         "[max_page_search_size] is deprecated inside pivot. Use settings instead.";
-
+    
+    public static final String MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-7-transform-max-page-search-size";
     private TransformDeprecations() {}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
@@ -186,7 +186,7 @@ public class PivotConfig implements Writeable, ToXContentObject {
                 new DeprecationIssue(
                     Level.WARNING,
                     "Transform [" + id + "] uses deprecated max_page_search_size",
-                    TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                    TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                     TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                     false,
                     null

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -750,7 +750,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null
@@ -772,7 +772,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null
@@ -802,7 +802,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                     new DeprecationIssue(
                         Level.WARNING,
                         "Transform [" + id + "] uses deprecated max_page_search_size",
-                        TransformDeprecations.BREAKING_CHANGES_BASE_URL,
+                        TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
                         false,
                         null


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/79664

This PR updates the URL used in deprecation messages for the max_page_search_size parameter in the create transforms and preview transforms APIs. It uses a short URL to point to the appropriate breaking changes content.