### PR TITLE
[7.15] Fix testBlobStoreCache (#79747)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -291,7 +291,8 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
                     .build();
             }
         });
-        ensureGreen(restoredAgainIndex);
+
+        ensureGreen("restored-*");
 
         logger.info("--> shards of [{}] should start without downloading bytes from the blob store", restoredAgainIndex);
         checkNoBlobStoreAccess(useSoftDeletes);


### PR DESCRIPTION
The attempt to fix this test in #78616 wasn't complete: we need to wait
for all mounted indices, not only the last restored one, before deleting
the indices. Otherwise one of the mounted index might still be
initializing and recreates the cached documents in
`.snapshot-blob-cache`  

Closes #78993