### PR TITLE
[7.16] [DOCS] Fix formatting for Docker mem lock example (#79963)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -276,7 +276,10 @@ https://docs.docker.com/engine/reference/commandline/dockerd/#default-ulimits[Do
 or explicitly set for the container as shown in the  <<docker-compose-file, sample compose file>>.
 When using `docker run`, you can specify:
 
-  -e "bootstrap.memory_lock=true" --ulimit memlock=-1:-1
+[source,sh]
+----
+-e "bootstrap.memory_lock=true" --ulimit memlock=-1:-1
+----
 
 ===== Randomize published ports
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Fix formatting for Docker mem lock example (#79963)