### PR TITLE
Reenable V7RestCompat for invalidateApiKey with single id

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -108,7 +108,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure{ task ->
   task.skipTest("rollup/put_job/Test basic put_job", "rollup was an experimental feature, also see #41227")
   task.skipTest("rollup/start_job/Test start job twice", "rollup was an experimental feature, also see #41227")
   task.skipTest("ml/trained_model_cat_apis/Test cat trained models", "A type field was added to cat.ml_trained_models #73660, this is a backwards compatible change. Still this is a cat api, and we don't support them with rest api compatibility. (the test would be very hard to transform too)")
-  task.skipTest("api_key/10_basic/Test invalidate api keys with single id", "waiting for https://github.com/elastic/elasticsearch/pull/78664")
   task.skipTest("indices.freeze/30_usage/Usage stats on frozen indices", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("indices.freeze/20_stats/Translog stats on frozen indices", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("indices.freeze/10_basic/Basic", "#70192 -- the freeze index API is removed from 8.0")


### PR DESCRIPTION
RestCompat for invalidate API key with a single id is merged. The test
can now be enabled.
Relates: #78664
