### PR TITLE
[DOCS] Fixes typo in preview datafeed API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -25,6 +25,7 @@ Previews a {dfeed}.
 == {api-prereq-title}
 
 Requires the following privileges:
+
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
    privilege)
 * source index configured in the {dfeed}: `read`.


### PR DESCRIPTION
This PR fixes a minor typo in the [preview datafeed API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html):

![image](https://user-images.githubusercontent.com/26471269/138942474-765dbc21-0fd3-4a66-9cfe-824816cad250.png)
