### PR TITLE
[7.11] [DOCS] Remove ESS icon from `index.number_of_shards` (#79653)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -36,7 +36,7 @@ specific index module:
 
 [[index-number-of-shards]]
 // tag::index-number-of-shards-tag[]
-`index.number_of_shards` {ess-icon}::
+`index.number_of_shards`::
 The number of primary shards that an index should have. Defaults to `1`. This setting can only be set at index creation time. It cannot be changed on a closed index.
 +
 NOTE: The number of shards are limited to `1024` per index. This limitation is a safety limit to prevent accidental creation of indices that can destabilize a cluster due to resource allocation. The limit can be modified by specifying `export ES_JAVA_OPTS="-Des.index.max_number_of_shards=128"` system property on every node that is part of the cluster.


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove ESS icon from `index.number_of_shards` (#79653)