### PR TITLE
[7.16] [Transform] Upgrader: only expand ids based on transform configs (#80076)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointTests.java
@@ -30,8 +30,12 @@ import static org.hamcrest.Matchers.lessThan;
 public class TransformCheckpointTests extends AbstractSerializingTransformTestCase<TransformCheckpoint> {
 
     public static TransformCheckpoint randomTransformCheckpoint() {
+        return randomTransformCheckpoint(randomAlphaOfLengthBetween(1, 10));
+    }
+
+    public static TransformCheckpoint randomTransformCheckpoint(String transformId) {
         return new TransformCheckpoint(
-            randomAlphaOfLengthBetween(1, 10),
+            transformId,
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomCheckpointsByIndex(),

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -427,9 +427,9 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         );
 
         // add another old one, but not with an existing id
-        transformId = "transform_oldindex";
-        docId = TransformConfig.documentId(transformId);
-        transformConfig = TransformConfigTests.randomTransformConfig(transformId);
+        final String oldTransformId = "transform_oldindex";
+        docId = TransformConfig.documentId(oldTransformId);
+        transformConfig = TransformConfigTests.randomTransformConfig(oldTransformId);
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
@@ -439,18 +439,29 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             client().index(request).actionGet();
         }
 
-        transformIds.add(transformId);
+        // add a new checkpoint doc for the old transform to check id expansion ignores other documents, see gh#80073
+        assertAsync(
+            listener -> transformConfigManager.putTransformCheckpoint(
+                TransformCheckpointTests.randomTransformCheckpoint(oldTransformId),
+                listener
+            ),
+            true,
+            null,
+            null
+        );
+
+        transformIds.add(oldTransformId);
         assertAsync(listener -> transformConfigManager.getAllTransformIds(listener), transformIds, null, null);
         assertAsync(
             listener -> transformConfigManager.getAllOutdatedTransformIds(listener),
-            tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(transformId)),
+            tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(oldTransformId)),
             null,
             null
         );
 
         assertAsync(
             listener -> transformConfigManager.expandAllTransformIds(true, 10, listener),
-            tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(transformId)),
+            tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(oldTransformId)),
             null,
             null
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -882,6 +882,10 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
             .setSize(page.getSize())
             .setFetchSource(false)
             .addDocValueField(TransformField.ID.getPreferredName())
+            .setQuery(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), TransformConfig.NAME))
+            )
             .request();
 
         executeAsyncWithOrigin(


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Transform] Upgrader: only expand ids based on transform configs (#80076)