### PR TITLE
Ensure system index doc types are migrated to `_doc`

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -237,7 +237,7 @@ public class FeatureMigrationIT extends ESIntegTestCase {
             );
         }
         if (descriptor.getMappings() == null) {
-            createRequest.addMapping("_doc", createSimpleMapping(false, descriptor.isInternal(), false), XContentType.JSON);
+            createRequest.addMapping("doc", createSimpleMapping(false, descriptor.isInternal(), false), XContentType.JSON);
         }
         CreateIndexResponse response = createRequest.get();
         assertTrue(response.isShardsAcknowledged());
@@ -318,11 +318,13 @@ public class FeatureMigrationIT extends ESIntegTestCase {
             .build();
     }
 
-    static String createSimpleMapping(boolean descriptorManaged, boolean descriptorInternal, boolean includeType) {
+    static String createSimpleMapping(boolean descriptorManaged, boolean descriptorInternal, boolean useStandardType) {
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
-            if (includeType) {
+            if (useStandardType) {
                 builder.startObject("_doc");
+            } else {
+                builder.startObject("doc");
             }
             {
                 builder.startObject("_meta");
@@ -341,9 +343,7 @@ public class FeatureMigrationIT extends ESIntegTestCase {
                 builder.endObject();
             }
             builder.endObject();
-            if (includeType) {
-                builder.endObject();
-            }
+            builder.endObject();
             return Strings.toString(builder);
         } catch (IOException e) {
             // Just rethrow, it should be impossible for this to throw here


### PR DESCRIPTION
This PR ensures that mapping types for unmanaged indices are properly
converted to use the standard `_doc` type if the old index is using
another type name, and modifies the test cases to ensure this situation
is tested.

Note that this PR is aimed at 7.16 only, as the issue it addresses is not
relevant for indices created after 7.0.0.

Fixes https://github.com/elastic/elasticsearch/issues/79681