### PR TITLE
[7.16] [DOCS] Edits formatting in create trained models API (#79758)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -373,19 +373,17 @@ An array of `trained_model` objects. Supported trained models are `tree` and
 (Optional, string)
 A human-readable description of the {infer} trained model.
 
-`estimated_heap_memory_usage_bytes`:::
+`estimated_heap_memory_usage_bytes`::
 (Optional, integer)
-The estimated heap usage in bytes to keep the trained model in memory.
-
-Can only be supplied if `defer_definition_decompression` is `true` or the
+The estimated heap usage in bytes to keep the trained model in memory. This
+property is supported only if `defer_definition_decompression` is `true` or the
 model definition is not supplied.
 
-`estimated_operations`:::
+`estimated_operations`::
 (Optional, integer)
 The estimated number of operations to use the trained model during inference.
-
-Can only be supplied if `defer_definition_decompression` is `true` or the
-model definition is not supplied.
+This property is supported only if `defer_definition_decompression` is `true` or
+the model definition is not supplied.
 
 //Begin inference_config
 `inference_config`::


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Edits formatting in create trained models API (#79758)