### PR TITLE
Enable bwc IndexingIT after backport

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -177,8 +177,6 @@ public class IndexingIT extends AbstractRollingTestCase {
         }
     }
 
-    // await backport to v8.0
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79994")
     public void testDateNanosFormatUpgrade() throws IOException {
         final String indexName = "test_date_nanos";
         switch (CLUSTER_TYPE) {


### PR DESCRIPTION
testDateNanosFormatUpgrade was disable until
a revert #80003 was backported to 8.0

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
