### PR TITLE
[ML] Reenable BasicRenormalizationIT.testDefaultRenormalization on Windows

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -34,7 +33,7 @@ public class BasicRenormalizationIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testDefaultRenormalization() throws Exception {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/44613", Constants.WINDOWS);
+
         String jobId = "basic-renormalization-it-test-default-renormalization-job";
         createAndRunJob(jobId, null);
 


### PR DESCRIPTION
This test failed on Windows years ago and wasn't investigated at the
time. Since it's been disabled so long there's no information about
why it failed. This change is to reenable the test on master so that
we can get more information about why it fails.

Relates #44613