### PR TITLE
SearchContext: remove unused variable

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -67,7 +67,6 @@ public abstract class SearchContext implements Releasable {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private InnerHitsContext innerHitsContext;
 
-    private boolean rewritten;
     private Query rewriteQuery;
 
     protected SearchContext() {}


### PR DESCRIPTION
remove `rewritten` as it isn't used anywhere.