### PR TITLE
[7.16] Grant additional privileges for endpoint transform indices to kibana_system (#79619)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -456,7 +456,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Fleet package upgrade
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs-*", "synthetics-*", "traces-*",
-                        "/metrics-.*&~(metrics-endpoint\\.metadata.*)/")
+                        "/metrics-.*&~(metrics-endpoint\\.metadata_current_default)/")
                     .privileges(UpdateSettingsAction.NAME, PutMappingAction.NAME, RolloverAction.NAME)
                     .build(),
                 // For src/dest indices of the Endpoint package that ships a transform

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -694,18 +694,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         ).forEach(action -> assertThat(kibanaRole.cluster().check(action, request, authentication), is(true)));
 
         Arrays.asList(
-            "metrics-endpoint.metadata" + randomAlphaOfLengthBetween(3, 8)
-        ).forEach(indexName -> {
-            assertOnlyReadAllowed(kibanaRole, indexName);
-            assertViewIndexMetadata(kibanaRole, indexName);
-
-            final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(indexAbstraction), is(false));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(PutMappingAction.NAME).test(indexAbstraction), is(false));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(false));
-        });
-
-        Arrays.asList(
             "metrics-endpoint.metadata_current_default",
             ".metrics-endpoint.metadata_current_default",
             ".metrics-endpoint.metadata_united_default"


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Grant additional privileges for endpoint transform indices to kibana_system (#79619)