### PR TITLE
Forbid zero value for shared cache range/recovery range/region size settings

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -72,7 +72,7 @@ public class FrozenCacheService implements Releasable {
         SHARED_CACHE_SETTINGS_PREFIX + "range_size",
         ByteSizeValue.ofMb(16).getStringRep(),
         s -> ByteSizeValue.parseBytesSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "range_size"),
-        getPageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "range_size"),
+        getPositivePageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "range_size"),
         Setting.Property.NodeScope
     );
 
@@ -80,7 +80,7 @@ public class FrozenCacheService implements Releasable {
         SHARED_CACHE_SETTINGS_PREFIX + "recovery_range_size",
         ByteSizeValue.ofKb(128L).getStringRep(),
         s -> ByteSizeValue.parseBytesSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "recovery_range_size"),
-        getPageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "recovery_range_size"),
+        getPositivePageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "recovery_range_size"),
         Setting.Property.NodeScope
     );
 
@@ -88,7 +88,7 @@ public class FrozenCacheService implements Releasable {
         SHARED_CACHE_SETTINGS_PREFIX + "region_size",
         SHARED_CACHE_RANGE_SIZE_SETTING,
         s -> ByteSizeValue.parseBytesSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "region_size"),
-        getPageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "region_size"),
+        getPositivePageSizeAlignedByteSizeValueValidator(SHARED_CACHE_SETTINGS_PREFIX + "region_size"),
         Setting.Property.NodeScope
     );
 
@@ -100,6 +100,15 @@ public class FrozenCacheService implements Releasable {
             if (value.getBytes() % SharedBytes.PAGE_SIZE != 0L) {
                 throw new SettingsException("setting [{}] must be multiple of {}", settingName, SharedBytes.PAGE_SIZE);
             }
+        };
+    }
+
+    private static Setting.Validator<ByteSizeValue> getPositivePageSizeAlignedByteSizeValueValidator(String settingName) {
+        return value -> {
+            if (value.getBytes() <= 0L) {
+                throw new SettingsException("setting [{}] must be greater than zero", settingName);
+            }
+            getPageSizeAlignedByteSizeValueValidator(settingName).validate(value);
         };
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.searchablesnapshots.cache.shared;
 
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -376,4 +377,30 @@ public class FrozenCacheServiceTests extends ESTestCase {
             assertEquals(val2.getBytes(), cacheService.getStats().getSize());
         }
     }
+
+    private void assertThatNonPositiveRecoveryRangeSizeRejected(Setting<ByteSizeValue> setting) {
+        final String value = randomFrom(ByteSizeValue.MINUS_ONE, ByteSizeValue.ZERO).getStringRep();
+        final Settings settings = Settings.builder()
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
+            .put(setting.getKey(), value)
+            .build();
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> setting.get(settings));
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause(), instanceOf(SettingsException.class));
+        assertThat(e.getCause().getMessage(), is("setting [" + setting.getKey() + "] must be greater than zero"));
+    }
+
+    public void testNonPositiveRegionSizeRejected() {
+        assertThatNonPositiveRecoveryRangeSizeRejected(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING);
+    }
+
+    public void testNonPositiveRangeSizeRejected() {
+        assertThatNonPositiveRecoveryRangeSizeRejected(FrozenCacheService.SHARED_CACHE_RANGE_SIZE_SETTING);
+    }
+
+    public void testNonPositiveRecoveryRangeSizeRejected() {
+        assertThatNonPositiveRecoveryRangeSizeRejected(FrozenCacheService.FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING);
+    }
+
 }


### PR DESCRIPTION
Today nothing prevents the `range_size`, `recovery_range_size` and `region_size` settings to be set to a value of zero, causing some divide by zero arithmetic exception down the road.