### PR TITLE
[8.0] [ML] Need to tolerate .ml-config being an alias (#80025)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
@@ -424,15 +424,17 @@ public class MlConfigMigratorIT extends MlSingleNodeTestCase {
     }
 
     private void addMlConfigIndex(Metadata.Builder metadata, RoutingTable.Builder routingTable) {
+        final String uuid = "_uuid";
         IndexMetadata.Builder indexMetadata = IndexMetadata.builder(MlConfigIndex.indexName());
         indexMetadata.settings(
             Settings.builder()
+                .put(IndexMetadata.SETTING_INDEX_UUID, uuid)
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
         );
         metadata.put(indexMetadata);
-        Index index = new Index(MlConfigIndex.indexName(), "_uuid");
+        Index index = new Index(MlConfigIndex.indexName(), uuid);
         ShardId shardId = new ShardId(index, 0);
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             shardId,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheck.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheck.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
@@ -57,15 +58,13 @@ public class MlConfigMigrationEligibilityCheck {
     }
 
     static boolean mlConfigIndexIsAllocated(ClusterState clusterState) {
-        if (clusterState.metadata().hasIndex(MlConfigIndex.indexName()) == false) {
+        IndexAbstraction configIndexOrAlias = clusterState.metadata().getIndicesLookup().get(MlConfigIndex.indexName());
+        if (configIndexOrAlias == null) {
             return false;
         }
 
-        IndexRoutingTable routingTable = clusterState.getRoutingTable().index(MlConfigIndex.indexName());
-        if (routingTable == null || routingTable.allPrimaryShardsActive() == false) {
-            return false;
-        }
-        return true;
+        IndexRoutingTable routingTable = clusterState.getRoutingTable().index(configIndexOrAlias.getWriteIndex());
+        return routingTable != null && routingTable.allPrimaryShardsActive();
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -164,7 +164,7 @@ public class MlConfigMigrator {
             return;
         }
 
-        if (clusterState.metadata().hasIndex(MlConfigIndex.indexName()) == false) {
+        if (clusterState.metadata().hasIndexAbstraction(MlConfigIndex.indexName()) == false) {
             createConfigIndex(
                 ActionListener.wrap(
                     response -> { unMarkMigrationInProgress.onResponse(Boolean.FALSE); },

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -77,6 +78,24 @@ public class MlConfigMigrationEligibilityCheckTests extends ESTestCase {
         assertFalse(check.canStartMigration(clusterState));
     }
 
+    public void testCanStartMigration_givenMlConfigIsAlias() {
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        // index has been replaced by an alias
+        String reindexedName = ".reindexed_ml_config";
+        Metadata.Builder metadata = Metadata.builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        addMlConfigIndex(reindexedName, MlConfigIndex.indexName(), metadata, routingTable);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metadata(metadata)
+            .routingTable(routingTable.build())
+            .build();
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+        assertTrue(check.canStartMigration(clusterState));
+    }
+
     public void testCanStartMigration_givenInactiveShards() {
         Settings settings = newSettings(true);
         givenClusterSettings(settings);
@@ -85,22 +104,35 @@ public class MlConfigMigrationEligibilityCheckTests extends ESTestCase {
         Metadata.Builder metadata = Metadata.builder();
         RoutingTable.Builder routingTable = RoutingTable.builder();
         addMlConfigIndex(metadata, routingTable);
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).metadata(metadata).build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metadata(metadata)
+            // the difference here is that the routing table that's been created is
+            // _not_ added to the cluster state, simulating no route to the index
+            .build();
 
         MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
         assertFalse(check.canStartMigration(clusterState));
     }
 
     private void addMlConfigIndex(Metadata.Builder metadata, RoutingTable.Builder routingTable) {
-        IndexMetadata.Builder indexMetadata = IndexMetadata.builder(MlConfigIndex.indexName());
+        addMlConfigIndex(MlConfigIndex.indexName(), null, metadata, routingTable);
+    }
+
+    private void addMlConfigIndex(String indexName, String aliasName, Metadata.Builder metadata, RoutingTable.Builder routingTable) {
+        final String uuid = "_uuid";
+        IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName);
         indexMetadata.settings(
             Settings.builder()
+                .put(IndexMetadata.SETTING_INDEX_UUID, uuid)
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
         );
+        if (aliasName != null) {
+            indexMetadata.putAlias(AliasMetadata.builder(aliasName));
+        }
         metadata.put(indexMetadata);
-        Index index = new Index(MlConfigIndex.indexName(), "_uuid");
+        Index index = new Index(indexName, uuid);
         ShardId shardId = new ShardId(index, 0);
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             shardId,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -470,15 +470,17 @@ public class JobManagerTests extends ESTestCase {
         Metadata.Builder metadata = Metadata.builder();
         RoutingTable.Builder routingTable = RoutingTable.builder();
 
+        final String uuid = "_uuid";
         IndexMetadata.Builder indexMetadata = IndexMetadata.builder(MlConfigIndex.indexName());
         indexMetadata.settings(
             Settings.builder()
+                .put(IndexMetadata.SETTING_INDEX_UUID, uuid)
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
         );
         metadata.put(indexMetadata);
-        Index index = new Index(MlConfigIndex.indexName(), "_uuid");
+        Index index = new Index(MlConfigIndex.indexName(), uuid);
         ShardId shardId = new ShardId(index, 0);
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             shardId,
@@ -503,7 +505,7 @@ public class JobManagerTests extends ESTestCase {
             new UpdateJobAction.Request("closed-job-not-migrated", null),
             ActionListener.wrap(
                 response -> fail("response not expected: " + response),
-                exception -> { assertThat(exception, instanceOf(ElasticsearchStatusException.class)); }
+                exception -> assertThat(exception, instanceOf(ElasticsearchStatusException.class))
             )
         );
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Need to tolerate .ml-config being an alias (#80025)