### PR TITLE
[8.0] Disable testing conventions task on Windows (#79970)

### DIFF
--- a/qa/repository-old-versions/build.gradle
+++ b/qa/repository-old-versions/build.gradle
@@ -39,6 +39,7 @@ jdks {
 
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   logger.warn("Disabling repository-old-versions tests because we can't get the pid file on windows")
+  tasks.named("testingConventions").configure { enabled = false }
 } else {
   /* Set up tasks to unzip and run the old versions of ES before running the integration tests.
    * To avoid testing against too many old versions, always pick first and last version per major


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Disable testing conventions task on Windows (#79970)