### PR TITLE
Don't Fill Stack Traces in SnapshotShardFailure

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.snapshots.IndexShardSnapshotFailedException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -26,7 +25,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Stores information about failures that occurred during shard snapshotting process
+ * Stores information about failures that occurred during shard snapshotting process for serialization as part of {@link SnapshotInfo}.
  */
 public class SnapshotShardFailure extends ShardOperationFailedException {
 
@@ -35,12 +34,7 @@ public class SnapshotShardFailure extends ShardOperationFailedException {
     private final ShardId shardId;
 
     SnapshotShardFailure(StreamInput in) throws IOException {
-        nodeId = in.readOptionalString();
-        shardId = new ShardId(in);
-        super.shardId = shardId.getId();
-        index = shardId.getIndexName();
-        reason = in.readString();
-        status = RestStatus.readFrom(in);
+        this(in.readOptionalString(), new ShardId(in), in.readString(), RestStatus.readFrom(in));
     }
 
     /**
@@ -63,9 +57,12 @@ public class SnapshotShardFailure extends ShardOperationFailedException {
      * @param status  rest status
      */
     private SnapshotShardFailure(@Nullable String nodeId, ShardId shardId, String reason, RestStatus status) {
-        super(shardId.getIndexName(), shardId.id(), reason, status, new IndexShardSnapshotFailedException(shardId, reason));
         this.nodeId = nodeId;
         this.shardId = shardId;
+        this.index = shardId.getIndexName();
+        this.reason = reason;
+        super.shardId = shardId.getId();
+        this.status = status;
     }
 
     /**
@@ -189,5 +186,11 @@ public class SnapshotShardFailure extends ShardOperationFailedException {
     @Override
     public int hashCode() {
         return Objects.hash(shardId, reason, nodeId, status.getStatus());
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // no need for stack-traces here as we are not serializing them anyway
+        return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
@@ -34,7 +34,12 @@ public class SnapshotShardFailure extends ShardOperationFailedException {
     private final ShardId shardId;
 
     SnapshotShardFailure(StreamInput in) throws IOException {
-        this(in.readOptionalString(), new ShardId(in), in.readString(), RestStatus.readFrom(in));
+        nodeId = in.readOptionalString();
+        shardId = new ShardId(in);
+        super.shardId = shardId.getId();
+        index = shardId.getIndexName();
+        reason = in.readString();
+        status = RestStatus.readFrom(in);
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -137,7 +137,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         );
                         // Add each failed shard's exception as suppressed, the exception contains
                         // information about which shard failed
-                        snapInfo.shardFailures().forEach(failure -> e.addSuppressed(failure.getCause()));
+                        // TODO: this seems wrong, investigate whether we actually need all the shard level exception here given that we
+                        // could be dealing with tens of thousands of them at a time
+                        snapInfo.shardFailures().forEach(e::addSuppressed);
                         // Call the failure handler to register this as a failure and persist it
                         onFailure(e);
                     }


### PR DESCRIPTION
We don't use this class as an actual exception that is thrown. It's only used as
part of `SnapshotInfo` in the repository and APIs. As such, neither do we make
any actual use of the stack-trace in it, nor of its `cause` which only holds redundant
information to begin with (outside of the adjusted and unnecessary `cause` use in SLM).

I realized this one when investigating #79718 which started logging a lot of slow transport thread warnings. The hottest action on the transport threads turned out to be filling in the stack traces here due to https://github.com/elastic/elasticsearch/pull/78507. Outside of speeding up  and stabilizing the test (though not fixing it, that is incoming in a separate PR) this change is somewhat useful for production use cases as well when thinking about large clusters. Assuming clusters of tens of thousands of shards, we could run into situations where we'd have to fill in the same number of stack traces in a hot loop on either CS applier or transport threads, both of which we shouldn't do something that slow + expensive on. 