### PR TITLE
Evaluate wrapped proxy request for compression

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -281,8 +281,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             // compressed.
             final boolean shouldCompress = compress == Compression.Enabled.TRUE
                 || (compress == Compression.Enabled.INDEXING_DATA
-                && request instanceof RawIndexingDataTransportRequest
-                && ((RawIndexingDataTransportRequest) request).isRawIndexingData());
+                    && request instanceof RawIndexingDataTransportRequest
+                    && ((RawIndexingDataTransportRequest) request).isRawIndexingData());
             return shouldCompress ? compressionScheme : null;
         }
 

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -262,15 +262,28 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             TcpChannel channel = channel(options.type());
+
+            // In this is a proxy request, determine whether we want to compress based on the wrapped request
+            final TransportRequest wrapped;
+            if (request instanceof TransportActionProxy.ProxyRequest) {
+                wrapped = ((TransportActionProxy.ProxyRequest<?>) request).wrapped;
+            } else {
+                wrapped = request;
+            }
+
+            final Compression.Scheme schemeToUse = getCompressionScheme(wrapped);
+            outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), schemeToUse, false);
+        }
+
+        private Compression.Scheme getCompressionScheme(TransportRequest request) {
             // We compress if total transport compression is enabled or if indexing_data transport compression
             // is enabled and the request is a RawIndexingDataTransportRequest which indicates it should be
             // compressed.
             final boolean shouldCompress = compress == Compression.Enabled.TRUE
                 || (compress == Compression.Enabled.INDEXING_DATA
-                    && request instanceof RawIndexingDataTransportRequest
-                    && ((RawIndexingDataTransportRequest) request).isRawIndexingData());
-            final Compression.Scheme schemeToUse = shouldCompress ? compressionScheme : null;
-            outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), schemeToUse, false);
+                && request instanceof RawIndexingDataTransportRequest
+                && ((RawIndexingDataTransportRequest) request).isRawIndexingData());
+            return shouldCompress ? compressionScheme : null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -111,7 +111,7 @@ public final class TransportActionProxy {
         }
     }
 
-    static class ProxyRequest<T extends TransportRequest> extends TransportRequest implements RawIndexingDataTransportRequest {
+    static class ProxyRequest<T extends TransportRequest> extends TransportRequest {
         final T wrapped;
         final DiscoveryNode targetNode;
 
@@ -132,14 +132,6 @@ public final class TransportActionProxy {
             super.writeTo(out);
             targetNode.writeTo(out);
             wrapped.writeTo(out);
-        }
-
-        @Override
-        public boolean isRawIndexingData() {
-            if (wrapped instanceof RawIndexingDataTransportRequest) {
-                return ((RawIndexingDataTransportRequest) wrapped).isRawIndexingData();
-            }
-            return false;
         }
     }
 


### PR DESCRIPTION
Currently there are certain types of requests which are compressed at
the wire. When these requests are proxied, we have had proxy request
implement the relevant interface. However, as we expand this type of
logic, it makes sense to unwrap the request and evaluate it directly.