### PR TITLE
[DOCS] Add transient settings migration guide

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -48,8 +48,9 @@ PUT /_cluster/settings
 
 An example of a transient update:
 
-NOTE: Transient settings are deprecated and will be removed in a future release.
-Use persistent cluster settings instead.
+// tag::transient-settings-deprecation[]
+deprecated::[7.16,Transient settings are deprecated and will be removed in a future release. Use persistent cluster settings instead. See the <<transient-settings-migration-guide>>.]
+// end::transient-settings-deprecation[]
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -292,8 +292,10 @@ unexpectedly, leading to a potentially undesired cluster configuration.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of transient settings when modifying
-your cluster settings through the `PUT _cluster/settings` REST API. When modifying cluster settings
-use only persistent settings.
+your cluster settings through the `PUT _cluster/settings` REST API. Use persistent
+settings instead. See the
+{ref}/transient-settings-migration-guide.html[Transient settings migration
+guide]. 
 ====
 
 [discrete]
@@ -348,3 +350,5 @@ To override the defaults, configure the `script.cache.max_size`,
 `script.max_compilations_rate`, and `script.cache.expire` settings.
 ====
 // end::notable-breaking-changes[]
+
+include::transient-settings-migration-guide.asciidoc[]

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -285,8 +285,8 @@ as it will no longer be recognized in the next major release.
 ====
 *Details* +
 Transient cluster settings are now deprecated and will be removed in a future release. This is because transient
-cluster settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts,
-which can forcibly happen if enough master-eligible nodes fail. In such an event, the cluster state will be recovered
+cluster settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts or
+cluster instability. In these cases, {es} recovers the cluster state
 from persistent storage, effectively erasing the transient settings. The loss of transient settings can happen
 unexpectedly, leading to a potentially undesired cluster configuration.
 

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -23,12 +23,12 @@ settings unexpectedly, leading to a potentially undesired cluster configuration.
 
 To avoid deprecation warnings, reset any transient settings you've configured on
 your cluster. Convert any transient setting you'd like to keep to a persistent
-setting, which persists across cluster restarts.
+setting, which persists across cluster restarts. You should also update any
+custom workflows and applications to use persistent settings instead of
+transient settings.
 
 IMPORTANT: Some Elastic products may use transient settings. These settings
-should not be changed. However, you should update your workflows and
-applications to discontinue use of transient settings and use persistent
-settings instead.
+should not be changed.
 
 To reset and convert transient settings:
 

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -27,8 +27,8 @@ setting, which persists across cluster restarts.
 
 IMPORTANT: Some Elastic products may use transient settings. These settings
 should not be changed. However, you should update your workflows and
-applications to discontinue transient settings and use persistent settings
-instead.
+applications to discontinue use of transient settings and use persistent
+settings instead.
 
 To reset and convert transient settings:
 

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -50,7 +50,7 @@ The API returns:
 <<cluster-update-settings,cluster update settings API>> request. Reset all
 transient settings in the same request.
 +
-NOTE: The equest will trigger a deprecation warning.
+NOTE: The request will trigger a deprecation warning.
 +
 [source,console]
 ----

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -15,15 +15,17 @@ PUT _cluster/settings
 // TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
 ////
 
-Transient cluster settings are deprecated. Transient settings don't survive full
-cluster restarts. A cluster restart can occur unexpectedly if enough
-master-eligible nodes fail, resulting in an unwanted cluster configuration.
+Transient cluster settings are deprecated. Previously, you could use transient
+settings to make temporary configuration changes to a cluster. However,
+transient settings don't survive full cluster restarts. A cluster restart can
+occur forcibly if enough master-eligible nodes fail. This can clear transient
+settings unexpectedly, leading to a potentially undesired cluster configuration.
 
-You can convert any transient setting you'd like to keep to a persistent
-setting, which persists across cluster restarts. You can then reset your
-configured transient settings to avoid deprecation warnings.
+To avoid deprecation warnings, reset any transient settings on your cluster.
+Convert any transient setting you'd like to keep to a persistent setting, which
+persists across cluster restarts.
 
-To migrate from transient settings:
+To reset and convert transient settings:
 
 . Get a list of any configured transient settings using the
 <<cluster-get-settings,cluster get settings API>>.
@@ -34,23 +36,28 @@ GET _cluster/settings?flat_settings=true&filter_path=transient
 ----
 // TEST[continued]
 +
-The API returns:
+The API returns transient settings in the `transient` object. If this object is
+empty, your cluster has no transient settings, and you can skip the remaining
+steps.
 +
 [source,console-result]
 ----
 {
+  "persistent": { ... },
   "transient": {
     "cluster.indices.close.enable": "false",
     "indices.recovery.max_bytes_per_sec": "50mb"
   }
 }
 ----
+// TESTRESPONSE[s/"persistent": \{ \.\.\. \},//]
 
-. Copy any settings you'd like to convert into the `persistent` object of a
-<<cluster-update-settings,cluster update settings API>> request. Reset all
-transient settings in the same request.
+. Copy any transient setting you'd like to convert to a persistent setting into
+the `persistent` object of a <<cluster-update-settings,cluster update settings
+API>> request. In the same request, reset all transient settings by assigning
+them a `null` value.
 +
-NOTE: The request will trigger a deprecation warning.
+NOTE: Resetting transient settings will emit a deprecation warning.
 +
 [source,console]
 ----
@@ -69,7 +76,7 @@ PUT _cluster/settings
 // TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
 
 . Use the <<cluster-get-settings,cluster get settings API>> to confirm your
-cluster has no transient settings.
+cluster has no remaining transient settings.
 +
 [source,console]
 ----
@@ -77,20 +84,22 @@ GET _cluster/settings?flat_settings=true
 ----
 // TEST[continued]
 +
-If there are no transient settings, the response's `transient` property is
-empty:
+If the `transient` object is empty, your cluster has no transient settings.
 +
 [source,console-result]
 ----
 {
   "persistent": {
     "cluster.indices.close.enable": "false",
-    "indices.recovery.max_bytes_per_sec": "50mb"
+    "indices.recovery.max_bytes_per_sec": "50mb",
+    ...
   },
   "transient": {
   }
 }
 ----
+// TESTRESPONSE[s/"50mb",/"50mb"/]
+// TESTRESPONSE[s/\.\.\.//]
 
 ////
 [source,console]

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -57,10 +57,9 @@ steps.
 ----
 // TESTRESPONSE[s/"persistent": \{ \.\.\. \},//]
 
-. Copy any transient setting you'd like to convert to a persistent setting into
-the `persistent` object of a <<cluster-update-settings,cluster update settings
-API>> request. In the same request, reset transient settings by assigning them a
-`null` value.
+. Copy any settings you'd like to convert into the `persistent` object of a
+<<cluster-update-settings,cluster update settings API>> request. In the same
+request, reset transient settings by assigning them a `null` value.
 +
 NOTE: Resetting transient settings will emit a deprecation warning.
 +

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -16,19 +16,19 @@ PUT _cluster/settings
 ////
 
 Transient cluster settings are deprecated. Previously, you could use transient
-settings to make temporary configuration changes to a cluster. However,
-transient settings don't survive full cluster restarts. A cluster restart can
-occur forcibly if enough master-eligible nodes fail. This can clear transient
-settings unexpectedly, leading to a potentially undesired cluster configuration.
+settings to make temporary configuration changes to a cluster. However, a
+cluster restart or cluster instability can unexpectedly clear these settings,
+leading to a potentially undesired cluster configuration.
 
 To avoid deprecation warnings, reset any transient settings you've configured on
 your cluster. Convert any transient setting you'd like to keep to a persistent
-setting, which persists across cluster restarts. You should also update any
-custom workflows and applications to use persistent settings instead of
-transient settings.
+setting, which persists across cluster restarts and cluster instability. You
+should also update any custom workflows and applications to use persistent
+settings instead of transient settings.
 
-IMPORTANT: Some Elastic products may use transient settings. These settings
-should not be changed.
+IMPORTANT: Some Elastic products may use transient settings when performing
+specific operations. Only reset transient settings configured by you, your
+users, or your custom workflows and applications.
 
 To reset and convert transient settings:
 

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -21,9 +21,14 @@ transient settings don't survive full cluster restarts. A cluster restart can
 occur forcibly if enough master-eligible nodes fail. This can clear transient
 settings unexpectedly, leading to a potentially undesired cluster configuration.
 
-To avoid deprecation warnings, reset any transient settings on your cluster.
-Convert any transient setting you'd like to keep to a persistent setting, which
-persists across cluster restarts.
+To avoid deprecation warnings, reset any transient settings you've configured on
+your cluster. Convert any transient setting you'd like to keep to a persistent
+setting, which persists across cluster restarts.
+
+IMPORTANT: Some Elastic products may use transient settings. These settings
+should not be changed. However, you should update your workflows and
+applications to discontinue transient settings and use persistent settings
+instead.
 
 To reset and convert transient settings:
 
@@ -54,8 +59,8 @@ steps.
 
 . Copy any transient setting you'd like to convert to a persistent setting into
 the `persistent` object of a <<cluster-update-settings,cluster update settings
-API>> request. In the same request, reset all transient settings by assigning
-them a `null` value.
+API>> request. In the same request, reset transient settings by assigning them a
+`null` value.
 +
 NOTE: Resetting transient settings will emit a deprecation warning.
 +
@@ -68,7 +73,8 @@ PUT _cluster/settings
     "indices.recovery.max_bytes_per_sec": "50mb"
   },
   "transient": {
-    "*": null
+    "cluster.indices.close.enable": null,
+    "indices.recovery.max_bytes_per_sec": null
   }
 }
 ----

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -1,0 +1,107 @@
+[[transient-settings-migration-guide]]
+=== Transient settings migration guide
+
+////
+[source,console]
+----
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.indices.close.enable": false,
+    "indices.recovery.max_bytes_per_sec": "50mb"
+  }
+}
+----
+// TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
+////
+
+Transient cluster settings are deprecated. Transient settings don't survive full
+cluster restarts. A cluster restart can occur unexpectedly if enough
+master-eligible nodes fail, resulting in an unwanted cluster configuration.
+
+You can convert any transient setting you'd like to keep to a persistent
+setting, which persists across cluster restarts. You can then reset your
+configured transient settings to avoid deprecation warnings.
+
+To migrate from transient settings:
+
+. Get a list of any configured transient settings using the
+<<cluster-get-settings,cluster get settings API>>.
++
+[source,console]
+----
+GET _cluster/settings?flat_settings=true&filter_path=transient
+----
+// TEST[continued]
++
+The API returns:
++
+[source,console-result]
+----
+{
+  "transient": {
+    "cluster.indices.close.enable": "false",
+    "indices.recovery.max_bytes_per_sec": "50mb"
+  }
+}
+----
+
+. Copy any settings you'd like to convert into the `persistent` object of a
+<<cluster-update-settings,cluster update settings API>> request. Reset all
+transient settings in the same request.
++
+NOTE: The equest will trigger a deprecation warning.
++
+[source,console]
+----
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.indices.close.enable": false,
+    "indices.recovery.max_bytes_per_sec": "50mb"
+  },
+  "transient": {
+    "*": null
+  }
+}
+----
+// TEST[continued]
+// TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
+
+. Use the <<cluster-get-settings,cluster get settings API>> to confirm your
+cluster has no transient settings.
++
+[source,console]
+----
+GET _cluster/settings?flat_settings=true
+----
+// TEST[continued]
++
+If there are no transient settings, the response's `transient` property is
+empty:
++
+[source,console-result]
+----
+{
+  "persistent": {
+    "cluster.indices.close.enable": "false",
+    "indices.recovery.max_bytes_per_sec": "50mb"
+  },
+  "transient": {
+  }
+}
+----
+
+////
+[source,console]
+----
+PUT _cluster/settings
+{
+  "persistent" : {
+    "cluster.indices.close.enable": null,
+    "indices.recovery.max_bytes_per_sec": null
+  }
+}
+----
+// TEST[continued]
+////

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -59,7 +59,7 @@ steps.
 
 . Copy any settings you'd like to convert into the `persistent` object of a
 <<cluster-update-settings,cluster update settings API>> request. In the same
-request, reset transient settings by assigning them a `null` value.
+request, reset any transient settings by assigning them a `null` value.
 +
 NOTE: Resetting transient settings will emit a deprecation warning.
 +
@@ -72,8 +72,7 @@ PUT _cluster/settings
     "indices.recovery.max_bytes_per_sec": "50mb"
   },
   "transient": {
-    "cluster.indices.close.enable": null,
-    "indices.recovery.max_bytes_per_sec": null
+    "*": null
   }
 }
 ----

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -148,8 +148,7 @@ doesn't require a restart and ensures a setting's value is the same on all
 nodes.
 ====
 
-NOTE: Transient settings are deprecated and will be removed in a future release.
-Use persistent cluster settings instead.
+include::{es-repo-dir}/cluster/update-settings.asciidoc[tag=transient-settings-deprecation]
 --
 
 [[static-cluster-setting]]


### PR DESCRIPTION
Changes:

* Adds a transient settings migration guide to the 7.16 docs.
* Updates the related deprecation docs to link to the guide.

Closes #80055 

Relates to #79167.

### Forwardports

This deprecation is currently in the 7.16 docs only. However, I plan to forwardport to 8.0 and main based on the discussion in #79953.

In the 8.0 and main forwardports, I plan to add the guide and deprecation notice to the 8.0 migration docs. Let me know if there are any objections.

### Previews


* Transient settings migration guide: https://elasticsearch_80091.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/transient-settings-migration-guide.html
* Transient settings deprecation: https://elasticsearch_80091.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/migrating-7.16.html#breaking_716_settings_deprecations
* Deprecation admonition: https://elasticsearch_80091.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/settings.html#cluster-setting-types