### PR TITLE
Fix race condition in XPackUsageRestCancellationIT

### DIFF
--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/XPackUsageRestCancellationIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/XPackUsageRestCancellationIT.java
@@ -53,7 +53,6 @@ import java.util.concurrent.CountDownLatch;
 import static org.elasticsearch.action.support.ActionTestUtils.wrapAsRestResponseListener;
 import static org.elasticsearch.test.TaskAssertions.assertAllCancellableTasksAreCancelled;
 import static org.elasticsearch.test.TaskAssertions.assertAllTasksHaveFinished;
-import static org.elasticsearch.test.TaskAssertions.awaitTaskWithPrefix;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -89,7 +88,6 @@ public class XPackUsageRestCancellationIT extends ESIntegTestCase {
         final Cancellable cancellable = getRestClient().performRequestAsync(request, wrapAsRestResponseListener(future));
 
         assertThat(future.isDone(), equalTo(false));
-        awaitTaskWithPrefix(actionName);
 
         blockingXPackUsageActionExecuting.await();
         cancellable.cancel();


### PR DESCRIPTION
Ensure that the blocking XPackUsageAction is executed before cancelling
the request to ensure that the action is not cancelled at the beginning
of the TransportMasterAction.

Closes #72471
