### PR TITLE
[ML] reduce the logging spam for the ml initializer for annotation index creation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -10,7 +10,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -10,6 +10,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -54,6 +55,7 @@ public class MlInitializationService implements ClusterStateListener {
     private final ThreadPool threadPool;
     private final AtomicBoolean isIndexCreationInProgress = new AtomicBoolean(false);
     private final AtomicBoolean mlInternalIndicesHidden = new AtomicBoolean(false);
+    private volatile String previousException;
 
     private final MlDailyMaintenanceService mlDailyMaintenanceService;
 
@@ -143,8 +145,13 @@ public class MlInitializationService implements ClusterStateListener {
                 event.state(),
                 MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT,
                 ActionListener.wrap(r -> isIndexCreationInProgress.set(false), e -> {
+                    if (e.getMessage().equals(previousException)) {
+                        logger.debug("Error creating ML annotations index or aliases", e);
+                    } else {
+                        previousException = e.getMessage();
+                        logger.error("Error creating ML annotations index or aliases", e);
+                    }
                     isIndexCreationInProgress.set(false);
-                    logger.error("Error creating ML annotations index or aliases", e);
                 })
             );
         }


### PR DESCRIPTION
It is possible that the annotation index is in an unsupported state. Consequently, the same exception is thrown whenever the MlInitializationService attempts to create the index.

Logging all those failures at the `error` level doesn't make sense. This commit only logs the first seen (of duplicate errors) as `error` and the rest of `debug`.

Whenever the error changes, it is logged.

closes https://github.com/elastic/elasticsearch/issues/65217