### PR TITLE
Miscellaneous fixes for LDAP SDK v6 upgrade

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -435,10 +435,11 @@ public class LdapRealmTests extends LdapTestCase {
         PlainActionFuture<AuthenticationResult<User>> future = new PlainActionFuture<>();
         ldap.authenticate(new UsernamePasswordToken("Horatio Hornblower", new SecureString(PASSWORD)), future);
         final AuthenticationResult<User> result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
+        assertThat(result, notNullValue());
+        assertThat(result.toString(), result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
         User user = result.getValue();
         assertThat(user, notNullValue());
-        assertThat(user.roles(), arrayContaining("avenger"));
+        assertThat(user.toString(), user.roles(), arrayContaining("avenger"));
     }
 
     /**
@@ -530,7 +531,8 @@ public class LdapRealmTests extends LdapTestCase {
         PlainActionFuture<AuthenticationResult<User>> future = new PlainActionFuture<>();
         ldap.authenticate(new UsernamePasswordToken("Horatio Hornblower", new SecureString(PASSWORD)), future);
         final AuthenticationResult<User> result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
+        assertThat(result, notNullValue());
+        assertThat(result.toString(), result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
         User user = result.getValue();
         assertThat(user, notNullValue());
         assertThat(user.roles(), arrayContainingInAnyOrder("_user_hhornblo", "sales_admin"));
@@ -560,7 +562,8 @@ public class LdapRealmTests extends LdapTestCase {
         PlainActionFuture<AuthenticationResult<User>> future = new PlainActionFuture<>();
         ldap.authenticate(new UsernamePasswordToken(VALID_USERNAME, new SecureString(PASSWORD)), future);
         final AuthenticationResult<User> result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.CONTINUE));
+        assertThat(result, notNullValue());
+        assertThat(result.toString(), result.getStatus(), is(AuthenticationResult.Status.CONTINUE));
         assertThat(result.getValue(), nullValue());
         assertThat(result.getMessage(), is("authenticate failed"));
         assertThat(result.getException(), notNullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
@@ -47,7 +47,7 @@ public class SearchGroupsResolverInMemoryTests extends LdapTestCase {
     @After
     public void closeConnection() {
         if (connection != null) {
-            connection.close();
+            connection.closeWithoutUnbind();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapServerDebugLogging.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapServerDebugLogging.java
@@ -52,6 +52,7 @@ public class LdapServerDebugLogging {
     }
 
     public void configure(InMemoryDirectoryServerConfig config) {
+        targetLogger.info("Configuring debug logging for LDAP server [{}]", config);
         config.setLDAPDebugLogHandler(logHandler);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -156,7 +156,7 @@ public abstract class LdapTestCase extends ESTestCase {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 try (var c = ds.getConnection()) {
                     assertThat("Failed to connect to " + ds + " - ", c.isConnected(), is(true));
-                    logger.info("Test connection to [{}] was successful ({})", ds, c);
+                    logger.info("Test connection to [{}](port {}) was successful ({})", ds, ds.getListenPort(), c);
                 } catch (LDAPException e) {
                     throw new AssertionError("Failed to connect to " + ds, e);
                 }


### PR DESCRIPTION
This commit makes a few changes to LDAP testing to improve
the stability of tests on UnboudID LDAP SDK v6

Backport of: #79891
