### PR TITLE
[8.0] [ML] Fixing doc test substitution bug

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -692,7 +692,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version" : "8.0.0"/"version" : $body.version/]
+// TESTRESPONSE[s/"version": "8.0.0"/"version": $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
The substitutions should not have a space after the field
name.

Backport of #79943