### PR TITLE
Wait 3 seconds for the server to reload trust

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -285,10 +286,12 @@ public class LdapSessionFactoryTests extends LdapTestCase {
             Files.copy(realCa, ldapCaPath, StandardCopyOption.REPLACE_EXISTING);
             resourceWatcher.notifyNow(ResourceWatcherService.Frequency.HIGH);
 
-            final LdapSession session = session(sessionFactory, user, userPass);
-            assertThat(session.userDn(), is("cn=Horatio Hornblower,ou=people,o=sevenSeas"));
-
-            session.close();
+            // Occasionally the reload doesn't take immediate effect so the next connection fails.
+            assertBusy(() -> {
+                final LdapSession session = session(sessionFactory, user, userPass);
+                assertThat(session.userDn(), is("cn=Horatio Hornblower,ou=people,o=sevenSeas"));
+                session.close();
+            }, 3, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
Sometimes the final session seems to fail because it is still using
the old trust configuration. This commit adds an assertBusy to give it
time to settle.

Resolves: #77024