### PR TITLE
optimize getIndices in IndicesSegmentResponse

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -41,6 +41,50 @@
   - match:   { indices.index1.shards.0.0.segments._0.num_docs: 1}
 
 ---
+"segments from multiple indices":
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      indices.create:
+        index: index2
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      index:
+        index: index1
+        body: { foo: bar }
+        refresh: true
+
+  - do:
+      index:
+        index: index2
+        body: { foo: bar }
+        refresh: true
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.segments: {}
+
+  - gte: { _shards.total: 2 }
+  - match:   { indices.index1.shards.0.0.routing.primary: true}
+  - match:   { indices.index1.shards.0.0.segments._0.num_docs: 1}
+  - match:   { indices.index2.shards.0.0.routing.primary: true}
+  - match:   { indices.index2.shards.0.0.segments._0.num_docs: 1}
+
+---
 "closed segments test":
   - skip:
       features: ["allowed_warnings"]

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
@@ -20,7 +20,7 @@ public class IndexSegments implements Iterable<IndexShardSegments> {
 
     private final Map<Integer, IndexShardSegments> indexShards;
 
-    IndexSegments(String index, ShardSegments[] shards) {
+    IndexSegments(String index, List<ShardSegments> shards) {
         this.index = index;
 
         Map<Integer, List<ShardSegments>> tmpIndexShards = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
@@ -23,17 +23,12 @@ public class IndexSegments implements Iterable<IndexShardSegments> {
     IndexSegments(String index, List<ShardSegments> shards) {
         this.index = index;
 
-        Map<Integer, List<ShardSegments>> tmpIndexShards = new HashMap<>();
+        final Map<Integer, List<ShardSegments>> segmentsByShardId = new HashMap<>();
         for (ShardSegments shard : shards) {
-            List<ShardSegments> lst = tmpIndexShards.get(shard.getShardRouting().id());
-            if (lst == null) {
-                lst = new ArrayList<>();
-                tmpIndexShards.put(shard.getShardRouting().id(), lst);
-            }
-            lst.add(shard);
+            segmentsByShardId.computeIfAbsent(shard.getShardRouting().id(), k -> new ArrayList<>()).add(shard);
         }
         indexShards = new HashMap<>();
-        for (Map.Entry<Integer, List<ShardSegments>> entry : tmpIndexShards.entrySet()) {
+        for (Map.Entry<Integer, List<ShardSegments>> entry : segmentsByShardId.entrySet()) {
             indexShards.put(
                 entry.getKey(),
                 new IndexShardSegments(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -61,10 +61,7 @@ public class IndicesSegmentResponse extends BroadcastResponse {
 
         final Map<String, List<ShardSegments>> segmentsByIndex = new HashMap<>();
         for (ShardSegments shard : shards) {
-            segmentsByIndex.computeIfAbsent(
-                shard.getShardRouting().getIndexName(),
-                k -> new ArrayList<>()
-            ).add(shard);
+            segmentsByIndex.computeIfAbsent(shard.getShardRouting().getIndexName(), k -> new ArrayList<>()).add(shard);
         }
         for (Map.Entry<String, List<ShardSegments>> entry : segmentsByIndex.entrySet()) {
             indicesSegments.put(entry.getKey(), new IndexSegments(entry.getKey(), entry.getValue()));


### PR DESCRIPTION
The getIndices method in IndicesSegmentResponse will traverse shards for n+1 times (n is indices count), which can be optimized to just traverse once by using Map and its computeIfAbsent method. 
Same logic can be found in IndexSegments’ constructor， where we just traverse shard once.
This PR just want to make elasticsearch code better, thougth getIndices method may be called Infrequently and has no performance issue.
