### PR TITLE
Upgrade Mockito to 4.0.0

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @Ignore("https://github.com/elastic/elasticsearch/issues/77190")
@@ -109,7 +109,7 @@ public class GenerateReleaseNotesTaskTest extends GradleUnitTestCase {
             partitionedFiles,
             hasEntry(equalTo(QualifiedVersion.of("8.0.0-SNAPSHOT")), hasItem(new File("docs/changelog/1234.yaml")))
         );
-        verifyZeroInteractions(gitWrapper);
+        verifyNoMoreInteractions(gitWrapper);
     }
 
     /**
@@ -128,7 +128,7 @@ public class GenerateReleaseNotesTaskTest extends GradleUnitTestCase {
         // then:
         assertThat(partitionedFiles, aMapWithSize(1));
         assertThat(partitionedFiles, hasEntry(equalTo(QualifiedVersion.of("8.5.0")), hasItem(new File("docs/changelog/1234.yaml"))));
-        verifyZeroInteractions(gitWrapper);
+        verifyNoMoreInteractions(gitWrapper);
     }
 
     /**
@@ -146,7 +146,7 @@ public class GenerateReleaseNotesTaskTest extends GradleUnitTestCase {
         // then:
         assertThat(partitionedFiles, aMapWithSize(1));
         assertThat(partitionedFiles, hasEntry(equalTo(QualifiedVersion.of("8.0.0-alpha1")), hasItem(new File("docs/changelog/1234.yaml"))));
-        verifyZeroInteractions(gitWrapper);
+        verifyNoMoreInteractions(gitWrapper);
     }
 
     /**

--- a/client/sniffer/src/test/java/org/elasticsearch/client/sniff/SnifferTests.java
+++ b/client/sniffer/src/test/java/org/elasticsearch/client/sniff/SnifferTests.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollectionOf;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -204,7 +204,7 @@ public class SnifferTests extends RestClientTestCase {
         int totalRuns = nodesSniffer.runs.get();
         assertEquals(iters, totalRuns);
         int setNodesRuns = totalRuns - nodesSniffer.failures.get() - nodesSniffer.emptyList.get();
-        verify(restClient, times(setNodesRuns)).setNodes(anyCollectionOf(Node.class));
+        verify(restClient, times(setNodesRuns)).setNodes(anyCollection());
         verifyNoMoreInteractions(restClient);
     }
 
@@ -270,7 +270,7 @@ public class SnifferTests extends RestClientTestCase {
         int totalRuns = nodesSniffer.runs.get();
         assertEquals(0, totalRuns);
         int setNodesRuns = totalRuns - nodesSniffer.failures.get() - nodesSniffer.emptyList.get();
-        verify(restClient, times(setNodesRuns)).setNodes(anyCollectionOf(Node.class));
+        verify(restClient, times(setNodesRuns)).setNodes(anyCollection());
         verifyNoMoreInteractions(restClient);
     }
 
@@ -414,7 +414,7 @@ public class SnifferTests extends RestClientTestCase {
 
             assertEquals(completedTasks, nodesSniffer.runs.get());
             int setNodesRuns = nodesSniffer.runs.get() - nodesSniffer.failures.get() - nodesSniffer.emptyList.get();
-            verify(restClient, times(setNodesRuns)).setNodes(anyCollectionOf(Node.class));
+            verify(restClient, times(setNodesRuns)).setNodes(anyCollection());
             verifyNoMoreInteractions(restClient);
         } finally {
             executor.shutdown();

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -25,8 +25,8 @@ dependencies {
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   // mockito
-  api 'org.mockito:mockito-core:3.12.4'
-  api 'net.bytebuddy:byte-buddy:1.11.13'
+  api 'org.mockito:mockito-core:4.0.0'
+  api 'net.bytebuddy:byte-buddy:1.11.19'
   api 'org.objenesis:objenesis:3.2'
 }
 

--- a/libs/grok/src/test/java/org/elasticsearch/grok/MatcherWatchdogTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/MatcherWatchdogTests.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MatcherWatchdogTests extends ESTestCase {
 
@@ -77,7 +76,7 @@ public class MatcherWatchdogTests extends ESTestCase {
             (delay, command) -> threadPool.schedule(command, delay, TimeUnit.MILLISECONDS)
         );
         // Periodic action is not scheduled because no thread is registered
-        verifyZeroInteractions(threadPool);
+        verifyNoMoreInteractions(threadPool);
         CompletableFuture<Runnable> commandFuture = new CompletableFuture<>();
         // Periodic action is scheduled because a thread is registered
         doAnswer(invocationOnMock -> {
@@ -92,7 +91,7 @@ public class MatcherWatchdogTests extends ESTestCase {
         watchdog.unregister(matcher);
         command.run();
         // Periodic action is not scheduled again because no thread is registered
-        verifyZeroInteractions(threadPool);
+        verifyNoMoreInteractions(threadPool);
         watchdog.register(matcher);
         Thread otherThread = new Thread(() -> {
             Matcher otherMatcher = mock(Matcher.class);

--- a/libs/nio/src/test/java/org/elasticsearch/nio/NioSelectorTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/NioSelectorTests.java
@@ -301,7 +301,7 @@ public class NioSelectorTests extends ESTestCase {
             selector.close();
             selector.queueWrite(new FlushReadyWrite(channelContext, buffers, listener));
         });
-        verify(listener).accept(isNull(Void.class), any(ClosedSelectorException.class));
+        verify(listener).accept(isNull(), any(ClosedSelectorException.class));
     }
 
     public void testQueueWriteChannelIsClosed() throws Exception {
@@ -312,7 +312,7 @@ public class NioSelectorTests extends ESTestCase {
         selector.preSelect();
 
         verify(channelContext, times(0)).queueWriteOperation(writeOperation);
-        verify(listener).accept(isNull(Void.class), any(ClosedChannelException.class));
+        verify(listener).accept(isNull(), any(ClosedChannelException.class));
     }
 
     public void testQueueWriteChannelIsUnregistered() throws Exception {
@@ -323,7 +323,7 @@ public class NioSelectorTests extends ESTestCase {
         selector.preSelect();
 
         verify(channelContext, times(0)).queueWriteOperation(writeOperation);
-        verify(listener).accept(isNull(Void.class), any(IllegalStateException.class));
+        verify(listener).accept(isNull(), any(IllegalStateException.class));
     }
 
     public void testQueueWriteSuccessful() throws Exception {
@@ -484,7 +484,7 @@ public class NioSelectorTests extends ESTestCase {
 
         selector.cleanupAndCloseChannels();
 
-        verify(listener).accept(isNull(Void.class), any(ClosedSelectorException.class));
+        verify(listener).accept(isNull(), any(ClosedSelectorException.class));
         verify(eventHandler).handleClose(channelContext);
         verify(eventHandler).handleClose(unregisteredContext);
     }

--- a/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
@@ -229,7 +229,7 @@ public class SocketChannelContextTests extends ESTestCase {
         ByteBuffer[] buffers = { ByteBuffer.wrap(createMessage(10)) };
         context.sendMessage(buffers, listener);
 
-        verify(listener).accept(isNull(Void.class), any(ClosedChannelException.class));
+        verify(listener).accept(isNull(), any(ClosedChannelException.class));
     }
 
     public void testSendMessageFromDifferentThreadIsQueuedWithSelector() throws Exception {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -93,7 +93,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @LuceneTestCase.SuppressFileSystems(value = "ExtrasFS") // Don't randomly add 'extra' files to directory.
@@ -324,7 +323,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
 
         // Subsequent updates shouldn't trigger a reload.
         databaseNodeService.updateDatabase("_name", "_md5", geoIpTmpDir.resolve("some-file"));
-        verifyZeroInteractions(ingestService);
+        verifyNoMoreInteractions(ingestService);
     }
 
     private String mockSearches(String databaseName, int firstChunk, int lastChunk) throws IOException {

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
@@ -22,8 +22,8 @@ import java.text.ParseException;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +46,7 @@ public class ExpressionFieldScriptTests extends ESTestCase {
 
         IndexNumericFieldData fieldData = mock(IndexNumericFieldData.class);
         when(fieldData.getFieldName()).thenReturn("field");
-        when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
+        when(fieldData.load(any())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
         lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData);

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +47,7 @@ public class ExpressionNumberSortScriptTests extends ESTestCase {
 
         IndexNumericFieldData fieldData = mock(IndexNumericFieldData.class);
         when(fieldData.getFieldName()).thenReturn("field");
-        when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
+        when(fieldData.load(any())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
         lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData);

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +46,7 @@ public class ExpressionTermsSetQueryTests extends ESTestCase {
 
         IndexNumericFieldData fieldData = mock(IndexNumericFieldData.class);
         when(fieldData.getFieldName()).thenReturn("field");
-        when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
+        when(fieldData.load(any())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
         lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -86,7 +86,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class MetadataRolloverServiceTests extends ESTestCase {
@@ -839,8 +839,8 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         assertSame(rolloverResult.clusterState, clusterState);
 
         verify(createIndexService).validateIndexName(any(), same(clusterState));
-        verifyZeroInteractions(createIndexService);
-        verifyZeroInteractions(metadataIndexAliasesService);
+        verifyNoMoreInteractions(createIndexService);
+        verifyNoMoreInteractions(metadataIndexAliasesService);
 
         reset(createIndexService);
         doThrow(new InvalidIndexNameException("test", "invalid")).when(createIndexService).validateIndexName(any(), any());
@@ -859,8 +859,8 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         );
 
         verify(createIndexService).validateIndexName(any(), same(clusterState));
-        verifyZeroInteractions(createIndexService);
-        verifyZeroInteractions(metadataIndexAliasesService);
+        verifyNoMoreInteractions(createIndexService);
+        verifyNoMoreInteractions(metadataIndexAliasesService);
     }
 
     public void testRolloverClusterStateForDataStreamNoTemplate() throws Exception {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class TransportBulkActionIngestTests extends ESTestCase {
@@ -253,7 +253,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
             ActionListener.wrap(response -> {}, exception -> { throw new AssertionError(exception); })
         );
         assertTrue(action.isExecuted);
-        verifyZeroInteractions(ingestService);
+        verifyNoMoreInteractions(ingestService);
     }
 
     public void testSingleItemBulkActionIngestSkipped() throws Exception {
@@ -266,7 +266,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
             ActionListener.wrap(response -> {}, exception -> { throw new AssertionError(exception); })
         );
         assertTrue(action.isExecuted);
-        verifyZeroInteractions(ingestService);
+        verifyNoMoreInteractions(ingestService);
     }
 
     public void testIngestLocal() throws Exception {
@@ -314,7 +314,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         completionHandler.getValue().accept(DUMMY_WRITE_THREAD, null);
         assertTrue(action.isExecuted);
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 
     public void testSingleItemBulkActionIngestLocal() throws Exception {
@@ -354,7 +354,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         completionHandler.getValue().accept(DUMMY_WRITE_THREAD, null);
         assertTrue(action.isExecuted);
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 
     public void testIngestSystemLocal() throws Exception {
@@ -402,7 +402,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         completionHandler.getValue().accept(DUMMY_WRITE_THREAD, null);
         assertTrue(action.isExecuted);
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 
     public void testIngestForward() throws Exception {
@@ -562,7 +562,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         completionHandler.getValue().accept(DUMMY_WRITE_THREAD, null);
         assertTrue(action.isExecuted);
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 
     public void testDoExecuteCalledTwiceCorrectly() throws Exception {
@@ -607,7 +607,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         assertTrue(action.isExecuted);
         assertTrue(action.indexCreated); // now the index is created since we skipped the ingest node path.
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 
     public void testNotFindDefaultPipelineFromTemplateMatches() {
@@ -626,7 +626,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
             })
         );
         assertEquals(IngestService.NOOP_PIPELINE_NAME, indexRequest.getPipeline());
-        verifyZeroInteractions(ingestService);
+        verifyNoMoreInteractions(ingestService);
 
     }
 
@@ -778,6 +778,6 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         completionHandler.getValue().accept(DUMMY_WRITE_THREAD, null);
         assertTrue(action.isExecuted);
         assertFalse(responseCalled.get()); // listener would only be called by real index action, not our mocked one
-        verifyZeroInteractions(transportService);
+        verifyNoMoreInteractions(transportService);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/resync/TransportResyncReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/resync/TransportResyncReplicationActionTests.java
@@ -60,7 +60,7 @@ import static org.elasticsearch.transport.TransportService.NOOP_TRANSPORT_INTERC
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -144,7 +144,7 @@ public class TransportResyncReplicationActionTests extends ESTestCase {
                     acquiredPermits.incrementAndGet();
                     callback.onResponse(acquiredPermits::decrementAndGet);
                     return null;
-                }).when(indexShard).acquirePrimaryOperationPermit(anyActionListener(), anyString(), anyObject(), eq(true));
+                }).when(indexShard).acquirePrimaryOperationPermit(anyActionListener(), anyString(), any(), eq(true));
                 when(indexShard.getReplicationGroup()).thenReturn(
                     new ReplicationGroup(
                         shardRoutingTable,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -113,7 +113,6 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -939,7 +938,7 @@ public class TransportReplicationActionTests extends ESTestCase {
             ActionListener<Releasable> argument = (ActionListener<Releasable>) invocation.getArguments()[0];
             argument.onResponse(count::decrementAndGet);
             return null;
-        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), anyObject(), eq(forceExecute));
+        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), any(), eq(forceExecute));
         when(shard.getActiveOperationsCount()).thenAnswer(i -> count.get());
 
         final IndexService indexService = mock(IndexService.class);
@@ -1569,7 +1568,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                 callback.onFailure(new ShardNotInPrimaryModeException(shardId, IndexShardState.STARTED));
             }
             return null;
-        }).when(indexShard).acquirePrimaryOperationPermit(any(ActionListener.class), anyString(), anyObject(), eq(forceExecute));
+        }).when(indexShard).acquirePrimaryOperationPermit(any(ActionListener.class), anyString(), any(), eq(forceExecute));
         doAnswer(invocation -> {
             long term = (Long) invocation.getArguments()[0];
             ActionListener<Releasable> callback = (ActionListener<Releasable>) invocation.getArguments()[3];
@@ -1582,8 +1581,7 @@ public class TransportReplicationActionTests extends ESTestCase {
             count.incrementAndGet();
             callback.onResponse(count::decrementAndGet);
             return null;
-        }).when(indexShard)
-            .acquireReplicaOperationPermit(anyLong(), anyLong(), anyLong(), any(ActionListener.class), anyString(), anyObject());
+        }).when(indexShard).acquireReplicaOperationPermit(anyLong(), anyLong(), anyLong(), any(ActionListener.class), anyString(), any());
         when(indexShard.getActiveOperationsCount()).thenAnswer(i -> count.get());
 
         when(indexShard.routingEntry()).thenAnswer(invocationOnMock -> {

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -74,7 +74,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -517,7 +516,7 @@ public class TransportWriteActionTests extends ESTestCase {
             count.incrementAndGet();
             callback.onResponse(count::decrementAndGet);
             return null;
-        }).when(indexShard).acquirePrimaryOperationPermit(anyActionListener(), anyString(), anyObject());
+        }).when(indexShard).acquirePrimaryOperationPermit(anyActionListener(), anyString(), any());
         doAnswer(invocation -> {
             long term = (Long) invocation.getArguments()[0];
             @SuppressWarnings("unchecked")
@@ -531,7 +530,7 @@ public class TransportWriteActionTests extends ESTestCase {
             count.incrementAndGet();
             callback.onResponse(count::decrementAndGet);
             return null;
-        }).when(indexShard).acquireReplicaOperationPermit(anyLong(), anyLong(), anyLong(), anyActionListener(), anyString(), anyObject());
+        }).when(indexShard).acquireReplicaOperationPermit(anyLong(), anyLong(), anyLong(), anyActionListener(), anyString(), any());
         when(indexShard.routingEntry()).thenAnswer(invocationOnMock -> {
             final ClusterState state = clusterService.state();
             final RoutingNode node = state.getRoutingNodes().node(state.nodes().getLocalNodeId());

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySetOf;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +55,7 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
 
     public MetadataIndexAliasesServiceTests() {
         // Mock any deletes so we don't need to worry about how MetadataDeleteIndexService does its job
-        when(deleteIndexService.deleteIndices(any(ClusterState.class), anySetOf(Index.class))).then(i -> {
+        when(deleteIndexService.deleteIndices(any(ClusterState.class), anySet())).then(i -> {
             ClusterState state = (ClusterState) i.getArguments()[0];
             @SuppressWarnings("unchecked")
             Collection<Index> indices = (Collection<Index>) i.getArguments()[1];

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -125,7 +125,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -666,7 +665,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         doAnswer(invocation -> {
             ((ActionListener<Releasable>) invocation.getArguments()[0]).onResponse(() -> {});
             return null;
-        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), anyObject());
+        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), any());
 
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder("test")
             .settings(
@@ -754,7 +753,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             freed.set(false);
             ((ActionListener<Releasable>) invocation.getArguments()[0]).onResponse(() -> freed.set(true));
             return null;
-        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), anyObject());
+        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), any());
 
         Thread cancelingThread = new Thread(() -> cancellableThreads.cancel("test"));
         cancelingThread.start();

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -54,7 +54,7 @@ import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -96,16 +96,8 @@ public class DefaultSearchContextTests extends ESTestCase {
         when(indexCache.query()).thenReturn(queryCache);
         when(indexService.cache()).thenReturn(indexCache);
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
-        when(
-            indexService.newSearchExecutionContext(
-                eq(shardId.id()),
-                eq(shardId.id()),
-                anyObject(),
-                anyObject(),
-                nullable(String.class),
-                anyObject()
-            )
-        ).thenReturn(searchExecutionContext);
+        when(indexService.newSearchExecutionContext(eq(shardId.id()), eq(shardId.id()), any(), any(), nullable(String.class), any()))
+            .thenReturn(searchExecutionContext);
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.hasNested()).thenReturn(randomBoolean());
         when(indexService.mapperService()).thenReturn(mapperService);

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import java.util.function.Function;
 
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,12 +39,12 @@ public class LeafDocLookupTests extends ESTestCase {
 
         MappedFieldType fieldType1 = mock(MappedFieldType.class);
         when(fieldType1.name()).thenReturn("field");
-        when(fieldType1.valueForDisplay(anyObject())).then(returnsFirstArg());
+        when(fieldType1.valueForDisplay(any())).then(returnsFirstArg());
         IndexFieldData<?> fieldData1 = createFieldData(docValues, "field");
 
         MappedFieldType fieldType2 = mock(MappedFieldType.class);
         when(fieldType1.name()).thenReturn("alias");
-        when(fieldType1.valueForDisplay(anyObject())).then(returnsFirstArg());
+        when(fieldType1.valueForDisplay(any())).then(returnsFirstArg());
         IndexFieldData<?> fieldData2 = createFieldData(docValues, "alias");
 
         docLookup = new LeafDocLookup(
@@ -102,7 +102,7 @@ public class LeafDocLookupTests extends ESTestCase {
 
         IndexFieldData<?> fieldData = mock(IndexFieldData.class);
         when(fieldData.getFieldName()).thenReturn(name);
-        doReturn(leafFieldData).when(fieldData).load(anyObject());
+        doReturn(leafFieldData).when(fieldData).load(any());
 
         return fieldData;
     }

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookupTests.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +32,7 @@ public class LeafStoredFieldsLookupTests extends ESTestCase {
         MappedFieldType fieldType = mock(MappedFieldType.class);
         when(fieldType.name()).thenReturn("field");
         // Add 10 when valueForDisplay is called so it is easy to be sure it *was* called
-        when(fieldType.valueForDisplay(anyObject())).then(invocation -> (Double) invocation.getArguments()[0] + 10);
+        when(fieldType.valueForDisplay(any())).then(invocation -> (Double) invocation.getArguments()[0] + 10);
 
         FieldInfo mockFieldInfo = new FieldInfo(
             "field",

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class RestoreServiceTests extends ESTestCase {
@@ -124,7 +124,7 @@ public class RestoreServiceTests extends ESTestCase {
         final RepositoriesService repositoriesService = mock(RepositoriesService.class);
         RestoreService.refreshRepositoryUuids(false, repositoriesService, listener);
         assertTrue(listener.isDone());
-        verifyZeroInteractions(repositoriesService);
+        verifyNoMoreInteractions(repositoriesService);
     }
 
     public void testRefreshRepositoryUuidsRefreshesAsNeeded() throws Exception {
@@ -140,7 +140,7 @@ public class RestoreServiceTests extends ESTestCase {
                 case 1:
                     final Repository notBlobStoreRepo = mock(Repository.class);
                     repositories.put(repositoryName, notBlobStoreRepo);
-                    finalAssertions.add(() -> verifyZeroInteractions(notBlobStoreRepo));
+                    finalAssertions.add(() -> verifyNoMoreInteractions(notBlobStoreRepo));
                     break;
                 case 2:
                     final Repository freshBlobStoreRepo = mock(BlobStoreRepository.class);

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
 
   // mockito
-  api 'org.mockito:mockito-core:3.12.4'
-  api 'net.bytebuddy:byte-buddy:1.11.13'
+  api 'org.mockito:mockito-core:4.0.0'
+  api 'net.bytebuddy:byte-buddy:1.11.19'
   api 'org.objenesis:objenesis:3.2'
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseOperationModeUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseOperationModeUpdateTests.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class LicenseOperationModeUpdateTests extends ESTestCase {
 
@@ -53,7 +53,7 @@ public class LicenseOperationModeUpdateTests extends ESTestCase {
         assertThat(license.operationMode(), equalTo(License.OperationMode.resolve(type)));
         OperationModeFileWatcherTests.writeMode("gold", licenseModeFile);
         license.setOperationModeFileWatcher(operationModeFileWatcher);
-        verifyZeroInteractions(resourceWatcherService);
+        verifyNoMoreInteractions(resourceWatcherService);
         assertThat(license.operationMode(), equalTo(License.OperationMode.resolve(type)));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -41,7 +41,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -96,7 +95,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         threadContext.putHeader(headerName, headerValue);
         ClientHelper.executeAsyncWithOrigin(client, origin, ClusterHealthAction.INSTANCE, new ClusterHealthRequest(), listener);
@@ -128,7 +127,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         threadContext.putHeader(headerName, headerValue);
         Client clientWithOrigin = ClientHelper.clientWithOrigin(client, origin);
@@ -154,7 +153,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
 
@@ -182,7 +181,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
         Map<String, String> headers = new HashMap<>(1);
@@ -215,7 +214,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
         Map<String, String> headers = new HashMap<>(1);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
@@ -49,7 +49,7 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
         T step = newInstance(randomStepKey(), randomStepKey());
 
         PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, null, null, f));
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     protected abstract T newInstance(Step.StepKey key, Step.StepKey nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
@@ -102,7 +102,7 @@ public class CloseFollowerIndexStepTests extends AbstractStepTestCase<CloseFollo
             .build();
         CloseFollowerIndexStep step = new CloseFollowerIndexStep(randomStepKey(), randomStepKey(), client);
         PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, emptyClusterState(), null, f));
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
@@ -136,7 +136,7 @@ public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCa
 
         PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, clusterState, null, f));
 
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     public final void testNoShardFollowTasksForManagedIndex() throws Exception {
@@ -159,7 +159,7 @@ public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCa
 
         PlainActionFuture.<Void, Exception>get(f -> step.performAction(managedIndex, clusterState, null, f));
 
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     private static ClusterState setupClusterStateWithFollowingIndex(IndexMetadata followerIndex) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
 
@@ -156,9 +156,9 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
             .build();
         PlainActionFuture.<Void, Exception>get(f -> step.performAction(firstGenerationIndex, clusterState, null, f));
 
-        verifyZeroInteractions(client);
-        verifyZeroInteractions(adminClient);
-        verifyZeroInteractions(indicesClient);
+        verifyNoMoreInteractions(client);
+        verifyNoMoreInteractions(adminClient);
+        verifyNoMoreInteractions(indicesClient);
     }
 
     private void mockClientRolloverCall(String rolloverTarget) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -228,7 +228,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             () -> PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, clusterState, null, f))
         );
 
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     public void testPerformActionAttrsNoNodesValid() {
@@ -390,7 +390,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         );
         assertEquals(indexMetadata.getIndex(), e.getIndex());
 
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     public void testPerformActionSomeShardsOnlyOnNewNodes() throws Exception {
@@ -668,7 +668,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             () -> PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, clusterState, null, f))
         );
 
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     private IndexRoutingTable.Builder createRoutingTable(IndexMetadata indexMetadata, Index index, DiscoveryNodes discoveryNodes) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
@@ -168,7 +168,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         assertThat(conditionMetHolder[0], is(true));
         assertThat(informationContextHolder[0], nullValue());
         assertThat(exceptionHolder[0], nullValue());
-        Mockito.verifyZeroInteractions(client);
+        Mockito.verifyNoMoreInteractions(client);
     }
 
     private static ShardFollowNodeTaskStatus createShardFollowTaskStatus(int shardId, long leaderGCP, long followerGCP) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForRolloverReadyStep> {
 
@@ -240,9 +240,9 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         assertEquals(true, conditionsMet.get());
 
-        verifyZeroInteractions(client);
-        verifyZeroInteractions(adminClient);
-        verifyZeroInteractions(indicesClient);
+        verifyNoMoreInteractions(client);
+        verifyNoMoreInteractions(adminClient);
+        verifyNoMoreInteractions(indicesClient);
     }
 
     private void mockRolloverIndexCall(String rolloverTarget, WaitForRolloverReadyStep step) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/support/SecurityQueryTemplateEvaluatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/support/SecurityQueryTemplateEvaluatorTests.java
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SecurityQueryTemplateEvaluatorTests extends ESTestCase {
@@ -119,7 +119,7 @@ public class SecurityQueryTemplateEvaluatorTests extends ESTestCase {
         String querySource = Strings.toString(new TermQueryBuilder("field", "value").toXContent(builder, ToXContent.EMPTY_PARAMS));
         String result = SecurityQueryTemplateEvaluator.evaluateTemplate(querySource, scriptService, null);
         assertThat(result, sameInstance(querySource));
-        verifyZeroInteractions(scriptService);
+        verifyNoMoreInteractions(scriptService);
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -569,7 +569,7 @@ public class SSLServiceTests extends ESTestCase {
 
         when(sslService.sslConfiguration(settings)).thenReturn(sslConfig);
         when(sslService.sslContext(sslConfig)).thenReturn(sslContext);
-        when(sslService.supportedCiphers(any(String[].class), anyListOf(String.class), any(Boolean.TYPE))).thenAnswer(inv -> {
+        when(sslService.supportedCiphers(any(String[].class), anyList(), any(Boolean.TYPE))).thenAnswer(inv -> {
             final Object[] args = inv.getArguments();
             assertThat(args[0], is(supportedCiphers));
             assertThat(args[1], is(requestedCiphers));

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -138,7 +138,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
-        Mockito.verifyZeroInteractions(clusterService);
+        Mockito.verifyNoMoreInteractions(clusterService);
     }
 
     public void testRunPolicyPhaseCompletePolicyStep() {
@@ -156,7 +156,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
 
-        Mockito.verifyZeroInteractions(clusterService);
+        Mockito.verifyNoMoreInteractions(clusterService);
     }
 
     public void testRunPolicyPhaseCompleteWithMoreStepsPolicyStep() {
@@ -208,7 +208,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
-        Mockito.verifyZeroInteractions(clusterService);
+        Mockito.verifyNoMoreInteractions(clusterService);
     }
 
     public void testRunPolicyErrorStepOnRetryableFailedStep() {
@@ -702,7 +702,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
         assertEquals(0, step.getExecuteCount());
-        Mockito.verifyZeroInteractions(clusterService);
+        Mockito.verifyNoMoreInteractions(clusterService);
     }
 
     public void testRunPolicyAsyncWaitStepClusterStateChangeIgnored() {
@@ -723,7 +723,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
         assertEquals(0, step.getExecuteCount());
-        Mockito.verifyZeroInteractions(clusterService);
+        Mockito.verifyNoMoreInteractions(clusterService);
     }
 
     public void testRunPolicyThatDoesntExist() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -530,7 +530,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         Mockito.reset(clusterService);
         SchedulerEngine.Event schedulerEvent = new SchedulerEngine.Event("foo", randomLong(), randomLong());
         indexLifecycleService.triggered(schedulerEvent);
-        Mockito.verifyZeroInteractions(indicesClient, clusterService);
+        Mockito.verifyNoMoreInteractions(indicesClient, clusterService);
     }
 
     public void testParsingOriginationDateBeforeIndexCreation() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,7 +51,7 @@ public class LifecyclePolicyClientTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
 
@@ -87,7 +87,7 @@ public class LifecyclePolicyClientTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
         Map<String, String> headers = new HashMap<>(1);
@@ -128,7 +128,7 @@ public class LifecyclePolicyClientTests extends ESTestCase {
             latch.countDown();
             ((ActionListener<?>) invocationOnMock.getArguments()[2]).onResponse(null);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
         Map<String, String> headers = new HashMap<>(1);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class MachineLearningTests extends ESTestCase {
@@ -87,7 +87,7 @@ public class MachineLearningTests extends ESTestCase {
         machineLearning.prepareForIndicesMigration(clusterService, client, ActionListener.wrap(response::set, e -> fail(e.getMessage())));
 
         assertThat(response.get(), equalTo(Collections.singletonMap("already_in_upgrade_mode", true)));
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
 
         machineLearning.indicesMigrationComplete(
             response.get(),
@@ -97,7 +97,7 @@ public class MachineLearningTests extends ESTestCase {
         );
 
         // Neither pre nor post should have called any action
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     public void testMaxOpenWorkersSetting_givenDefault() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -39,7 +39,6 @@ import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -95,11 +94,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
 
         registry.clusterChanged(createClusterChangedEvent(nodes));
 
-        verify(client, times(4)).execute(
-            same(PutComposableIndexTemplateAction.INSTANCE),
-            putIndexTemplateRequestCaptor.capture(),
-            anyObject()
-        );
+        verify(client, times(4)).execute(same(PutComposableIndexTemplateAction.INSTANCE), putIndexTemplateRequestCaptor.capture(), any());
 
         PutComposableIndexTemplateAction.Request req = putIndexTemplateRequestCaptor.getAllValues()
             .stream()
@@ -122,11 +117,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
 
         registry.clusterChanged(createClusterChangedEvent(nodes));
 
-        verify(client, times(4)).execute(
-            same(PutComposableIndexTemplateAction.INSTANCE),
-            putIndexTemplateRequestCaptor.capture(),
-            anyObject()
-        );
+        verify(client, times(4)).execute(same(PutComposableIndexTemplateAction.INSTANCE), putIndexTemplateRequestCaptor.capture(), any());
 
         PutComposableIndexTemplateAction.Request req = putIndexTemplateRequestCaptor.getAllValues()
             .stream()

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DatafeedTimingStatsReporterTests extends ESTestCase {
 
@@ -50,7 +49,7 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         reporter.reportSearchDuration(null);
         assertThat(reporter.getCurrentTimingStats(), equalTo(createDatafeedTimingStats(JOB_ID, 3, 10, 10000.0)));
 
-        verifyZeroInteractions(timingStatsPersister);
+        verifyNoMoreInteractions(timingStatsPersister);
     }
 
     public void testReportSearchDuration_Zero() {
@@ -95,7 +94,7 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         reporter.reportDataCounts(null);
         assertThat(reporter.getCurrentTimingStats(), equalTo(createDatafeedTimingStats(JOB_ID, 3, 10, 10000.0)));
 
-        verifyZeroInteractions(timingStatsPersister);
+        verifyNoMoreInteractions(timingStatsPersister);
     }
 
     public void testReportDataCounts() {
@@ -122,7 +121,7 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         reporter.reportDataCounts(createDataCounts(0));
         reporter.finishReporting();
 
-        verifyZeroInteractions(timingStatsPersister);
+        verifyNoMoreInteractions(timingStatsPersister);
     }
 
     public void testFinishReporting_WithChange() {
@@ -143,7 +142,7 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         // This call would normally trigger persisting but because of the "disallowPersisting" call above it will not.
         reporter.reportSearchDuration(ONE_SECOND);
 
-        verifyZeroInteractions(timingStatsPersister);
+        verifyNoMoreInteractions(timingStatsPersister);
     }
 
     public void testTimingStatsDifferSignificantly() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -72,7 +72,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class DestinationIndexTests extends ESTestCase {
@@ -380,7 +379,7 @@ public class DestinationIndexTests extends ESTestCase {
             equalTo("A field that matches the dest.results_field [ml] already exists; please set a different results_field")
         );
 
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     public void testReadMetadata_GivenNoMeta() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -68,7 +68,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class JobResultsProviderTests extends ESTestCase {
@@ -758,7 +757,7 @@ public class JobResultsProviderTests extends ESTestCase {
             )
         );
 
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     public void testDatafeedTimingStats_MultipleDocumentsAtOnce() throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class TimingStatsReporterTests extends ESTestCase {
 
@@ -44,7 +43,7 @@ public class TimingStatsReporterTests extends ESTestCase {
         TimingStatsReporter reporter = createReporter(stats);
         assertThat(reporter.getCurrentTimingStats(), equalTo(stats));
 
-        verifyZeroInteractions(bulkResultsPersister);
+        verifyNoMoreInteractions(bulkResultsPersister);
     }
 
     public void testReporting() {
@@ -92,7 +91,7 @@ public class TimingStatsReporterTests extends ESTestCase {
         TimingStatsReporter reporter = createReporter(new TimingStats(JOB_ID));
         reporter.finishReporting();
 
-        verifyZeroInteractions(bulkResultsPersister);
+        verifyNoMoreInteractions(bulkResultsPersister);
     }
 
     public void testFinishReporting_WithChange() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/normalizer/ScoresUpdaterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/normalizer/ScoresUpdaterTests.java
@@ -36,7 +36,6 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyListOf;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -419,7 +418,7 @@ public class ScoresUpdaterTests extends ESTestCase {
 
     private void verifyNormalizerWasInvoked(int times) throws IOException {
         int bucketSpan = job.getAnalysisConfig() == null ? 0 : ((Long) job.getAnalysisConfig().getBucketSpan().seconds()).intValue();
-        verify(normalizer, times(times)).normalize(eq(bucketSpan), anyListOf(Normalizable.class), eq(QUANTILES_STATE));
+        verify(normalizer, times(times)).normalize(eq(bucketSpan), anyList(), eq(QUANTILES_STATE));
     }
 
     private void verifyNothingWasUpdated() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -457,7 +456,7 @@ public class HttpExporterTests extends ESTestCase {
 
         assertThat(HttpExporter.createSniffer(config, client, listener), nullValue());
 
-        verifyZeroInteractions(client, listener);
+        verifyNoMoreInteractions(client, listener);
     }
 
     public void testCreateSniffer() throws IOException {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -509,12 +508,12 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
 
         if (expected == Boolean.TRUE) {
             verify(responseChecker).apply(response);
-            verifyZeroInteractions(dneResponseChecker);
+            verifyNoMoreInteractions(dneResponseChecker);
         } else if (expected == Boolean.FALSE) {
-            verifyZeroInteractions(responseChecker);
+            verifyNoMoreInteractions(responseChecker);
             verify(dneResponseChecker).apply(response);
         } else {
-            verifyZeroInteractions(responseChecker, dneResponseChecker);
+            verifyNoMoreInteractions(responseChecker, dneResponseChecker);
         }
 
         verifyCheckListener(expected);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests {@link TemplateHttpResource}.
@@ -71,7 +71,7 @@ public class TemplateHttpResourceTests extends AbstractPublishableHttpResourceTe
         RestClient mockClient = mock(RestClient.class);
         SetOnce<HttpResource.ResourcePublishResult> result = new SetOnce<>();
         resource.doPublish(mockClient, ActionListener.wrap(result::set, e -> { throw new RuntimeException("Unexpected exception", e); }));
-        verifyZeroInteractions(mockClient); // Should not have used the client at all.
+        verifyNoMoreInteractions(mockClient); // Should not have used the client at all.
         HttpResource.ResourcePublishResult resourcePublishResult = result.get();
         assertThat(resourcePublishResult, notNullValue());
         assertThat(resourcePublishResult.getResourceState(), notNullValue());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -46,7 +46,7 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
         resource.doCheck(client, wrapMockListener(checkListener));
 
         verify(checkListener).onResponse(true);
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     public void testDoCheckExistsFor404() {

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -59,7 +59,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -317,7 +317,7 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
         ).repository(repositoryName);
         encryptedRepository.licenseStateSupplier = () -> {
             MockLicenseState mockLicenseState = mock(MockLicenseState.class);
-            when(mockLicenseState.isAllowed(anyObject())).thenReturn(false);
+            when(mockLicenseState.isAllowed(any())).thenReturn(false);
             return mockLicenseState;
         };
 

--- a/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/SingleUseKeyTests.java
+++ b/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/SingleUseKeyTests.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SingleUseKeyTests extends ESTestCase {
@@ -75,7 +75,7 @@ public class SingleUseKeyTests extends ESTestCase {
         assertThat(generatedSingleUseKey2.getKeyId(), equalTo(testKeyId));
         assertThat(generatedSingleUseKey2.getNonce(), equalTo(nonce + 1));
         assertThat(generatedSingleUseKey2.getKey().getEncoded(), equalTo(testKeyPlaintext));
-        verifyZeroInteractions(keyGenerator);
+        verifyNoMoreInteractions(keyGenerator);
     }
 
     public void testConcurrentWrapAround() throws Exception {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -609,7 +609,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             ((ActionListener) invocationOnMock.getArguments()[2]).onResponse(r);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
@@ -714,7 +714,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             ((ActionListener) invocationOnMock.getArguments()[2]).onResponse(r);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
@@ -819,7 +819,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             ((ActionListener) invocationOnMock.getArguments()[2]).onResponse(r);
             return null;
-        }).when(client).execute(anyObject(), anyObject(), anyObject());
+        }).when(client).execute(any(), any(), any());
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         RollupJobStatus status = new RollupJobStatus(IndexerState.STOPPED, null);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/ScrollHelperIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/ScrollHelperIntegTests.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -109,11 +109,11 @@ public class ScrollHelperIntegTests extends ESSingleNodeTestCase {
             listener.onResponse(response);
             return null;
         };
-        doAnswer(returnResponse).when(client).search(eq(request), anyObject());
+        doAnswer(returnResponse).when(client).search(eq(request), any());
         /* The line below simulates the evil cluster. A working cluster would return
          * a response with 0 hits. Our simulated broken cluster returns the same
          * response over and over again. */
-        doAnswer(returnResponse).when(client).searchScroll(anyObject(), anyObject());
+        doAnswer(returnResponse).when(client).searchScroll(any(), any());
 
         AtomicReference<Exception> failure = new AtomicReference<>();
         ScrollHelper.fetchAllByEntity(client, request, new ActionListener<Collection<SearchHit>>() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -49,7 +49,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
@@ -90,7 +89,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             assertEquals(authentication, contextAuth);
             assertThat(readerContext.getFromContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
 
-            verifyZeroInteractions(auditTrailService);
+            verifyNoMoreInteractions(auditTrailService);
         }
     }
 
@@ -126,7 +125,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                 authentication.writeToContext(threadContext);
                 listener.validateReaderContext(readerContext, Empty.INSTANCE);
                 assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
-                verifyZeroInteractions(auditTrail);
+                verifyNoMoreInteractions(auditTrail);
             }
 
             try (StoredContext ignore = threadContext.newStoredContext(false)) {
@@ -140,7 +139,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                 authentication.writeToContext(threadContext);
                 listener.validateReaderContext(readerContext, Empty.INSTANCE);
                 assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
-                verifyZeroInteractions(auditTrail);
+                verifyNoMoreInteractions(auditTrail);
             }
 
             try (StoredContext ignore = threadContext.newStoredContext(false)) {
@@ -247,7 +246,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             auditId,
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, original.getUser().roles())
         );
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
 
         // original user being run as
         User user = new User(new User("test", "role"), new User("authenticated", "runas"));
@@ -266,7 +265,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             auditId,
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, original.getUser().roles())
         );
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
 
         // both user are run as
         current = new Authentication(
@@ -285,7 +284,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             auditId,
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, original.getUser().roles())
         );
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
 
         // different authenticated by type
         Authentication differentRealmType = new Authentication(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyActionTests.java
@@ -45,7 +45,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportGrantApiKeyActionTests extends ESTestCase {
 
@@ -157,7 +157,7 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
         final ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, future::actionGet);
         assertThat(exception, throwableWithMessage("authentication failed for testing"));
 
-        verifyZeroInteractions(apiKeyGenerator);
+        verifyNoMoreInteractions(apiKeyGenerator);
     }
 
     public void testGrantApiKeyWithAccessToken() throws Exception {
@@ -178,7 +178,7 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
         action.doExecute(null, request, future);
 
         assertThat(future.actionGet(), sameInstance(response));
-        verifyZeroInteractions(authenticationService);
+        verifyNoMoreInteractions(authenticationService);
     }
 
     public void testGrantApiKeyWithInvalidatedAccessToken() throws Exception {
@@ -201,8 +201,8 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
         final ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, future::actionGet);
         assertThat(exception, throwableWithMessage("token expired"));
 
-        verifyZeroInteractions(authenticationService);
-        verifyZeroInteractions(apiKeyGenerator);
+        verifyNoMoreInteractions(authenticationService);
+        verifyNoMoreInteractions(apiKeyGenerator);
     }
 
     private Authentication buildAuthentication(String username) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleActionTests.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportDeleteRoleActionTests extends ESTestCase {
 
@@ -73,7 +73,7 @@ public class TransportDeleteRoleActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), is(instanceOf(IllegalArgumentException.class)));
         assertThat(throwableRef.get().getMessage(), containsString("is reserved and cannot be deleted"));
-        verifyZeroInteractions(rolesStore);
+        verifyNoMoreInteractions(rolesStore);
     }
 
     public void testValidRole() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesActionTests.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportGetRolesActionTests extends ESTestCase {
 
@@ -101,7 +101,7 @@ public class TransportGetRolesActionTests extends ESTestCase {
             .map(RoleDescriptor::getName)
             .collect(Collectors.toList());
         assertThat(retrievedRoleNames, containsInAnyOrder(expectedNames.toArray(Strings.EMPTY_ARRAY)));
-        verifyZeroInteractions(rolesStore);
+        verifyNoMoreInteractions(rolesStore);
     }
 
     public void testStoreRoles() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleActionTests.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportPutRoleActionTests extends ESTestCase {
 
@@ -120,7 +120,7 @@ public class TransportPutRoleActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), is(instanceOf(IllegalArgumentException.class)));
         assertThat(throwableRef.get().getMessage(), containsString("is reserved and cannot be modified"));
-        verifyZeroInteractions(rolesStore);
+        verifyNoMoreInteractions(rolesStore);
     }
 
     public void testValidRole() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -362,7 +362,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> tokenResponseFuture.actionGet());
         assertThat(e.getMessage(), containsString("could not decode base64 kerberos ticket"));
         // The code flow should stop after above failure and never reach authenticationService
-        Mockito.verifyZeroInteractions(authenticationService);
+        Mockito.verifyNoMoreInteractions(authenticationService);
     }
 
     public void testServiceAccountCannotCreateOAuthToken() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordActionTests.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportChangePasswordActionTests extends ESTestCase {
 
@@ -95,7 +95,7 @@ public class TransportChangePasswordActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is anonymous and cannot be modified"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testInternalUsers() {
@@ -146,7 +146,7 @@ public class TransportChangePasswordActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is internal"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testValidUser() {
@@ -244,7 +244,7 @@ public class TransportChangePasswordActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("incorrect password hashing algorithm"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testException() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserActionTests.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransportDeleteUserActionTests extends ESTestCase {
 
@@ -78,7 +78,7 @@ public class TransportDeleteUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is anonymous and cannot be deleted"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testInternalUser() {
@@ -125,7 +125,7 @@ public class TransportDeleteUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is internal"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testReservedUser() {
@@ -166,7 +166,7 @@ public class TransportDeleteUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is reserved and cannot be deleted"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testValidUser() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersActionTests.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class TransportGetUsersActionTests extends ESTestCase {
@@ -133,7 +133,7 @@ public class TransportGetUsersActionTests extends ESTestCase {
         } else {
             assertThat("expected an empty array but got: " + Arrays.toString(users), users, emptyArray());
         }
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testInternalUser() {
@@ -182,7 +182,7 @@ public class TransportGetUsersActionTests extends ESTestCase {
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is internal"));
         assertThat(responseRef.get(), is(nullValue()));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testReservedUsersOnly() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class TransportPutUserActionTests extends ESTestCase {
@@ -92,7 +92,7 @@ public class TransportPutUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is anonymous and cannot be modified"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testSystemUser() {
@@ -135,7 +135,7 @@ public class TransportPutUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is internal"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testReservedUser() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledActionTests.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -106,7 +106,7 @@ public class TransportSetEnabledActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is anonymous"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testInternalUser() throws Exception {
@@ -167,7 +167,7 @@ public class TransportSetEnabledActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("is internal"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testValidUser() throws Exception {
@@ -358,6 +358,6 @@ public class TransportSetEnabledActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), instanceOf(IllegalArgumentException.class));
         assertThat(throwableRef.get().getMessage(), containsString("own account"));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -37,7 +37,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail.PRINCIPAL_ROLES_FIELD_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class AuditTrailServiceTests extends ESTestCase {
@@ -132,7 +132,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, token, "_action", request);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -145,7 +145,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, "_action", request);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -158,7 +158,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, restRequest);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -171,7 +171,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, token, restRequest);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -184,7 +184,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", request);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -197,7 +197,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationFailed(requestId, "_realm", token, restRequest);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -210,7 +210,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).anonymousAccessDenied(requestId, "_action", request);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -232,7 +232,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).accessGranted(requestId, authentication, "_action", request, authzInfo);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -254,7 +254,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).accessDenied(requestId, authentication, "_action", request, authzInfo);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -268,7 +268,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).connectionGranted(inetAddress, "client", rule);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -282,7 +282,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).connectionDenied(inetAddress, "client", rule);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -300,7 +300,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationSuccess(requestId, authentication, restRequest);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 
@@ -318,7 +318,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 verify(auditTrail).authenticationSuccess(requestId, authentication, "_action", request);
             }
         } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+            verifyNoMoreInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -161,7 +161,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -396,7 +395,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             setCompletedToTrue(completed);
         }, this::logAndFail));
         assertThat(completed.get(), is(true));
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
     }
 
     public void testTokenMissing() throws Exception {
@@ -750,8 +749,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.v1(), is(authentication));
             assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.REALM));
-            verifyZeroInteractions(auditTrail);
-            verifyZeroInteractions(firstRealm, secondRealm);
+            verifyNoMoreInteractions(auditTrail);
+            verifyNoMoreInteractions(firstRealm, secondRealm);
             verify(operatorPrivilegesService, times(1)).maybeMarkOperatorUser(result.v1(), threadContext);
         });
     }
@@ -766,7 +765,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         } catch (ElasticsearchSecurityException e) {
             expectAuditRequestId(threadContext);
             assertAuthenticationException(e, containsString("unable to authenticate user [idonotexist] for REST request [/]"));
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -811,7 +810,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         } catch (ElasticsearchSecurityException e) {
             // expected
             assertAuthenticationException(e);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
         if (requestIdAlreadyPresent) {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
@@ -830,7 +829,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         } catch (ElasticsearchSecurityException e) {
             // expected
             assertAuthenticationException(e);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
         verify(auditTrail).anonymousAccessDenied(expectAuditRequestId(threadContext), restRequest);
     }
@@ -882,7 +881,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testAuthenticateRestDisabledUser() throws Exception {
@@ -899,7 +898,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId, token, restRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testAuthenticateTransportSuccess() throws Exception {
@@ -1124,7 +1123,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             verify(auditTrail).tamperedRequest(reqId.get(), "_action", message);
             verifyNoMoreInteractions(auditTrail);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1168,7 +1167,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             verify(auditTrail).anonymousAccessDenied(reqId.get(), "_action", transportRequest);
             verifyNoMoreInteractions(auditTrail);
             assertAuthenticationException(e);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1232,7 +1231,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             verify(auditTrail).anonymousAccessDenied(reqId.get(), "_action", transportRequest);
             verifyNoMoreInteractions(auditTrail);
             assertAuthenticationException(e);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1304,7 +1303,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         String reqId = expectAuditRequestId(threadContext);
         verify(auditTrail).anonymousAccessDenied(reqId, request);
         verifyNoMoreInteractions(auditTrail);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testAnonymousUserTransportNoDefaultUser() throws Exception {
@@ -1395,7 +1394,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 reqId.set(expectAuditRequestId(threadContext));
             }
             verify(auditTrail).authenticationFailed(reqId.get(), "_action", transportRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1408,7 +1407,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(e.getMessage(), is("realm doesn't like tokens"));
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).authenticationFailed(reqId, restRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1424,7 +1423,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like supports"));
             verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1440,7 +1439,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(e.getMessage(), is("realm doesn't like supports"));
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).authenticationFailed(reqId, token, restRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1491,7 +1490,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId.get(), secondRealm.name(), token, "_action", transportRequest);
         verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testRealmAuthenticateGracefulTerminateAuthenticationProcess() {
@@ -1522,7 +1521,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId.get(), firstRealm.name(), token, "_action", transportRequest);
         verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testRealmAuthenticateThrowingException() throws Exception {
@@ -1547,7 +1546,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 reqId.set(expectAuditRequestId(threadContext));
             }
             verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1564,7 +1563,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(e.getMessage(), is("realm doesn't like authenticate"));
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).authenticationFailed(reqId, token, restRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1593,7 +1592,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 reqId.set(expectAuditRequestId(threadContext));
             }
             verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1613,7 +1612,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(e.getMessage(), is("realm doesn't want to lookup"));
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).authenticationFailed(reqId, token, restRequest);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1743,7 +1742,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).runAsDenied(eq(reqId), any(Authentication.class), eq(restRequest), eq(EmptyAuthorizationInfo.INSTANCE));
             verifyNoMoreInteractions(auditTrail);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1778,7 +1777,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 eq(EmptyAuthorizationInfo.INSTANCE)
             );
             verifyNoMoreInteractions(auditTrail);
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -1814,7 +1813,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId.get(), token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testAuthenticateRestDisabledRunAsUser() throws Exception {
@@ -1840,7 +1839,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         verify(auditTrail).authenticationFailed(reqId, token, restRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
-        verifyZeroInteractions(operatorPrivilegesService);
+        verifyNoMoreInteractions(operatorPrivilegesService);
     }
 
     public void testAuthenticateWithToken() throws Exception {
@@ -1922,7 +1921,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 success.set(true);
                 latch.countDown();
             }, e -> {
-                verifyZeroInteractions(operatorPrivilegesService);
+                verifyNoMoreInteractions(operatorPrivilegesService);
                 if (requestIdAlreadyPresent) {
                     assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
                 } else {
@@ -1993,7 +1992,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
             assertEquals("token expired", e.getMessage());
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -2022,7 +2021,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             } else {
                 assertThat(e.getMessage(), containsString("missing authentication credentials"));
             }
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -2181,7 +2180,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             }
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
         }
     }
 
@@ -2249,7 +2248,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 reqId.set(expectAuditRequestId(threadContext));
             }
             assertThat(e, sameInstance(bailOut));
-            verifyZeroInteractions(operatorPrivilegesService);
+            verifyNoMoreInteractions(operatorPrivilegesService);
             final ServiceAccountToken serviceToken = ServiceAccountToken.fromBearerString(new SecureString(bearerString.toCharArray()));
             verify(auditTrail).authenticationFailed(
                 eq(reqId.get()),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class AuthenticatorChainTests extends ESTestCase {
@@ -106,10 +106,10 @@ public class AuthenticatorChainTests extends ESTestCase {
         final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
         authenticatorChain.authenticateAsync(context, future);
         assertThat(future.actionGet(), is(authentication));
-        verifyZeroInteractions(serviceAccountAuthenticator);
-        verifyZeroInteractions(oAuth2TokenAuthenticator);
-        verifyZeroInteractions(apiKeyAuthenticator);
-        verifyZeroInteractions(realmsAuthenticator);
+        verifyNoMoreInteractions(serviceAccountAuthenticator);
+        verifyNoMoreInteractions(oAuth2TokenAuthenticator);
+        verifyNoMoreInteractions(apiKeyAuthenticator);
+        verifyNoMoreInteractions(realmsAuthenticator);
         verify(authenticationContextSerializer, never()).writeToContext(any(), any());
         verify(operatorPrivilegesService, times(1)).maybeMarkOperatorUser(eq(authentication), any());
     }
@@ -140,9 +140,9 @@ public class AuthenticatorChainTests extends ESTestCase {
         final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
         authenticatorChain.authenticateAsync(context, future);
         assertThat(future.actionGet(), is(authentication));
-        verifyZeroInteractions(oAuth2TokenAuthenticator);
-        verifyZeroInteractions(apiKeyAuthenticator);
-        verifyZeroInteractions(realmsAuthenticator);
+        verifyNoMoreInteractions(oAuth2TokenAuthenticator);
+        verifyNoMoreInteractions(apiKeyAuthenticator);
+        verifyNoMoreInteractions(realmsAuthenticator);
         verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
         verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
     }
@@ -163,8 +163,8 @@ public class AuthenticatorChainTests extends ESTestCase {
         assertThat(future.actionGet(), is(authentication));
         verify(serviceAccountAuthenticator).extractCredentials(eq(context));
         verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
-        verifyZeroInteractions(apiKeyAuthenticator);
-        verifyZeroInteractions(realmsAuthenticator);
+        verifyNoMoreInteractions(apiKeyAuthenticator);
+        verifyNoMoreInteractions(realmsAuthenticator);
         verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
         verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
     }
@@ -189,7 +189,7 @@ public class AuthenticatorChainTests extends ESTestCase {
         verify(serviceAccountAuthenticator, never()).authenticate(eq(context), any());
         verify(oAuth2TokenAuthenticator).extractCredentials(eq(context));
         verify(oAuth2TokenAuthenticator, never()).authenticate(eq(context), any());
-        verifyZeroInteractions(realmsAuthenticator);
+        verifyNoMoreInteractions(realmsAuthenticator);
         verify(authenticationContextSerializer).writeToContext(eq(authentication), any());
         verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(authentication), any());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
@@ -38,7 +38,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class InternalRealmsTests extends ESTestCase {
 
@@ -54,7 +54,7 @@ public class InternalRealmsTests extends ESTestCase {
             securityIndex
         );
         assertThat(factories, hasEntry(is(NativeRealmSettings.TYPE), any(Realm.Factory.class)));
-        verifyZeroInteractions(securityIndex);
+        verifyNoMoreInteractions(securityIndex);
 
         final RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, "test");
         Settings settings = Settings.builder()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -176,7 +175,7 @@ public class ReservedRealmTests extends ESTestCase {
         final AuthenticationResult<User> result = listener.actionGet();
         assertThat(result.getStatus(), is(AuthenticationResult.Status.CONTINUE));
         assertNull(result.getValue());
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testAuthenticationEnabledUserWithStoredPassword() throws Throwable {
@@ -309,7 +308,7 @@ public class ReservedRealmTests extends ESTestCase {
         reservedRealm.doLookupUser(principal, assertListenerIsOnlyCalledOnce(listener));
         final User user = listener.actionGet();
         assertNull(user);
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testLookupDisabledAnonymous() throws Exception {
@@ -345,7 +344,7 @@ public class ReservedRealmTests extends ESTestCase {
         PlainActionFuture<User> listener = new PlainActionFuture<>();
         reservedRealm.doLookupUser(principal, assertListenerIsOnlyCalledOnce(listener));
         assertThat(listener.actionGet(), equalTo(expectedUser));
-        verifyZeroInteractions(usersStore);
+        verifyNoMoreInteractions(usersStore);
     }
 
     public void testLookupThrows() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStoreTests.java
@@ -26,7 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class CompositeServiceAccountTokenStoreTests extends ESTestCase {
 
@@ -85,12 +85,12 @@ public class CompositeServiceAccountTokenStoreTests extends ESTestCase {
             assertThat(future.get().getTokenSource(), is(tokenSource));
             if (store1Success) {
                 verify(store1).authenticate(eq(token), any());
-                verifyZeroInteractions(store2);
-                verifyZeroInteractions(store3);
+                verifyNoMoreInteractions(store2);
+                verifyNoMoreInteractions(store3);
             } else if (store2Success) {
                 verify(store1).authenticate(eq(token), any());
                 verify(store2).authenticate(eq(token), any());
-                verifyZeroInteractions(store3);
+                verifyNoMoreInteractions(store3);
             } else {
                 verify(store1).authenticate(eq(token), any());
                 verify(store2).authenticate(eq(token), any());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/ApiKeyGeneratorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/ApiKeyGeneratorTests.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySetOf;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -62,7 +62,7 @@ public class ApiKeyGeneratorTests extends ESTestCase {
             ActionListener<Set<RoleDescriptor>> listener = (ActionListener<Set<RoleDescriptor>>) args[args.length - 1];
             listener.onResponse(roleDescriptors);
             return null;
-        }).when(rolesStore).getRoleDescriptors(anySetOf(String.class), any(ActionListener.class));
+        }).when(rolesStore).getRoleDescriptors(anySet(), any(ActionListener.class));
 
         CreateApiKeyResponse response = new CreateApiKeyResponse(
             "name",
@@ -82,7 +82,7 @@ public class ApiKeyGeneratorTests extends ESTestCase {
             listener.onResponse(response);
 
             return null;
-        }).when(apiKeyService).createApiKey(same(authentication), same(request), anySetOf(RoleDescriptor.class), any(ActionListener.class));
+        }).when(apiKeyService).createApiKey(same(authentication), same(request), anySet(), any(ActionListener.class));
 
         final PlainActionFuture<CreateApiKeyResponse> future = new PlainActionFuture<>();
         generator.generateApiKey(authentication, request, future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -222,7 +222,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class AuthorizationServiceTests extends ESTestCase {
@@ -2770,7 +2769,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             "user1"
         );
         // The operator related exception is verified in the authorize(...) call
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
     }
 
     public void testAuthorizedIndiciesTimeChecker() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -108,7 +108,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.oneOf;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySetOf;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -357,7 +357,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 );
             }
             return Void.TYPE;
-        }).when(rolesStore).roles(anySetOf(String.class), anyActionListener());
+        }).when(rolesStore).roles(anySet(), anyActionListener());
 
         doAnswer(i -> {
             User user = (User) i.getArguments()[0];

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -101,7 +101,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class RBACEngineTests extends ESTestCase {
@@ -193,7 +192,7 @@ public class RBACEngineTests extends ESTestCase {
         when(authenticatedBy.getType()).thenReturn(randomAlphaOfLengthBetween(4, 12));
 
         assertFalse(engine.checkSameUserPermissions(action, request, authentication));
-        verifyZeroInteractions(user, request, authentication);
+        verifyNoMoreInteractions(user, request, authentication);
     }
 
     public void testSameUserPermissionRunAsChecksAuthenticatedBy() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -126,8 +126,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyCollectionOf;
-import static org.mockito.ArgumentMatchers.anySetOf;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
@@ -188,7 +188,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             null
         );
         FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
 
         when(fileRolesStore.roleDescriptors(Collections.singleton("fls"))).thenReturn(Collections.singleton(flsRole));
         when(fileRolesStore.roleDescriptors(Collections.singleton("dls"))).thenReturn(Collections.singleton(dlsRole));
@@ -270,7 +270,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             null
         );
         FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         when(fileRolesStore.roleDescriptors(Collections.singleton("fls"))).thenReturn(Collections.singleton(flsRole));
         when(fileRolesStore.roleDescriptors(Collections.singleton("dls"))).thenReturn(Collections.singleton(dlsRole));
         when(fileRolesStore.roleDescriptors(Collections.singleton("fls_dls"))).thenReturn(Collections.singleton(flsDlsRole));
@@ -316,10 +316,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testNegativeLookupsAreCached() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
 
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
@@ -335,7 +335,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
             callback.onResponse(Collections.emptyList());
             return null;
-        }).when(nativePrivilegeStore).getPrivileges(anySetOf(String.class), anySetOf(String.class), anyActionListener());
+        }).when(nativePrivilegeStore).getPrivileges(anySet(), anySet(), anyActionListener());
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
@@ -359,10 +359,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
         assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
         effectiveRoleDescriptors.set(null);
         assertEquals(Role.EMPTY, role);
-        verify(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
-        verify(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(reservedRolesStore).accept(anySet(), anyActionListener());
+        verify(fileRolesStore).accept(anySet(), anyActionListener());
         verify(fileRolesStore).roleDescriptors(eq(Collections.singleton(roleName)));
-        verify(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(nativeRolesStore).accept(anySet(), anyActionListener());
         verify(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
 
         final int numberOfTimesToCall = scaledRandomIntBetween(0, 32);
@@ -385,7 +385,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
         if (getSuperuserRole && numberOfTimesToCall > 0) {
             // the superuser role was requested so we get the role descriptors again
-            verify(reservedRolesStore, times(2)).accept(anySetOf(String.class), anyActionListener());
+            verify(reservedRolesStore, times(2)).accept(anySet(), anyActionListener());
             verify(nativePrivilegeStore).getPrivileges(isASet(), isASet(), anyActionListener());
         }
         verifyNoMoreInteractions(fileRolesStore, reservedRolesStore, nativeRolesStore, nativePrivilegeStore);
@@ -393,10 +393,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testNegativeLookupsCacheDisabled() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -431,10 +431,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
         assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
         effectiveRoleDescriptors.set(null);
         assertEquals(Role.EMPTY, role);
-        verify(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
-        verify(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(reservedRolesStore).accept(anySet(), anyActionListener());
+        verify(fileRolesStore).accept(anySet(), anyActionListener());
         verify(fileRolesStore).roleDescriptors(eq(Collections.singleton(roleName)));
-        verify(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(nativeRolesStore).accept(anySet(), anyActionListener());
         verify(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
 
         assertFalse(compositeRolesStore.isValueInNegativeLookupCache(roleName));
@@ -443,10 +443,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testNegativeLookupsAreNotCachedWithFailures() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -481,10 +481,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
         assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
         effectiveRoleDescriptors.set(null);
         assertEquals(Role.EMPTY, role);
-        verify(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
-        verify(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(reservedRolesStore).accept(anySet(), anyActionListener());
+        verify(fileRolesStore).accept(anySet(), anyActionListener());
         verify(fileRolesStore).roleDescriptors(eq(Collections.singleton(roleName)));
-        verify(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        verify(nativeRolesStore).accept(anySet(), anyActionListener());
         verify(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
 
         final int numberOfTimesToCall = scaledRandomIntBetween(0, 32);
@@ -498,20 +498,20 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }
 
         assertFalse(compositeRolesStore.isValueInNegativeLookupCache(roleName));
-        verify(reservedRolesStore, times(numberOfTimesToCall + 1)).accept(anySetOf(String.class), anyActionListener());
-        verify(fileRolesStore, times(numberOfTimesToCall + 1)).accept(anySetOf(String.class), anyActionListener());
+        verify(reservedRolesStore, times(numberOfTimesToCall + 1)).accept(anySet(), anyActionListener());
+        verify(fileRolesStore, times(numberOfTimesToCall + 1)).accept(anySet(), anyActionListener());
         verify(fileRolesStore, times(numberOfTimesToCall + 1)).roleDescriptors(eq(Collections.singleton(roleName)));
-        verify(nativeRolesStore, times(numberOfTimesToCall + 1)).accept(anySetOf(String.class), anyActionListener());
+        verify(nativeRolesStore, times(numberOfTimesToCall + 1)).accept(anySet(), anyActionListener());
         verify(nativeRolesStore, times(numberOfTimesToCall + 1)).getRoleDescriptors(isASet(), anyActionListener());
         verifyNoMoreInteractions(fileRolesStore, reservedRolesStore, nativeRolesStore);
     }
 
     public void testCustomRolesProviders() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -595,8 +595,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
         assertThat(role.indices().groups()[1].indices()[0], anyOf(equalTo("foo"), equalTo("bar")));
 
         // make sure negative lookups are cached
-        verify(inMemoryProvider1).accept(anySetOf(String.class), anyActionListener());
-        verify(inMemoryProvider2).accept(anySetOf(String.class), anyActionListener());
+        verify(inMemoryProvider1).accept(anySet(), anyActionListener());
+        verify(inMemoryProvider2).accept(anySet(), anyActionListener());
 
         final int numberOfTimesToCall = scaledRandomIntBetween(1, 8);
         for (int i = 0; i < numberOfTimesToCall; i++) {
@@ -754,7 +754,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 );
             listener.onResponse(set);
             return null;
-        }).when(privilegeStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
+        }).when(privilegeStore).getPrivileges(anyCollection(), anyCollection(), anyActionListener());
         CompositeRolesStore.buildRoleFromDescriptors(
             Sets.newHashSet(role1, role2),
             cache,
@@ -805,10 +805,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testCustomRolesProviderFailures() throws Exception {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -870,10 +870,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testCustomRolesProvidersLicensing() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -981,11 +981,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final AtomicInteger numInvalidation = new AtomicInteger(0);
 
         FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         ReservedRolesStore reservedRolesStore = mock(ReservedRolesStore.class);
-        doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(reservedRolesStore).accept(anySet(), anyActionListener());
         NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
 
         CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
             Settings.EMPTY,
@@ -1040,11 +1040,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final AtomicInteger numInvalidation = new AtomicInteger(0);
 
         FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         ReservedRolesStore reservedRolesStore = mock(ReservedRolesStore.class);
-        doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(reservedRolesStore).accept(anySet(), anyActionListener());
         NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
         final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
             SECURITY_ENABLED_SETTINGS,
             fileRolesStore,
@@ -1069,10 +1069,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testDefaultRoleUserWithoutRoles() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1109,9 +1109,9 @@ public class CompositeRolesStoreTests extends ESTestCase {
             .put(AnonymousUser.ROLES_SETTING.getKey(), "anonymous_user_role")
             .build();
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             Set<String> names = (Set<String>) invocationOnMock.getArguments()[0];
@@ -1120,7 +1120,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 return Collections.singleton(rd);
             }
             return Collections.emptySet();
-        }).when(fileRolesStore).roleDescriptors(anySetOf(String.class));
+        }).when(fileRolesStore).roleDescriptors(anySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1153,10 +1153,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testDoesNotUseRolesStoreForXPacAndAsyncSearchUser() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1201,10 +1201,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testGetRolesForSystemUserThrowsException() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1237,10 +1237,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testApiKeyAuthUsesApiKeyService() throws Exception {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1267,7 +1267,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
             listener.onResponse(Collections.emptyList());
             return Void.TYPE;
-        }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
+        }).when(nativePrivStore).getPrivileges(anyCollection(), anyCollection(), anyActionListener());
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
@@ -1308,10 +1308,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testApiKeyAuthUsesApiKeyServiceWithScopedRole() throws Exception {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1339,7 +1339,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
             listener.onResponse(Collections.emptyList());
             return Void.TYPE;
-        }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
+        }).when(nativePrivStore).getPrivileges(anyCollection(), anyCollection(), anyActionListener());
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
@@ -1491,16 +1491,16 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
     public void testCacheEntryIsReusedForIdenticalApiKeyRoles() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
-        doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
         final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
-        doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
-        when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         doAnswer((invocationOnMock) -> {
             @SuppressWarnings("unchecked")
             ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
             callback.onResponse(RoleRetrievalResult.failure(new RuntimeException("intentionally failed!")));
             return null;
-        }).when(nativeRolesStore).getRoleDescriptors(anySetOf(String.class), anyActionListener());
+        }).when(nativeRolesStore).getRoleDescriptors(anySet(), anyActionListener());
         final ReservedRolesStore reservedRolesStore = spy(new ReservedRolesStore());
         ThreadContext threadContext = new ThreadContext(SECURITY_ENABLED_SETTINGS);
         ApiKeyService apiKeyService = mock(ApiKeyService.class);
@@ -1511,7 +1511,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
             listener.onResponse(Collections.emptyList());
             return Void.TYPE;
-        }).when(nativePrivStore).getPrivileges(anyCollectionOf(String.class), anyCollectionOf(String.class), anyActionListener());
+        }).when(nativePrivStore).getPrivileges(anyCollection(), anyCollection(), anyActionListener());
 
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
@@ -1872,12 +1872,12 @@ public class CompositeRolesStoreTests extends ESTestCase {
     ) {
         if (fileRolesStore == null) {
             fileRolesStore = mock(FileRolesStore.class);
-            doCallRealMethod().when(fileRolesStore).accept(anySetOf(String.class), anyActionListener());
-            when(fileRolesStore.roleDescriptors(anySetOf(String.class))).thenReturn(Collections.emptySet());
+            doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
+            when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
         }
         if (nativeRolesStore == null) {
             nativeRolesStore = mock(NativeRolesStore.class);
-            doCallRealMethod().when(nativeRolesStore).accept(anySetOf(String.class), anyActionListener());
+            doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
             doAnswer((invocationOnMock) -> {
                 @SuppressWarnings("unchecked")
                 ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
@@ -1887,7 +1887,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }
         if (reservedRolesStore == null) {
             reservedRolesStore = mock(ReservedRolesStore.class);
-            doCallRealMethod().when(reservedRolesStore).accept(anySetOf(String.class), anyActionListener());
+            doCallRealMethod().when(reservedRolesStore).accept(anySet(), anyActionListener());
         }
         if (licenseState == null) {
             licenseState = new XPackLicenseState(() -> 0);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesTests.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class OperatorPrivilegesTests extends ESTestCase {
@@ -82,7 +82,7 @@ public class OperatorPrivilegesTests extends ESTestCase {
             threadContext
         );
         assertNull(e);
-        verifyZeroInteractions(operatorOnlyRegistry);
+        verifyNoMoreInteractions(operatorOnlyRegistry);
     }
 
     public void testMarkOperatorUser() throws IllegalAccessException {
@@ -245,21 +245,21 @@ public class OperatorPrivilegesTests extends ESTestCase {
     public void testMaybeInterceptRequestWillNotInterceptRequestsOtherThanRestoreSnapshotRequest() {
         final TransportRequest transportRequest = mock(TransportRequest.class);
         operatorPrivilegesService.maybeInterceptRequest(new ThreadContext(Settings.EMPTY), transportRequest);
-        verifyZeroInteractions(xPackLicenseState);
+        verifyNoMoreInteractions(xPackLicenseState);
     }
 
     public void testNoOpService() {
         final Authentication authentication = mock(Authentication.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         NOOP_OPERATOR_PRIVILEGES_SERVICE.maybeMarkOperatorUser(authentication, threadContext);
-        verifyZeroInteractions(authentication);
+        verifyNoMoreInteractions(authentication);
         assertNull(threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY));
 
         final TransportRequest request = mock(TransportRequest.class);
         assertNull(
             NOOP_OPERATOR_PRIVILEGES_SERVICE.check(mock(Authentication.class), randomAlphaOfLengthBetween(10, 20), request, threadContext)
         );
-        verifyZeroInteractions(request);
+        verifyNoMoreInteractions(request);
     }
 
     public void testNoOpServiceMaybeInterceptRequest() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
@@ -59,7 +59,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SecurityRestFilterTests extends ESTestCase {
@@ -93,7 +93,7 @@ public class SecurityRestFilterTests extends ESTestCase {
         }).when(authcService).authenticate(eq(request), anyActionListener());
         filter.handleRequest(request, channel, null);
         verify(restHandler).handleRequest(request, channel, null);
-        verifyZeroInteractions(channel);
+        verifyNoMoreInteractions(channel);
     }
 
     public void testProcessSecondaryAuthentication() throws Exception {
@@ -136,7 +136,7 @@ public class SecurityRestFilterTests extends ESTestCase {
         );
         filter.handleRequest(request, channel, null);
         verify(restHandler).handleRequest(request, channel, null);
-        verifyZeroInteractions(channel);
+        verifyNoMoreInteractions(channel);
 
         assertThat(secondaryAuthRef.get(), notNullValue());
         assertThat(secondaryAuthRef.get().getAuthentication(), sameInstance(secondaryAuthentication));
@@ -148,7 +148,7 @@ public class SecurityRestFilterTests extends ESTestCase {
         RestRequest request = mock(RestRequest.class);
         filter.handleRequest(request, channel, null);
         verify(restHandler).handleRequest(request, channel, null);
-        verifyZeroInteractions(channel, authcService);
+        verifyNoMoreInteractions(channel, authcService);
     }
 
     public void testProcessAuthenticationFailedNoTrace() throws Exception {
@@ -230,7 +230,7 @@ public class SecurityRestFilterTests extends ESTestCase {
         } else {
             assertThat(restResponse.content().utf8ToString(), not(containsString(ElasticsearchException.STACK_TRACE)));
         }
-        verifyZeroInteractions(restHandler);
+        verifyNoMoreInteractions(restHandler);
     }
 
     public void testProcessOptionsMethod() throws Exception {
@@ -238,8 +238,8 @@ public class SecurityRestFilterTests extends ESTestCase {
         when(request.method()).thenReturn(RestRequest.Method.OPTIONS);
         filter.handleRequest(request, channel, null);
         verify(restHandler).handleRequest(request, channel, null);
-        verifyZeroInteractions(channel);
-        verifyZeroInteractions(authcService);
+        verifyNoMoreInteractions(channel);
+        verifyNoMoreInteractions(authcService);
     }
 
     public void testProcessFiltersBodyCorrectly() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SecurityBaseRestHandlerTests extends ESTestCase {
@@ -62,7 +62,7 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
 
         try (NodeClient client = new NoOpNodeClient(this.getTestName())) {
             assertFalse(consumerCalled.get());
-            verifyZeroInteractions(licenseState);
+            verifyNoMoreInteractions(licenseState);
             handler.handleRequest(fakeRestRequest, fakeRestChannel, client);
 
             if (securityEnabled) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterTests.java
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ServerTransportFilterTests extends ESTestCase {
@@ -129,7 +128,7 @@ public class ServerTransportFilterTests extends ESTestCase {
         } catch (ElasticsearchSecurityException e) {
             assertThat(e.getMessage(), equalTo("authc failed"));
         }
-        verifyZeroInteractions(authzService);
+        verifyNoMoreInteractions(authzService);
     }
 
     public void testInboundAuthorizationException() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class IPFilterTests extends ESTestCase {
@@ -266,7 +266,7 @@ public class IPFilterTests extends ESTestCase {
         String message = String.format(Locale.ROOT, "Expected address %s to be allowed", "8.8.8.8");
         InetAddress address = InetAddresses.forString("8.8.8.8");
         assertThat(message, ipFilter.accept("default", new InetSocketAddress(address, 0)), is(true));
-        verifyZeroInteractions(auditTrail);
+        verifyNoMoreInteractions(auditTrail);
 
         // for sanity enable license and check that it is denied
         when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(true);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VE
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class CursorTests extends ESTestCase {
 
@@ -46,7 +46,7 @@ public class CursorTests extends ESTestCase {
         PlainActionFuture<Boolean> future = newFuture();
         cursor.clear(clientMock, future);
         assertFalse(future.actionGet());
-        verifyZeroInteractions(clientMock);
+        verifyNoMoreInteractions(clientMock);
     }
 
     @SuppressWarnings("unchecked")
@@ -61,7 +61,7 @@ public class CursorTests extends ESTestCase {
         ArgumentCaptor<ClearScrollRequest> request = ArgumentCaptor.forClass(ClearScrollRequest.class);
         verify(clientMock).clearScroll(request.capture(), any(ActionListener.class));
         assertEquals(Collections.singletonList(cursorString), request.getValue().getScrollIds());
-        verifyZeroInteractions(listenerMock);
+        verifyNoMoreInteractions(listenerMock);
     }
 
     private static SqlQueryResponse createRandomSqlResponse() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -68,12 +68,11 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class WatcherIndexingListenerTests extends ESTestCase {
@@ -104,7 +103,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
 
         Engine.Index index = listener.preIndex(shardId, operation);
         assertThat(index, is(operation));
-        verifyZeroInteractions(parser);
+        verifyNoMoreInteractions(parser);
     }
 
     public void testPreIndexCheckActive() throws Exception {
@@ -113,7 +112,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
 
         Engine.Index index = listener.preIndex(shardId, operation);
         assertThat(index, is(operation));
-        verifyZeroInteractions(parser);
+        verifyNoMoreInteractions(parser);
     }
 
     public void testPostIndex() throws Exception {
@@ -127,11 +126,11 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         boolean watchActive = randomBoolean();
         boolean isNewWatch = randomBoolean();
         Watch watch = mockWatch("_id", watchActive, isNewWatch);
-        when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenReturn(watch);
+        when(parser.parseWithSecrets(any(), eq(true), any(), any(), any(), anyLong(), anyLong())).thenReturn(watch);
 
         listener.postIndex(shardId, operation, result);
         ZonedDateTime now = DateUtils.nowWithMillisResolution(clock);
-        verify(parser).parseWithSecrets(eq(operation.id()), eq(true), eq(BytesArray.EMPTY), eq(now), anyObject(), anyLong(), anyLong());
+        verify(parser).parseWithSecrets(eq(operation.id()), eq(true), eq(BytesArray.EMPTY), eq(now), any(), anyLong(), anyLong());
 
         if (isNewWatch) {
             if (watchActive) {
@@ -157,12 +156,12 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         boolean watchActive = randomBoolean();
         boolean isNewWatch = randomBoolean();
         Watch watch = mockWatch("_id", watchActive, isNewWatch);
-        when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenReturn(watch);
+        when(parser.parseWithSecrets(any(), eq(true), any(), any(), any(), anyLong(), anyLong())).thenReturn(watch);
 
         listener.postIndex(shardId, operation, result);
         ZonedDateTime now = DateUtils.nowWithMillisResolution(clock);
-        verify(parser).parseWithSecrets(eq(operation.id()), eq(true), eq(BytesArray.EMPTY), eq(now), anyObject(), anyLong(), anyLong());
-        verifyZeroInteractions(triggerService);
+        verify(parser).parseWithSecrets(eq(operation.id()), eq(true), eq(BytesArray.EMPTY), eq(now), any(), anyLong(), anyLong());
+        verifyNoMoreInteractions(triggerService);
     }
 
     // this test emulates an index with 10 shards, and ensures that triggering only happens on a
@@ -176,7 +175,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(result.getResultType()).thenReturn(Engine.Result.Type.SUCCESS);
 
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
-        when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenReturn(watch);
+        when(parser.parseWithSecrets(any(), eq(true), any(), any(), any(), anyLong(), anyLong())).thenReturn(watch);
 
         for (int idx = 0; idx < totalShardCount; idx++) {
             final Map<ShardId, ShardAllocationConfiguration> localShards = new HashMap<>();
@@ -220,9 +219,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(operation.id()).thenReturn(id);
         when(operation.source()).thenReturn(BytesArray.EMPTY);
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
-        when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenThrow(
-            new IOException("self thrown")
-        );
+        when(parser.parseWithSecrets(any(), eq(true), any(), any(), any(), anyLong(), anyLong())).thenThrow(new IOException("self thrown"));
         when(result.getResultType()).thenReturn(Engine.Result.Type.SUCCESS);
 
         ElasticsearchParseException exc = expectThrows(
@@ -240,7 +237,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
 
         listener.postIndex(shardId, operation, result);
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPostIndexRemoveTriggerOnDocumentRelatedException_ignoreNonWatcherDocument() throws Exception {
@@ -250,7 +247,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(shardId.getIndexName()).thenReturn(randomAlphaOfLength(4));
 
         listener.postIndex(shardId, operation, result);
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPostIndexRemoveTriggerOnEngineLevelException() throws Exception {
@@ -258,7 +255,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
 
         listener.postIndex(shardId, operation, new ElasticsearchParseException("whatever"));
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPostIndexRemoveTriggerOnEngineLevelException_ignoreNonWatcherDocument() throws Exception {
@@ -267,14 +264,14 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(result.getResultType()).thenReturn(Engine.Result.Type.SUCCESS);
 
         listener.postIndex(shardId, operation, new ElasticsearchParseException("whatever"));
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPreDeleteCheckActive() throws Exception {
         listener.setConfiguration(INACTIVE);
         listener.preDelete(shardId, delete);
 
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPreDeleteCheckIndex() throws Exception {
@@ -282,7 +279,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
 
         listener.preDelete(shardId, delete);
 
-        verifyZeroInteractions(triggerService);
+        verifyNoMoreInteractions(triggerService);
     }
 
     public void testPreDelete() throws Exception {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -51,7 +51,6 @@ import static org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateR
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -61,7 +60,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class WatcherLifeCycleServiceTests extends ESTestCase {
@@ -98,11 +96,11 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         when(watcherService.validate(clusterState)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, previousClusterState));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
 
         // Trying to start a second time, but that should have no effect.
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, previousClusterState));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testStartWithStateNotRecoveredBlock() {
@@ -112,7 +110,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .nodes(nodes)
             .build();
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testShutdown() {
@@ -131,7 +129,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testManualStartStop() {
@@ -176,12 +174,12 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         reset(watcherService);
         when(watcherService.validate(clusterState)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, stoppedClusterState));
-        verify(watcherService, times(1)).start(eq(clusterState), anyObject());
+        verify(watcherService, times(1)).start(eq(clusterState), any());
 
         // no change, keep going
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testNoLocalShards() {
@@ -246,7 +244,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         // no further invocations should happen if the cluster state does not change in regard to local shards
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutLocalShards, clusterStateWithoutLocalShards));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testReplicaWasAddedOrRemoved() {
@@ -388,7 +386,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", currentState, previousState));
-        verify(watcherService, times(0)).pauseExecution(anyObject());
+        verify(watcherService, times(0)).pauseExecution(any());
         verify(watcherService, times(0)).reload(any(), any());
     }
 
@@ -426,11 +424,11 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         // now remove watches index, and ensure that pausing is only called once, no matter how often called (i.e. each CS update)
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutWatcherIndex, clusterStateWithWatcherIndex));
-        verify(watcherService, times(1)).pauseExecution(anyObject());
+        verify(watcherService, times(1)).pauseExecution(any());
 
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutWatcherIndex, clusterStateWithWatcherIndex));
-        verifyZeroInteractions(watcherService);
+        verifyNoMoreInteractions(watcherService);
     }
 
     public void testWatcherServiceDoesNotStartIfIndexTemplatesAreMissing() throws Exception {
@@ -445,7 +443,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(eq(state))).thenReturn(true);
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", state, state));
-        verify(watcherService, times(0)).start(any(ClusterState.class), anyObject());
+        verify(watcherService, times(0)).start(any(ClusterState.class), any());
     }
 
     public void testWatcherStopsWhenMasterNodeIsMissing() {
@@ -554,11 +552,11 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         // initialize the previous state, so all the allocation ids are loaded
-        when(watcherService.validate(anyObject())).thenReturn(true);
+        when(watcherService.validate(any())).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("whatever", previousState, currentState));
 
         reset(watcherService);
-        when(watcherService.validate(anyObject())).thenReturn(true);
+        when(watcherService.validate(any())).thenReturn(true);
         ClusterChangedEvent event = new ClusterChangedEvent("whatever", currentState, previousState);
         lifeCycleService.clusterChanged(event);
         verify(watcherService).reload(eq(event.state()), anyString());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class IndexActionTests extends ESTestCase {
@@ -441,6 +441,6 @@ public class IndexActionTests extends ESTestCase {
 
         Action.Result result = executable.execute("my_id", ctx, payload);
         assertThat(result.status(), is(Status.SIMULATED));
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/text/TextTemplateTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/text/TextTemplateTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class TextTemplateTests extends ESTestCase {
@@ -144,7 +144,7 @@ public class TextTemplateTests extends ESTestCase {
     private void assertNoCompilation(String input) {
         String output = engine.render(new TextTemplate(input), Collections.emptyMap());
         assertThat(input, is(output));
-        verifyZeroInteractions(service);
+        verifyNoMoreInteractions(service);
     }
 
     private void assertScriptServiceInvoked(final String input) {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
@@ -110,7 +110,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -1182,7 +1181,7 @@ public class ExecutionServiceTests extends ESTestCase {
 
         ActionWrapper actionWrapper = mock(ActionWrapper.class);
         ActionWrapperResult actionWrapperResult = new ActionWrapperResult("_action", actionResult);
-        when(actionWrapper.execute(anyObject())).thenReturn(actionWrapperResult);
+        when(actionWrapper.execute(any())).thenReturn(actionWrapperResult);
 
         when(watch.actions()).thenReturn(Collections.singletonList(actionWrapper));
 
@@ -1239,7 +1238,7 @@ public class ExecutionServiceTests extends ESTestCase {
         when(ctx.watch()).thenReturn(watch);
 
         WatchExecutionSnapshot snapshot = new WatchExecutionSnapshot(ctx, new StackTraceElement[] {});
-        when(ctx.createSnapshot(anyObject())).thenReturn(snapshot);
+        when(ctx.createSnapshot(any())).thenReturn(snapshot);
 
         return ctx;
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/http/HttpInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/http/HttpInputTests.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -128,7 +128,7 @@ public class HttpInputTests extends ESTestCase {
 
         ExecutableHttpInput input = new ExecutableHttpInput(httpInput, httpClient, templateEngine);
         when(httpClient.execute(any(HttpRequest.class))).thenReturn(response);
-        when(templateEngine.render(eq(new TextTemplate("_body")), anyMapOf(String.class, Object.class))).thenReturn("_body");
+        when(templateEngine.render(eq(new TextTemplate("_body")), anyMap())).thenReturn("_body");
 
         WatchExecutionContext ctx = WatcherTestUtils.createWatchExecutionContext();
         HttpInput.Result result = input.execute(ctx, new Payload.Simple());
@@ -145,7 +145,7 @@ public class HttpInputTests extends ESTestCase {
         String notJson = "This is not json";
         HttpResponse response = new HttpResponse(123, notJson.getBytes(StandardCharsets.UTF_8));
         when(httpClient.execute(any(HttpRequest.class))).thenReturn(response);
-        when(templateEngine.render(eq(new TextTemplate("_body")), anyMapOf(String.class, Object.class))).thenReturn("_body");
+        when(templateEngine.render(eq(new TextTemplate("_body")), anyMap())).thenReturn("_body");
 
         WatchExecutionContext ctx = WatcherTestUtils.createWatchExecutionContext();
         HttpInput.Result result = input.execute(ctx, new Payload.Simple());
@@ -259,7 +259,7 @@ public class HttpInputTests extends ESTestCase {
 
         when(httpClient.execute(any(HttpRequest.class))).thenReturn(response);
 
-        when(templateEngine.render(eq(new TextTemplate("_body")), anyMapOf(String.class, Object.class))).thenReturn("_body");
+        when(templateEngine.render(eq(new TextTemplate("_body")), anyMap())).thenReturn("_body");
 
         WatchExecutionContext ctx = WatcherTestUtils.createWatchExecutionContext();
         HttpInput.Result result = input.execute(ctx, new Payload.Simple());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -64,7 +64,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -72,7 +71,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class WatcherIndexTemplateRegistryTests extends ESTestCase {
@@ -127,7 +126,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ArgumentCaptor<PutComposableIndexTemplateAction.Request> argumentCaptor = ArgumentCaptor.forClass(
             PutComposableIndexTemplateAction.Request.class
         );
-        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), anyObject());
+        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), any());
 
         // now delete one template from the cluster state and lets retry
         Map<String, Integer> existingTemplates = new HashMap<>();
@@ -135,7 +134,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ClusterChangedEvent newEvent = createClusterChangedEvent(existingTemplates, nodes);
         registry.clusterChanged(newEvent);
         argumentCaptor = ArgumentCaptor.forClass(PutComposableIndexTemplateAction.Request.class);
-        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), anyObject());
+        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), any());
         PutComposableIndexTemplateAction.Request req = argumentCaptor.getAllValues()
             .stream()
             .filter(r -> r.name().equals(WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME))
@@ -160,7 +159,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ArgumentCaptor<PutComposableIndexTemplateAction.Request> argumentCaptor = ArgumentCaptor.forClass(
             PutComposableIndexTemplateAction.Request.class
         );
-        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), anyObject());
+        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), any());
 
         // now delete one template from the cluster state and lets retry
         Map<String, Integer> existingTemplates = new HashMap<>();
@@ -168,9 +167,9 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ClusterChangedEvent newEvent = createClusterChangedEvent(existingTemplates, nodes);
         registry.clusterChanged(newEvent);
         ArgumentCaptor<PutIndexTemplateRequest> captor = ArgumentCaptor.forClass(PutIndexTemplateRequest.class);
-        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), anyObject());
+        verify(client, times(1)).execute(same(PutComposableIndexTemplateAction.INSTANCE), argumentCaptor.capture(), any());
         captor.getAllValues().forEach(req -> assertNull(req.settings().get("index.lifecycle.name")));
-        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), anyObject(), anyObject());
+        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), any(), any());
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() {
@@ -179,7 +178,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
-        verify(client, times(1)).execute(eq(PutLifecycleAction.INSTANCE), anyObject(), anyObject());
+        verify(client, times(1)).execute(eq(PutLifecycleAction.INSTANCE), any(), any());
     }
 
     public void testPolicyAlreadyExists() {
@@ -196,7 +195,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         policyMap.put(policy.getName(), policy);
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), policyMap, nodes);
         registry.clusterChanged(event);
-        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), anyObject(), anyObject());
+        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), any(), any());
     }
 
     public void testNoPolicyButILMDisabled() {
@@ -212,7 +211,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         );
         ClusterChangedEvent event = createClusterChangedEvent(Settings.EMPTY, Collections.emptyMap(), Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
-        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), anyObject(), anyObject());
+        verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), any(), any());
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
@@ -235,7 +234,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             policyMap.put(policy.getName(), different);
             ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), policyMap, nodes);
             registry.clusterChanged(event);
-            verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), anyObject(), anyObject());
+            verify(client, times(0)).execute(eq(PutLifecycleAction.INSTANCE), any(), any());
         }
     }
 
@@ -283,7 +282,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ClusterChangedEvent event = createClusterChangedEvent(existingTemplates, nodes);
         registry.clusterChanged(event);
 
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
@@ -295,7 +294,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         ClusterChangedEvent event = createClusterChangedEvent(existingTemplates, nodes);
         registry.clusterChanged(event);
 
-        verifyZeroInteractions(client);
+        verifyNoMoreInteractions(client);
     }
 
     private ClusterChangedEvent createClusterChangedEvent(Map<String, Integer> existingTemplateNames, DiscoveryNodes nodes) {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/script/ScriptTransformTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/script/ScriptTransformTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -156,7 +156,7 @@ public class ScriptTransformTests extends ESTestCase {
             "whatever",
             "whatever"
         );
-        when(scriptService.compile(anyObject(), eq(WatcherTransformScript.CONTEXT))).thenThrow(scriptException);
+        when(scriptService.compile(any(), eq(WatcherTransformScript.CONTEXT))).thenThrow(scriptException);
 
         ScriptTransformFactory transformFactory = new ScriptTransformFactory(scriptService);
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -93,7 +93,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
                 )
             );
             return null;
-        }).when(client).get(anyObject(), anyObject());
+        }).when(client).get(any(), any());
 
         doAnswer(invocation -> {
             ContextPreservingActionListener listener = (ContextPreservingActionListener) invocation.getArguments()[2];
@@ -106,7 +106,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
                 )
             );
             return null;
-        }).when(client).execute(eq(WatcherStatsAction.INSTANCE), anyObject(), anyObject());
+        }).when(client).execute(eq(WatcherStatsAction.INSTANCE), any(), any());
 
         AckWatchRequest ackWatchRequest = new AckWatchRequest(watchId);
         PlainActionFuture<AckWatchResponse> listener = PlainActionFuture.newFuture();
@@ -136,7 +136,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
                 )
             );
             return null;
-        }).when(client).execute(eq(WatcherStatsAction.INSTANCE), anyObject(), anyObject());
+        }).when(client).execute(eq(WatcherStatsAction.INSTANCE), any(), any());
 
         AckWatchRequest ackWatchRequest = new AckWatchRequest(watchId);
         PlainActionFuture<AckWatchResponse> listener = PlainActionFuture.newFuture();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -60,8 +59,7 @@ public class TransportPutWatchActionTests extends ESTestCase {
         TransportService transportService = mock(TransportService.class);
 
         WatchParser parser = mock(WatchParser.class);
-        when(parser.parseWithSecrets(eq("_id"), eq(false), anyObject(), anyObject(), anyObject(), anyBoolean(), anyLong(), anyLong()))
-            .thenReturn(watch);
+        when(parser.parseWithSecrets(eq("_id"), eq(false), any(), any(), any(), anyBoolean(), anyLong(), anyLong())).thenReturn(watch);
 
         Client client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);


### PR DESCRIPTION
Mockito 4.0 removes several deprecated methods. This commit updates
usages of those deprecated methods and upgrades mockito. The changes
include:
* Replace anyMapOf,anyListOf,anySetOf,anyCollectionOf with the same
  method name without `Of` and no longer taking any arguments.
* Replace anyObject with any
* Removing argument from isNull
* Replace verifyZeroInteractions with verifyNoMoreInteractions

The changes here were completely mechanical, done entirely with forms of find/replace within IntelliJ.