### PR TITLE
[7.12] [DOCS] Fix 7.9 breaking changes for stack template removal (#79773)

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -20,8 +20,8 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [discrete]
 [[breaking_79_indices_changes]]
 === Indices changes
-.{es} includes built-in index templates for `logs-*-*` and `metrics-*-*`.
 
+.{es} includes built-in index templates for `logs-*-*` and `metrics-*-*`.
 [%collapsible]
 ====
 *Details* +
@@ -41,6 +41,12 @@ non-overlapping index pattern or assign templates with an overlapping pattern a
 For example, if you don't use {agent} and want to use a template for the
 `logs-*` index pattern, assign your template a priority of `200`. This ensures
 your template is applied instead of the built-in template for `logs-*-*`.
+
+To disable all built-in index and component templates, set
+{ref}/index-management-settings.html#stack-templates-enabled[`stack.templates.enabled`]
+to `false` in {ref}/settings.html#config-files-location[`elasticsearch.yml`]
+before start up. If the templates already exist, this setting ensures {es} does
+not recreate the built-in templates after deletion.
 ====
 //end::notable-breaking-changes[]
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix 7.9 breaking changes for stack template removal (#79773)