### PR TITLE
Revert "Leverage artifact transformations to unpack old test es distributions (#79827)"

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -11,8 +11,6 @@ import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.AntFixture
-import org.elasticsearch.gradle.transform.UnzipTransform
-import org.gradle.api.internal.artifacts.ArtifactAttributes
 
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
@@ -104,17 +102,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     systemProperty "tests.fromOld", "false"
   }
 } else {
-  /* Register a gradle artifact transformation to unpack resolved elasticsearch distributions. We only resolve
-   * zip files here. Using artifact transforms allow a better caching of the downloaded distros as the
-   * transformed (unpacked) distro will be cached by gradle resulting in less unpacking
-   *
-   * To avoid testing against too many old versions, always pick first and last version per major
-   */
-  project.getDependencies().registerTransform(UnzipTransform.class, transformSpec -> {
-    transformSpec.getFrom().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE);
-    transformSpec.getTo().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
-  });
-
+  /* Set up tasks to unzip and run the old versions of ES before running the
+   * integration tests. */
   def versions = ['2', '1', '090']
   if (Os.isFamily(Os.FAMILY_MAC)) {
     // 0.90 fails sometimes on mac, given that it is so old, let us disable it
@@ -122,10 +111,21 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     versions = ['2', '1']
   }
   versions.each { version ->
-    def oldEsDependency = configurations['es' + version]
-    oldEsDependency.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
+    // TODO Rene: we should be able to replace these unzip tasks with gradle artifact transforms
+    TaskProvider<Sync> unzip = tasks.register("unzipEs${version}", Sync) {
+      Configuration oldEsDependency = configurations['es' + version]
+      dependsOn oldEsDependency
+      /* Use a closure here to delay resolution of the dependency until we need
+       * it */
+      from {
+        oldEsDependency.collect { zipTree(it) }
+      }
+      into temporaryDir
+    }
+
     TaskProvider<AntFixture> fixture = tasks.register("oldEs${version}Fixture", AntFixture) {
-      dependsOn project.configurations.oldesFixture, jdks.legacy, oldEsDependency
+      dependsOn project.configurations.oldesFixture, jdks.legacy
+      dependsOn unzip
       executable = "${BuildParams.runtimeJavaHome}/bin/java"
       env 'CLASSPATH', "${-> project.configurations.oldesFixture.asPath}"
       // old versions of Elasticsearch need JAVA_HOME
@@ -136,7 +136,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       }
       args 'oldes.OldElasticsearch',
         baseDir,
-        "${ -> oldEsDependency.singleFile.getPath()}",
+        unzip.get().temporaryDir,
         version == '090'
       waitCondition = { fixture, ant ->
         // the fixture writes the ports file when Elasticsearch's HTTP service

--- a/qa/repository-old-versions/build.gradle
+++ b/qa/repository-old-versions/build.gradle
@@ -14,8 +14,6 @@ import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.AntFixture
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
-import org.elasticsearch.gradle.transform.UnzipTransform
-import org.gradle.api.internal.artifacts.ArtifactAttributes
 
 apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.internal-testclusters'
@@ -42,17 +40,9 @@ jdks {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   logger.warn("Disabling repository-old-versions tests because we can't get the pid file on windows")
 } else {
-  /* Register a gradle artifact transformation to unpack resolved elasticsearch distributions. We only resolve
-   * zip files here. Using artifact transforms allow a better caching of the downloaded distros as the
-   * transformed (unpacked) distro will be cached by gradle resulting in less unpacking
-   *
+  /* Set up tasks to unzip and run the old versions of ES before running the integration tests.
    * To avoid testing against too many old versions, always pick first and last version per major
    */
-  project.getDependencies().registerTransform(UnzipTransform.class, transformSpec -> {
-    transformSpec.getFrom().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE);
-    transformSpec.getTo().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
-  });
-
   for (String versionString : ['5.0.0', '5.6.16', '6.0.0', '6.8.20']) {
     Version version = Version.fromString(versionString)
     String packageName = 'org.elasticsearch.distribution.zip'
@@ -60,11 +50,24 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     String versionNoDots = version.toString().replace('.', '_')
     String configName = "es${versionNoDots}"
 
-    def config = configurations.create(configName)
-    config.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
+    configurations.create(configName)
+
     dependencies.add(configName, artifact)
 
+    // TODO Rene: we should be able to replace these unzip tasks with gradle artifact transforms
+    TaskProvider<Sync> unzip = tasks.register("unzipEs${versionNoDots}", Sync) {
+      Configuration oldEsDependency = configurations[configName]
+      dependsOn oldEsDependency
+      /* Use a closure here to delay resolution of the dependency until we need
+       * it */
+      from {
+        oldEsDependency.collect { zipTree(it) }
+      }
+      into temporaryDir
+    }
+
     String repoLocation = "${buildDir}/cluster/shared/repo/${versionNoDots}"
+
     String clusterName = versionNoDots
 
     def testClusterProvider = testClusters.register(clusterName) {
@@ -73,7 +76,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     }
 
     TaskProvider<AntFixture> fixture = tasks.register("oldES${versionNoDots}Fixture", AntFixture) {
-      dependsOn project.configurations.oldesFixture, jdks.legacy, config
+      dependsOn project.configurations.oldesFixture, jdks.legacy
+      dependsOn unzip
       executable = "${BuildParams.runtimeJavaHome}/bin/java"
       env 'CLASSPATH', "${-> project.configurations.oldesFixture.asPath}"
       // old versions of Elasticsearch need JAVA_HOME
@@ -84,7 +88,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       }
       args 'oldes.OldElasticsearch',
         baseDir,
-        "${ -> config.getSingleFile().toPath()}",
+        unzip.get().temporaryDir,
         false,
         "path.repo: ${repoLocation}"
       maxWaitInSeconds 60


### PR DESCRIPTION
This reverts commit 664b82160be10f602a1a0eb9ee1d5ca1078e2881.
This might have caused oldEs090Fixture failures (see #79898)

We have not been able to reproduce the problem nor locally or on an centos8
We will revisit this advancement once we narrowed down the reasoning
of those failures