### PR TITLE
[DOCS] Add system indices deprecation

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -10,10 +10,12 @@ your application to {es} 7.16.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_716_settings_changes>>
+* <<breaking_716_tls_changes>>
 * <<breaking_716_ilm_changes>>
 * <<breaking_716_monitoring_changes>>
-
 * <<breaking_716_settings_deprecations>>
+* <<breaking_716_indices_deprecations>>
+* <<breaking_716_cluster_deprecations>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -297,6 +299,29 @@ use only persistent settings.
 ====
 
 [discrete]
+[[breaking_716_indices_deprecations]]
+==== Indices deprecations
+
+[[deprecation-system-indices]]
+.Direct access to system indices is deprecated.
+[%collapsible]
+====
+*Details* +
+Directly accessing system indices is deprecated. In {es} 8.0, you must add the
+`allow_restricted_indices` permission set to `true` on a user role to access
+system indices. Refer to 
+{ref}/defining-roles.html#roles-indices-priv[indices privileges] for
+information on adding this permission to an index privilege.
+
+*Impact* +
+Accessing system indices directly results in warnings in the header of API 
+responses. Use {kib} or the associated feature's {es} APIs to manage the data 
+that you want to access. While it's still possible to access system indices in
+{es} 7.16, they are reserved only for internal use by Elastic products and
+should not be accessed directly.
+====
+
+[discrete]
 [[breaking_716_cluster_deprecations]]
 ==== Cluster deprecations
 
@@ -322,7 +347,7 @@ parameter `?return_200_for_cluster_health_timeout` in your request.
 ====
 
 [[script-context-cache-deprecated]]
-.The script context cache is deprecated
+.The script context cache is deprecated.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -315,10 +315,10 @@ information on adding this permission to an index privilege.
 
 *Impact* +
 Accessing system indices directly results in warnings in the header of API 
-responses. Use {kib} or the associated feature's {es} APIs to manage the data 
-that you want to access. While it's still possible to access system indices in
-{es} 7.16, they are reserved only for internal use by Elastic products and
-should not be accessed directly.
+responses and in the deprecation logs. Use {kib} or the associated feature's
+{es} APIs to manage the data that you want to access. While it's still possible 
+to access system indices in {es} 7.16, they are reserved only for internal use
+by Elastic products and should not be accessed directly.
 ====
 
 [discrete]


### PR DESCRIPTION
If an application or API directly accesses system indices, we generate warnings in the deprecation log as indicated in #79633. This PR adds a deprecation notice to the migration docs so that we can inform users of this change and link to additional docs for guidance.

#80028 will add a deprecation message to the 8.0 migration guide.

Preview link: https://elasticsearch_80095.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/migrating-7.16.html#breaking_716_indices_deprecations

Relates to #79679