### PR TITLE
[8.0] [DOCS] Clarify HTTP and transport TLS settings (#79952)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2019,6 +2019,7 @@ a PKCS#12 container includes trusted certificate ("anchor") entries look for
 :verifies!:
 :server:
 :ssl-context:            security-http
+:ssl-layer:              HTTP networking layer, which {es} uses to communicate with other clients
 
 include::ssl-settings.asciidoc[]
 
@@ -2029,6 +2030,7 @@ include::ssl-settings.asciidoc[]
 :verifies:
 :server:
 :ssl-context:            security-transport
+:ssl-layer:              transport networking layer, which nodes use to communicate with each other
 
 include::ssl-settings.asciidoc[]
 

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -4,7 +4,7 @@ You can configure the following TLS/SSL settings.
 ifdef::server[]
 +{ssl-prefix}.ssl.enabled+::
 (<<static-cluster-setting,Static>>)
-Used to enable or disable TLS/SSL. The default is `false`.
+Used to enable or disable TLS/SSL on the {ssl-layer}. The default is `false`.
 endif::server[]
 
 +{ssl-prefix}.ssl.supported_protocols+::


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Clarify HTTP and transport TLS settings (#79952)