### PR TITLE
[7.16] Upgrade Gradle Enterprise plugin to 3.7.1 (#79643)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-  id "com.gradle.enterprise" version "3.6.4"
+  id "com.gradle.enterprise" version "3.7.1"
 }
 
 includeBuild "build-conventions"


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Upgrade Gradle Enterprise plugin to 3.7.1 (#79643)