### PR TITLE
[7.16] mute failing test in SqlSearchPageTimeoutIT (#79933)

### DIFF
--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
@@ -32,6 +32,7 @@ public class SqlSearchPageTimeoutIT extends AbstractSqlIntegTestCase {
         return settings.build();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/79928")
     public void testSearchContextIsCleanedUpAfterPageTimeoutForHitsQueries() throws Exception {
         setupTestIndex();
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - mute failing test in SqlSearchPageTimeoutIT (#79933)