### PR TITLE
Reenable REST compat tests after backport of #77013

### DIFF
--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -47,12 +47,3 @@ tasks.named("thirdPartyAudit").configure {
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.addAllowedWarningRegex("\\[types removal\\].*")
 }
-
-tasks.named("yamlRestTestV7CompatTest").configure {
-  systemProperty 'tests.rest.blacklist', [
-    //marked as not needing compatible api
-    'ingest/200_default_pipeline/Test index with default pipeline',
-    'ingest/240_required_pipeline/Test index with final pipeline',
-    'ingest/240_required_pipeline/Test final pipeline when target index is changed',
-  ].join(',')
-}


### PR DESCRIPTION
Completes the backport of https://github.com/elastic/elasticsearch/pull/77013