### PR TITLE
Fix failure starting OldElasticsearch fixture with some checkout dirs

### DIFF
--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -92,7 +92,7 @@ public class OldElasticsearch {
             command.add("-f");
         }
         command.add("-p");
-        command.add(baseDir.resolve("pid").toString());
+        command.add("\"" + baseDir.resolve("pid") + "\"");
         ProcessBuilder subprocess = new ProcessBuilder(command);
         Process process = subprocess.start();
         System.out.println("Running " + command);

--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -92,7 +92,7 @@ public class OldElasticsearch {
             command.add("-f");
         }
         command.add("-p");
-        command.add("\"" + baseDir.resolve("pid") + "\"");
+        command.add(baseDir.resolve("pid").toString().replaceAll("&", "\\&"));
         ProcessBuilder subprocess = new ProcessBuilder(command);
         Process process = subprocess.start();
         System.out.println("Running " + command);


### PR DESCRIPTION
Jenkins includes `&&` in some checkout directory paths for some of our jobs. This causes issues if we then include absolute paths as command line arguments without quoting them. This fixes usages of the old elasticsearch test fixture which passes the pid directory as an absolute path via a command line argument. The fix here is just the quote the argument.

Closes #79898