### PR TITLE
Fix tsdb's shrink test in multi-version cluster 

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/80_index_resize.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/80_index_resize.yml
@@ -2,6 +2,18 @@ setup:
   - skip:
       version: " - 7.99.99"
       reason: introduced in 8.0.0
+      features: "arbitrary_key"
+
+  # Force allocating all shards to a single node so that we can shrink later.
+  # In production you can move the shards to the single node after they've been
+  # built but that is very difficult during testing, especially during multi
+  # version tests.
+
+  - do:
+      nodes.info:
+        node_id: data:true
+  - set:
+      nodes._arbitrary_key_: node_id
 
   - do:
       indices.create:
@@ -13,6 +25,8 @@ setup:
                 routing_path: [metricset, k8s.pod.uid]
                 number_of_shards: 3
                 number_of_replicas: 0
+                # ensure everything is allocated on the same data node for shrink
+                routing.allocation.include._id: $node_id
             mappings:
               properties:
                 "@timestamp":
@@ -99,25 +113,6 @@ shrink:
   - skip:
       version: " - 7.99.99"
       reason: introduced in 8.0.0
-      features: "arbitrary_key"
-
-  - do:
-      nodes.info:
-        node_id: data:true
-  - set:
-      nodes._arbitrary_key_: node_id
-
-  - do:
-      indices.put_settings:
-        index: test
-        body:
-          index.routing.allocation.include._id: $node_id
-
-  - do:
-      cluster.health:
-        wait_for_status: green
-        wait_for_no_relocating_shards: true
-        index: test
 
   - do:
       indices.shrink:


### PR DESCRIPTION
We weren't running tsdb's shrink test in multi-version clusters until
today because we didn't have more than one version to run against. Today
we forked an 8.1 branch and discovered that the test has trouble running
in mixed version clusters because shards can't move from newer versions
to older versions. This fixes the test by locking the shard to a single
node when we create it.

Closes #79936