### PR TITLE
[8.0] [DOCS] Remove `[testenv="gold+"]` attributes (#79309)

### DIFF
--- a/docs/reference/commands/certgen.asciidoc
+++ b/docs/reference/commands/certgen.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[certgen]]
 == elasticsearch-certgen
 

--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[certutil]]
 == elasticsearch-certutil
 

--- a/docs/reference/commands/croneval.asciidoc
+++ b/docs/reference/commands/croneval.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[elasticsearch-croneval]]
 == elasticsearch-croneval
 

--- a/docs/reference/commands/saml-metadata.asciidoc
+++ b/docs/reference/commands/saml-metadata.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[saml-metadata]]
 == elasticsearch-saml-metadata
 

--- a/docs/reference/commands/service-tokens-command.asciidoc
+++ b/docs/reference/commands/service-tokens-command.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[service-tokens-command]]
 == elasticsearch-service-tokens
 

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[setup-passwords]]
 == elasticsearch-setup-passwords
 

--- a/docs/reference/commands/syskeygen.asciidoc
+++ b/docs/reference/commands/syskeygen.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[syskeygen]]
 == elasticsearch-syskeygen
 

--- a/docs/reference/commands/users-command.asciidoc
+++ b/docs/reference/commands/users-command.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[users-command]]
 == elasticsearch-users
 

--- a/docs/reference/ilm/index-rollover.asciidoc
+++ b/docs/reference/ilm/index-rollover.asciidoc
@@ -1,4 +1,5 @@
 [[index-rollover]]
+[testenv="basic"]
 === Rollover
 
 When indexing time series data like logs or metrics, you can't write to a single index indefinitely. 
@@ -39,8 +40,6 @@ This is the active index that handles all write requests.
 On each rollover, the new index becomes the write index.
 
 [discrete]
-[role="xpack"]
-[testenv="basic"]
 [[ilm-automatic-rollover]]
 === Automatic rollover
 

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [testenv="basic"]
 [[ingest-enriching-data]]
 == Enrich your data
@@ -79,8 +78,6 @@ properties to help streamline them:
 * They are <<indices-forcemerge,force merged>> for fast retrieval.
 --
 
-[role="xpack"]
-[testenv="basic"]
 [[enrich-setup]]
 === Set up an enrich processor
 

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -1,4 +1,5 @@
 [[snapshots-register-repository]]
+[testenv="basic"]
 == Register a snapshot repository
 ++++
 <titleabbrev>Register a repository</titleabbrev>
@@ -191,8 +192,6 @@ NOTE: URLs using the `ftp`, `http`, `https`, or `jar` protocols do not need to
 be registered in the `path.repo` setting.
 
 [discrete]
-[role="xpack"]
-[testenv="basic"]
 [[snapshots-source-only-repository]]
 === Source only repository
 

--- a/docs/reference/sql/endpoints/odbc.asciidoc
+++ b/docs/reference/sql/endpoints/odbc.asciidoc
@@ -1,6 +1,5 @@
 :odbc: {es-sql} ODBC Driver
 
-[role="xpack"]
 [testenv="platinum"]
 [[sql-odbc]]
 == SQL ODBC

--- a/x-pack/docs/en/security/auditing/auditing-search-queries.asciidoc
+++ b/x-pack/docs/en/security/auditing/auditing-search-queries.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="gold+"]
 [[auditing-search-queries]]
 === Auditing search queries
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove `[testenv="gold+"]` attributes (#79309)