### PR TITLE
[7.15][DOCS] Adds deprecation details for max_page_search_size

### DIFF
--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -211,4 +211,19 @@ Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
 
+[discrete]
+[[breaking_78_transform_changes]]
+=== Transforms changes
+
+.The `max_page_search_size` property is deprecated in the `pivot` {transform} configuration object
+[%collapsible]
+====
+*Details* +
+The `max_page_search_size` property within `pivot` is deprecated in the
+<<put-transform,create {transform}>> and <<preview-transform,preview {transform}>>
+APIs.
+
+*Impact* +
+Use the `max_page_search_size` property within `settings` instead.
+====
 //end::notable-breaking-changes[]

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -111,6 +111,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 `group_by`:::
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
+
+`max_page_search_size`:::
+(Optional, integer)
+deprecated:[7.8.0,Moved to `settings`.]
 ====
 //End pivot
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -143,6 +143,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 
+`max_page_search_size`:::
+(Optional, integer)
+deprecated:[7.8.0,Moved to `settings`.]
 ====
 //End pivot
 


### PR DESCRIPTION
Backports the documentation changes from https://github.com/elastic/elasticsearch/pull/79664