### PR TITLE
[8.0] Check for multiple javadocs in java headers (#79603)

### DIFF
--- a/build-tools-internal/src/main/resources/checkstyle.xml
+++ b/build-tools-internal/src/main/resources/checkstyle.xml
@@ -12,6 +12,16 @@
 
   <module name="SuppressWarningsFilter" />
 
+  <module name="RegexpMultiline">
+    <property name="id" value="MultipleHeaderJavadoc" />
+    <property name="format" value="^\s*\/\*\n(\s\*[A-Za-z0-9 \.\/\;\,\.\-\(\)\\\x{22}\/\:\@\=\'\]\[\_\x{3E}\x{3C}]*\n)+(\s\*\/)\s+package" />
+    <property name="fileExtensions" value="java" />
+    <property name="minimum" value="1" />
+    <property name="maximum" value="1" />
+    <property name="matchAcrossLines" value="true" />
+    <property name="message" value="Duplicate header javadocs are forbidden" />
+  </module>
+
   <!-- Checks Java files and forbids empty Javadoc comments. -->
   <!-- Although you can use the "JavadocStyle" rule for this, it considers Javadoc -->
   <!-- that only contains a "@return" line to be empty. -->

--- a/build-tools-internal/src/main/resources/checkstyle_suppressions.xml
+++ b/build-tools-internal/src/main/resources/checkstyle_suppressions.xml
@@ -21,7 +21,10 @@
 
   <!-- Intentionally doesn't have a package declaration to test logging
     configuration of classes that aren't in packages. -->
-  <suppress files="test[/\\]framework[/\\]src[/\\]test[/\\]java[/\\]Dummy.java" checks="PackageDeclaration" />
+  <suppress files="test[/\\]framework[/\\]src[/\\]test[/\\]java[/\\]Dummy.java" checks=".*" />
+
+  <!-- package-info java files can contain multiple javadoc statements in header  -->
+  <suppress files=".+package\-info\.java" id="MultipleHeaderJavadoc" />
 
   <!-- Intentionally has long example curl commands to coincide with sibling Painless tests. -->
   <suppress files="modules[/\\]lang-painless[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]painless[/\\]ContextExampleTests.java" checks="LineLength" />

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
@@ -17,7 +17,6 @@ public class TestUtils {
     public static String normalizeString(String input, File projectRootDir) {
         try {
             String normalizedPathPrefix = projectRootDir.getCanonicalPath().replaceAll("\\\\", "/");
-            System.out.println("normalizedPathPrefix = " + normalizedPathPrefix);
             return input.lines()
                 .map(it -> it.replaceAll("\\\\", "/"))
                 .map(it -> it.replaceAll(normalizedPathPrefix, "."))

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/StoredScriptsIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/StoredScriptsIT.java
@@ -1,4 +1,3 @@
-package org.elasticsearch.client;
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -6,6 +5,8 @@ package org.elasticsearch.client;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.client;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.storedscripts.DeleteStoredScriptRequest;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/StoredScriptsDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/StoredScriptsDocumentationIT.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.client.documentation;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.client.documentation;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.client.documentation;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;

--- a/libs/core/src/main/java/org/elasticsearch/core/FastMath.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/FastMath.java
@@ -1,12 +1,5 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
-/* @notice
+ * @notice
  * Copyright 2012 Jeff Hain
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,9 +24,7 @@
  * software is freely granted, provided that this notice
  * is preserved.
  * =============================================================================
- */
-
-/*
+ *
  * This code sourced from:
  * https://github.com/yannrichet/jmathplot/blob/f25426e0ab0e68647ad2b75f577c7be050ecac86/src/main/java/org/math/plot/utils/FastMath.java
  */

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/io/IOUtils.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/io/IOUtils.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/libs/core/src/test/java/org/elasticsearch/core/internal/io/IOUtilsTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/io/IOUtilsTests.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/ESLZ4Compressor.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/ESLZ4Compressor.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/ESLZ4Decompressor.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/ESLZ4Decompressor.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4Constants.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4Constants.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4SafeUtils.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4SafeUtils.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4Utils.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/LZ4Utils.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/SafeUtils.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/SafeUtils.java
@@ -1,4 +1,6 @@
 /*
+ * @notice
+ *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.elasticsearch.lz4;

--- a/libs/lz4/src/main/java/org/elasticsearch/lz4/package-info.java
+++ b/libs/lz4/src/main/java/org/elasticsearch/lz4/package-info.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  *
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/DerParser.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/DerParser.java
@@ -1,18 +1,19 @@
-/* @notice
-  Copyright (c) 1998-2010 AOL Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+/*
+ * @notice
+ * Copyright (c) 1998-2010 AOL Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
  */
 
 package org.elasticsearch.common.ssl;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzer.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzer.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.analysis.common;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.analysis.common;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/FingerprintAnalyzerTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/FingerprintAnalyzerTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.analysis.common;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.analysis.common;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PatternAnalyzerTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PatternAnalyzerTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.analysis.common;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.analysis.common;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SnowballAnalyzerTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SnowballAnalyzerTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.analysis.common;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.analysis.common;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/DateField.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/DateField.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.script.expression;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,7 @@ package org.elasticsearch.script.expression;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+package org.elasticsearch.script.expression;
 
 import org.apache.lucene.search.DoubleValuesSource;
 import org.elasticsearch.index.fielddata.IndexFieldData;

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/DateObject.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/DateObject.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.script.expression;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.script.expression;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.script.expression;
 
 import org.apache.lucene.search.DoubleValuesSource;
 import org.elasticsearch.common.time.DateFormatters;

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/GeoField.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/GeoField.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.script.expression;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.script.expression;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.script.expression;
 
 import org.apache.lucene.search.DoubleValuesSource;
 import org.elasticsearch.index.fielddata.IndexFieldData;

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/NumericField.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/NumericField.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.script.expression;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.script.expression;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.script.expression;
 
 import org.apache.lucene.search.DoubleValuesSource;
 import org.elasticsearch.index.fielddata.IndexFieldData;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicExpressionTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicExpressionTests.java
@@ -1,9 +1,3 @@
-package org.elasticsearch.painless;
-
-import java.util.Collections;
-
-import static java.util.Collections.singletonMap;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -11,6 +5,12 @@ import static java.util.Collections.singletonMap;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.painless;
+
+import java.util.Collections;
+
+import static java.util.Collections.singletonMap;
 
 public class BasicExpressionTests extends ScriptTestCase {
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicStatementTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicStatementTests.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
 package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.spi.Whitelist;
@@ -11,14 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
-
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
 
 public class BasicStatementTests extends ScriptTestCase {
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FeatureTestObject.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FeatureTestObject.java
@@ -1,9 +1,3 @@
-package org.elasticsearch.painless;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -11,6 +5,12 @@ import java.util.function.Function;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.painless;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
 
 /** Currently just a dummy class for testing a few features not yet exposed by whitelist! */
 public class FeatureTestObject {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FeatureTestObject2.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FeatureTestObject2.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.painless;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.painless;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.painless;
 
 /** Currently just a dummy class for testing a few features not yet exposed by whitelist! */
 public class FeatureTestObject2 {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/OverloadTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/OverloadTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.painless;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.painless;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.painless;
 
 /** Tests method overloading */
 public class OverloadTests extends ScriptTestCase {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/TryCatchTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/TryCatchTests.java
@@ -1,7 +1,3 @@
-package org.elasticsearch.painless;
-
-import java.util.Collections;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -9,6 +5,10 @@ import java.util.Collections;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.painless;
+
+import java.util.Collections;
 
 /** tests for throw/try/catch in painless */
 public class TryCatchTests extends ScriptTestCase {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/CopyBytesServerSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/CopyBytesServerSocketChannel.java
@@ -4,8 +4,9 @@
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
- */
-/*
+ *
+ * ============================================================================
+ *
  * Copyright 2012 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/CopyBytesSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/CopyBytesSocketChannel.java
@@ -4,8 +4,9 @@
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
- */
-/*
+ *
+ * =============================================================================
+ *
  * Copyright 2012 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeyFilter.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeyFilter.java
@@ -1,6 +1,5 @@
-package org.elasticsearch.plugin.analysis.icu;
-
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,6 +15,8 @@ package org.elasticsearch.plugin.analysis.icu;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.elasticsearch.plugin.analysis.icu;
 
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RawCollationKey;

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringTools.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringTools.java
@@ -1,6 +1,5 @@
-package org.elasticsearch.plugin.analysis.icu;
-
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,6 +15,8 @@ package org.elasticsearch.plugin.analysis.icu;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.elasticsearch.plugin.analysis.icu;
 
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringToolsTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringToolsTests.java
@@ -1,6 +1,5 @@
-package org.elasticsearch.plugin.analysis.icu;
-
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,6 +15,7 @@ package org.elasticsearch.plugin.analysis.icu;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.elasticsearch.plugin.analysis.icu;
 
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;

--- a/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/plugin/analysis/ukrainian/XUkrainianMorfologikAnalyzer.java
+++ b/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/plugin/analysis/ukrainian/XUkrainianMorfologikAnalyzer.java
@@ -1,4 +1,5 @@
-/*@notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.ingest.attachment;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.ingest.attachment;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.ingest.attachment;
 
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaException;

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.ingest.attachment;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.ingest.attachment;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.ingest.attachment;
 
 import org.apache.lucene.util.LuceneTestCase.SuppressFileSystems;
 import org.apache.lucene.util.TestUtil;

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.ingest.attachment;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,7 @@ package org.elasticsearch.ingest.attachment;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+package org.elasticsearch.ingest.attachment;
 
 import org.elasticsearch.test.ESTestCase;
 

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -4,9 +4,9 @@
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
- */
-
-/*
+ *
+ * =============================================================================
+ *
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.cluster.routing;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.cluster.routing;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.cluster.routing;
 
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 

--- a/server/src/main/java/org/elasticsearch/common/collect/EvictingQueue.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/EvictingQueue.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Copyright (C) 2012 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/ProviderInstanceBindingImpl.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/ProviderInstanceBindingImpl.java
@@ -1,18 +1,18 @@
 /*
-Copyright (C) 2007 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright (C) 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.elasticsearch.common.inject.internal;
 

--- a/server/src/main/java/org/elasticsearch/common/logging/JsonThrowablePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/JsonThrowablePatternConverter.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/server/src/main/java/org/elasticsearch/common/lucene/FilterIndexCommit.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/FilterIndexCommit.java
@@ -6,25 +6,6 @@
  * Side Public License, v 1.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.elasticsearch.common.lucene;
 
 import org.apache.lucene.index.IndexCommit;

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.common.lucene.uid;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.common.lucene.uid;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.common.lucene.uid;
 
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Copyright (C) 2008 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtilsRounding.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtilsRounding.java
@@ -1,17 +1,18 @@
-/* @notice
- *  Copyright 2001-2014 Stephen Colebourne
+/*
+ * @notice
+ * Copyright 2001-2014 Stephen Colebourne
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.elasticsearch.common.time;
 

--- a/server/src/main/java/org/elasticsearch/http/CorsHandler.java
+++ b/server/src/main/java/org/elasticsearch/http/CorsHandler.java
@@ -1,11 +1,6 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-/*
+ * @notice
+ *
  * Copyright 2013 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version
@@ -19,8 +14,16 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
+ * =============================================================================
+ * Modifications copyright Elasticsearch B.V.
+ *
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
-
 package org.elasticsearch.http;
 
 import org.elasticsearch.common.Strings;

--- a/server/src/main/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollector.java
+++ b/server/src/main/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollector.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/server/src/main/java/org/elasticsearch/lucene/similarity/LegacyBM25Similarity.java
+++ b/server/src/main/java/org/elasticsearch/lucene/similarity/LegacyBM25Similarity.java
@@ -1,12 +1,5 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
-/* @notice
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
+++ b/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/server/src/main/java/org/elasticsearch/rest/RestCompatibleVersionHelper.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestCompatibleVersionHelper.java
@@ -5,13 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchStatusException;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
@@ -6,25 +6,6 @@
  * Side Public License, v 1.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.action.admin.indices.diskusage.AnalyzeIndexDiskUsageAction;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/StatsBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/StatsBucket.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.search.aggregations.pipeline;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.search.aggregations.pipeline;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.search.aggregations.metrics.Stats;
 

--- a/server/src/main/java/org/elasticsearch/shutdown/PluginShutdownService.java
+++ b/server/src/main/java/org/elasticsearch/shutdown/PluginShutdownService.java
@@ -6,13 +6,6 @@
  * Side Public License, v 1.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
 package org.elasticsearch.shutdown;
 
 import org.apache.logging.log4j.LogManager;

--- a/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
@@ -4,8 +4,7 @@
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
- */
-/*
+ *
  * Copyright 2014 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version

--- a/server/src/main/java/org/elasticsearch/transport/ReuseBuffersLZ4BlockOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/transport/ReuseBuffersLZ4BlockOutputStream.java
@@ -1,11 +1,4 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-/*
  * Copyright 2020 Adrien Grand and the lz4-java contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/server/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -6,14 +6,6 @@
  * Side Public License, v 1.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.usage;
 
 import org.elasticsearch.action.admin.cluster.node.usage.NodeUsage;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatusTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.action.admin.cluster.snapshots.status;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.action.admin.cluster.snapshots.status;
 
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.UUIDs;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetStoredScriptResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetStoredScriptResponseTests.java
@@ -1,10 +1,12 @@
-package org.elasticsearch.action.admin.cluster.storedscripts;/*
-                                                             * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-                                                             * or more contributor license agreements. Licensed under the Elastic License
-                                                             * 2.0 and the Server Side Public License, v 1; you may not use this file except
-                                                             * in compliance with, at your election, the Elastic License 2.0 or the Server
-                                                             * Side Public License, v 1.
-                                                             */
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.storedscripts;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.script.Script;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.cluster.routing.allocation;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.cluster.routing.allocation;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;

--- a/server/src/test/java/org/elasticsearch/common/collect/EvictingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/EvictingQueueTests.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Copyright (C) 2012 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Copyright (C) 2008 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -1,5 +1,5 @@
 /*
-x * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server

--- a/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -1,5 +1,5 @@
 /*
-x * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0 and the Server Side Public License, v 1; you may not use this file except
  * in compliance with, at your election, the Elastic License 2.0 or the Server

--- a/test/framework/src/main/java/org/elasticsearch/index/store/EsBaseDirectoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/store/EsBaseDirectoryTestCase.java
@@ -1,5 +1,3 @@
-package org.elasticsearch.index.store;
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,6 +5,8 @@ package org.elasticsearch.index.store;
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+package org.elasticsearch.index.store;
 
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;

--- a/x-pack/plugin/analytics/src/internalClusterTest/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsWithRequestBreakerIT.java
+++ b/x-pack/plugin/analytics/src/internalClusterTest/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsWithRequestBreakerIT.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.xpack.analytics.multiterms;
 
 import org.elasticsearch.ElasticsearchException;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 package org.elasticsearch.xpack.ccr;
 
 import org.apache.lucene.util.SetOnce;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
@@ -1,18 +1,19 @@
-/* @notice
- Copyright (c) 2006 Damien Miller <djm@mindrot.org>
-
- Permission to use, copy, modify, and distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-*/
+/*
+ * @notice
+ * Copyright (c) 2006 Damien Miller <djm@mindrot.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 package org.elasticsearch.xpack.core.security.authc.support;
 
 import org.elasticsearch.common.settings.SecureString;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/MultiShardTermsEnum.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/MultiShardTermsEnum.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -6,7 +7,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/utils/ExceptionsHelper.java
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 package org.elasticsearch.xpack.core.transform.utils;
 
 /**

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -5,25 +5,6 @@
  * 2.0.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.elasticsearch.xpack.fleet;
 
 import org.apache.http.util.EntityUtils;

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -5,25 +5,6 @@
  * 2.0.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.elasticsearch.xpack.fleet;
 
 import org.elasticsearch.client.Client;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
@@ -3,9 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- */
-
-/*
+ *
  * ELASTICSEARCH CONFIDENTIAL
  * __________________
  *

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/heuristic/LongBinomialDistribution.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/heuristic/LongBinomialDistribution.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/XExternalRefSorter.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/XExternalRefSorter.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
@@ -1,23 +1,23 @@
-/* @notice
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- */
-
 /*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
  * This code sourced from:
  * http://svn.apache.org/repos/asf/directory/studio/tags/2.0.0.v20170904-M13/plugins/valueeditors/src/main/java/org/apache/directory/studio/valueeditors/msad/InPlaceMsAdObjectSidValueEditor.java
  */

--- a/x-pack/plugin/spatial/src/test/java/org/apache/lucene/geo/XShapeTestUtil.java
+++ b/x-pack/plugin/spatial/src/test/java/org/apache/lucene/geo/XShapeTestUtil.java
@@ -1,4 +1,5 @@
-/* @notice
+/*
+ * @notice
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -1,5 +1,4 @@
 /*
- /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/KnnVectorQueryBuilder.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.xpack.vectors.query;
 
 import org.apache.lucene.search.Query;


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Check for multiple javadocs in java headers (#79603)