### PR TITLE
[7.15] [DOCS] Fix a few spelling mistakes in libs (#79761)

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
@@ -98,7 +98,7 @@ public final class DissectKey {
     /**
      * Copy constructor to explicitly override the modifier.
      * @param key The key to copy (except for the modifier)
-     * @param modifier the modifer to use for this copy
+     * @param modifier the modifier to use for this copy
      */
     DissectKey(DissectKey key, DissectKey.Modifier modifier){
         this.modifier = modifier;

--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectMatch.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectMatch.java
@@ -93,7 +93,7 @@ final class DissectMatch {
     }
 
     /**
-     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occured.
+     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occurred.
      *
      * @return the map of the results.
      */

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationKeys.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationKeys.java
@@ -102,7 +102,7 @@ public class SslConfigurationKeys {
     public static final String KEYSTORE_TYPE = "keystore.type";
     /**
      * The {@link javax.net.ssl.KeyManagerFactory#getAlgorithm() key management algorithm} to use when
-     * connstructing a Key manager from a {@link #KEYSTORE_PATH keystore}.
+     * constructing a Key manager from a {@link #KEYSTORE_PATH keystore}.
      */
     public static final String KEYSTORE_ALGORITHM = "keystore.algorithm";
     // -- PEM


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Fix a few spelling mistakes in libs (#79761)