### PR TITLE
Fix TimeseriesLifecycleTypeTests.testValidateColdPhase

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -149,7 +149,6 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/78158")
     public void testValidateColdPhase() {
         LifecycleAction invalidAction = null;
         Map<String, LifecycleAction> actions = randomSubsetOf(VALID_COLD_ACTIONS)
@@ -168,10 +167,10 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
                 equalTo("invalid action [" + invalidAction.getWriteableName() + "] defined in phase [cold]"));
         } else {
             TimeseriesLifecycleType.INSTANCE.validate(coldPhase.values());
-        }
-        if (actions.containsKey(FreezeAction.NAME)) {
-            assertSettingDeprecationsAndWarnings(new Setting<?>[0],
-                new DeprecationWarning(DeprecationLogger.CRITICAL, TimeseriesLifecycleType.FREEZE_ACTION_DEPRECATION_WARNING));
+            if (actions.containsKey(FreezeAction.NAME)) {
+                assertSettingDeprecationsAndWarnings(new Setting<?>[0],
+                    new DeprecationWarning(DeprecationLogger.CRITICAL, TimeseriesLifecycleType.FREEZE_ACTION_DEPRECATION_WARNING));
+            }
         }
     }
 


### PR DESCRIPTION
This test was checking for the deprecation warning about `freeze` being present, however, in the
event that the policy is invalid due to an invalid action, an exception is thrown before the
deprecation warning ever happens. This caused the test to fail in some cases.

Resolves #78158
