### PR TITLE
[Transform] Transform Reset API

### DIFF
--- a/docs/reference/transform/api-quickref.asciidoc
+++ b/docs/reference/transform/api-quickref.asciidoc
@@ -15,6 +15,7 @@ _transform/
 * <<get-transform,Get {transforms}>>
 * <<get-transform-stats,Get {transforms} statistics>>
 * <<preview-transform,Preview {transforms}>>
+* <<reset-transform,Reset {transforms}>>
 * <<start-transform,Start {transforms}>>
 * <<stop-transform,Stop {transforms}>>
 * <<update-transform,Update {transforms}>>

--- a/docs/reference/transform/apis/index.asciidoc
+++ b/docs/reference/transform/apis/index.asciidoc
@@ -9,6 +9,8 @@ include::get-transform.asciidoc[leveloffset=+2]
 include::get-transform-stats.asciidoc[leveloffset=+2]
 //PREVIEW
 include::preview-transform.asciidoc[leveloffset=+2]
+//RESET
+include::reset-transform.asciidoc[leveloffset=+2]
 //START
 include::start-transform.asciidoc[leveloffset=+2]
 //STOP

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -20,7 +20,7 @@ Resets an existing {transform}.
 
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
-* Before you can reset the {transform}, you must stop it.
+* Before you can reset the {transform}, you must stop it; alternatively, use the `force` query parameter.
 
 [[reset-transform-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -1,0 +1,56 @@
+[role="xpack"]
+[testenv="basic"]
+[[reset-transform]]
+= Reset {transform} API
+
+[subs="attributes"]
+++++
+<titleabbrev>Reset {transform}</titleabbrev>
+++++
+
+Resets an existing {transform}.
+
+[[reset-transform-request]]
+== {api-request-title}
+
+`POST _transform/<transform_id>/_reset`
+
+[[reset-transform-prereqs]]
+== {api-prereq-title}
+
+* Requires the `manage_transform` cluster privilege. This privilege is included
+in the `transform_admin` built-in role.
+* Before you can reset the {transform}, you must stop it.
+
+[[reset-transform-path-parms]]
+== {api-path-parms-title}
+
+`<transform_id>`::
+(Required, string)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
+
+[[reset-transform-query-parms]]
+== {api-query-parms-title}
+
+`force`::
+(Optional, Boolean) When `true`, the {transform} is reset regardless of its
+current state. The default value is `false`, meaning that the {transform} must be
+`stopped` before it can be reset.
+
+[[reset-transform-examples]]
+== {api-examples-title}
+
+[source,console]
+--------------------------------------------------
+POST _transform/ecommerce_transform/_reset
+--------------------------------------------------
+// TEST[skip:setup kibana sample data]
+
+When the {transform} is reset, you receive the following results:
+
+[source,console-result]
+----
+{
+  "acknowledged" : true
+}
+----

--- a/docs/reference/transform/apis/transform-apis.asciidoc
+++ b/docs/reference/transform/apis/transform-apis.asciidoc
@@ -7,6 +7,7 @@
 * <<get-transform>>
 * <<get-transform-stats>>
 * <<preview-transform>>
+* <<reset-transform>>
 * <<start-transform>>
 * <<stop-transform>>
 * <<update-transform>>

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
@@ -1,0 +1,36 @@
+{
+  "transform.reset_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/reset-transform.html",
+      "description":"Resets an existing transform."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_transform/{transform_id}/_reset",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the transform to reset"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+      "force":{
+        "type":"boolean",
+        "required":false,
+        "description":"When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
+      }
+    }
+  }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ResetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ResetTransformAction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.transform.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ResetTransformAction extends ActionType<AcknowledgedResponse> {
+
+    public static final String NAME = "cluster:admin/transform/reset";
+    public static final ResetTransformAction INSTANCE = new ResetTransformAction();
+
+    private ResetTransformAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends AcknowledgedRequest<Request> {
+
+        private final String id;
+        private final boolean force;
+
+        public Request(String id, boolean force, TimeValue timeout) {
+            super(timeout);
+            this.id = ExceptionsHelper.requireNonNull(id, TransformField.ID.getPreferredName());
+            this.force = force;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            id = in.readString();
+            force = in.readBoolean();
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public boolean isForce() {
+            return force;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(id);
+            out.writeBoolean(force);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public int hashCode() {
+            // the base class does not implement hashCode, therefore we need to hash timeout ourselves
+            return Objects.hash(timeout(), id, force);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            // the base class does not implement equals, therefore we need to check timeout ourselves
+            return Objects.equals(id, other.id) && force == other.force && timeout().equals(other.timeout());
+        }
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -85,6 +85,7 @@ public class Constants {
         "cluster:admin/transform/delete",
         "cluster:admin/transform/preview",
         "cluster:admin/transform/put",
+        "cluster:admin/transform/reset",
         "cluster:admin/transform/start",
         "cluster:admin/transform/stop",
         "cluster:admin/transform/update",

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_reset.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_reset.yml
@@ -1,0 +1,179 @@
+setup:
+  - do:
+      indices.create:
+        index: airline-data
+        body:
+          mappings:
+            properties:
+              time:
+                type: date
+              airline:
+                type: keyword
+              responsetime:
+                type: float
+              event_rate:
+                type: integer
+  - do:
+      transform.put_transform:
+        transform_id: "airline-transform-start-reset"
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "airline-data-by-airline-start-reset" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "sync": {
+              "time": {
+                "field": "time",
+                "delay": "90m"
+              }
+            }
+          }
+
+---
+teardown:
+  - do:
+      transform.stop_transform:
+        transform_id: "airline-transform-start-reset"
+        wait_for_completion: true
+        wait_for_checkpoint: false
+        ignore: 404
+  - do:
+      transform.delete_transform:
+        transform_id: "airline-transform-start-reset"
+        ignore: 404
+
+---
+"Test reset transform when it does not exist":
+  - do:
+      catch: missing
+      transform.reset_transform:
+        transform_id: "missing transform"
+
+---
+"Test reset new transform":
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-start-reset"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-start-reset" }
+  - match: { transforms.0.state: "stopped" }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_false: ''
+
+  - do:
+      transform.reset_transform:
+        transform_id: "airline-transform-start-reset"
+  - match: { acknowledged: true }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_false: ''
+
+---
+"Test reset running transform":
+  - do:
+      transform.start_transform:
+        transform_id: "airline-transform-start-reset"
+  - match: { acknowledged: true }
+
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-start-reset"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-start-reset" }
+  - match: { transforms.0.state: "/started|indexing/" }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_true: ''
+
+  - do:
+      catch: /Cannot reset transform \[airline-transform-start-reset\] as the task is running/
+      transform.reset_transform:
+        transform_id: "airline-transform-start-reset"
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_true: ''
+
+---
+"Test reset stopped transform":
+  - do:
+      transform.start_transform:
+        transform_id: "airline-transform-start-reset"
+  - match: { acknowledged: true }
+
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-start-reset"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-start-reset" }
+  - match: { transforms.0.state: "/started|indexing/" }
+
+  - do:
+      transform.stop_transform:
+        transform_id: "airline-transform-start-reset"
+        wait_for_completion: true
+        wait_for_checkpoint: false
+        ignore: 404
+
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-start-reset"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-start-reset" }
+  - match: { transforms.0.state: "stopped" }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_true: ''
+
+  - do:
+      transform.reset_transform:
+        transform_id: "airline-transform-start-reset"
+  - match: { acknowledged: true }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_false: ''
+
+---
+"Test force reseting a running transform":
+  - do:
+      transform.start_transform:
+        transform_id: "airline-transform-start-reset"
+  - match: { acknowledged: true }
+
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-start-reset"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-start-reset" }
+  - match: { transforms.0.state: "/started|indexing/" }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_true: ''
+
+  - do:
+      transform.reset_transform:
+        transform_id: "airline-transform-start-reset"
+        force: true
+  - match: { acknowledged: true }
+
+  - do:
+      indices.exists:
+        index: airline-data-by-airline-start-reset
+  - is_false: ''

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexMetadataIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexMetadataIT.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Map;
 
-public class TransformMetadataIT extends TransformRestTestCase {
+public class TransformDestIndexMetadataIT extends TransformRestTestCase {
 
     private boolean indicesCreated = false;
 
@@ -38,7 +38,7 @@ public class TransformMetadataIT extends TransformRestTestCase {
         indicesCreated = true;
     }
 
-    public void testMetadata() throws Exception {
+    public void testTransformDestIndexMetadata() throws Exception {
         long testStarted = System.currentTimeMillis();
         createPivotReviewsTransform("test_meta", "pivot_reviews", null);
         startAndWaitForTransform("test_meta", "pivot_reviews");

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformResetIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformResetIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.integration;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransformResetIT extends TransformRestTestCase {
+
+    private static final String TEST_USER_NAME = "transform_user";
+    private static final String TEST_ADMIN_USER_NAME_1 = "transform_admin_1";
+    private static final String BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1 = basicAuthHeaderValue(
+        TEST_ADMIN_USER_NAME_1,
+        TEST_PASSWORD_SECURE_STRING
+    );
+    private static final String DATA_ACCESS_ROLE = "test_data_access";
+
+    private static boolean indicesCreated = false;
+
+    // preserve indices in order to reuse source indices in several test cases
+    @Override
+    protected boolean preserveIndicesUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
+    @Override
+    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
+        RestClientBuilder builder = RestClient.builder(hosts);
+        configureClient(builder, settings);
+        builder.setStrictDeprecationMode(false);
+        return builder.build();
+    }
+
+    @Before
+    public void createIndexes() throws IOException {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        setupUser(TEST_USER_NAME, Arrays.asList("transform_user", DATA_ACCESS_ROLE));
+        setupUser(TEST_ADMIN_USER_NAME_1, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
+
+        // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
+        if (indicesCreated) {
+            return;
+        }
+
+        createReviewsIndex();
+        indicesCreated = true;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testReset() throws Exception {
+        String transformId = "old_transform";
+        String transformDest = transformId + "_idx";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformDest);
+
+        final Request createTransformRequest = createRequestWithAuth(
+            "PUT",
+            getTransformEndpoint() + transformId,
+            BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1
+        );
+        String config = "{ \"dest\": {\"index\":\""
+            + transformDest
+            + "\"},"
+            + " \"source\": {\"index\":\""
+            + REVIEWS_INDEX_NAME
+            + "\"},"
+            + " \"pivot\": {"
+            + "   \"group_by\": {"
+            + "     \"reviewer\": {"
+            + "       \"terms\": {"
+            + "         \"field\": \"user_id\""
+            + " } } },"
+            + "   \"aggregations\": {"
+            + "     \"avg_rating\": {"
+            + "       \"avg\": {"
+            + "         \"field\": \"stars\""
+            + " } } }"
+            + " }"
+            + "}";
+        createTransformRequest.setJsonEntity(config);
+        Map<String, Object> createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));
+        assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+
+        // Verify that reset works on a new transform
+        resetTransform(transformId, false);
+
+        // Start the transform
+        startTransform(transformId);
+
+        // Verify that reset doesn't work when the transform is running
+        ResponseException e = expectThrows(ResponseException.class, () -> resetTransform(transformId, false));
+        assertThat(e.getMessage(), containsString("Cannot reset transform [old_transform] as the task is running. Stop the task first"));
+
+        // Verify that reset with [force=true] works even when the transform is running
+        resetTransform(transformId, true);
+
+        // Start the transform again
+        startTransform(transformId);
+
+        // Verify that reset works on a stopped transform
+        stopTransform(transformId, false);
+        resetTransform(transformId, false);
+    }
+}

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -383,6 +383,13 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         refreshIndex(transformIndex);
     }
 
+    protected void resetTransform(String transformId, boolean force) throws IOException {
+        final Request resetTransformRequest = createRequestWithAuth("POST", getTransformEndpoint() + transformId + "/_reset", null);
+        resetTransformRequest.addParameter(TransformField.FORCE.getPreferredName(), Boolean.toString(force));
+        Map<String, Object> resetTransformResponse = entityAsMap(client().performRequest(resetTransformRequest));
+        assertThat(resetTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+    }
+
     protected Request createRequestWithAuth(final String method, final String endpoint, final String authHeader) {
         final Request request = new Request(method, endpoint);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -65,6 +65,7 @@ import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
 import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
+import org.elasticsearch.xpack.core.transform.action.ResetTransformAction;
 import org.elasticsearch.xpack.core.transform.action.SetResetModeAction;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
@@ -76,6 +77,7 @@ import org.elasticsearch.xpack.transform.action.TransportGetTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportGetTransformStatsAction;
 import org.elasticsearch.xpack.transform.action.TransportPreviewTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportPutTransformAction;
+import org.elasticsearch.xpack.transform.action.TransportResetTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportSetTransformResetModeAction;
 import org.elasticsearch.xpack.transform.action.TransportStartTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportStopTransformAction;
@@ -93,6 +95,7 @@ import org.elasticsearch.xpack.transform.rest.action.RestGetTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestGetTransformStatsAction;
 import org.elasticsearch.xpack.transform.rest.action.RestPreviewTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestPutTransformAction;
+import org.elasticsearch.xpack.transform.rest.action.RestResetTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestStartTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestStopTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestUpdateTransformAction;
@@ -167,7 +170,8 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
             new RestPreviewTransformAction(),
             new RestUpdateTransformAction(),
             new RestCatTransformAction(),
-            new RestUpgradeTransformsAction()
+            new RestUpgradeTransformsAction(),
+            new RestResetTransformAction()
         );
     }
 
@@ -186,6 +190,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
             new ActionHandler<>(SetResetModeAction.INSTANCE, TransportSetTransformResetModeAction.class),
             new ActionHandler<>(ValidateTransformAction.INSTANCE, TransportValidateTransformAction.class),
             new ActionHandler<>(UpgradeTransformsAction.INSTANCE, TransportUpgradeTransformsAction.class),
+            new ActionHandler<>(ResetTransformAction.INSTANCE, TransportResetTransformAction.class),
 
             // usage and info
             new ActionHandler<>(XPackUsageFeatureAction.TRANSFORM, TransformUsageTransportAction.class),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.transform.action.ResetTransformAction;
+import org.elasticsearch.xpack.core.transform.action.ResetTransformAction.Request;
+import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
+import org.elasticsearch.xpack.transform.TransformServices;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.TransformIndex;
+
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.core.ClientHelper.TRANSFORM_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class TransportResetTransformAction extends AcknowledgedTransportMasterNodeAction<Request> {
+
+    private static final Logger logger = LogManager.getLogger(TransportResetTransformAction.class);
+
+    private final TransformConfigManager transformConfigManager;
+    private final TransformAuditor auditor;
+    private final Client client;
+    private final SecurityContext securityContext;
+    private final Settings settings;
+
+    @Inject
+    public TransportResetTransformAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformServices transformServices,
+        Client client,
+        Settings settings
+    ) {
+        super(
+            ResetTransformAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            Request::new,
+            indexNameExpressionResolver,
+            ThreadPool.Names.SAME
+        );
+        this.transformConfigManager = transformServices.getConfigManager();
+        this.auditor = transformServices.getAuditor();
+        this.client = Objects.requireNonNull(client);
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
+            ? new SecurityContext(settings, threadPool.getThreadContext())
+            : null;
+        this.settings = settings;
+    }
+
+    @Override
+    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
+        final PersistentTasksCustomMetadata pTasksMeta = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+        final boolean transformIsRunning = pTasksMeta != null && pTasksMeta.getTask(request.getId()) != null;
+        if (transformIsRunning && request.isForce() == false) {
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Cannot reset transform [" + request.getId() + "] as the task is running. Stop the task first",
+                    RestStatus.CONFLICT
+                )
+            );
+            return;
+        }
+
+        final SetOnce<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>> transformConfigAndVersionHolder = new SetOnce<>();
+
+        // <6> Reset transform
+        ActionListener<TransformUpdater.UpdateResult> updateTransformListener = ActionListener.wrap(
+            unusedUpdateResult -> transformConfigManager.resetTransform(request.getId(), ActionListener.wrap(resetResponse -> {
+                logger.debug("[{}] reset transform", request.getId());
+                auditor.info(request.getId(), "Reset transform.");
+                listener.onResponse(AcknowledgedResponse.of(resetResponse));
+            }, listener::onFailure)),
+            listener::onFailure
+        );
+
+        // <5> Upgrade transform to the latest version
+        ActionListener<AcknowledgedResponse> deleteDestIndexListener = ActionListener.wrap(unusedDeleteDestIndexResponse -> {
+            final ClusterState clusterState = clusterService.state();
+            TransformUpdater.updateTransform(
+                securityContext,
+                indexNameExpressionResolver,
+                clusterState,
+                settings,
+                client,
+                transformConfigManager,
+                transformConfigAndVersionHolder.get().v1(),
+                TransformConfigUpdate.EMPTY,
+                transformConfigAndVersionHolder.get().v2(),
+                false, // defer validation
+                false, // dry run
+                false, // check access
+                request.timeout(),
+                updateTransformListener
+            );
+        }, listener::onFailure);
+
+        // <4> Delete destination index if it was created by transform.
+        ActionListener<Boolean> isDestinationIndexCreatedByTransformListener = ActionListener.wrap(isDestinationIndexCreatedByTransform -> {
+            if (isDestinationIndexCreatedByTransform == false) {
+                // Destination index was created outside of transform, we don't delete it and just move on.
+                deleteDestIndexListener.onResponse(AcknowledgedResponse.TRUE);
+                return;
+            }
+            String destIndex = transformConfigAndVersionHolder.get().v1().getDestination().getIndex();
+            DeleteIndexRequest deleteDestIndexRequest = new DeleteIndexRequest(destIndex);
+            executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteIndexAction.INSTANCE, deleteDestIndexRequest, deleteDestIndexListener);
+        }, listener::onFailure);
+
+        // <3> Check if the destination index was created by transform
+        ActionListener<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>> getTransformConfigurationListener = ActionListener.wrap(
+            transformConfigAndVersion -> {
+                transformConfigAndVersionHolder.set(transformConfigAndVersion);
+                String destIndex = transformConfigAndVersion.v1().getDestination().getIndex();
+                TransformIndex.isDestinationIndexCreatedByTransform(client, destIndex, isDestinationIndexCreatedByTransformListener);
+            },
+            listener::onFailure
+        );
+
+        // <2> Fetch transform configuration
+        ActionListener<StopTransformAction.Response> stopTransformActionListener = ActionListener.wrap(
+            unusedStopResponse -> transformConfigManager.getTransformConfigurationForUpdate(
+                request.getId(),
+                getTransformConfigurationListener
+            ),
+            listener::onFailure
+        );
+
+        // <1> Stop transform if it's currently running
+        if (transformIsRunning == false) {
+            stopTransformActionListener.onResponse(null);
+            return;
+        }
+        StopTransformAction.Request stopTransformRequest = new StopTransformAction.Request(request.getId(), true, false, null, true, false);
+        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, StopTransformAction.INSTANCE, stopTransformRequest, stopTransformActionListener);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
@@ -133,7 +133,7 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
         final ClusterState clusterState = clusterService.state();
 
         transformConfigManager.getTransformConfigurationForUpdate(id, ActionListener.wrap(configAndVersion -> {
-            TransformConfigUpdate update = new TransformConfigUpdate(null, null, null, null, null, null, null, null);
+            TransformConfigUpdate update = TransformConfigUpdate.EMPTY;
             TransformConfig config = configAndVersion.v1();
 
             /*

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
@@ -594,6 +595,51 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
     @Override
     public void getAllOutdatedTransformIds(ActionListener<Tuple<Long, Set<String>>> listener) {
         expandAllTransformIds(true, MAX_RESULTS_WINDOW, listener);
+    }
+
+    @Override
+    public void resetTransform(String transformId, ActionListener<Boolean> listener) {
+        ActionListener<BulkByScrollResponse> deleteListener = ActionListener.wrap(dbqResponse -> { listener.onResponse(true); }, e -> {
+            if (e.getClass() == IndexNotFoundException.class) {
+                listener.onFailure(
+                    new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                );
+            } else {
+                listener.onFailure(e);
+            }
+        });
+
+        SearchRequest searchRequest = new SearchRequest().indices(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .source(
+                new SearchSourceBuilder()
+                    // find and count all the documents corresponding to the given transform id
+                    .query(QueryBuilders.termQuery(TransformField.ID.getPreferredName(), transformId))
+                    .trackTotalHitsUpTo(1)
+            );
+        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(searchResponse -> {
+            if (searchResponse.getHits().getTotalHits().value == 0) {
+                listener.onFailure(
+                    new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                );
+                return;
+            }
+
+            QueryBuilder dbqQuery = QueryBuilders.constantScoreQuery(
+                QueryBuilders.boolQuery()
+                    // delete documents corresponding to given transform id...
+                    .filter(QueryBuilders.termQuery(TransformField.ID.getPreferredName(), transformId))
+                    // ...except given transform's config document
+                    .mustNot(QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId)))
+            );
+            DeleteByQueryRequest dbqRequest = createDeleteByQueryRequest().indices(
+                TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+            ).setQuery(dbqQuery).setRefresh(true);
+            executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteByQueryAction.INSTANCE, dbqRequest, deleteListener);
+        }, deleteListener::onFailure));
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
@@ -170,6 +170,15 @@ public interface TransformConfigManager {
     void getAllOutdatedTransformIds(ActionListener<Tuple<Long, Set<String>>> listener);
 
     /**
+     * This deletes documents corresponding to the transform id (e.g. checkpoints).
+     * Configuration is left intact.
+     *
+     * @param transformId the transform id
+     * @param listener listener to call after inner request returned
+     */
+    void resetTransform(String transformId, ActionListener<Boolean> listener);
+
+    /**
      * This deletes the configuration and all other documents corresponding to the transform id (e.g. checkpoints).
      *
      * @param transformId the transform id

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestResetTransformAction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.transform.rest.action;
+
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.action.ResetTransformAction;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestResetTransformAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID + "_reset"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        if (restRequest.hasContent()) {
+            throw new IllegalArgumentException("reset transform requests can not have a request body");
+        }
+
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        boolean force = restRequest.paramAsBoolean(TransformField.FORCE.getPreferredName(), false);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+
+        ResetTransformAction.Request request = new ResetTransformAction.Request(id, force, timeout);
+
+        return channel -> client.execute(ResetTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "transform_reset_transform_action";
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
@@ -295,13 +295,18 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
     }
 
     @Override
-    public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
-        configs.remove(transformId);
-        oldConfigs.remove(transformId);
+    public void resetTransform(String transformId, ActionListener<Boolean> listener) {
         transformStoredDocs.remove(transformId);
         oldTransformStoredDocs.remove(transformId);
         checkpoints.remove(transformId);
         oldCheckpoints.remove(transformId);
+    }
+
+    @Override
+    public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
+        configs.remove(transformId);
+        oldConfigs.remove(transformId);
+        resetTransform(transformId, listener);
     }
 
     public void putOrUpdateOldTransformStoredDoc(


### PR DESCRIPTION
This PR introduces Transform Reset API.
Analogously to Anomaly Detection Jobs Reset API, Transform Reset API will reset the transform i.e. bring it to the fresh (newly created) state.
Request is of the form:
```
POST _transform/{transform_id}/_reset
```

Note: Since this is `8.1` feature, it does not need to be added to HLRC.

Relates https://github.com/elastic/elasticsearch/issues/75768