### PR TITLE
[ML] removing old 7.x bwc serialization code

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -162,11 +162,7 @@ public class MlMetadata implements Metadata.Custom {
         this.datafeeds = datafeeds;
         this.groupOrJobLookup = new GroupOrJobLookup(jobs.values());
         this.upgradeMode = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            this.resetMode = in.readBoolean();
-        } else {
-            this.resetMode = false;
-        }
+        this.resetMode = in.readBoolean();
     }
 
     @Override
@@ -174,9 +170,7 @@ public class MlMetadata implements Metadata.Custom {
         writeMap(jobs, out);
         writeMap(datafeeds, out);
         out.writeBoolean(upgradeMode);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeBoolean(resetMode);
-        }
+        out.writeBoolean(resetMode);
     }
 
     private static <T extends Writeable> void writeMap(Map<String, T> map, StreamOutput out) throws IOException {
@@ -240,11 +234,7 @@ public class MlMetadata implements Metadata.Custom {
                 MlMetadataDiff::readDatafeedDiffFrom
             );
             upgradeMode = in.readBoolean();
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-                resetMode = in.readBoolean();
-            } else {
-                resetMode = false;
-            }
+            resetMode = in.readBoolean();
         }
 
         /**
@@ -264,9 +254,7 @@ public class MlMetadata implements Metadata.Custom {
             jobs.writeTo(out);
             datafeeds.writeTo(out);
             out.writeBoolean(upgradeMode);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-                out.writeBoolean(resetMode);
-            }
+            out.writeBoolean(resetMode);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,7 +35,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
     }
 
     public static class Includes implements Writeable {
-        static final String DEFINITION = "definition";
+        public static final String DEFINITION = "definition";
         static final String TOTAL_FEATURE_IMPORTANCE = "total_feature_importance";
         static final String FEATURE_IMPORTANCE_BASELINE = "feature_importance_baseline";
         static final String HYPERPARAMETERS = "hyperparameters";
@@ -126,18 +125,6 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
         private final Includes includes;
         private final List<String> tags;
 
-        @Deprecated
-        public Request(String id, boolean includeModelDefinition, List<String> tags) {
-            setResourceId(id);
-            setAllowNoResources(true);
-            this.tags = tags == null ? Collections.emptyList() : tags;
-            if (includeModelDefinition) {
-                this.includes = Includes.forModelDefinition();
-            } else {
-                this.includes = Includes.empty();
-            }
-        }
-
         public Request(String id) {
             this(id, null, null);
         }
@@ -151,11 +138,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-                this.includes = new Includes(in);
-            } else {
-                this.includes = in.readBoolean() ? Includes.forModelDefinition() : Includes.empty();
-            }
+            this.includes = new Includes(in);
             this.tags = in.readStringList();
         }
 
@@ -175,11 +158,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-                this.includes.writeTo(out);
-            } else {
-                out.writeBoolean(this.includes.isIncludeModelDefinition());
-            }
+            this.includes.writeTo(out);
             out.writeStringCollection(tags);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
@@ -15,11 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdate;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
@@ -74,18 +69,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             super(in);
             this.modelId = in.readString();
             this.objectsToInfer = Collections.unmodifiableList(in.readList(StreamInput::readMap));
-            if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
-                this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
-            } else {
-                InferenceConfig oldConfig = in.readNamedWriteable(InferenceConfig.class);
-                if (oldConfig instanceof RegressionConfig) {
-                    this.update = RegressionConfigUpdate.fromConfig((RegressionConfig) oldConfig);
-                } else if (oldConfig instanceof ClassificationConfig) {
-                    this.update = ClassificationConfigUpdate.fromConfig((ClassificationConfig) oldConfig);
-                } else {
-                    throw new IOException("Unexpected configuration type [" + oldConfig.getName() + "]");
-                }
-            }
+            this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
         }
 
@@ -115,11 +99,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             super.writeTo(out);
             out.writeString(modelId);
             out.writeCollection(objectsToInfer, StreamOutput::writeMap);
-            if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
-                out.writeNamedWriteable(update);
-            } else {
-                out.writeNamedWriteable(update.toConfig());
-            }
+            out.writeNamedWriteable(update);
             out.writeBoolean(previouslyLicensed);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -74,11 +73,7 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             jobId = in.readString();
             snapshotId = in.readString();
             deleteInterveningResults = in.readBoolean();
-            if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
-                force = in.readBoolean();
-            } else {
-                force = false;
-            }
+            force = in.readBoolean();
         }
 
         public Request(String jobId, String snapshotId) {
@@ -121,9 +116,7 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             out.writeString(jobId);
             out.writeString(snapshotId);
             out.writeBoolean(deleteInterveningResults);
-            if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
-                out.writeBoolean(force);
-            }
+            out.writeBoolean(force);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -173,30 +173,17 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
 
     public DataFrameAnalyticsConfig(StreamInput in) throws IOException {
         this.id = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
-            description = in.readOptionalString();
-        } else {
-            description = null;
-        }
+        this.description = in.readOptionalString();
         this.source = new DataFrameAnalyticsSource(in);
         this.dest = new DataFrameAnalyticsDest(in);
         this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
         this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::new);
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
         this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
-        if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
-            createTime = in.readOptionalInstant();
-            version = in.readBoolean() ? Version.readVersion(in) : null;
-        } else {
-            createTime = null;
-            version = null;
-        }
-        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
-            allowLazyStart = in.readBoolean();
-        } else {
-            allowLazyStart = false;
-        }
-        maxNumThreads = in.readVInt();
+        this.createTime = in.readOptionalInstant();
+        this.version = in.readBoolean() ? Version.readVersion(in) : null;
+        this.allowLazyStart = in.readBoolean();
+        this.maxNumThreads = in.readVInt();
     }
 
     public String getId() {
@@ -291,27 +278,21 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
-        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
-            out.writeOptionalString(description);
-        }
+        out.writeOptionalString(description);
         source.writeTo(out);
         dest.writeTo(out);
         out.writeNamedWriteable(analysis);
         out.writeOptionalWriteable(analyzedFields);
         out.writeOptionalWriteable(modelMemoryLimit);
         out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
-        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
-            out.writeOptionalInstant(createTime);
-            if (version != null) {
-                out.writeBoolean(true);
-                Version.writeVersion(version, out);
-            } else {
-                out.writeBoolean(false);
-            }
+        out.writeOptionalInstant(createTime);
+        if (version != null) {
+            out.writeBoolean(true);
+            Version.writeVersion(version, out);
+        } else {
+            out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
-            out.writeBoolean(allowLazyStart);
-        }
+        out.writeBoolean(allowLazyStart);
         out.writeVInt(maxNumThreads);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -219,23 +219,11 @@ public class Classification implements DataFrameAnalysis {
         dependentVariable = in.readString();
         boostedTreeParams = new BoostedTreeParams(in);
         predictionFieldName = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
-            classAssignmentObjective = in.readEnum(ClassAssignmentObjective.class);
-        } else {
-            classAssignmentObjective = ClassAssignmentObjective.MAXIMIZE_MINIMUM_RECALL;
-        }
+        classAssignmentObjective = in.readEnum(ClassAssignmentObjective.class);
         numTopClasses = in.readOptionalVInt();
         trainingPercent = in.readDouble();
-        if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
-            randomizeSeed = in.readOptionalLong();
-        } else {
-            randomizeSeed = Randomness.get().nextLong();
-        }
-        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-            featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
-        } else {
-            featureProcessors = Collections.emptyList();
-        }
+        randomizeSeed = in.readOptionalLong();
+        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
         earlyStoppingEnabled = in.readBoolean();
     }
 
@@ -286,17 +274,11 @@ public class Classification implements DataFrameAnalysis {
         out.writeString(dependentVariable);
         boostedTreeParams.writeTo(out);
         out.writeOptionalString(predictionFieldName);
-        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
-            out.writeEnum(classAssignmentObjective);
-        }
+        out.writeEnum(classAssignmentObjective);
         out.writeOptionalVInt(numTopClasses);
         out.writeDouble(trainingPercent);
-        if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
-            out.writeOptionalLong(randomizeSeed);
-        }
-        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-            out.writeNamedWriteableList(featureProcessors);
-        }
+        out.writeOptionalLong(randomizeSeed);
+        out.writeNamedWriteableList(featureProcessors);
         out.writeBoolean(earlyStoppingEnabled);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -140,15 +139,9 @@ public class OutlierDetection implements DataFrameAnalysis {
         nNeighbors = in.readOptionalVInt();
         method = in.readBoolean() ? in.readEnum(Method.class) : null;
         featureInfluenceThreshold = in.readOptionalDouble();
-        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
-            computeFeatureInfluence = in.readBoolean();
-            outlierFraction = in.readDouble();
-            standardizationEnabled = in.readBoolean();
-        } else {
-            computeFeatureInfluence = true;
-            outlierFraction = 0.05;
-            standardizationEnabled = true;
-        }
+        computeFeatureInfluence = in.readBoolean();
+        outlierFraction = in.readDouble();
+        standardizationEnabled = in.readBoolean();
     }
 
     @Override
@@ -169,11 +162,9 @@ public class OutlierDetection implements DataFrameAnalysis {
 
         out.writeOptionalDouble(featureInfluenceThreshold);
 
-        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
-            out.writeBoolean(computeFeatureInfluence);
-            out.writeDouble(outlierFraction);
-            out.writeBoolean(standardizationEnabled);
-        }
+        out.writeBoolean(computeFeatureInfluence);
+        out.writeDouble(outlierFraction);
+        out.writeBoolean(standardizationEnabled);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -183,11 +183,7 @@ public class Regression implements DataFrameAnalysis {
         randomizeSeed = in.readOptionalLong();
         lossFunction = in.readEnum(LossFunction.class);
         lossFunctionParameter = in.readOptionalDouble();
-        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-            featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
-        } else {
-            featureProcessors = Collections.emptyList();
-        }
+        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
         earlyStoppingEnabled = in.readBoolean();
     }
 
@@ -242,9 +238,7 @@ public class Regression implements DataFrameAnalysis {
         out.writeOptionalLong(randomizeSeed);
         out.writeEnum(lossFunction);
         out.writeOptionalDouble(lossFunctionParameter);
-        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-            out.writeNamedWriteableList(featureProcessors);
-        }
+        out.writeNamedWriteableList(featureProcessors);
         out.writeBoolean(earlyStoppingEnabled);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -235,13 +235,8 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             : null;
 
         this.inferenceConfig = in.readOptionalNamedWriteable(InferenceConfig.class);
-        if (in.getVersion().onOrAfter(VERSION_3RD_PARTY_CONFIG_ADDED)) {
-            this.modelType = in.readOptionalEnum(TrainedModelType.class);
-            this.location = in.readOptionalNamedWriteable(TrainedModelLocation.class);
-        } else {
-            this.modelType = null;
-            this.location = null;
-        }
+        this.modelType = in.readOptionalEnum(TrainedModelType.class);
+        this.location = in.readOptionalNamedWriteable(TrainedModelLocation.class);
     }
 
     public String getModelId() {
@@ -381,10 +376,8 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalNamedWriteable(inferenceConfig);
-        if (out.getVersion().onOrAfter(VERSION_3RD_PARTY_CONFIG_ADDED)) {
-            out.writeOptionalEnum(modelType);
-            out.writeOptionalNamedWriteable(location);
-        }
+        out.writeOptionalEnum(modelType);
+        out.writeOptionalNamedWriteable(location);
     }
 
     @Override
@@ -886,11 +879,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         }
 
         public static LazyModelDefinition fromStreamInput(StreamInput input) throws IOException {
-            if (input.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
-                return new LazyModelDefinition(input.readBytesReference(), null);
-            } else {
-                return fromBase64String(input.readString());
-            }
+            return new LazyModelDefinition(input.readBytesReference(), null);
         }
 
         private LazyModelDefinition(LazyModelDefinition definition) {
@@ -950,11 +939,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
-                out.writeBytesReference(getCompressedDefinition());
-            } else {
-                out.writeString(getBase64CompressedDefinition());
-            }
+            out.writeBytesReference(getCompressedDefinition());
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
@@ -234,11 +234,6 @@ public class ClassificationConfigUpdate implements InferenceConfigUpdate, NamedX
     }
 
     @Override
-    public InferenceConfig toConfig() {
-        return apply(ClassificationConfig.EMPTY_PARAMS);
-    }
-
-    @Override
     public boolean isSupported(InferenceConfig inferenceConfig) {
         return inferenceConfig instanceof ClassificationConfig;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -36,11 +36,6 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
     }
 
     @Override
-    public InferenceConfig toConfig() {
-        throw new UnsupportedOperationException("the empty config update cannot be rewritten");
-    }
-
-    @Override
     public boolean isSupported(InferenceConfig config) {
         return true;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
@@ -22,8 +22,6 @@ public interface InferenceConfigUpdate extends NamedWriteable {
 
     InferenceConfig apply(InferenceConfig originalConfig);
 
-    InferenceConfig toConfig();
-
     boolean isSupported(InferenceConfig config);
 
     String getResultsField();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
@@ -9,9 +9,4 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 public abstract class NlpConfigUpdate implements InferenceConfigUpdate {
 
-    @Override
-    public InferenceConfig toConfig() {
-        throw new UnsupportedOperationException("cannot serialize to nodes before 7.8");
-    }
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
@@ -161,11 +161,6 @@ public class RegressionConfigUpdate implements InferenceConfigUpdate, NamedXCont
     }
 
     @Override
-    public InferenceConfig toConfig() {
-        return apply(RegressionConfig.EMPTY_PARAMS);
-    }
-
-    @Override
     public boolean isSupported(InferenceConfig inferenceConfig) {
         return inferenceConfig instanceof RegressionConfig;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
@@ -49,11 +49,6 @@ public class ResultsFieldUpdate implements InferenceConfigUpdate {
     }
 
     @Override
-    public InferenceConfig toConfig() {
-        return new RegressionConfig(resultsField);
-    }
-
-    @Override
     public boolean isSupported(InferenceConfig config) {
         return true;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.job.config;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -174,11 +173,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         influencers = Collections.unmodifiableList(in.readStringList());
 
         multivariateByFields = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
-            modelPruneWindow = in.readOptionalTimeValue();
-        } else {
-            modelPruneWindow = null;
-        }
+        modelPruneWindow = in.readOptionalTimeValue();
     }
 
     @Override
@@ -200,9 +195,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
 
         out.writeOptionalBoolean(multivariateByFields);
 
-        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
-            out.writeOptionalTimeValue(modelPruneWindow);
-        }
+        out.writeOptionalTimeValue(modelPruneWindow);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.job.config;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -130,14 +131,36 @@ public class DataDescription implements ToXContentObject, Writeable {
     }
 
     public DataDescription(StreamInput in) throws IOException {
+        if (in.getVersion().before(Version.V_8_0_0)) {
+            DataFormat.readFromStream(in);
+        }
         timeFieldName = in.readString();
         timeFormat = in.readString();
+        if (in.getVersion().before(Version.V_8_0_0)) {
+            // fieldDelimiter
+            if (in.readBoolean()) {
+                in.read();
+            }
+            // quoteCharacter
+            if (in.readBoolean()) {
+                in.read();
+            }
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        if (out.getVersion().before(Version.V_8_0_0)) {
+            DataFormat.XCONTENT.writeTo(out);
+        }
         out.writeString(timeFieldName);
         out.writeString(timeFormat);
+        if (out.getVersion().before(Version.V_8_0_0)) {
+            // fieldDelimiter
+            out.writeBoolean(false);
+            // quoteCharacter
+            out.writeBoolean(false);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.job.config;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -131,36 +130,14 @@ public class DataDescription implements ToXContentObject, Writeable {
     }
 
     public DataDescription(StreamInput in) throws IOException {
-        if (in.getVersion().before(Version.V_8_0_0)) {
-            DataFormat.readFromStream(in);
-        }
         timeFieldName = in.readString();
         timeFormat = in.readString();
-        if (in.getVersion().before(Version.V_8_0_0)) {
-            // fieldDelimiter
-            if (in.readBoolean()) {
-                in.read();
-            }
-            // quoteCharacter
-            if (in.readBoolean()) {
-                in.read();
-            }
-        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(Version.V_8_0_0)) {
-            DataFormat.XCONTENT.writeTo(out);
-        }
         out.writeString(timeFieldName);
         out.writeString(timeFormat);
-        if (out.getVersion().before(Version.V_8_0_0)) {
-            // fieldDelimiter
-            out.writeBoolean(false);
-            // quoteCharacter
-            out.writeBoolean(false);
-        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -193,11 +193,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         allowLazyOpen = in.readOptionalBoolean();
         blocked = in.readOptionalWriteable(Blocked::new);
 
-        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
-            modelPruneWindow = in.readOptionalTimeValue();
-        } else {
-            modelPruneWindow = null;
-        }
+        modelPruneWindow = in.readOptionalTimeValue();
     }
 
     @Override
@@ -240,9 +236,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalBoolean(allowLazyOpen);
         out.writeOptionalWriteable(blocked);
 
-        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
-            out.writeOptionalTimeValue(modelPruneWindow);
-        }
+        out.writeOptionalTimeValue(modelPruneWindow);
     }
 
     public String getJobId() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
@@ -36,15 +36,6 @@ public class DeleteExpiredDataActionRequestTests extends AbstractBWCWireSerializ
 
     @Override
     protected Request mutateInstanceForVersion(Request instance, Version version) {
-        if (version.before(Version.V_7_8_0)) {
-            return new Request();
-        }
-        if (version.before(Version.V_7_9_0)) {
-            Request request = new Request();
-            request.setRequestsPerSecond(instance.getRequestsPerSecond());
-            request.setTimeout(instance.getTimeout());
-            return request;
-        }
         return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsRequestTests.java
@@ -13,8 +13,6 @@ import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Includes;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Request;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -47,16 +45,6 @@ public class GetTrainedModelsRequestTests extends AbstractBWCWireSerializationTe
 
     @Override
     protected Request mutateInstanceForVersion(Request instance, Version version) {
-        if (version.before(Version.V_7_10_0)) {
-            Set<String> includes = new HashSet<>();
-            if (instance.getIncludes().isIncludeModelDefinition()) {
-                includes.add(Includes.DEFINITION);
-            }
-            Request request = new Request(instance.getResourceId(), instance.getTags(), includes);
-            request.setPageParams(instance.getPageParams());
-            request.setAllowNoResources(instance.isAllowNoResources());
-            return request;
-        }
         return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -69,14 +69,6 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
 
     @Override
     protected Response mutateInstanceForVersion(Response instance, Version version) {
-        if (version.before(Version.V_7_8_0)) {
-            List<Response.TrainedModelStats> stats = instance.getResources()
-                .results()
-                .stream()
-                .map(s -> new Response.TrainedModelStats(s.getModelId(), s.getIngestStats(), s.getPipelineCount(), null))
-                .collect(Collectors.toList());
-            return new Response(new QueryPage<>(stats, instance.getResources().count(), RESULTS_FIELD));
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
@@ -68,9 +68,6 @@ public class AggProviderWireSerializationTests extends AbstractBWCWireSerializat
 
     @Override
     protected AggProvider mutateInstanceForVersion(AggProvider instance, Version version) {
-        if (version.before(Version.V_8_0_0)) {
-            return new AggProvider(instance.getAggs(), instance.getParsedAggs(), instance.getParsingException(), false);
-        }
         return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/AggProviderWireSerializationTests.java
@@ -68,6 +68,9 @@ public class AggProviderWireSerializationTests extends AbstractBWCWireSerializat
 
     @Override
     protected AggProvider mutateInstanceForVersion(AggProvider instance, Version version) {
+        if (version.before(Version.V_8_0_0)) {
+            return new AggProvider(instance.getAggs(), instance.getParsedAggs(), instance.getParsingException(), false);
+        }
         return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsStateTests.java
@@ -6,18 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESTestCase;
-
-import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class DataFrameAnalyticsStateTests extends ESTestCase {
 
@@ -39,13 +31,6 @@ public class DataFrameAnalyticsStateTests extends ESTestCase {
         assertThat(DataFrameAnalyticsState.STOPPING.toString(), equalTo("stopping"));
         assertThat(DataFrameAnalyticsState.STOPPED.toString(), equalTo("stopped"));
         assertThat(DataFrameAnalyticsState.FAILED.toString(), equalTo("failed"));
-    }
-
-    public void testWriteStartingStateToPost75() throws IOException {
-        StreamOutput streamOutput = mock(StreamOutput.class);
-        when(streamOutput.getVersion()).thenReturn(Version.V_7_5_0);
-        DataFrameAnalyticsState.STARTING.writeTo(streamOutput);
-        verify(streamOutput, times(1)).writeEnum(DataFrameAnalyticsState.STARTING);
     }
 
     public void testIsAnyOf() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -126,45 +126,13 @@ public class ClassificationTests extends AbstractBWCSerializationTestCase<Classi
             instance.getDependentVariable(),
             BoostedTreeParamsTests.mutateForVersion(instance.getBoostedTreeParams(), version),
             instance.getPredictionFieldName(),
-            version.onOrAfter(Version.V_7_7_0) ? instance.getClassAssignmentObjective() : null,
+            instance.getClassAssignmentObjective(),
             instance.getNumTopClasses(),
             instance.getTrainingPercent(),
             instance.getRandomizeSeed(),
-            version.onOrAfter(Version.V_7_10_0) ? instance.getFeatureProcessors() : Collections.emptyList(),
+            instance.getFeatureProcessors(),
             instance.getEarlyStoppingEnabled()
         );
-    }
-
-    @Override
-    protected void assertOnBWCObject(Classification bwcSerializedObject, Classification testInstance, Version version) {
-        if (version.onOrAfter(Version.V_7_6_0)) {
-            super.assertOnBWCObject(bwcSerializedObject, testInstance, version);
-            return;
-        }
-
-        Classification newBwc = new Classification(
-            bwcSerializedObject.getDependentVariable(),
-            bwcSerializedObject.getBoostedTreeParams(),
-            bwcSerializedObject.getPredictionFieldName(),
-            bwcSerializedObject.getClassAssignmentObjective(),
-            bwcSerializedObject.getNumTopClasses(),
-            bwcSerializedObject.getTrainingPercent(),
-            42L,
-            bwcSerializedObject.getFeatureProcessors(),
-            bwcSerializedObject.getEarlyStoppingEnabled()
-        );
-        Classification newInstance = new Classification(
-            testInstance.getDependentVariable(),
-            testInstance.getBoostedTreeParams(),
-            testInstance.getPredictionFieldName(),
-            testInstance.getClassAssignmentObjective(),
-            testInstance.getNumTopClasses(),
-            testInstance.getTrainingPercent(),
-            42L,
-            testInstance.getFeatureProcessors(),
-            testInstance.getEarlyStoppingEnabled()
-        );
-        super.assertOnBWCObject(newBwc, newInstance, version);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -49,12 +49,6 @@ public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<Outl
     }
 
     public static OutlierDetection mutateForVersion(OutlierDetection instance, Version version) {
-        if (version.before(Version.V_7_5_0)) {
-            return new OutlierDetection.Builder(instance).setComputeFeatureInfluence(true)
-                .setOutlierFraction(0.05)
-                .setStandardizationEnabled(true)
-                .build();
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -120,41 +120,9 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
             instance.getRandomizeSeed(),
             instance.getLossFunction(),
             instance.getLossFunctionParameter(),
-            version.onOrAfter(Version.V_7_10_0) ? instance.getFeatureProcessors() : Collections.emptyList(),
+            instance.getFeatureProcessors(),
             instance.getEarlyStoppingEnabled()
         );
-    }
-
-    @Override
-    protected void assertOnBWCObject(Regression bwcSerializedObject, Regression testInstance, Version version) {
-        if (version.onOrAfter(Version.V_7_6_0)) {
-            super.assertOnBWCObject(bwcSerializedObject, testInstance, version);
-            return;
-        }
-
-        Regression newBwc = new Regression(
-            bwcSerializedObject.getDependentVariable(),
-            bwcSerializedObject.getBoostedTreeParams(),
-            bwcSerializedObject.getPredictionFieldName(),
-            bwcSerializedObject.getTrainingPercent(),
-            42L,
-            bwcSerializedObject.getLossFunction(),
-            bwcSerializedObject.getLossFunctionParameter(),
-            bwcSerializedObject.getFeatureProcessors(),
-            bwcSerializedObject.getEarlyStoppingEnabled()
-        );
-        Regression newInstance = new Regression(
-            testInstance.getDependentVariable(),
-            testInstance.getBoostedTreeParams(),
-            testInstance.getPredictionFieldName(),
-            testInstance.getTrainingPercent(),
-            42L,
-            testInstance.getLossFunction(),
-            testInstance.getLossFunctionParameter(),
-            testInstance.getFeatureProcessors(),
-            testInstance.getEarlyStoppingEnabled()
-        );
-        super.assertOnBWCObject(newBwc, newInstance, version);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -385,6 +385,11 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     @Override
     protected TrainedModelConfig mutateInstanceForVersion(TrainedModelConfig instance, Version version) {
-        return instance;
+        TrainedModelConfig.Builder builder = new TrainedModelConfig.Builder(instance);
+        if (version.before(TrainedModelConfig.VERSION_3RD_PARTY_CONFIG_ADDED)) {
+            builder.setModelType(null);
+            builder.setLocation(null);
+        }
+        return builder.build();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -385,17 +385,6 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     @Override
     protected TrainedModelConfig mutateInstanceForVersion(TrainedModelConfig instance, Version version) {
-        TrainedModelConfig.Builder builder = new TrainedModelConfig.Builder(instance);
-        if (version.before(Version.V_7_7_0)) {
-            builder.setDefaultFieldMap(null);
-        }
-        if (version.before(Version.V_7_8_0)) {
-            builder.setInferenceConfig(null);
-        }
-        if (version.before(TrainedModelConfig.VERSION_3RD_PARTY_CONFIG_ADDED)) {
-            builder.setModelType((TrainedModelType) null);
-            builder.setLocation(null);
-        }
-        return builder.build();
+        return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
@@ -26,7 +26,4 @@ public class EmptyConfigUpdateTests extends AbstractWireSerializingTestCase<Empt
         return new EmptyConfigUpdate();
     }
 
-    public void testToConfig() {
-        expectThrows(UnsupportedOperationException.class, () -> new EmptyConfigUpdate().toConfig());
-    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.autoscaling;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -46,7 +47,11 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public MlScalingReason(StreamInput in) throws IOException {
         this.waitingAnalyticsJobs = in.readStringList();
         this.waitingAnomalyJobs = in.readStringList();
-        this.waitingModels = in.readStringList();
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            this.waitingModels = in.readStringList();
+        } else {
+            this.waitingModels = List.of();
+        }
         this.passedConfiguration = Settings.readSettingsFromStream(in);
         this.currentMlCapacity = new AutoscalingCapacity(in);
         this.requiredCapacity = in.readOptionalWriteable(AutoscalingCapacity::new);
@@ -126,7 +131,9 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
-        out.writeStringCollection(this.waitingModels);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeStringCollection(this.waitingModels);
+        }
         Settings.writeSettingsToStream(this.passedConfiguration, out);
         this.currentMlCapacity.writeTo(out);
         out.writeOptionalWriteable(this.requiredCapacity);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.autoscaling;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -47,13 +46,8 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public MlScalingReason(StreamInput in) throws IOException {
         this.waitingAnalyticsJobs = in.readStringList();
         this.waitingAnomalyJobs = in.readStringList();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            this.waitingModels = in.readStringList();
-        } else {
-            this.waitingModels = List.of();
-        }
+        this.waitingModels = in.readStringList();
         this.passedConfiguration = Settings.readSettingsFromStream(in);
-        ;
         this.currentMlCapacity = new AutoscalingCapacity(in);
         this.requiredCapacity = in.readOptionalWriteable(AutoscalingCapacity::new);
         this.largestWaitingAnalyticsJob = in.readOptionalVLong();
@@ -132,9 +126,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeStringCollection(this.waitingModels);
-        }
+        out.writeStringCollection(this.waitingModels);
         Settings.writeSettingsToStream(this.passedConfiguration, out);
         this.currentMlCapacity.writeTo(out);
         out.writeOptionalWriteable(this.requiredCapacity);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Includes.DEFINITION;
 import static org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Request.ALLOW_NO_MATCH;
 import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
@@ -82,7 +83,11 @@ public class RestGetTrainedModelsAction extends BaseRestHandler {
                 "[{}] parameter is deprecated! Use [include=definition] instead.",
                 INCLUDE_MODEL_DEFINITION
             );
-            request = new GetTrainedModelsAction.Request(modelId, restRequest.paramAsBoolean(INCLUDE_MODEL_DEFINITION, false), tags);
+            request = new GetTrainedModelsAction.Request(
+                modelId,
+                tags,
+                restRequest.paramAsBoolean(INCLUDE_MODEL_DEFINITION, false) ? Set.of(DEFINITION) : Set.of()
+            );
         } else {
             request = new GetTrainedModelsAction.Request(modelId, tags, includes);
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -93,7 +93,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -627,17 +626,6 @@ public class JobManagerTests extends ESTestCase {
             job.getAnalysisConfig().getCategorizationAnalyzerConfig(),
             equalTo(CategorizationAnalyzerConfig.buildStandardCategorizationAnalyzer(categorizationFilters))
         );
-    }
-
-    // TODO: This test can be deleted from branches that would never have to talk to a 7.13 node
-    public void testSetDefaultCategorizationAnalyzer_GivenOldNodeInCluster() throws IOException {
-
-        List<String> categorizationFilters = randomBoolean() ? Collections.singletonList("query: .*") : null;
-        Job.Builder jobBuilder = createCategorizationJob(null, categorizationFilters);
-        JobManager.validateCategorizationAnalyzerOrSetDefault(jobBuilder, analysisRegistry, Version.V_7_13_0);
-
-        Job job = jobBuilder.build(new Date());
-        assertThat(job.getAnalysisConfig().getCategorizationAnalyzerConfig(), nullValue());
     }
 
     private Job.Builder createCategorizationJob(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/CategoryDefinitionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/CategoryDefinitionTests.java
@@ -173,10 +173,6 @@ public class CategoryDefinitionTests extends AbstractBWCSerializationTestCase<Ca
 
     @Override
     protected CategoryDefinition mutateInstanceForVersion(CategoryDefinition instance, Version version) {
-        if (version.before(Version.V_7_8_0)) {
-            instance.setPreferredToCategories(new long[0]);
-            instance.setNumMatches(0L);
-        }
         return instance;
     }
 }


### PR DESCRIPTION
This commit removes all the old serialization code to that was added when serializing to nodes with a version before 8.0.0. 

It also removes specific tests for those versions and some code only used by older versions.