### PR TITLE
[7.16] [DOCS] Fix typo (#79609)

### DIFF
--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -78,7 +78,7 @@ Dates
 // tag::decimal-warning[]
 will accept numbers with a decimal point like `{"date": 1618249875.123456}`
 but there are some cases ({es-issue}70085[#70085]) where we'll lose precision
-on those dates so should avoid them.
+on those dates so they should be avoided.
 // end::decimal-warning[]
 ====
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Fix typo (#79609)