### PR TITLE
[8.0] [ML] removing allow_no_[datafeeds|jobs] from v8 APIs (#80048)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -37,12 +37,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
-        "deprecated":true
-      },
       "format":{
         "type":"string",
         "description":"a short version of the Accept header, e.g. json, yaml"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -37,12 +37,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-        "deprecated":true
-      },
       "bytes":{
         "type":"enum",
         "description":"The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
@@ -32,12 +32,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-        "deprecated":true
-      },
       "force":{
         "type":"boolean",
         "required":false,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -36,12 +36,6 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
-      },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
-        "deprecated":true
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -37,12 +37,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
-        "deprecated":true
-      },
       "exclude_generated": {
         "required": false,
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -36,12 +36,6 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-        "deprecated":true
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
@@ -37,12 +37,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-        "deprecated":true
-      },
       "exclude_generated": {
         "required": false,
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -55,11 +55,6 @@
       "allow_no_match":{
         "type":"boolean",
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-        "deprecated":true
       }
     },
     "body":{

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
@@ -21,6 +21,10 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class MachineLearningField {
+
+    public static final String DEPRECATED_ALLOW_NO_JOBS_PARAM = "allow_no_jobs";
+    public static final String DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM = "allow_no_datafeeds";
+
     public static final Setting<Boolean> AUTODETECT_PROCESS = Setting.boolSetting(
         "xpack.ml.autodetect_process",
         true,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
@@ -33,8 +33,6 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        @Deprecated
-        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String datafeedId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -54,8 +54,6 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        @Deprecated
-        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String datafeedId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
@@ -31,8 +31,6 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        @Deprecated
-        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String jobId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
@@ -58,8 +58,6 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
 
     public static class Request extends BaseTasksRequest<Request> {
 
-        @Deprecated
-        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String jobId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -26,6 +27,10 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Objects;
+
+import static org.elasticsearch.core.RestApiVersion.equalTo;
+import static org.elasticsearch.core.RestApiVersion.onOrAfter;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM;
 
 public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> {
 
@@ -41,9 +46,9 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
 
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField FORCE = new ParseField("force");
-        @Deprecated
-        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
-        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match", ALLOW_NO_DATAFEEDS);
+        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match").forRestApiVersion(onOrAfter(RestApiVersion.V_8));
+        public static final ParseField ALLOW_NO_MATCH_V7 = new ParseField("allow_no_match", DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM)
+            .forRestApiVersion(equalTo(RestApiVersion.V_7));
 
         public static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
         static {
@@ -54,6 +59,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             );
             PARSER.declareBoolean(Request::setForce, FORCE);
             PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
+            PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH_V7);
         }
 
         public static Request fromXContent(XContentParser parser) {
@@ -167,7 +173,11 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
             builder.field(TIMEOUT.getPreferredName(), stopTimeout.getStringRep());
             builder.field(FORCE.getPreferredName(), force);
-            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
+            if (builder.getRestApiVersion() == RestApiVersion.V_7) {
+                builder.field(DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM, allowNoMatch);
+            } else {
+                builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
+            }
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestCompatibilityChecker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestCompatibilityChecker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.rest;
+
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.rest.RestRequest;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+public final class RestCompatibilityChecker {
+
+    private RestCompatibilityChecker() {}
+
+    public static <T> void checkAndSetDeprecatedParam(
+        String deprecatedParam,
+        String newParam,
+        RestApiVersion compatVersion,
+        RestRequest restRequest,
+        BiFunction<RestRequest, String, T> extractor,
+        Consumer<T> setter
+    ) {
+        final T paramValue;
+        if (restRequest.getRestApiVersion() == compatVersion && restRequest.hasParam(deprecatedParam)) {
+            LoggingDeprecationHandler.INSTANCE.logRenamedField(null, () -> null, deprecatedParam, newParam, true);
+            paramValue = extractor.apply(restRequest, deprecatedParam);
+        } else {
+            paramValue = extractor.apply(restRequest, newParam);
+        }
+        setter.accept(paramValue);
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -21,8 +20,10 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestGetDatafeedStatsAction extends BaseRestHandler {
 
@@ -50,14 +51,13 @@ public class RestGetDatafeedStatsAction extends BaseRestHandler {
             datafeedId = GetDatafeedsStatsAction.ALL;
         }
         Request request = new Request(datafeedId);
-        if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
-            LoggingDeprecationHandler.INSTANCE.logRenamedField(null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH);
-        }
-        request.setAllowNoMatch(
-            restRequest.paramAsBoolean(
-                Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())
-            )
+        checkAndSetDeprecatedParam(
+            DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM,
+            Request.ALLOW_NO_MATCH,
+            RestApiVersion.V_7,
+            restRequest,
+            (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+            request::setAllowNoMatch
         );
         return channel -> client.execute(GetDatafeedsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
@@ -7,13 +7,13 @@
 package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction.Request;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 
 import java.io.IOException;
@@ -22,9 +22,11 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM;
 import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestGetDatafeedsAction extends BaseRestHandler {
 
@@ -50,14 +52,13 @@ public class RestGetDatafeedsAction extends BaseRestHandler {
             datafeedId = GetDatafeedsAction.ALL;
         }
         Request request = new Request(datafeedId);
-        if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
-            LoggingDeprecationHandler.INSTANCE.logRenamedField(null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH);
-        }
-        request.setAllowNoMatch(
-            restRequest.paramAsBoolean(
-                Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())
-            )
+        checkAndSetDeprecatedParam(
+            DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM,
+            GetDatafeedsStatsAction.Request.ALLOW_NO_MATCH,
+            RestApiVersion.V_7,
+            restRequest,
+            (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+            request::setAllowNoMatch
         );
         return channel -> client.execute(GetDatafeedsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -27,8 +26,10 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestStopDatafeedAction extends BaseRestHandler {
 
@@ -62,19 +63,13 @@ public class RestStopDatafeedAction extends BaseRestHandler {
             if (restRequest.hasParam(Request.FORCE.getPreferredName())) {
                 request.setForce(restRequest.paramAsBoolean(Request.FORCE.getPreferredName(), request.isForce()));
             }
-            if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
-                LoggingDeprecationHandler.INSTANCE.logRenamedField(
-                    null,
-                    () -> null,
-                    Request.ALLOW_NO_DATAFEEDS,
-                    Request.ALLOW_NO_MATCH.getPreferredName()
-                );
-            }
-            request.setAllowNoMatch(
-                restRequest.paramAsBoolean(
-                    Request.ALLOW_NO_MATCH.getPreferredName(),
-                    restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())
-                )
+            checkAndSetDeprecatedParam(
+                DEPRECATED_ALLOW_NO_DATAFEEDS_PARAM,
+                Request.ALLOW_NO_MATCH.getPreferredName(),
+                RestApiVersion.V_7,
+                restRequest,
+                (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+                request::setAllowNoMatch
             );
         }
         return channel -> client.execute(StopDatafeedAction.INSTANCE, request, new RestBuilderListener<Response>(channel) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.rest.job;
 
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -21,8 +20,10 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_JOBS_PARAM;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestCloseJobAction extends BaseRestHandler {
 
@@ -55,19 +56,13 @@ public class RestCloseJobAction extends BaseRestHandler {
             if (restRequest.hasParam(Request.FORCE.getPreferredName())) {
                 request.setForce(restRequest.paramAsBoolean(Request.FORCE.getPreferredName(), request.isForce()));
             }
-            if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
-                LoggingDeprecationHandler.INSTANCE.logRenamedField(
-                    null,
-                    () -> null,
-                    Request.ALLOW_NO_JOBS,
-                    Request.ALLOW_NO_MATCH.getPreferredName()
-                );
-            }
-            request.setAllowNoMatch(
-                restRequest.paramAsBoolean(
-                    Request.ALLOW_NO_MATCH.getPreferredName(),
-                    restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())
-                )
+            checkAndSetDeprecatedParam(
+                DEPRECATED_ALLOW_NO_JOBS_PARAM,
+                Request.ALLOW_NO_MATCH.getPreferredName(),
+                RestApiVersion.V_7,
+                restRequest,
+                (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+                request::setAllowNoMatch
             );
         }
         return channel -> client.execute(CloseJobAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.rest.job;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -22,8 +21,10 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_JOBS_PARAM;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestGetJobStatsAction extends BaseRestHandler {
 
@@ -51,11 +52,13 @@ public class RestGetJobStatsAction extends BaseRestHandler {
             jobId = Metadata.ALL;
         }
         Request request = new Request(jobId);
-        if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
-            LoggingDeprecationHandler.INSTANCE.logRenamedField(null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH);
-        }
-        request.setAllowNoMatch(
-            restRequest.paramAsBoolean(Request.ALLOW_NO_MATCH, restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch()))
+        checkAndSetDeprecatedParam(
+            DEPRECATED_ALLOW_NO_JOBS_PARAM,
+            Request.ALLOW_NO_MATCH,
+            RestApiVersion.V_7,
+            restRequest,
+            (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+            request::setAllowNoMatch
         );
         return channel -> client.execute(GetJobsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.rest.job;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -24,9 +23,11 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_JOBS_PARAM;
 import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestGetJobsAction extends BaseRestHandler {
 
@@ -54,11 +55,13 @@ public class RestGetJobsAction extends BaseRestHandler {
             jobId = Metadata.ALL;
         }
         Request request = new Request(jobId);
-        if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
-            LoggingDeprecationHandler.INSTANCE.logRenamedField(null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH);
-        }
-        request.setAllowNoMatch(
-            restRequest.paramAsBoolean(Request.ALLOW_NO_MATCH, restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch()))
+        checkAndSetDeprecatedParam(
+            DEPRECATED_ALLOW_NO_JOBS_PARAM,
+            Request.ALLOW_NO_MATCH,
+            RestApiVersion.V_7,
+            restRequest,
+            (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+            request::setAllowNoMatch
         );
         return channel -> client.execute(GetJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.rest.results;
 
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -22,8 +21,10 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.DEPRECATED_ALLOW_NO_JOBS_PARAM;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 import static org.elasticsearch.xpack.ml.MachineLearning.PRE_V7_BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.RestCompatibilityChecker.checkAndSetDeprecatedParam;
 
 public class RestGetOverallBucketsAction extends BaseRestHandler {
 
@@ -65,19 +66,13 @@ public class RestGetOverallBucketsAction extends BaseRestHandler {
             if (restRequest.hasParam(Request.END.getPreferredName())) {
                 request.setEnd(restRequest.param(Request.END.getPreferredName()));
             }
-            if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
-                LoggingDeprecationHandler.INSTANCE.logRenamedField(
-                    null,
-                    () -> null,
-                    Request.ALLOW_NO_JOBS,
-                    Request.ALLOW_NO_MATCH.getPreferredName()
-                );
-            }
-            request.setAllowNoMatch(
-                restRequest.paramAsBoolean(
-                    Request.ALLOW_NO_MATCH.getPreferredName(),
-                    restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())
-                )
+            checkAndSetDeprecatedParam(
+                DEPRECATED_ALLOW_NO_JOBS_PARAM,
+                Request.ALLOW_NO_MATCH.getPreferredName(),
+                RestApiVersion.V_7,
+                restRequest,
+                (r, s) -> r.paramAsBoolean(s, request.allowNoMatch()),
+                request::setAllowNoMatch
             );
         }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -65,15 +65,6 @@ setup:
   - match: { count: 0 }
   - match: { datafeeds: [] }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      ml.get_datafeeds:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: true
-  - match: { count: 0 }
-  - match: { datafeeds: [] }
-
 ---
 "Test get datafeed with expression that does not match and not allow_no_match":
   - skip:
@@ -85,14 +76,6 @@ setup:
       ml.get_datafeeds:
         datafeed_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.get_datafeeds:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: false
 
 ---
 "Test put datafeed referring to missing job_id":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -114,15 +114,6 @@ setup:
   - match: { count: 0 }
   - match: { datafeeds: [] }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      ml.get_datafeed_stats:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: true
-  - match: { count: 0 }
-  - match: { datafeeds: [] }
-
 ---
 "Test get datafeed stats with expression that does not match and not allow_no_match":
   - skip:
@@ -134,14 +125,6 @@ setup:
       ml.get_datafeed_stats:
         datafeed_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.get_datafeed_stats:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: false
 
 ---
 "Test get single datafeed stats":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -26,15 +26,6 @@
   - match: { count: 0 }
   - match: { jobs: [] }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      ml.get_jobs:
-        job_id: "missing-*"
-        allow_no_jobs: true
-  - match: { count: 0 }
-  - match: { jobs: [] }
-
 ---
 "Test get jobs with expression that does not match and not allow_no_match":
   - skip:
@@ -46,14 +37,6 @@
       ml.get_jobs:
         job_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.get_jobs:
-        job_id: "missing-*"
-        allow_no_jobs: false
 
 ---
 "Test job crud apis":
@@ -872,14 +855,6 @@
         allow_no_match: true
   - match: { closed: true }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      ml.close_job:
-        job_id: "missing-*"
-        allow_no_jobs: true
-  - match: { closed: true }
-
 ---
 "Test close jobs with expression that does not match and not allow_no_match":
   - skip:
@@ -890,14 +865,6 @@
       ml.close_job:
         job_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.close_job:
-        job_id: "missing-*"
-        allow_no_jobs: false
 
 ---
 "Test force close job":
@@ -1529,25 +1496,4 @@
         body:  >
           {
             "allow_no_match" : true
-          }
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.close_job:
-        job_id: job-that-doesnot-exist*
-        body:  >
-          {
-            "allow_no_jobs" : false
-          }
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      ml.close_job:
-        job_id: job-that-doesnot-exist*
-        body:  >
-          {
-            "allow_no_jobs" : true
           }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -250,14 +250,6 @@ setup:
         job_id: "none-matching-*"
         allow_no_match: false
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.get_overall_buckets:
-        job_id: "none-matching-*"
-        allow_no_jobs: false
-
 ---
 "Test overall buckets given top_n is 0":
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -229,14 +229,6 @@ setup:
         allow_no_match: true
   - match: { count: 0 }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      ml.get_job_stats:
-        job_id: "missing-*"
-        allow_no_jobs: true
-  - match: { count: 0 }
-
 ---
 "Test get job stats given pattern and not allow_no_match":
   - skip:
@@ -248,14 +240,6 @@ setup:
       ml.get_job_stats:
         job_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.get_job_stats:
-        job_id: "missing-*"
-        allow_no_jobs: false
 
 ---
 "Test reading v54 data counts and model size stats":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
@@ -251,14 +251,6 @@ setup:
         allow_no_match: true
   - match: { stopped: true }
 
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      ml.stop_datafeed:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: true
-  - match: { stopped: true }
-
 ---
 "Test stop with expression that does not match and not allow_no_match":
   - skip:
@@ -270,14 +262,6 @@ setup:
       ml.stop_datafeed:
         datafeed_id: "missing-*"
         allow_no_match: false
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.stop_datafeed:
-        datafeed_id: "missing-*"
-        allow_no_datafeeds: false
 
 ---
 "Test stop with body params":
@@ -300,27 +284,6 @@ setup:
         body:  >
           {
             "allow_no_match" : true
-          }
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      catch: missing
-      ml.stop_datafeed:
-        datafeed_id: missing-*
-        body:  >
-          {
-            "allow_no_datafeeds" : false
-          }
-
-  - do:
-      warnings:
-        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
-      ml.stop_datafeed:
-        datafeed_id: missing-*
-        body:  >
-          {
-            "allow_no_datafeeds" : true
           }
 
 ---


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] removing allow_no_[datafeeds|jobs] from v8 APIs (#80048)