### PR TITLE
Add a note about support for deprecation.skip_deprecated_settings

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -47,6 +47,7 @@ You can use the following settings to control the behavior of the deprecation in
 [[skip_deprecated_settings]]
 NOTE: This setting is designed for indirect use by {ess-trial}[{ess}], {ece-ref}[{ece}], and {eck-ref}[{eck}].
 Direct use is not supported.
+
 // tag::skip_deprecated_settings-tag[]
 `deprecation.skip_deprecated_settings`
 (<<dynamic-cluster-setting,Dynamic>>)

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -47,13 +47,11 @@ You can use the following settings to control the behavior of the deprecation in
 [[skip_deprecated_settings]]
 NOTE: This setting is designed for indirect use by {ess-trial}[{ess}], {ece-ref}[{ece}], and {eck-ref}[{eck}].
 Direct use is not supported.
-
 // tag::skip_deprecated_settings-tag[]
 `deprecation.skip_deprecated_settings`
 (<<dynamic-cluster-setting,Dynamic>>)
 Defaults to an empty list. Set to a list of setting names to be ignored by the deprecation info API. Any
 deprecations related to settings in this list will not be returned by the API. Simple wildcard matching is supported.
-
 // end::skip_deprecated_settings-tag[]
 
 [[migration-api-example]]

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -45,11 +45,15 @@ data streams or indices are returned.
 You can use the following settings to control the behavior of the deprecation info API:
 
 [[skip_deprecated_settings]]
+NOTE: This setting is designed for indirect use by {ess-trial}[{ess}], {ece-ref}[{ece}], and {eck-ref}[{eck}].
+Direct use is not supported.
+
 // tag::skip_deprecated_settings-tag[]
 `deprecation.skip_deprecated_settings`
 (<<dynamic-cluster-setting,Dynamic>>)
 Defaults to an empty list. Set to a list of setting names to be ignored by the deprecation info API. Any
 deprecations related to settings in this list will not be returned by the API. Simple wildcard matching is supported.
+
 // end::skip_deprecated_settings-tag[]
 
 [[migration-api-example]]


### PR DESCRIPTION
This commit adds a warning that this setting should only
be used indirectly by ESS/ECE/ECK. Wording is borrowed from
[cloud-only](https://github.com/elastic/docs/blob/54335b0790212af5c4054f9398bf4f15088b5f9c/shared/attributes.asciidoc#L145) 

### Preview

https://elasticsearch_80035.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html

cc: @colings86 
