### PR TITLE
[ML] fixing ML test failures due to the 8.1.0 version bump

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.datafeed;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -22,7 +21,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79932")
 public class AggProviderWireSerializationTests extends AbstractBWCWireSerializationTestCase<AggProvider> {
 
     @Override
@@ -70,7 +68,7 @@ public class AggProviderWireSerializationTests extends AbstractBWCWireSerializat
 
     @Override
     protected AggProvider mutateInstanceForVersion(AggProvider instance, Version version) {
-        if (version.onOrBefore(Version.V_8_0_0)) {
+        if (version.before(Version.V_8_0_0)) {
             return new AggProvider(instance.getAggs(), instance.getParsedAggs(), instance.getParsingException(), false);
         }
         return instance;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -105,7 +105,6 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
     // - _node_name0 is too old (version 7.2.0)
     // - _node_name1 is too old (version 7.9.1)
     // - _node_name2 is too old (version 7.9.2)
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79939")
     public void testGetAssignment_MlNodesAreTooOld() {
         TaskExecutor executor = createTaskExecutor();
         TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, false);
@@ -130,11 +129,15 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
                 ),
                 containsString(
                     "Not opening job [data_frame_id] on node [{_node_name1}{version=7.9.1}], "
-                        + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher"
+                        + "because the data frame analytics created for version ["
+                        + Version.CURRENT
+                        + "] requires a node of version [7.10.0] or higher"
                 ),
                 containsString(
                     "Not opening job [data_frame_id] on node [{_node_name2}{version=7.9.2}], "
-                        + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher"
+                        + "because the data frame analytics created for version ["
+                        + Version.CURRENT
+                        + "] requires a node of version [7.10.0] or higher"
                 )
             )
         );


### PR DESCRIPTION
Fixing test failures due to version 8.1.0 version bump.

closes: https://github.com/elastic/elasticsearch/issues/79939
closes: https://github.com/elastic/elasticsearch/issues/79932

