### PR TITLE
[8.0] Wait 3 seconds for the server to reload trust (#79778)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -41,6 +41,7 @@ import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
 
@@ -351,10 +352,12 @@ public class LdapSessionFactoryTests extends LdapTestCase {
             Files.copy(realCa, ldapCaPath, StandardCopyOption.REPLACE_EXISTING);
             resourceWatcher.notifyNow(ResourceWatcherService.Frequency.HIGH);
 
-            final LdapSession session = session(sessionFactory, user, userPass);
-            assertThat(session.userDn(), is("cn=Horatio Hornblower,ou=people,o=sevenSeas"));
-
-            session.close();
+            // Occasionally the reload doesn't take immediate effect so the next connection fails.
+            assertBusy(() -> {
+                final LdapSession session = session(sessionFactory, user, userPass);
+                assertThat(session.userDn(), is("cn=Horatio Hornblower,ou=people,o=sevenSeas"));
+                session.close();
+            }, 3, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Wait 3 seconds for the server to reload trust (#79778)