### PR TITLE
[7.10] [DOCS]  `_id` is required for bulk API's `update` action (#79774)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -293,8 +293,7 @@ Removes the specified document from the index.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 `_id`::
-(Required, string) 
-The document ID.
+(Required, string) The document ID.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --
@@ -321,7 +320,8 @@ The following line must contain the partial document and update options.
 --
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+`_id`::
+(Required, string) The document ID.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS]  `_id` is required for bulk API's `update` action (#79774)