### PR TITLE
Convert remote license checker to use LicensedFeature (#79876)

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.ccr.action.ShardChangesAction;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -244,7 +243,7 @@ public class CcrLicenseChecker {
         final Function<Exception, ElasticsearchStatusException> unknownLicense
     ) {
         // we have to check the license on the remote cluster
-        new RemoteClusterLicenseChecker(client, XPackLicenseState::isCcrAllowedForOperationMode).checkRemoteClusterLicenses(
+        new RemoteClusterLicenseChecker(client, CcrConstants.CCR_FEATURE).checkRemoteClusterLicenses(
             Collections.singletonList(clusterAlias),
             new ActionListener<RemoteClusterLicenseChecker.LicenseCheck>() {
 
@@ -452,11 +451,7 @@ public class CcrLicenseChecker {
             clusterAlias,
             leaderIndex,
             clusterAlias,
-            RemoteClusterLicenseChecker.buildErrorMessage(
-                "ccr",
-                licenseCheck.remoteClusterLicenseInfo(),
-                RemoteClusterLicenseChecker::isAllowedByLicense
-            )
+            RemoteClusterLicenseChecker.buildErrorMessage(CcrConstants.CCR_FEATURE, licenseCheck.remoteClusterLicenseInfo())
         );
         return new ElasticsearchStatusException(message, RestStatus.BAD_REQUEST);
     }
@@ -469,11 +464,7 @@ public class CcrLicenseChecker {
             Locale.ROOT,
             "can not fetch remote cluster state as the remote cluster [%s] is not licensed for [ccr]; %s",
             clusterAlias,
-            RemoteClusterLicenseChecker.buildErrorMessage(
-                "ccr",
-                licenseCheck.remoteClusterLicenseInfo(),
-                RemoteClusterLicenseChecker::isAllowedByLicense
-            )
+            RemoteClusterLicenseChecker.buildErrorMessage(CcrConstants.CCR_FEATURE, licenseCheck.remoteClusterLicenseInfo())
         );
         return new ElasticsearchStatusException(message, RestStatus.BAD_REQUEST);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -458,10 +458,6 @@ public class XPackLicenseState {
         return usage.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> timeConverter.apply(e.getValue())));
     }
 
-    public static boolean isMachineLearningAllowedForOperationMode(final OperationMode operationMode) {
-        return isAllowedByOperationMode(operationMode, OperationMode.PLATINUM);
-    }
-
     public static boolean isFipsAllowedForOperationMode(final OperationMode operationMode) {
         return isAllowedByOperationMode(operationMode, OperationMode.PLATINUM);
     }
@@ -508,11 +504,7 @@ public class XPackLicenseState {
         }
     }
 
-    public static boolean isCcrAllowedForOperationMode(final OperationMode operationMode) {
-        return isAllowedByOperationMode(operationMode, OperationMode.PLATINUM);
-    }
-
-    public static boolean isAllowedByOperationMode(final OperationMode operationMode, final OperationMode minimumMode) {
+    static boolean isAllowedByOperationMode(final OperationMode operationMode, final OperationMode minimumMode) {
         if (OperationMode.TRIAL == operationMode) {
             return true;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -157,10 +157,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
         responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
         responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
 
-        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-            client,
-            operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
         final AtomicReference<RemoteClusterLicenseChecker.LicenseCheck> licenseCheck = new AtomicReference<>();
 
         licenseChecker.checkRemoteClusterLicenses(
@@ -202,10 +200,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             return null;
         }).when(client).execute(same(XPackInfoAction.INSTANCE), any(), any());
 
-        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-            client,
-            operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
         final AtomicReference<RemoteClusterLicenseChecker.LicenseCheck> licenseCheck = new AtomicReference<>();
 
         licenseChecker.checkRemoteClusterLicenses(
@@ -251,10 +247,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
         responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
         responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
 
-        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-            client,
-            operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
         final AtomicReference<Exception> exception = new AtomicReference<>();
 
         licenseChecker.checkRemoteClusterLicenses(
@@ -294,10 +288,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
                 return null;
             }).when(client).execute(same(XPackInfoAction.INSTANCE), any(), any());
 
-            final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-                client,
-                operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-            );
+            LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+            final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
 
             final List<String> remoteClusterAliases = Collections.singletonList("valid");
             licenseChecker.checkRemoteClusterLicenses(
@@ -337,10 +329,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
             responses.add(new XPackInfoResponse(null, createPlatinumLicenseResponse(), null));
 
-            final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-                client,
-                operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-            );
+            LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+            final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
 
             final AtomicBoolean listenerInvoked = new AtomicBoolean();
             threadPool.getThreadContext().putHeader("key", "value");
@@ -383,10 +373,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             "platinum-cluster",
             platinumLicence
         );
-        final AssertionError e = expectThrows(
-            AssertionError.class,
-            () -> RemoteClusterLicenseChecker.buildErrorMessage("", info, RemoteClusterLicenseChecker::isAllowedByLicense)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "foo", License.OperationMode.PLATINUM);
+        final AssertionError e = expectThrows(AssertionError.class, () -> RemoteClusterLicenseChecker.buildErrorMessage(feature, info));
         assertThat(e, hasToString(containsString("license must be incompatible to build error message")));
     }
 
@@ -396,9 +384,10 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             "basic-cluster",
             basicLicense
         );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
         assertThat(
-            RemoteClusterLicenseChecker.buildErrorMessage("Feature", info, RemoteClusterLicenseChecker::isAllowedByLicense),
-            equalTo("the license mode [BASIC] on cluster [basic-cluster] does not enable [Feature]")
+            RemoteClusterLicenseChecker.buildErrorMessage(feature, info),
+            equalTo("the license mode [BASIC] on cluster [basic-cluster] does not enable [feature]")
         );
     }
 
@@ -408,8 +397,9 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             "expired-cluster",
             expiredLicense
         );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "foo", License.OperationMode.PLATINUM);
         assertThat(
-            RemoteClusterLicenseChecker.buildErrorMessage("Feature", info, RemoteClusterLicenseChecker::isAllowedByLicense),
+            RemoteClusterLicenseChecker.buildErrorMessage(feature, info),
             equalTo("the license on cluster [expired-cluster] is not active")
         );
     }
@@ -424,10 +414,8 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             return null;
         }).when(client).execute(same(XPackInfoAction.INSTANCE), any(), any());
 
-        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(
-            client,
-            operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.PLATINUM);
+        final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
         final AtomicReference<Exception> exception = new AtomicReference<>();
 
         licenseChecker.checkRemoteClusterLicenses(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -30,8 +30,8 @@ import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.TestProcessor;
 import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.protocol.xpack.XPackInfoRequest;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.LicenseInfo;
@@ -100,6 +100,7 @@ public class SourceDestValidatorTests extends ESTestCase {
     private Client clientWithPlatinumLicense;
     private Client clientWithTrialLicense;
     private RemoteClusterLicenseChecker remoteClusterLicenseCheckerBasic;
+    private LicensedFeature platinumFeature;
 
     private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
     private final TransportService transportService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool);
@@ -201,10 +202,9 @@ public class SourceDestValidatorTests extends ESTestCase {
     public void setupComponents() {
         clientWithBasicLicense = new MockClientLicenseCheck(getTestName(), "basic", LicenseStatus.ACTIVE);
         clientWithExpiredBasicLicense = new MockClientLicenseCheck(getTestName(), "basic", LicenseStatus.EXPIRED);
-        remoteClusterLicenseCheckerBasic = new RemoteClusterLicenseChecker(
-            clientWithBasicLicense,
-            (operationMode -> operationMode != License.OperationMode.MISSING)
-        );
+        LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.BASIC);
+        platinumFeature = LicensedFeature.momentary(null, "platinum-feature", License.OperationMode.PLATINUM);
+        remoteClusterLicenseCheckerBasic = new RemoteClusterLicenseChecker(clientWithBasicLicense, feature);
         clientWithPlatinumLicense = new MockClientLicenseCheck(getTestName(), "platinum", LicenseStatus.ACTIVE);
         clientWithTrialLicense = new MockClientLicenseCheck(getTestName(), "trial", LicenseStatus.ACTIVE);
     }
@@ -680,10 +680,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithBasicLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithBasicLicense, platinumFeature),
                 ingestService,
                 new String[] { REMOTE_BASIC + ":" + "SOURCE_1" },
                 "dest",
@@ -714,10 +711,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithPlatinumLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithPlatinumLicense, platinumFeature),
                 ingestService,
                 new String[] { REMOTE_PLATINUM + ":" + "SOURCE_1" },
                 "dest",
@@ -739,10 +733,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithPlatinumLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithPlatinumLicense, platinumFeature),
                 ingestService,
                 new String[] { REMOTE_PLATINUM + ":" + "SOURCE_1" },
                 "dest",
@@ -765,10 +756,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithTrialLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithTrialLicense, platinumFeature),
                 ingestService,
                 new String[] { REMOTE_PLATINUM + ":" + "SOURCE_1" },
                 "dest",
@@ -793,10 +781,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithExpiredBasicLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithExpiredBasicLicense, platinumFeature),
                 ingestService,
                 new String[] { REMOTE_BASIC + ":" + "SOURCE_1" },
                 "dest",
@@ -824,10 +809,7 @@ public class SourceDestValidatorTests extends ESTestCase {
                 CLUSTER_STATE,
                 indexNameExpressionResolver,
                 remoteClusterService,
-                new RemoteClusterLicenseChecker(
-                    clientWithExpiredBasicLicense,
-                    operationMode -> XPackLicenseState.isAllowedByOperationMode(operationMode, License.OperationMode.PLATINUM)
-                ),
+                new RemoteClusterLicenseChecker(clientWithExpiredBasicLicense, platinumFeature),
                 ingestService,
                 new String[] { "non_existing_remote:" + "SOURCE_1" },
                 "dest",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -225,7 +225,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             if (remoteIndices.isEmpty() == false) {
                 final RemoteClusterLicenseChecker remoteClusterLicenseChecker = new RemoteClusterLicenseChecker(
                     client,
-                    XPackLicenseState::isMachineLearningAllowedForOperationMode
+                    MachineLearningField.ML_API_FEATURE
                 );
                 remoteClusterLicenseChecker.checkRemoteClusterLicenses(
                     RemoteClusterLicenseChecker.remoteClusterAliases(
@@ -459,11 +459,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             "cannot start datafeed [%s] as it is configured to use indices on remote cluster [%s] that is not licensed for ml; %s",
             datafeedId,
             licenseCheck.remoteClusterLicenseInfo().clusterAlias(),
-            RemoteClusterLicenseChecker.buildErrorMessage(
-                "ml",
-                licenseCheck.remoteClusterLicenseInfo(),
-                RemoteClusterLicenseChecker::isAllowedByLicense
-            )
+            RemoteClusterLicenseChecker.buildErrorMessage(MachineLearningField.ML_API_FEATURE, licenseCheck.remoteClusterLicenseInfo())
         );
         return new ElasticsearchStatusException(message, RestStatus.BAD_REQUEST);
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -134,7 +134,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             transportService.getRemoteClusterService(),
             DiscoveryNode.isRemoteClusterClient(settings)
                 /* transforms are BASIC so always allowed, no need to check license */
-                ? new RemoteClusterLicenseChecker(client, mode -> true)
+                ? new RemoteClusterLicenseChecker(client, null)
                 : null,
             ingestService,
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
@@ -85,7 +85,7 @@ public class TransportValidateTransformAction extends HandledTransportAction<Req
             transportService.getRemoteClusterService(),
             DiscoveryNode.isRemoteClusterClient(settings)
                 /* transforms are BASIC so always allowed, no need to check license */
-                ? new RemoteClusterLicenseChecker(client, mode -> true)
+                ? new RemoteClusterLicenseChecker(client, null)
                 : null,
             ingestService,
             clusterService.getNodeName(),


### PR DESCRIPTION
The RemoteClusterLicenseChecker pulls the license level of a remote
cluster and checks it allows a local feature to communicate with that
cluster. It does the check with a lambda, but these methods could be out
of sync with the actual licensed feature. This commit converts the
remote license checker to take in the feature object that should be
checked.