### PR TITLE
[Transform] Upgrader: only expand ids based on transform configs

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointTests.java
@@ -30,8 +30,12 @@ import static org.hamcrest.Matchers.lessThan;
 public class TransformCheckpointTests extends AbstractSerializingTransformTestCase<TransformCheckpoint> {
 
     public static TransformCheckpoint randomTransformCheckpoint() {
+        return randomTransformCheckpoint(randomAlphaOfLengthBetween(1, 10));
+    }
+
+    public static TransformCheckpoint randomTransformCheckpoint(String transformId) {
         return new TransformCheckpoint(
-            randomAlphaOfLengthBetween(1, 10),
+            transformId,
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomCheckpointsByIndex(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -882,6 +882,10 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
             .setSize(page.getSize())
             .setFetchSource(false)
             .addDocValueField(TransformField.ID.getPreferredName())
+            .setQuery(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), TransformConfig.NAME))
+            )
             .request();
 
         executeAsyncWithOrigin(


### PR DESCRIPTION
adds a filter when retrieving outdated transform ids, only transform configurations are of interest

fixes #80073

Labelled as non-issue because the upgrader is a new unreleased feature, however this is a technically a bug