### PR TITLE
[DOCS] Fix formatting for Docker mem lock example

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -271,7 +271,10 @@ https://docs.docker.com/engine/reference/commandline/dockerd/#default-ulimits[Do
 or explicitly set for the container as shown in the  <<docker-compose-file, sample compose file>>.
 When using `docker run`, you can specify:
 
-  -e "bootstrap.memory_lock=true" --ulimit memlock=-1:-1
+[source,sh]
+----
+-e "bootstrap.memory_lock=true" --ulimit memlock=-1:-1
+----
 
 ===== Randomize published ports
 


### PR DESCRIPTION
This places the example in a code snippet block rather than just using monospace.

**Before:**
<img width="771" alt="Screen Shot 2021-10-27 at 5 07 37 PM" src="https://user-images.githubusercontent.com/40268737/139148676-83b71ec6-3f79-41d4-afd1-ef3c5647c3ca.PNG">

**After:**
<img width="756" alt="Screen Shot 2021-10-27 at 5 18 51 PM" src="https://user-images.githubusercontent.com/40268737/139148694-c0b07566-000c-4694-a34b-7ff1b01c7328.PNG">:
