### PR TITLE
Fix Snapshot BwC Version for WRITER_UUIDs

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -127,8 +127,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static final Version UUIDS_IN_REPO_DATA_VERSION = Version.V_7_12_0;
 
-    // TODO: Update to 7.16 after backporting
-    public static final Version FILE_INFO_WRITER_UUIDS_IN_SHARD_DATA_VERSION = Version.CURRENT;
+    public static final Version FILE_INFO_WRITER_UUIDS_IN_SHARD_DATA_VERSION = Version.V_7_16_0;
 
     public static final Version OLD_SNAPSHOT_FORMAT = Version.V_7_5_0;
 


### PR DESCRIPTION
This was backported as asked for by the TODO, so adjusting the version
to make sure we're not regressing on the metadata version needlessly
when moving from 7.16 to 8.
