### PR TITLE
[8.0] [ML] Retain built-in ML roles granting Kibana privileges (#80014)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -285,7 +285,13 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             .indices(".ml-annotations*")
                             .privileges("view_index_metadata", "read", "write")
                             .build() },
-                    // TODO: remove Kibana privileges from ML backend roles in 8.0.0
+                    // This role also grants Kibana privileges related to ML.
+                    // This makes it completely clear to UI administrators that
+                    // if they grant the Elasticsearch backend role to a user then
+                    // they cannot expect Kibana privileges to stop that user from
+                    // accessing ML functionality - the user could switch to curl
+                    // or even Kibana dev console and call the ES endpoints directly
+                    // bypassing the Kibana privileges layer entirely.
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
                         RoleDescriptor.ApplicationResourcePrivileges.builder()
                             .application("kibana-*")
@@ -313,7 +319,13 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             .indices(".ml-annotations*")
                             .privileges("view_index_metadata", "read", "write")
                             .build() },
-                    // TODO: remove Kibana privileges from ML backend roles in 8.0.0
+                    // This role also grants Kibana privileges related to ML.
+                    // This makes it completely clear to UI administrators that
+                    // if they grant the Elasticsearch backend role to a user then
+                    // they cannot expect Kibana privileges to stop that user from
+                    // accessing ML functionality - the user could switch to curl
+                    // or even Kibana dev console and call the ES endpoints directly
+                    // bypassing the Kibana privileges layer entirely.
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
                         RoleDescriptor.ApplicationResourcePrivileges.builder()
                             .application("kibana-*")


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Retain built-in ML roles granting Kibana privileges (#80014)