### PR TITLE
[7.16] [DOCS] Add experimental label to TSDB mapping params and settings (#79647)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -328,6 +328,7 @@ indicates no ingest pipeline will run.
 
 [[index-mapping-dimension-fields-limit]]
 `index.mapping.dimension_fields.limit`::
+experimental:[] 
 For internal use by Elastic only. Maximum number of time series dimensions for
 the index. Defaults to `16`.
 +

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -154,6 +154,7 @@ The following parameters are accepted by `keyword` fields:
 
 // tag::dimension[]
 `time_series_dimension`::
+experimental:[]
 (Optional, Boolean) For internal use by Elastic only. Marks the field as a time
 series dimension. Defaults to `false`.
 +

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -184,6 +184,7 @@ A numeric field can't be both a time series dimension and a time series metric.
 
 // tag::time_series_metric[]
 `time_series_metric`::
+experimental:[]
 (Optional, string) For internal use by Elastic only. Marks the field as a time
 series metric. The value is the metric type. Defaults to `null` (Not a time
 series metric).


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Add experimental label to TSDB mapping params and settings (#79647)