### PR TITLE
[7.16] [ML] Account for service being triggered twice in tests (#80000)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
@@ -149,10 +150,10 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
             latch.await(5, TimeUnit.SECONDS);
         }
 
-        verify(client, times(2)).threadPool();
-        verify(client).execute(same(DeleteExpiredDataAction.INSTANCE), any(), any());
-        verify(client).execute(same(GetJobsAction.INSTANCE), any(), any());
-        verify(mlAssignmentNotifier).auditUnassignedMlTasks(any(), any());
+        verify(client, Mockito.atLeast(2)).threadPool();
+        verify(client, Mockito.atLeast(1)).execute(same(DeleteExpiredDataAction.INSTANCE), any(), any());
+        verify(client, Mockito.atLeast(1)).execute(same(GetJobsAction.INSTANCE), any(), any());
+        verify(mlAssignmentNotifier, Mockito.atLeast(1)).auditUnassignedMlTasks(any(), any());
         verifyNoMoreInteractions(client, mlAssignmentNotifier);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [ML] Account for service being triggered twice in tests (#80000)