### PR TITLE
[DOCS] Add deprecation notice for system indices

### DIFF
--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -13,7 +13,9 @@
 *Details* +
 Directly accessing system indices is deprecated, and will be prevented by
 default in a future major version. System indices are reserved only for internal
-use by Elastic products and should not be accessed directly.
+use by Elastic products and should not be accessed directly. While it's still
+possible to access system indices, you should only do so with the guidance of
+Elastic Support.
 
 *Impact* +
 Accessing system indices directly results in warnings in the deprecation logs.

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -11,16 +11,17 @@
 [%collapsible]
 ====
 *Details* +
-Directly accessing system indices is deprecated, and will be prevented by
-default in a future major version. System indices are reserved only for internal
-use by Elastic products and should not be accessed directly. While it's still
-possible to access system indices, you should only do so with the guidance of
-Elastic Support.
+Directly accessing system indices is deprecated, and may be prevented in a
+future version. If you must access a system index, create a security role with
+an index permission that targets the specific index and set the
+`allow_restricted_indices` permission to `true`. Refer to 
+{ref}/defining-roles.html#roles-indices-priv[indices privileges] for
+information on adding this permission to an index privilege.
 
 *Impact* +
-Accessing system indices directly results in warnings in the deprecation logs.
-Use {kib} or the associated feature's {es} APIs to manage the data that you
-want to access.
+Accessing system indices directly results in warnings in the header of API
+responses. Use {kib} or the associated feature's {es} APIs to manage the data
+that you want to access.
 ====
 
 .The deprecated `_upgrade` API has been removed.

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -6,6 +6,21 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[deprecation-system-indices]]
+.Direct access to system indices is deprecated.
+[%collapsible]
+====
+*Details* +
+Directly accessing system indices is deprecated, and will be prevented by
+default in a future major version. System indices are reserved only for internal
+use by Elastic products and should not be accessed directly.
+
+*Impact* +
+Accessing system indices directly results in warnings in the deprecation logs.
+Use {kib} or the associated feature's {es} APIs to manage the data that you
+want to access.
+====
+
 .The deprecated `_upgrade` API has been removed.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -20,7 +20,7 @@ information on adding this permission to an index privilege.
 
 *Impact* +
 Accessing system indices directly results in warnings in the header of API
-responses. Use {kib} or the associated feature's {es} APIs to manage the data
+responses. If available, use {kib} or the associated feature's {es} APIs to manage the data
 that you want to access.
 ====
 


### PR DESCRIPTION
In 7.16, directly accessing system indices is deprecated. If an application or API directly accesses system indices, we generate warnings in the deprecation log as indicated in #79633. PR #80095 will add a deprecation message for 7.16.

In 8.0, users _must_ add the `allow_restricted_indices` permission set to `true` on a user role to access
system indices. This PR adds a deprecation notice to the 8.0 migration docs so that we can inform users of this change and link to documentation for guidance.

**We should wait until #79679 is merged so that we can link directly to that documentation for more details.**

Preview link: https://elasticsearch_80028.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_indices_changes

Relates to #79679