### PR TITLE
Scriptfield test: set number of shards to 1

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/20_scriptfield.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/20_scriptfield.yml
@@ -5,6 +5,8 @@ setup:
         indices.create:
           index: test
           body:
+            settings:
+              number_of_shards: "1"
             mappings:
               properties:
                 foo:


### PR DESCRIPTION
The `20_scriptfield`:"Scripted Field with error accessing an
unsupported field via the script fields api" test expects to fail because
the field is not yet supported in the fields API.

However, if the number of shards in the target index is randomly more
than one, the empty shard will succeed leading to a 200 response rather
than the expected 400 response.

This change forces the number of shards to 1 to avoid this scenario.

Fixes: #79986