### PR TITLE
[7.15] [DOCS] Add missing system config entry (#79830)

### DIFF
--- a/docs/reference/setup/sysconfig.asciidoc
+++ b/docs/reference/setup/sysconfig.asciidoc
@@ -1,13 +1,14 @@
 [[system-config]]
-== Important System Configuration
+== Important system configuration
 
-Ideally, Elasticsearch should run alone on a server and use all of the
+Ideally, {es} should run alone on a server and use all of the
 resources available to it. In order to do so, you need to configure your
-operating system to allow the user running Elasticsearch to access more
+operating system to allow the user running {es} to access more
 resources than allowed by default.
 
 The following settings *must* be considered before going to production:
 
+* <<setting-system-settings,Configure system settings>>
 * <<setup-configuration-memory,Disable swapping>>
 * <<file-descriptors,Increase file descriptors>>
 * <<vm-max-map-count,Ensure sufficient virtual memory>>
@@ -20,14 +21,14 @@ The following settings *must* be considered before going to production:
 [discrete]
 === Development mode vs production mode
 
-By default, Elasticsearch assumes that you are working in development mode.
+By default, {es} assumes that you are working in development mode.
 If any of the above settings are not configured correctly, a warning will be
 written to the log file, but you will be able to start and run your
-Elasticsearch node.
+{es} node.
 
-As soon as you configure a network setting like `network.host`, Elasticsearch
+As soon as you configure a network setting like `network.host`, {es}
 assumes that you are moving to production and will upgrade the above warnings
-to exceptions. These exceptions will prevent your Elasticsearch node from
+to exceptions. These exceptions will prevent your {es} node from
 starting. This is an important safety measure to ensure that you will not
 lose data because of a malconfigured server.
 

--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -6,8 +6,8 @@ install Elasticsearch, and which operating system you are using.
 
 When using the `.zip` or `.tar.gz` packages, system settings can be configured:
 
-* temporarily with <<ulimit,`ulimit`>>, or
-* permanently in <<limits.conf,`/etc/security/limits.conf`>>.
+* Temporarily with <<ulimit,`ulimit`>>.
+* Permanently in <<limits.conf,`/etc/security/limits.conf`>>.
 
 When using the RPM or Debian packages, most system settings are set in the
 <<sysconfig,system configuration file>>. However, systems which use systemd


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add missing system config entry (#79830)