### PR TITLE
Fix/setting deprecation log level correctly

### DIFF
--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ConstructingObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ConstructingObjectParserTests.java
@@ -742,7 +742,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
             assertWarnings(
                 false,
                 new DeprecationWarning(
-                    DeprecationLogger.CRITICAL,
+                    DeprecationLogger.DeprecationLevel.CRITICAL,
                     "[struct_with_compatible_fields][1:14] " + "Deprecated field [old_name] used, expected [new_name] instead"
                 )
             );

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -233,8 +233,10 @@ public class ObjectParserTests extends ESTestCase {
         assertEquals("foo", s.test);
         assertWarnings(
             false,
-            new DeprecationWarning(DeprecationLogger.DeprecationLevel.CRITICAL, "[CRITICAL] [foo][1:15] Deprecated field [old_test] used," +
-                " expected [test] instead")
+            new DeprecationWarning(
+                DeprecationLogger.DeprecationLevel.CRITICAL,
+                "[CRITICAL] [foo][1:15] Deprecated field [old_test] used, expected [test] instead"
+            )
         );
     }
 

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -233,7 +233,8 @@ public class ObjectParserTests extends ESTestCase {
         assertEquals("foo", s.test);
         assertWarnings(
             false,
-            new DeprecationWarning(DeprecationLogger.CRITICAL, "[foo][1:15] Deprecated field [old_test] used, " + "expected [test] instead")
+            new DeprecationWarning(DeprecationLogger.DeprecationLevel.CRITICAL, "[CRITICAL] [foo][1:15] Deprecated field [old_test] used," +
+                " expected [test] instead")
         );
     }
 
@@ -1168,8 +1169,8 @@ public class ObjectParserTests extends ESTestCase {
             assertWarnings(
                 false,
                 new DeprecationWarning(
-                    DeprecationLogger.CRITICAL,
-                    "[struct_with_compatible_fields][1:14] " + "Deprecated field [old_name] used, expected [new_name] instead"
+                    DeprecationLogger.DeprecationLevel.CRITICAL,
+                    "[CRITICAL] [struct_with_compatible_fields][1:14] " + "Deprecated field [old_name] used, expected [new_name] instead"
                 )
             );
 

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectParserTests.java
@@ -235,7 +235,7 @@ public class ObjectParserTests extends ESTestCase {
             false,
             new DeprecationWarning(
                 DeprecationLogger.DeprecationLevel.CRITICAL,
-                "[CRITICAL] [foo][1:15] Deprecated field [old_test] used, expected [test] instead"
+                "[foo][1:15] Deprecated field [old_test] used, expected [test] instead"
             )
         );
     }
@@ -1172,7 +1172,7 @@ public class ObjectParserTests extends ESTestCase {
                 false,
                 new DeprecationWarning(
                     DeprecationLogger.DeprecationLevel.CRITICAL,
-                    "[CRITICAL] [struct_with_compatible_fields][1:14] " + "Deprecated field [old_name] used, expected [new_name] instead"
+                    "[struct_with_compatible_fields][1:14] " + "Deprecated field [old_name] used, expected [new_name] instead"
                 )
             );
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -486,7 +486,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 boolean valid = metadata.isValid(currentState.metadata().settings());
                 if (valid && metadata.isCloseToExpiration()) {
                     HeaderWarning.addWarning(
-                        DeprecationLogger.CRITICAL,
+                        DeprecationLogger.DeprecationLevel.CRITICAL,
                         "database [{}] was not updated for over 25 days, geoip processor"
                             + " will stop working if there is no update for 30 days",
                         databaseFile

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -74,7 +74,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             new Setting<?>[] {},
             new DeprecationWarning(
                 DeprecationLogger.DeprecationLevel.CRITICAL,
-                "[CRITICAL] Setting [discovery.ec2.access_key] is set but " + "[discovery.ec2.secret_key] is not, which will be " +
+                "Setting [discovery.ec2.access_key] is set but " + "[discovery.ec2.secret_key] is not, which will be " +
                     "unsupported in future"
             )
         );
@@ -93,7 +93,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             new Setting<?>[] {},
             new DeprecationWarning(
                 DeprecationLogger.DeprecationLevel.CRITICAL,
-                "[CRITICAL] Setting [discovery.ec2.secret_key] is set but " + "[discovery.ec2.access_key] is not, which will be " +
+                "Setting [discovery.ec2.secret_key] is set but " + "[discovery.ec2.access_key] is not, which will be " +
                     "unsupported in future"
             )
         );
@@ -111,8 +111,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         );
         assertThat(
             e.getMessage(),
-            is("[CRITICAL] Setting [discovery.ec2.session_token] is set but [discovery.ec2.access_key] and [discovery.ec2.secret_key] are" +
-                " not")
+            is("Setting [discovery.ec2.session_token] is set but [discovery.ec2.access_key] and [discovery.ec2.secret_key] are not")
         );
     }
 

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -74,8 +74,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             new Setting<?>[] {},
             new DeprecationWarning(
                 DeprecationLogger.DeprecationLevel.CRITICAL,
-                "Setting [discovery.ec2.access_key] is set but " + "[discovery.ec2.secret_key] is not, which will be " +
-                    "unsupported in future"
+                "Setting [discovery.ec2.access_key] is set but [discovery.ec2.secret_key] is not, which will be unsupported in future"
             )
         );
     }
@@ -93,8 +92,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             new Setting<?>[] {},
             new DeprecationWarning(
                 DeprecationLogger.DeprecationLevel.CRITICAL,
-                "Setting [discovery.ec2.secret_key] is set but " + "[discovery.ec2.access_key] is not, which will be " +
-                    "unsupported in future"
+                "Setting [discovery.ec2.secret_key] is set but [discovery.ec2.access_key] is not, which will be unsupported in future"
             )
         );
     }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -73,8 +73,9 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] {},
             new DeprecationWarning(
-                DeprecationLogger.CRITICAL,
-                "Setting [discovery.ec2.access_key] is set but " + "[discovery.ec2.secret_key] is not, which will be unsupported in future"
+                DeprecationLogger.DeprecationLevel.CRITICAL,
+                "[CRITICAL] Setting [discovery.ec2.access_key] is set but " + "[discovery.ec2.secret_key] is not, which will be " +
+                    "unsupported in future"
             )
         );
     }
@@ -91,8 +92,9 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] {},
             new DeprecationWarning(
-                DeprecationLogger.CRITICAL,
-                "Setting [discovery.ec2.secret_key] is set but " + "[discovery.ec2.access_key] is not, which will be unsupported in future"
+                DeprecationLogger.DeprecationLevel.CRITICAL,
+                "[CRITICAL] Setting [discovery.ec2.secret_key] is set but " + "[discovery.ec2.access_key] is not, which will be " +
+                    "unsupported in future"
             )
         );
     }
@@ -109,7 +111,8 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         );
         assertThat(
             e.getMessage(),
-            is("Setting [discovery.ec2.session_token] is set but [discovery.ec2.access_key] and [discovery.ec2.secret_key] are not")
+            is("[CRITICAL] Setting [discovery.ec2.session_token] is set but [discovery.ec2.access_key] and [discovery.ec2.secret_key] are" +
+                " not")
         );
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -172,9 +172,9 @@ public class EvilLoggerTests extends ESTestCase {
         for (int i = 0; i < 128; i++) {
             assertLogLine(
                 deprecationEvents.get(i),
-                DeprecationLogger.CRITICAL,
+                Level.WARN,
                 "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
-                "This is a maybe logged deprecation message" + i
+                "[CRITICAL] This is a maybe logged deprecation message" + i
             );
         }
 
@@ -205,7 +205,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertThat(deprecationEvents.size(), equalTo(1));
             assertLogLine(
                 deprecationEvents.get(0),
-                DeprecationLogger.CRITICAL,
+                Level.WARN,
                 "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
                 "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! "
                     + "See the breaking changes documentation for the next major version."

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1539,8 +1539,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     @SuppressWarnings("unchecked")
     public void testSystemIndexMetadataIsUpgraded() throws Exception {
-        final String systemIndexWarning = "this request accesses system indices: [.tasks], but in a future major version, direct "
-            + "access to system indices will be prevented by default";
+        final String systemIndexWarning = "[CRITICAL] this request accesses system indices: [.tasks], but in a future major version, "
+            + "direct access to system indices will be prevented by default";
         if (isRunningAgainstOldCluster()) {
             // create index
             Request createTestIndex = new Request("PUT", "/test_index_old");

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -104,7 +104,7 @@ public class JsonLoggerTests extends ESTestCase {
             );
         }
 
-        assertWarnings(true, new DeprecationWarning(DeprecationLogger.DeprecationLevel.WARNING,"deprecated warn message1"));
+        assertWarnings(true, new DeprecationWarning(DeprecationLogger.DeprecationLevel.WARNING, "deprecated warn message1"));
     }
 
     public void testDeprecatedMessageWithoutXOpaqueId() throws IOException {

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -104,7 +104,7 @@ public class JsonLoggerTests extends ESTestCase {
             );
         }
 
-        assertWarnings(true, new DeprecationWarning(Level.WARN, "deprecated warn message1"));
+        assertWarnings(true, new DeprecationWarning(DeprecationLogger.DeprecationLevel.WARNING,"deprecated warn message1"));
     }
 
     public void testDeprecatedMessageWithoutXOpaqueId() throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.snapshots;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.AssociatedIndexDescriptor;
@@ -364,8 +364,8 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
             new MockLogAppender.SeenEventExpectation(
                 "restore-system-index-from-snapshot",
                 "org.elasticsearch.deprecation.snapshots.RestoreService",
-                DeprecationLogger.CRITICAL,
-                "Restoring system indices by name is deprecated. Use feature states instead. System indices: [.test-system-idx]"
+                Level.WARN,
+                "[CRITICAL] Restoring system indices by name is deprecated. Use feature states instead. System indices: [.test-system-idx]"
             )
         );
 

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -91,7 +91,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_15_0 = new Version(7150099, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_7_15_1 = new Version(7150199, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_7_15_2 = new Version(7150299, org.apache.lucene.util.Version.LUCENE_8_9_0);
-    public static final Version V_7_16_0 = new Version(7160099, org.apache.lucene.util.Version.LUCENE_8_10_1);
+    public static final Version V_7_16_0 = new Version(7160099, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_8_0_0 = new Version(8000099, org.apache.lucene.util.Version.LUCENE_9_0_0);
     public static final Version V_8_1_0 = new Version(8010099, org.apache.lucene.util.Version.LUCENE_9_0_0);
     public static final Version CURRENT = V_8_1_0;

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -91,7 +91,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_15_0 = new Version(7150099, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_7_15_1 = new Version(7150199, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_7_15_2 = new Version(7150299, org.apache.lucene.util.Version.LUCENE_8_9_0);
-    public static final Version V_7_16_0 = new Version(7160099, org.apache.lucene.util.Version.LUCENE_8_9_0);
+    public static final Version V_7_16_0 = new Version(7160099, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_8_0_0 = new Version(8000099, org.apache.lucene.util.Version.LUCENE_9_0_0);
     public static final Version V_8_1_0 = new Version(8010099, org.apache.lucene.util.Version.LUCENE_9_0_0);
     public static final Version CURRENT = V_8_1_0;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -566,7 +566,7 @@ public class MetadataIndexTemplateService {
                 name
             );
             logger.warn(warning);
-            HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning);
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, "[CRITICAL] " + warning);
         }
 
         ComposableIndexTemplate finalIndexTemplate = template;
@@ -959,7 +959,7 @@ public class MetadataIndexTemplateService {
                     request.name
                 );
                 logger.warn(warning);
-                HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning);
+                HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, "[CRITICAL] " + warning);
             } else {
                 // Otherwise, this is a hard error, the user should use V2 index templates instead
                 String error = String.format(

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.common.logging;
 
-import org.apache.logging.log4j.Level;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -25,6 +24,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.CRITICAL;
+
 /**
  * This is a simplistic logger that adds warning messages to HTTP headers.
  * Use <code>HeaderWarning.addWarning(message,params)</code>. Message will be formatted according to RFC7234.
@@ -33,10 +34,10 @@ import java.util.regex.Pattern;
 public class HeaderWarning {
     /**
      * Regular expression to test if a string matches the RFC7234 specification for warning headers. This pattern assumes that the warn code
-     * is always 299 or 300. Further, this pattern assumes that the warn agent represents a version of Elasticsearch including the build
+     * is always 299. Further, this pattern assumes that the warn agent represents a version of Elasticsearch including the build
      * hash.
      */
-    public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile("(?:299|300) " + // log level code
+    public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile("299 " + // log level code
         "Elasticsearch-" + // warn agent
         "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
         "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
@@ -54,15 +55,14 @@ public class HeaderWarning {
 
     /*
      * RFC7234 specifies the warning format as warn-code <space> warn-agent <space> "warn-text" [<space> "warn-date"]. Here, warn-code is a
-     * three-digit number with various standard warn codes specified, and is left off of this static prefix so that it can be added based
-     * on the log level received. The warn code will be either 299 or 300 at runtime, which are apt for our purposes as
-     * they represent miscellaneous persistent warnings (can be presented to a human, or logged, and must not be removed by a cache).
-     * The warn-agent is an arbitrary token; here we use the Elasticsearch version and build hash. The warn text must be quoted. The
-     * warn-date is an optional quoted field that can be in a variety of specified date formats; here we use RFC 1123 format.
+     * three-digit number with various standard warn codes specified. The warn code 299 is apt for our purposes as it represents a
+     * miscellaneous persistent warning (can be presented to a human, or logged, and must not be removed by a cache). The warn-agent is an
+     * arbitrary token; here we use the Elasticsearch version and build hash. The warn text must be quoted. The warn-date is an optional
+     * quoted field that can be in a variety of specified date formats; here we use RFC 1123 format.
      */
     private static final String WARNING_PREFIX = String.format(
         Locale.ROOT,
-        " Elasticsearch-%s%s-%s",
+        "299 Elasticsearch-%s%s-%s",
         Version.CURRENT.toString(),
         Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
         Build.CURRENT.hash()
@@ -195,11 +195,11 @@ public class HeaderWarning {
      * @param s the warning string to format
      * @return a warning value formatted according to RFC 7234
      */
-    public static String formatWarning(final Level level, final String s) {
+    public static String formatWarning(final DeprecationLogger.DeprecationLevel level, final String s) {
         // Assume that the common scenario won't have a string to escape and encode.
-        int length = WARNING_PREFIX.length() + s.length() + 6;
+        int length = WARNING_PREFIX.length() + s.length() + 10;
         final StringBuilder sb = new StringBuilder(length);
-        sb.append(level.intLevel() + WARNING_PREFIX).append(" \"").append(escapeAndEncode(s)).append("\"");
+        sb.append(WARNING_PREFIX).append(" \"")/*.append(" \"[").append(level).append("] ")*/.append(escapeAndEncode(s)).append("\"");
         return sb.toString();
     }
 
@@ -313,17 +313,17 @@ public class HeaderWarning {
             .orElse("");
     }
 
-    public static void addWarning(Level level, String message, Object... params) {
+    public static void addWarning(DeprecationLogger.DeprecationLevel level, String message, Object... params) {
         addWarning(THREAD_CONTEXT, level, message, params);
     }
 
     // package scope for testing
     static void addWarning(Set<ThreadContext> threadContexts, String message, Object... params) {
-        addWarning(threadContexts, DeprecationLogger.CRITICAL, message, params);
+        addWarning(threadContexts, CRITICAL, message, params);
     }
 
     // package scope for testing
-    static void addWarning(Set<ThreadContext> threadContexts, Level level, String message, Object... params) {
+    static void addWarning(Set<ThreadContext> threadContexts, DeprecationLogger.DeprecationLevel level, String message, Object... params) {
         final Iterator<ThreadContext> iterator = threadContexts.iterator();
         if (iterator.hasNext()) {
             final String formattedMessage = LoggerMessageFormat.format(message, params);

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -191,7 +191,7 @@ public class HeaderWarning {
      * Format a warning string in the proper warning format by prepending a warn code, warn agent, wrapping the warning string in quotes,
      * and appending the RFC 7231 date.
      *
-     * @param level the level of the warning - Level.WARN or DeprecationLogger.CRITICAL
+     * @param level the level of the warning - DeprecationLogger.DeprecationLevel.WARN or DeprecationLogger.DeprecationLevel.CRITICAL
      * @param s the warning string to format
      * @return a warning value formatted according to RFC 7234
      */

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarningAppender.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarningAppender.java
@@ -35,10 +35,10 @@ public class HeaderWarningAppender extends AbstractAppender {
             String messagePattern = esLogMessage.getMessagePattern();
             Object[] arguments = esLogMessage.getArguments();
 
-            HeaderWarning.addWarning(event.getLevel(), messagePattern, arguments);
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, messagePattern, arguments);
         } else {
             final String formattedMessage = event.getMessage().getFormattedMessage();
-            HeaderWarning.addWarning(event.getLevel(), formattedMessage);
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, formattedMessage);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestPutIndexTemplateAction.class);
-    public static final String DEPRECATION_WARNING = "Legacy index templates are deprecated in favor of composable templates.";
+    public static final String DEPRECATION_WARNING = "[CRITICAL] Legacy index templates are deprecated in favor of composable templates.";
     private static final RestApiVersion DEPRECATION_VERSION = RestApiVersion.V_8;
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]"
         + " Specifying include_type_name in put index template requests is deprecated."

--- a/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.common.logging;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 
-import org.apache.logging.log4j.Level;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
@@ -25,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.CRITICAL;
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.WARNING;
 import static org.elasticsearch.common.logging.HeaderWarning.WARNING_HEADER_PATTERN;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.containsString;
@@ -191,19 +192,16 @@ public class HeaderWarningTests extends ESTestCase {
 
     public void testWarningValueFromWarningHeader() {
         final String s = randomAlphaOfLength(16);
-        final String first = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, s);
+        final String first = HeaderWarning.formatWarning(CRITICAL, s);
         assertThat(HeaderWarning.extractWarningValueFromWarningHeader(first, false), equalTo(s));
 
         final String withPos = "[context][1:11] Blah blah blah";
-        final String formatted = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, withPos);
+        final String formatted = HeaderWarning.formatWarning(CRITICAL, withPos);
         assertThat(HeaderWarning.extractWarningValueFromWarningHeader(formatted, true), equalTo("Blah blah blah"));
 
         final String withNegativePos = "[context][-1:-1] Blah blah blah";
         assertThat(
-            HeaderWarning.extractWarningValueFromWarningHeader(
-                HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, withNegativePos),
-                true
-            ),
+            HeaderWarning.extractWarningValueFromWarningHeader(HeaderWarning.formatWarning(CRITICAL, withNegativePos), true),
             equalTo("Blah blah blah")
         );
     }
@@ -289,7 +287,7 @@ public class HeaderWarningTests extends ESTestCase {
         Settings settings = Settings.builder().put("http.max_warning_header_count", maxWarningHeaderCount).build();
         ThreadContext threadContext = new ThreadContext(settings);
         final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-        HeaderWarning.addWarning(threadContexts, Level.WARN, "A simple message 1");
+        HeaderWarning.addWarning(threadContexts, WARNING, "A simple message 1");
         final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
 
         assertThat(responseHeaders.size(), equalTo(1));
@@ -297,7 +295,7 @@ public class HeaderWarningTests extends ESTestCase {
         assertThat(responses, hasSize(1));
         assertThat(responses.get(0), warningValueMatcher);
         assertThat(responses.get(0), containsString("\"A simple message 1\""));
-        assertThat(responses.get(0), containsString(Integer.toString(Level.WARN.intLevel())));
+        assertThat(responses.get(0), containsString("299"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -21,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.CRITICAL;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -279,11 +279,11 @@ public class ThreadContextTests extends ESTestCase {
             threadContext.addResponseHeader("foo", "bar");
         }
 
-        final String value = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "qux");
+        final String value = HeaderWarning.formatWarning(CRITICAL, "qux");
         threadContext.addResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         // pretend that another thread created the same response at a different time
         if (randomBoolean()) {
-            final String duplicateValue = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "qux");
+            final String duplicateValue = HeaderWarning.formatWarning(CRITICAL, "qux");
             threadContext.addResponseHeader("baz", duplicateValue, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         }
 

--- a/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.script;
 
-import org.apache.logging.log4j.Level;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
 import org.elasticsearch.cluster.ClusterName;
@@ -36,6 +35,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.WARNING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_EXPIRE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_CACHE_SIZE_SETTING;
 import static org.elasticsearch.script.ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING;
@@ -269,7 +269,7 @@ public class ScriptServiceTests extends ESTestCase {
         scriptService.compile(script, context);
         scriptService.compile(script, context);
         assertEquals(1L, scriptService.stats().getCompilations());
-        assertWarnings(true, new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
+        assertWarnings(true, new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testGeneralCompilationStatsOnCacheHit() throws IOException {
@@ -297,7 +297,7 @@ public class ScriptServiceTests extends ESTestCase {
         scriptService.compile(new Script(ScriptType.STORED, null, "script", Collections.emptyMap()), ctx);
         assertEquals(1L, scriptService.stats().getCompilations());
         assertEquals(1L, scriptService.cacheStats().getContextStats().get(ctx.name).getCompilations());
-        assertWarnings(true, new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
+        assertWarnings(true, new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE));
     }
 
     public void testCacheEvictionCountedInCacheEvictionsStats() throws IOException {
@@ -315,7 +315,7 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(1L, scriptService.stats().getCacheEvictions());
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { contextCacheSizeSetting },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -401,7 +401,7 @@ public class ScriptServiceTests extends ESTestCase {
 
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { cacheSizeA, compilationRateA, cacheSizeB, compilationRateB },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -556,7 +556,7 @@ public class ScriptServiceTests extends ESTestCase {
         );
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { ingestExpire, fieldSize, scoreCompilation },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -639,7 +639,7 @@ public class ScriptServiceTests extends ESTestCase {
         assertEquals(new ScriptCache.CompilationRate(bCompilationRate), scriptService.cacheHolder.get().contextCache.get(b).get().rate);
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { aSetting, bSetting },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -665,7 +665,7 @@ public class ScriptServiceTests extends ESTestCase {
         );
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { field, ingest },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -703,7 +703,7 @@ public class ScriptServiceTests extends ESTestCase {
             new Setting<?>[] {
                 SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("field"),
                 SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getConcreteSettingForNamespace("ingest") },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 
@@ -827,7 +827,7 @@ public class ScriptServiceTests extends ESTestCase {
 
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] { cacheSizeContextSetting, cacheExpireContextSetting, compilationRateContextSetting },
-            new DeprecationWarning(Level.WARN, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
+            new DeprecationWarning(WARNING, USE_CONTEXT_RATE_KEY_DEPRECATION_MESSAGE)
         );
     }
 

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
@@ -82,7 +82,7 @@ public class ErrorQueryBuilder extends AbstractQueryBuilder<ErrorQueryBuilder> {
         }
         final String header = "[" + context.index().getName() + "][" + context.getShardId() + "]";
         if (error.getErrorType() == IndexError.ERROR_TYPE.WARNING) {
-            HeaderWarning.addWarning(DeprecationLogger.CRITICAL, header + " " + error.getMessage());
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, header + " " + error.getMessage());
             return new MatchAllDocsQuery();
         } else {
             throw new RuntimeException(header + " " + error.getMessage());

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -502,7 +502,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     /**
      * Convenience method to assert warnings for settings deprecations and general deprecation warnings. All warnings passed to this method
-     * are assumed to be at DeprecationLogger.CRITICAL level.
+     * are assumed to be at DeprecationLogger.DeprecationLevel.CRITICAL level.
      * @param expectedWarnings expected general deprecation warnings.
      */
     protected final void assertWarnings(String... expectedWarnings) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -493,8 +493,9 @@ public abstract class ESTestCase extends LuceneTestCase {
                 setting.getKey()
             );
             return new DeprecationWarning(
-                setting.getProperties().contains(Setting.Property.Deprecated) ? DeprecationLogger.DeprecationLevel.CRITICAL :
-                    DeprecationLogger.DeprecationLevel.WARNING,
+                setting.getProperties().contains(Setting.Property.Deprecated)
+                    ? DeprecationLogger.DeprecationLevel.CRITICAL
+                    : DeprecationLogger.DeprecationLevel.WARNING,
                 warningMessage
             );
         }), Arrays.stream(warnings)).toArray(DeprecationWarning[]::new));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -142,10 +142,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 + "patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template "
                 + "[my-it] will take precedence during new index creation"
         );
-        final String testHeaderWithQuotesAndBackslashes = HeaderWarning.formatWarning(
-            CRITICAL,
-            "test \"with quotes and \\ backslashes\""
-        );
+        final String testHeaderWithQuotesAndBackslashes = HeaderWarning.formatWarning(CRITICAL, "test \"with quotes and \\ backslashes\"");
 
         // require header and it matches (basic example)
         DoSection section = new DoSection(new XContentLocation(1, 1));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
@@ -34,6 +33,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.common.logging.DeprecationLogger.DeprecationLevel.CRITICAL;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -52,10 +52,10 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             section.checkWarningHeaders(emptyList());
         }
 
-        final String testHeader = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "test");
-        final String anotherHeader = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "another \"with quotes and \\ backslashes\"");
-        final String someMoreHeader = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "some more");
-        final String catHeader = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "cat");
+        final String testHeader = HeaderWarning.formatWarning(CRITICAL, "test");
+        final String anotherHeader = HeaderWarning.formatWarning(CRITICAL, "another \"with quotes and \\ backslashes\"");
+        final String someMoreHeader = HeaderWarning.formatWarning(CRITICAL, "some more");
+        final String catHeader = HeaderWarning.formatWarning(CRITICAL, "cat");
         // Any warning headers fail
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
@@ -135,15 +135,15 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
     public void testWarningHeadersRegex() {
 
-        final String testHeader = HeaderWarning.formatWarning(DeprecationLogger.CRITICAL, "test");
+        final String testHeader = HeaderWarning.formatWarning(CRITICAL, "test");
         final String realisticTestHeader = HeaderWarning.formatWarning(
-            DeprecationLogger.CRITICAL,
+            CRITICAL,
             "index template [my-it] has index "
                 + "patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template "
                 + "[my-it] will take precedence during new index creation"
         );
         final String testHeaderWithQuotesAndBackslashes = HeaderWarning.formatWarning(
-            DeprecationLogger.CRITICAL,
+            CRITICAL,
             "test \"with quotes and \\ backslashes\""
         );
 

--- a/x-pack/plugin/async-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/async-search/10_deprecation.yml
+++ b/x-pack/plugin/async-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/async-search/10_deprecation.yml
@@ -45,7 +45,7 @@ setup:
 
   - do:
       warnings:
-        - '[deprecated] query'
+        - '[CRITICAL] [deprecated] query'
       async_search.submit:
         index: test-*
         wait_for_completion_timeout: 10s
@@ -64,7 +64,7 @@ setup:
 
   - do:
       warnings:
-        - '[deprecated] query'
+        - '[CRITICAL] [deprecated] query'
       async_search.submit:
         index: test-*
         wait_for_completion_timeout: 10s
@@ -79,7 +79,7 @@ setup:
 
   - do:
       warnings:
-        - '[deprecated] query'
+        - '[CRITICAL] [deprecated] query'
       async_search.get:
         id: "$id"
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -425,7 +425,7 @@ public class XPackLicenseState {
     void checkExpiry() {
         String warning = status.expiryWarning;
         if (warning != null) {
-            HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning);
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -425,7 +425,7 @@ public class XPackLicenseState {
     void checkExpiry() {
         String warning = status.expiryWarning;
         if (warning != null) {
-            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning);
+            HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, "[CRITICAL] " + warning);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
@@ -170,7 +170,7 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
                     String warning = Messages.getMessage(TRAINED_MODEL_INPUTS_DIFFER_SIGNIFICANTLY, request.getModelId(), oldModelId);
                     auditor.warning(oldModelId, warning);
                     logger.warn("[{}] {}", oldModelId, warning);
-                    HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning);
+                    HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning);
                 }
             }
             clusterService.submitStateUpdateTask("update-model-alias", new AckedClusterStateUpdateTask(request, listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -241,7 +241,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
                 );
                 auditor.warning(jobId, warning);
                 logger.warn("[{}] {}", jobId, warning);
-                HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning);
+                HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning);
             }
             // Refresh memory requirement for jobs
             memoryTracker.addDataFrameAnalyticsJobMemoryAndRefreshAllOthers(

--- a/x-pack/plugin/spatial/src/yamlRestTestV7Compat/resources/rest-api-spec/test/geo_shape/10_compat_geo_shape_with_types.yml
+++ b/x-pack/plugin/spatial/src/yamlRestTestV7Compat/resources/rest-api-spec/test/geo_shape/10_compat_geo_shape_with_types.yml
@@ -15,7 +15,7 @@ setup:
         Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
       allowed_warnings_regex:
-        - "\\[types removal\\].*"
+        - "\\[CRITICAL\\] \\[types removal\\].*"
       indices.create:
         index: shapes
         include_type_name: true
@@ -32,7 +32,7 @@ setup:
         Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
       allowed_warnings_regex:
-        - "\\[types removal\\].*"
+        - "\\[CRITICAL\\] \\[types removal\\].*"
       index:
         index:  shapes
         type:   _doc
@@ -50,7 +50,7 @@ setup:
         Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
       warnings:
-        - "[types removal] Types are deprecated in [geo_shape] queries. The type should no longer be specified in the [indexed_shape] section."
+        - "[CRITICAL] [types removal] Types are deprecated in [geo_shape] queries. The type should no longer be specified in the [indexed_shape] section."
       search:
         rest_total_hits_as_int: true
         index: shapes

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/license/30_enterprise_license.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/license/30_enterprise_license.yml
@@ -39,7 +39,7 @@ teardown:
   ## Check the opt-in v5 license type
   - do:
       warnings:
-        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+        - "[CRITICAL] Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       license.get:
         accept_enterprise: true
 
@@ -52,7 +52,7 @@ teardown:
   ## Check the xpack info API as well
   - do:
       warnings:
-        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+        - "[CRITICAL] Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       xpack.info:
         accept_enterprise: true
   - match: { license.type: "enterprise" }
@@ -62,14 +62,14 @@ teardown:
   - do:
       catch: bad_request
       warnings:
-        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+        - "[CRITICAL] Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       license.get:
         accept_enterprise: false
 
   - do:
       catch: bad_request
       warnings:
-        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+        - "[CRITICAL] Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       xpack.info:
         accept_enterprise: false
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -67,7 +67,7 @@ setup:
 
   - do:
       warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+        - '[CRITICAL] Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       ml.get_datafeeds:
         datafeed_id: "missing-*"
         allow_no_datafeeds: true
@@ -88,7 +88,7 @@ setup:
 
   - do:
       warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+        - '[CRITICAL] Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_datafeeds:
         datafeed_id: "missing-*"
@@ -479,7 +479,7 @@ setup:
       features: warnings
   - do:
       warnings:
-        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
+        - "[CRITICAL] [ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
       ml.put_datafeed:
         datafeed_id: test-datafeed-indices-options-params-1
         ignore_throttled: false
@@ -499,7 +499,7 @@ setup:
 
   - do:
       warnings:
-        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
+        - "[CRITICAL] [ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
       ml.update_datafeed:
         datafeed_id: test-datafeed-indices-options-params-1
         ignore_throttled: false

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -116,7 +116,7 @@ setup:
 
   - do:
       warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+        - '[CRITICAL] Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       ml.get_datafeed_stats:
         datafeed_id: "missing-*"
         allow_no_datafeeds: true
@@ -137,7 +137,7 @@ setup:
 
   - do:
       warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+        - '[CRITICAL] Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_datafeed_stats:
         datafeed_id: "missing-*"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/post_data.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/post_data.yml
@@ -52,7 +52,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -135,7 +135,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -159,7 +159,7 @@ setup:
   # Send some data that should be ignored
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -175,7 +175,7 @@ setup:
   # Send data that will create results for the bucket after the skipped one
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -212,7 +212,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: missing
       ml.post_data:
         job_id: not_a_job
@@ -228,7 +228,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /parse_exception/
       ml.post_data:
         job_id: post-data-job
@@ -245,7 +245,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /parse_exception/
       ml.post_data:
         job_id: post-data-job
@@ -315,7 +315,7 @@ setup:
 
   - do:
       warnings:
-        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
+        - '[CRITICAL] Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /status_exception/
       ml.post_data:
         job_id: post-data-closed-job

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/users/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/users/10_basic.yml
@@ -125,7 +125,7 @@ teardown:
 
   - do:
       warnings:
-        - "this request accesses system indices: [.security-7], but in a future major version, direct access to system indices will be prevented by default"
+        - "[CRITICAL] this request accesses system indices: [.security-7], but in a future major version, direct access to system indices will be prevented by default"
       get:
         index: .security
         id: user-bob

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -218,7 +218,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             );
 
             List<String> warnings = TransformConfigLinter.getWarnings(function, source, syncConfig);
-            warnings.forEach(warning -> HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning));
+            warnings.forEach(warning -> HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning));
             listener.onResponse(new Response(docs, generatedDestIndexSettings));
         }, listener::onFailure);
 
@@ -230,7 +230,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
                     Clock.systemUTC()
                 );
                 List<String> warnings = TransformConfigLinter.getWarnings(function, source, syncConfig);
-                warnings.forEach(warning -> HeaderWarning.addWarning(DeprecationLogger.CRITICAL, warning));
+                warnings.forEach(warning -> HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, warning));
                 listener.onResponse(new Response(docs, generatedDestIndexSettings));
             } else {
                 List<Map<String, Object>> results = docs.stream().map(doc -> {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformNodes.java
@@ -161,7 +161,7 @@ public final class TransformNodes {
     public static void warnIfNoTransformNodes(ClusterState clusterState) {
         if (TransformMetadata.getTransformMetadata(clusterState).isResetMode() == false) {
             if (hasAnyTransformNode(clusterState.getNodes()) == false) {
-                HeaderWarning.addWarning(DeprecationLogger.CRITICAL, TransformMessages.REST_WARN_NO_TRANSFORM_NODES);
+                HeaderWarning.addWarning(DeprecationLogger.DeprecationLevel.CRITICAL, TransformMessages.REST_WARN_NO_TRANSFORM_NODES);
             }
         }
     }


### PR DESCRIPTION
This commit changes the deprecation logger so that all messages (critical or warning) are written out with "299" as
the level at the beginning of the header in order to be compliant with
https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5.7. The deprecation level (CRITICAL or WARNING) is now
written out in the beginning of the message.
