### PR TITLE
Changing test keytab to use aes256-cts-hmac-sha1-96 instead of des3-cbc-sha1-kd (#78703)

### DIFF
--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/kdc.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/kdc.conf.template
@@ -13,9 +13,8 @@
         kadmind_port = 749
         max_life = 12h 0m 0s
         max_renewable_life = 7d 0h 0m 0s
-        master_key_type = des3-cbc-sha1-kd
-        # This is the only supported enctype for fips 140-2
-        supported_enctypes = des3-cbc-sha1-kd:normal
+        master_key_type = aes256-cts-hmac-sha1-96
+        supported_enctypes = aes256-cts-hmac-sha1-96:normal
     }
 
 [logging]

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
@@ -14,9 +14,9 @@
     ignore_acceptor_hostname = true
     rdns = false
     # des3-cbc-sha1-kd is the only enctype available in fips 140-2
-    default_tgs_enctypes = des3-cbc-sha1-kd
-    default_tkt_enctypes = des3-cbc-sha1-kd
-    permitted_enctypes = des3-cbc-sha1-kd
+    default_tgs_enctypes = aes256-cts-hmac-sha1-96
+    default_tkt_enctypes = aes256-cts-hmac-sha1-96
+    permitted_enctypes = aes256-cts-hmac-sha1-96
     # udp_preference_limit = 1
     kdc_timeout = 3000
     canonicalize = true


### PR DESCRIPTION
The des3-cbc-sha1-kd encryption type is deprecated and no longer supported by newer jvm, causing tests
that use the krb5kdc-fixture to fail. This commit changes the encryption type of the test keytab to
aes256-cts-hmac-sha1-96.
Relates #78423 #78703