### PR TITLE
[7.15] [DOCS] ILM: Add ESS/ECE instructions for migrating to node roles (#79742)

### DIFF
--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -16,6 +16,39 @@ your data in a hot-warm-cold architecture,
 you can still use attribute-based allocation filters to
 control shard allocation for other purposes.
 
+{ess} and {ece} can perform the migration automatically. For self-managed
+deployments, you need to manually update your configuration, ILM policies, and
+indices to switch to node roles. 
+
+[discrete]
+[[cloud-migrate-to-node-roles]]
+=== Automatically migrate to node roles on {ess} or {ece}
+
+If you are using node attributes on {ess} or {ece}, you will be
+prompted to switch to node roles when you:
+
+* Upgrade to {es} 7.10 or higher
+* Deploy a warm, cold, or frozen data tier
+* {cloud}/ec-autoscaling.html[Enable autoscaling]
+
+These actions automatically update your cluster configuration
+and {ilm-init} policies to use node roles. Additionally, upgrading to
+version 7.14 or higher automatically update {ilm-init} policies
+whenever any configuration change is applied to your deployment.
+
+
+If you use custom index templates, check them after the automatic migration
+completes and remove any <<shard-allocation-filtering, attribute-based
+allocation filters>>.
+
+NOTE: You do not need to take any further action after the automatic migration.
+The following manual steps are only necessary if you do not allow the automatic
+migration or have a self-managed deployment.
+
+[discrete]
+[[on-prem-migrate-to-node-roles]]
+=== Migrate to node roles on self-managed deployments
+
 To switch to using node roles:
 
 . <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
@@ -28,7 +61,7 @@ on new indices.
 
 [discrete]
 [[assign-data-tier]]
-=== Assign data nodes to a data tier
+==== Assign data nodes to a data tier
 
 Configure the appropriate roles for each data node to assign it to one or more
 data tiers: `data_hot`, `data_content`, `data_warm`, `data_cold`, or `data_frozen`.
@@ -66,7 +99,7 @@ node.roles [ data_hot, data_content ]
 
 [discrete]
 [[remove-custom-allocation-settings]]
-=== Remove custom allocation settings from existing {ilm-init} policies
+==== Remove custom allocation settings from existing {ilm-init} policies
 
 Update the allocate action for each lifecycle phase to remove the attribute-based
 allocation settings. This enables {ilm-init} to inject the
@@ -85,7 +118,7 @@ your policy must include the hot, warm, and cold phases.
 
 [discrete]
 [[stop-setting-custom-hot-attribute]]
-=== Stop setting the custom hot attribute on new indices
+==== Stop setting the custom hot attribute on new indices
 
 When you create a data stream, its first backing index
 is now automatically assigned to `data_hot` nodes.
@@ -105,7 +138,7 @@ If you're using a custom index template, update it to remove the <<shard-allocat
 
 [discrete]
 [[set-tier-preference]]
-=== Set a tier preference for existing indices.
+==== Set a tier preference for existing indices.
 
 {ilm-init} automatically transitions managed indices through the available
 data tiers by automatically injecting a <<ilm-migrate,migrate action>>


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] ILM: Add ESS/ECE instructions for migrating to node roles (#79742)