### PR TITLE
[7.8] [DOCS]  `_id` is required for bulk API's `update` action (#79774)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -238,8 +238,7 @@ Removes the specified document from the index.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 `_id`::
-(Required, string) 
-The document ID.
+(Required, string) The document ID.
 --
 
 `index`::
@@ -262,11 +261,12 @@ The following line must contain the partial document and update options.
 --
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+`_id`::
+(Required, string) The document ID.
 --
 
 `doc`::
-(Optional, object) 
+(Optional, object)
 The partial document to index.
 Required for `update` operations. 
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS]  `_id` is required for bulk API's `update` action (#79774)