### PR TITLE
Remove `createParser` variant

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContent.java
@@ -100,14 +100,4 @@ public interface XContent {
      * Creates a parser over the provided reader.
      */
     XContentParser createParser(XContentParserConfiguration config, Reader reader) throws IOException;
-
-    /**
-     * Creates a parser over the provided reader.
-     * @deprecated Use {@link #createParser(XContentParserConfiguration, Reader)}
-     */
-    @Deprecated
-    default XContentParser createParser(NamedXContentRegistry registry, DeprecationHandler deprecationHandler, Reader reader)
-        throws IOException {
-        return createParser(XContentParserConfiguration.EMPTY.withRegistry(registry).withDeprecationHandler(deprecationHandler), reader);
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/common/logging/JsonLogsStream.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/logging/JsonLogsStream.java
@@ -8,10 +8,9 @@
 
 package org.elasticsearch.common.logging;
 
-import org.elasticsearch.xcontent.DeprecationHandler;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.BufferedReader;
@@ -38,11 +37,7 @@ public class JsonLogsStream {
 
     private JsonLogsStream(BufferedReader reader, ObjectParser<JsonLogLine, Void> logLineParser) throws IOException {
         this.reader = reader;
-        this.parser = JsonXContent.jsonXContent.createParser(
-            NamedXContentRegistry.EMPTY,
-            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-            reader
-        );
+        this.parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, reader);
         this.logLineParser = logLineParser;
     }
 

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateGenerateTool.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateGenerateTool.java
@@ -27,15 +27,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 
@@ -327,10 +326,9 @@ public class CertificateGenerateTool extends EnvironmentAwareCommand {
      */
     static Collection<CertificateInformation> parseFile(Path file) throws Exception {
         try (Reader reader = Files.newBufferedReader(file)) {
-            // EMPTY is safe here because we never use namedObject
-            XContentParser xContentParser = XContentType.YAML.xContent()
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, reader);
-            return InputFileParser.PARSER.parse(xContentParser, new ArrayList<>(), null);
+            try (XContentParser xContentParser = XContentType.YAML.xContent().createParser(XContentParserConfiguration.EMPTY, reader)) {
+                return InputFileParser.PARSER.parse(xContentParser, new ArrayList<>(), null);
+            }
         }
     }
 

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
@@ -31,17 +31,16 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 
@@ -982,9 +981,7 @@ public class CertificateTool extends LoggingAwareMultiCommand {
      */
     static Collection<CertificateInformation> parseFile(Path file) throws Exception {
         try (Reader reader = Files.newBufferedReader(file)) {
-            // EMPTY is safe here because we never use namedObject
-            XContentParser xContentParser = XContentType.YAML.xContent()
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, reader);
+            XContentParser xContentParser = XContentType.YAML.xContent().createParser(XContentParserConfiguration.EMPTY, reader);
             return CertificateToolParser.PARSER.parse(xContentParser, new ArrayList<>(), null);
         }
     }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
@@ -6,9 +6,8 @@
  */
 package org.elasticsearch.xpack.textstructure.structurefinder;
 
-import org.elasticsearch.xcontent.DeprecationHandler;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.io.IOException;
@@ -40,8 +39,7 @@ public class NdJsonTextStructureFinderFactory implements TextStructureFinderFact
             for (String sampleLine : sampleLines) {
                 try (
                     XContentParser parser = jsonXContent.createParser(
-                        NamedXContentRegistry.EMPTY,
-                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                        XContentParserConfiguration.EMPTY,
                         new ContextPrintingStringReader(sampleLine)
                     )
                 ) {


### PR DESCRIPTION
In #79814 I deprecated many variants of `XContent#createParser` in favor
of some new variants that bundle many of the arguments. This removes one
of the deprecated variants by converting all call sites to the new
variant.
