### PR TITLE
Switch get to as for BigInteger conversion in unsigned long

### DIFF
--- a/x-pack/plugin/mapper-unsigned-long/build.gradle
+++ b/x-pack/plugin/mapper-unsigned-long/build.gradle
@@ -34,6 +34,9 @@ restResources {
 
 tasks.named("yamlRestTestV7CompatTest").configure {
     systemProperty 'tests.rest.blacklist', [
-        '50_script_values/Scripted fields values return Long'
+        '50_script_values/Scripted fields values return Long',
+        '50_script_values/Scripted sort values',
+        '50_script_values/Script query',
+        '50_script_values/script_score query'
     ].join(',')
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
@@ -121,7 +121,7 @@ public class UnsignedLongDocValuesField implements UnsignedLongField, DocValuesF
     }
 
     @Override
-    public List<BigInteger> getBigIntegers() {
+    public List<BigInteger> asBigIntegers() {
         if (isEmpty()) {
             return Collections.emptyList();
         }
@@ -136,12 +136,12 @@ public class UnsignedLongDocValuesField implements UnsignedLongField, DocValuesF
     }
 
     @Override
-    public BigInteger getBigInteger(BigInteger defaultValue) {
-        return getBigInteger(0, defaultValue);
+    public BigInteger asBigInteger(BigInteger defaultValue) {
+        return asBigInteger(0, defaultValue);
     }
 
     @Override
-    public BigInteger getBigInteger(int index, BigInteger defaultValue) {
+    public BigInteger asBigInteger(int index, BigInteger defaultValue) {
         if (isEmpty() || index < 0 || index >= count) {
             return defaultValue;
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
@@ -14,21 +14,21 @@ import java.util.List;
 
 public interface UnsignedLongField extends Field {
 
+    /** Return all the values as a {@code List}. */
+    List<Long> getValues();
+
     /** Returns the 0th index value as an {@code long} if it exists, otherwise {@code defaultValue}. */
     long getValue(long defaultValue);
 
     /** Returns the value at {@code index} as an {@code long} if it exists, otherwise {@code defaultValue}. */
     long getValue(int index, long defaultValue);
 
-    /** Return all the values as a {@code List}. */
-    List<Long> getValues();
+    /** Converts all the values to {@code BigInteger} and returns them as a {@code List}. */
+    List<BigInteger> asBigIntegers();
 
     /** Returns the 0th index value as a {@code BigInteger} if it exists, otherwise {@code defaultValue}. */
-    BigInteger getBigInteger(BigInteger defaultValue);
+    BigInteger asBigInteger(BigInteger defaultValue);
 
     /** Returns the value at {@code index} as a {@code BigInteger} if it exists, otherwise {@code defaultValue}. */
-    BigInteger getBigInteger(int index, BigInteger defaultValue);
-
-    /** Converts all the values to {@code BigInteger} and returns them as a {@code List}. */
-    List<BigInteger> getBigIntegers();
+    BigInteger asBigInteger(int index, BigInteger defaultValue);
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
@@ -15,9 +15,9 @@ class org.elasticsearch.xpack.unsignedlong.UnsignedLongField @dynamic_type {
   long getValue(long)
   long getValue(int, long)
   List getValues()
-  BigInteger getBigInteger(BigInteger)
-  BigInteger getBigInteger(int, BigInteger)
-  List getBigIntegers()
+  BigInteger asBigInteger(BigInteger)
+  BigInteger asBigInteger(int, BigInteger)
+  List asBigIntegers()
 }
 
 class org.elasticsearch.xpack.unsignedlong.UnsignedLongDocValuesField @dynamic_type {

--- a/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/50_script_values.yml
+++ b/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/50_script_values.yml
@@ -74,7 +74,7 @@ setup:
               order: desc
               type: number
               script:
-                source: "field('ul').getBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue()"
+                source: "field('ul').asBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue()"
 
   - match: { hits.hits.0.sort: [1.8446744073709552E19] }
   - match: { hits.hits.1.sort: [1.8446744073709552E19] }
@@ -128,7 +128,7 @@ setup:
               filter:
                script:
                  script:
-                   source: "field('ul').getBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue() > 10E18"
+                   source: "field('ul').asBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue() > 10E18"
           sort: [ { ul: asc } ]
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "4" }
@@ -182,7 +182,7 @@ setup:
             script_score:
               query: {match_all: {}}
               script:
-                source: "field('ul').getBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue()"
+                source: "field('ul').asBigInteger(BigInteger.valueOf(Long.parseUnsignedLong('18446744073709551614'))).doubleValue()"
 
   - match: { hits.total.value: 5 }
   - do:


### PR DESCRIPTION
This changes the methods getBigInteger and getBigIntegers to asBigInteger and asBigIntegers since we have decided to use `as` for conversions within the scripting fields api instead of `get`.