### PR TITLE
[7.16] [DOCS] Clarify `max_count` only counts successful snapshot attempts (#79749)

### DIFF
--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -89,8 +89,10 @@ deletion. {slm-init} deletes expired snapshots based on the
 `max_count`::
 (Optional, integer)
 Maximum number of snapshots to retain, even if the snapshots have not yet
-expired. If the number of snapshots in the repository exceeds this limit, the 
-policy retains the most recent snapshots and deletes older snapshots.
+expired. If the number of snapshots in the repository exceeds this limit, the
+policy retains the most recent snapshots and deletes older snapshots. This limit
+only includes snapshots with a <<get-snapshot-api-response-state,`state`>> of
+`SUCCESS`.
 +
 NOTE: The maximum number of snapshots in a repository should not exceed `200`. This ensures that the snapshot repository metadata does not
 grow to a size which might destabilize the master node. If the `max_count` setting is not set, this limit should be enforced by configuring

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -283,6 +283,7 @@ Number of shards that were successfully included in the snapshot.
 Number of shards that failed to be included in the snapshot.
 ====
 
+[[get-snapshot-api-response-state]]
 `state`::
 +
 --


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Clarify `max_count` only counts successful snapshot attempts (#79749)