### PR TITLE
Fix typo in instructions for ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,7 +3,7 @@
 #
 # Use this file by running:
 #
-#     git blame --ignore-revs-file=.git-blame-ignore-rev <file>
+#     git blame --ignore-revs-file=.git-blame-ignore-revs <file>
 #
 # or by configuring `blame.ignoreRevsFile`. The latter ought to also work
 # with IDEs such as IntelliJ.


### PR DESCRIPTION
The file was renamed to plural (`-revs`) but the embedded instructions were not.
Relates: 07ff39e