### PR TITLE
[ML] fixing MlMetadata backwards compatibility bug with 7.13-16

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -162,7 +162,7 @@ public class MlMetadata implements Metadata.Custom {
         this.datafeeds = datafeeds;
         this.groupOrJobLookup = new GroupOrJobLookup(jobs.values());
         this.upgradeMode = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             this.resetMode = in.readBoolean();
         } else {
             this.resetMode = false;
@@ -174,7 +174,7 @@ public class MlMetadata implements Metadata.Custom {
         writeMap(jobs, out);
         writeMap(datafeeds, out);
         out.writeBoolean(upgradeMode);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeBoolean(resetMode);
         }
     }
@@ -240,7 +240,7 @@ public class MlMetadata implements Metadata.Custom {
                 MlMetadataDiff::readDatafeedDiffFrom
             );
             upgradeMode = in.readBoolean();
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
                 resetMode = in.readBoolean();
             } else {
                 resetMode = false;
@@ -264,7 +264,7 @@ public class MlMetadata implements Metadata.Custom {
             jobs.writeTo(out);
             datafeeds.writeTo(out);
             out.writeBoolean(upgradeMode);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
                 out.writeBoolean(resetMode);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -885,7 +885,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         }
 
         public static LazyModelDefinition fromStreamInput(StreamInput input) throws IOException {
-            if (input.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
+            if (input.getVersion().onOrAfter(Version.V_8_0_0)) {
                 return new LazyModelDefinition(input.readBytesReference(), null);
             } else {
                 return fromBase64String(input.readString());
@@ -949,7 +949,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
                 out.writeBytesReference(getCompressedDefinition());
             } else {
                 out.writeString(getBase64CompressedDefinition());


### PR DESCRIPTION
Since 7.13, MlMetadata with reset mode has been serializable. But, this was never adjusted in the 8.0.0 branch.

This commit fixes a serialization bug currently present in alpha + beta1 releases of Elasticsearch 8.0.0.

When MlMetadata exists in a cluster, a rolling upgrade, or mixed-version environment may fail to serialize cluster state between 8.0.0 nodes and nodes 7.13-7.16