### PR TITLE
Increase test timeout for CoordinatorTests testAllSearchesExecuted

### DIFF
--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -378,7 +378,7 @@ public class CoordinatorTests extends ESTestCase {
                 });
             }
 
-            assertTrue(completionCountdown.await(10L, TimeUnit.SECONDS));
+            assertTrue(completionCountdown.await(20L, TimeUnit.SECONDS));
             assertThat(coordinator.queue, empty());
 
             assertBusy(() -> assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(0)));


### PR DESCRIPTION
This test has failed only once and it was due to a timeout. Its average runtime is 0.2 seconds so it should be safe to increase its timeout to 20sec to catch outlier test runs without increasing overall test suite runtime.

Fixes #77020
