### PR TITLE
[8.0] Mute RestSqlIT::testAsyncTextPaginated (#80126)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -1276,6 +1276,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/80089")
     public void testAsyncTextPaginated() throws IOException, InterruptedException {
         final Map<String, String> acceptMap = new HashMap<>() {
             {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Mute RestSqlIT::testAsyncTextPaginated (#80126)