### PR TITLE
[ML] Fixing doc test substitution bug

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -657,7 +657,7 @@ PUT _ml/data_frame/analytics/loganalytics
   }
 }
 --------------------------------------------------
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/79931"]
+// TEST[setup:setup_logdata]
 
 
 The API returns the following result:
@@ -692,7 +692,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version" : "8.0.0"/"version" : $body.version/]
+// TESTRESPONSE[s/"version": "8.0.0"/"version": $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
The substitutions should not have a space after the field
name.

Fixes #79931