### PR TITLE
[8.0] SearchContext: remove unused variable (#79917)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -66,7 +66,6 @@ public abstract class SearchContext implements Releasable {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private InnerHitsContext innerHitsContext;
 
-    private boolean rewritten;
     private Query rewriteQuery;
 
     protected SearchContext() {}


### PR DESCRIPTION
Backports the following commits to 8.0:
 - SearchContext: remove unused variable (#79917)