### PR TITLE
[8.0] Fix failure starting OldElasticsearch fixture with some checkout dirs (#79972)

### DIFF
--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -92,7 +92,7 @@ public class OldElasticsearch {
             command.add("-f");
         }
         command.add("-p");
-        command.add(baseDir.resolve("pid").toString());
+        command.add(baseDir.resolve("pid").toString().replaceAll("&", "\\&"));
         ProcessBuilder subprocess = new ProcessBuilder(command);
         Process process = subprocess.start();
         System.out.println("Running " + command);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix failure starting OldElasticsearch fixture with some checkout dirs (#79972)