### PR TITLE
[7.15] [DOCS] Adds new transform limitation item and a note to the tutorial (#79479)

### DIFF
--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -241,6 +241,11 @@ destination index. In {kib}, if you copied the API request to your
 clipboard, paste it into the console, then refer to the `generated_dest_index` 
 object in the API response.
 
+NOTE: {transforms-cap} might have more configuration options provided by the 
+APIs than the options available in {kib}. For example, you can set an ingest 
+pipeline for `dest` by calling the <<put-transform>>. For all the {transform} 
+configuration options, refer to the <<transform-apis,documentation>>.
+
 .API example
 [%collapsible]
 ====

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -295,3 +295,11 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 === Up to 1,000 {transforms} are listed in {kib}
 
 The {transforms} management page in {kib} lists up to 1000 {transforms}.
+
+[discrete]
+[[transform-ui-support]]
+=== {kib} might not support every {transform} configuration option
+
+There might be configuration options available via the {transform} APIs that are 
+not supported in {kib}. For an exhaustive list of configuration options, refer 
+to the <<transform-apis,documentation>>.

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -8,8 +8,14 @@
 You can choose either of the following methods to transform your data:
 <<pivot-transform-overview,pivot>> or <<latest-transform-overview,latest>>.
 
-IMPORTANT: All {transforms} leave your source index intact. They create a new
-index that is dedicated to the transformed data.
+[IMPORTANT]
+====
+* All {transforms} leave your source index intact. They create a new
+  index that is dedicated to the transformed data.
+* {transforms-cap} might have more configuration options provided by the APIs 
+  than the options available in {kib}. For all the {transform} configuration 
+  options, refer to the <<transform-apis,API documentation>>.
+====
 
 {transforms-cap} are persistent tasks; they are stored in cluster state which 
 makes them resilient for node failures. Refer to <<transform-checkpoints>> and 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Adds new transform limitation item and a note to the tutorial (#79479)