### PR TITLE
Modify fleet search URLs to avoid url collisions

### DIFF
--- a/docs/reference/fleet/fleet-multi-search.asciidoc
+++ b/docs/reference/fleet/fleet-multi-search.asciidoc
@@ -17,9 +17,9 @@ without prior notice.
 [[fleet-multi-search-api-request]]
 ==== {api-request-title}
 
-`GET /_fleet/_msearch`
+`GET /_fleet/_fleet_msearch`
 
-`GET /<index>/_fleet/_msearch`
+`GET /<index>/_fleet/_fleet_msearch`
 
 [[fleet-multi-search-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/fleet/fleet-search.asciidoc
+++ b/docs/reference/fleet/fleet-search.asciidoc
@@ -42,7 +42,7 @@ timed out.
 [[fleet-search-api-request]]
 ==== {api-request-title}
 
-`GET /<target>/_fleet/_search`
+`GET /<target>/_fleet/_fleet_search`
 
 [[fleet-search-api-path-params]]
 ==== {api-path-parms-title}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.msearch.json
@@ -13,14 +13,14 @@
     "url":{
       "paths":[
         {
-          "path":"/_fleet/_msearch",
+          "path":"/_fleet/_fleet_msearch",
           "methods":[
             "GET",
             "POST"
           ]
         },
         {
-          "path":"/{index}/_fleet/_msearch",
+          "path":"/{index}/_fleet/_fleet_msearch",
           "methods":[
             "GET",
             "POST"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.search.json
@@ -13,7 +13,7 @@
     "url":{
       "paths":[
         {
-          "path":"/{index}/_fleet/_search",
+          "path":"/{index}/_fleet/_fleet_search",
           "methods":[
             "GET",
             "POST"

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
@@ -48,10 +48,10 @@ public class RestFleetMultiSearchAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(GET, "/_fleet/_msearch"),
-            new Route(POST, "/_fleet/_msearch"),
-            new Route(GET, "/{index}/_fleet/_msearch"),
-            new Route(POST, "/{index}/_fleet/_msearch")
+            new Route(GET, "/_fleet/_fleet_msearch"),
+            new Route(POST, "/_fleet/_fleet_msearch"),
+            new Route(GET, "/{index}/_fleet/_fleet_msearch"),
+            new Route(POST, "/{index}/_fleet/_fleet_msearch")
         );
     }
 

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetSearchAction.java
@@ -38,7 +38,7 @@ public class RestFleetSearchAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/{index}/_fleet/_search"), new Route(POST, "/{index}/_fleet/_search"));
+        return List.of(new Route(GET, "/{index}/_fleet/_fleet_search"), new Route(POST, "/{index}/_fleet/_fleet_search"));
     }
 
     @Override


### PR DESCRIPTION
Currently the fleet search URL of /_fleet/_msearch will collide with the
normal msearch API when the fleet plugin is not enabled. This is because
_fleet will be identified as an index to search. This commit resolves
the issue by changing the APIs to /_fleet/_fleet_search and
/_fleet/_fleet_msearch.