### PR TITLE
Use CorruptStateException if cluster state corrupt (#79805)

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -273,7 +273,7 @@ public class PersistedClusterStateService {
                     final String thisNodeId = userData.get(NODE_ID_KEY);
                     assert thisNodeId != null;
                     if (nodeId != null && nodeId.equals(thisNodeId) == false) {
-                        throw new IllegalStateException("unexpected node ID in metadata, found [" + thisNodeId +
+                        throw new CorruptStateException("unexpected node ID in metadata, found [" + thisNodeId +
                             "] in [" + dataPath + "] but expected [" + nodeId + "]");
                     } else if (nodeId == null) {
                         nodeId = thisNodeId;
@@ -355,7 +355,7 @@ public class PersistedClusterStateService {
                                     logger.error("checkIndex: {}", line);
                                 }
                             }
-                            throw new IllegalStateException(
+                            throw new CorruptStateException(
                                 "the index containing the cluster metadata under the data path ["
                                     + dataPath
                                     + "] has been changed by an external force after it was last written by Elasticsearch and is "
@@ -370,7 +370,7 @@ public class PersistedClusterStateService {
                         final OnDiskState onDiskState = loadOnDiskState(dataPath, directoryReader);
 
                         if (nodeId.equals(onDiskState.nodeId) == false) {
-                            throw new IllegalStateException("the index containing the cluster metadata under the data path [" + dataPath +
+                            throw new CorruptStateException("the index containing the cluster metadata under the data path [" + dataPath +
                                 "] belongs to a node with ID [" + onDiskState.nodeId + "] but this node's ID is [" + nodeId + "]");
                         }
 
@@ -379,7 +379,7 @@ public class PersistedClusterStateService {
                                 committedClusterUuid = onDiskState.metadata.clusterUUID();
                                 committedClusterUuidPath = dataPath;
                             } else if (committedClusterUuid.equals(onDiskState.metadata.clusterUUID()) == false) {
-                                throw new IllegalStateException("mismatched cluster UUIDs in metadata, found [" + committedClusterUuid +
+                                throw new CorruptStateException("mismatched cluster UUIDs in metadata, found [" + committedClusterUuid +
                                     "] in [" + committedClusterUuidPath + "] and [" + onDiskState.metadata.clusterUUID() + "] in ["
                                     + dataPath + "]");
                             }
@@ -407,7 +407,7 @@ public class PersistedClusterStateService {
         }
 
         if (bestOnDiskState.currentTerm != maxCurrentTermOnDiskState.currentTerm) {
-            throw new IllegalStateException("inconsistent terms found: best state is from [" + bestOnDiskState.dataPath +
+            throw new CorruptStateException("inconsistent terms found: best state is from [" + bestOnDiskState.dataPath +
                 "] in term [" + bestOnDiskState.currentTerm + "] but there is a stale state in [" + maxCurrentTermOnDiskState.dataPath +
                 "] with greater term [" + maxCurrentTermOnDiskState.currentTerm + "]");
         }
@@ -426,14 +426,14 @@ public class PersistedClusterStateService {
                 .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, bytes.bytes, bytes.offset, bytes.length));
             logger.trace("found global metadata with last-accepted term [{}]", metadata.coordinationMetadata().term());
             if (builderReference.get() != null) {
-                throw new IllegalStateException("duplicate global metadata found in [" + dataPath + "]");
+                throw new CorruptStateException("duplicate global metadata found in [" + dataPath + "]");
             }
             builderReference.set(Metadata.builder(metadata));
         });
 
         final Metadata.Builder builder = builderReference.get();
         if (builder == null) {
-            throw new IllegalStateException("no global metadata found in [" + dataPath + "]");
+            throw new CorruptStateException("no global metadata found in [" + dataPath + "]");
         }
 
         logger.trace("got global metadata, now reading index metadata");
@@ -445,7 +445,7 @@ public class PersistedClusterStateService {
                 .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, bytes.bytes, bytes.offset, bytes.length));
             logger.trace("found index metadata for {}", indexMetadata.getIndex());
             if (indexUUIDs.add(indexMetadata.getIndexUUID()) == false) {
-                throw new IllegalStateException("duplicate metadata found for " + indexMetadata.getIndex() + " in [" + dataPath + "]");
+                throw new CorruptStateException("duplicate metadata found for " + indexMetadata.getIndex() + " in [" + dataPath + "]");
             }
             builder.put(indexMetadata, false);
         });

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -214,14 +214,14 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
         final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
 
-        final String failure = expectThrows(IllegalStateException.class, () -> newNodeEnvironment(combinedPaths)).getMessage();
+        final String failure = expectThrows(CorruptStateException.class, () -> newNodeEnvironment(combinedPaths)).getMessage();
         assertThat(failure,
             allOf(containsString("unexpected node ID in metadata"), containsString(nodeIds[0]), containsString(nodeIds[1])));
         assertTrue("[" + failure + "] should match " + Arrays.toString(dataPaths2),
             Arrays.stream(dataPaths2).anyMatch(p -> failure.contains(p.toString())));
 
         // verify that loadBestOnDiskState has same check
-        final String message = expectThrows(IllegalStateException.class,
+        final String message = expectThrows(CorruptStateException.class,
             () -> new PersistedClusterStateService(Stream.of(combinedPaths).map(path -> NodeEnvironment.resolveNodePath(path, 0))
                 .toArray(Path[]::new), nodeIds[0], xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L
@@ -280,7 +280,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         }
 
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
-            final String message = expectThrows(IllegalStateException.class,
+            final String message = expectThrows(CorruptStateException.class,
                 () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message,
                 allOf(containsString("mismatched cluster UUIDs in metadata"), containsString(clusterUUID1), containsString(clusterUUID2)));
@@ -338,7 +338,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         }
 
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
-            final String message = expectThrows(IllegalStateException.class,
+            final String message = expectThrows(CorruptStateException.class,
                 () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(
                     containsString("inconsistent terms found"),
@@ -501,7 +501,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 }
             }
 
-            final String message = expectThrows(IllegalStateException.class,
+            final String message = expectThrows(CorruptStateException.class,
                 () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(containsString("no global metadata found"), containsString(brokenPath.toString())));
         }
@@ -532,7 +532,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 }
             }
 
-            final String message = expectThrows(IllegalStateException.class,
+            final String message = expectThrows(CorruptStateException.class,
                 () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(containsString("duplicate global metadata found"), containsString(brokenPath.toString())));
         }
@@ -578,7 +578,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 }
             }
 
-            final String message = expectThrows(IllegalStateException.class,
+            final String message = expectThrows(CorruptStateException.class,
                 () -> newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState()).getMessage();
             assertThat(message, allOf(
                 containsString("duplicate metadata found"),
@@ -879,7 +879,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     .collect(Collectors.toList())));
             }
 
-            assertThat(expectThrows(IllegalStateException.class, persistedClusterStateService::loadBestOnDiskState).getMessage(), allOf(
+            assertThat(expectThrows(CorruptStateException.class, persistedClusterStateService::loadBestOnDiskState).getMessage(), allOf(
                     startsWith("the index containing the cluster metadata under the data path ["),
                     endsWith("] has been changed by an external force after it was last written by Elasticsearch and is now unreadable")));
         }


### PR DESCRIPTION
Today we throw an `IllegalStateException` if we find some kind of
inconsistency in the on-disk cluster state. This commit moves to using
the more appropriate `CorruptStateException` instead.