### PR TITLE
[ML] Add queue_capacity to deployment stats

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
@@ -101,6 +101,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
             ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
             nodeStatsList);
 
         Map<String, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
@@ -145,6 +146,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
             ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
             nodeStatsList);
         var response = new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(),
             List.of(model1), 1);
@@ -202,6 +204,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
             ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
             nodeStatsList);
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -123,7 +123,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testScope() throws Exception {
-        MlFilter safeIps = MlFilter.builder("safe_ips").setItems("111.111.111.111", "222.222.222.222").build();
+        MlFilter safeIps = MlFilter.builder("safe_ips").setItems("111.111.111.111<", "222.222.222.222").build();
         assertThat(putMlFilter(safeIps).getFilter(), equalTo(safeIps));
 
         DetectionRule rule = new DetectionRule.Builder(RuleScope.builder().include("ip", "safe_ips")).build();
@@ -154,7 +154,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         }
 
         // Now send anomalous counts for our filtered IPs plus 333.333.333.333
-        List<String> namedIps = Arrays.asList("111.111.111.111", "222.222.222.222", "333.333.333.333");
+        List<String> namedIps = Arrays.asList("111.111.111.111<", "222.222.222.222", "333.333.333.333");
         long firstAnomalyTime = timestamp;
         for (int i = 0; i < 10; i++) {
             for (String ip : namedIps) {
@@ -225,7 +225,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         assertThat(records.size(), equalTo(2));
         for (AnomalyRecord record : records) {
             assertThat(record.getTimestamp().getTime(), equalTo(secondAnomalyTime));
-            assertThat(record.getOverFieldValue(), is(oneOf("111.111.111.111", "222.222.222.222")));
+            assertThat(record.getOverFieldValue(), is(oneOf("111.111.111.111<", "222.222.222.222")));
         }
 
         closeJob(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -123,7 +123,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testScope() throws Exception {
-        MlFilter safeIps = MlFilter.builder("safe_ips").setItems("111.111.111.111<", "222.222.222.222").build();
+        MlFilter safeIps = MlFilter.builder("safe_ips").setItems("111.111.111.111", "222.222.222.222").build();
         assertThat(putMlFilter(safeIps).getFilter(), equalTo(safeIps));
 
         DetectionRule rule = new DetectionRule.Builder(RuleScope.builder().include("ip", "safe_ips")).build();
@@ -154,7 +154,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         }
 
         // Now send anomalous counts for our filtered IPs plus 333.333.333.333
-        List<String> namedIps = Arrays.asList("111.111.111.111<", "222.222.222.222", "333.333.333.333");
+        List<String> namedIps = Arrays.asList("111.111.111.111", "222.222.222.222", "333.333.333.333");
         long firstAnomalyTime = timestamp;
         for (int i = 0; i < 10; i++) {
             for (String ip : namedIps) {
@@ -225,7 +225,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         assertThat(records.size(), equalTo(2));
         for (AnomalyRecord record : records) {
             assertThat(record.getTimestamp().getTime(), equalTo(secondAnomalyTime));
-            assertThat(record.getOverFieldValue(), is(oneOf("111.111.111.111<", "222.222.222.222")));
+            assertThat(record.getOverFieldValue(), is(oneOf("111.111.111.111", "222.222.222.222")));
         }
 
         closeJob(job.getId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -185,6 +185,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<Trai
             ByteSizeValue.ofBytes(task.getParams().getModelBytes()),
             task.getParams().getInferenceThreads(),
             task.getParams().getModelThreads(),
+            task.getParams().getQueueCapacity(),
             nodeStats)
         );
     }


### PR DESCRIPTION
Adds the `queue_capacity` to the response of the
get trained model deployment stats API.
