### PR TITLE
[7.15] [DOCS] Add `wildcard` parameter to `wildcard` query docs (#79722)

### DIFF
--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -40,6 +40,27 @@ GET /_search
 
 [[wildcard-query-field-params]]
 ==== Parameters for `<field>`
+
+`boost`::
+(Optional, float) Floating point number used to decrease or increase the
+<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
++
+You can use the `boost` parameter to adjust relevance scores for searches
+containing two or more queries.
++
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+
+`case_insensitive` added:[7.10.0]::
+(Optional, Boolean) Allows case insensitive matching of the
+pattern with the indexed field values when set to true. Default is false which means
+the case sensitivity of matching depends on the underlying field's mapping.
+
+`rewrite`::
+(Optional, string) Method used to rewrite the query. For valid values and more information, see the
+<<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
+
 `value`::
 (Required, string) Wildcard pattern for terms you wish to find in the provided
 `<field>`.
@@ -54,25 +75,9 @@ WARNING: Avoid beginning patterns with `*` or `?`. This can increase
 the iterations needed to find matching terms and slow search performance.
 --
 
-`boost`::
-(Optional, float) Floating point number used to decrease or increase the
-<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
-+
-You can use the `boost` parameter to adjust relevance scores for searches
-containing two or more queries.
-+
-Boost values are relative to the default value of `1.0`. A boost value between
-`0` and `1.0` decreases the relevance score. A value greater than `1.0`
-increases the relevance score.
-
-`rewrite`::
-(Optional, string) Method used to rewrite the query. For valid values and more information, see the
-<<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
-
-`case_insensitive` added:[7.10.0]::
-(Optional, Boolean) Allows case insensitive matching of the
-pattern with the indexed field values when set to true. Default is false which means
-the case sensitivity of matching depends on the underlying field's mapping.
+`wildcard`::
+(Required, string) An alias for the `value` parameter. If you specify both
+`value` and `wildcard`, the query uses the last one in the request body.
 
 [[wildcard-query-notes]]
 ==== Notes


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add `wildcard` parameter to `wildcard` query docs (#79722)