### PR TITLE
[DOCS] Adds breaking change for allow_no_datafeeds and allow_no_jobs

### DIFF
--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -101,4 +101,33 @@ status code when the request is attempting to modify an existing repository that
 *Impact* +
 Update client code that handles creation and deletion of repositories to reflect this change.
 ====
+
+. The `allow_no_datafeeds` property has been removed from {ml} APIs.
+[%collapsible]
+====
+*Details* +
+The `allow_no_datafeeds` property was deprecated in the
+{ref}/cat-datafeeds.html[cat {dfeeds}],
+{ref}/ml-get-datafeed.html[get {dfeeds}],
+{ref}/ml-get-datafeed-stats.html[get {dfeed} statistics], and
+{ref}/ml-stop-datafeed.html[stop {dfeeds}] APIs in 7.9.0.
+
+*Impact* +
+Use `allow_no_match` instead.
+====
+
+. The `allow_no_jobs` property has been removed from {ml} APIs.
+[%collapsible]
+====
+*Details* +
+The `allow_no_jobs` property was deprecated in the
+{ref}/cat-anomaly-detectors.html[cat anomaly detectors],
+{ref}/ml-close-job.html[close {anomaly-jobs}],
+{ref}/ml-get-job.html[get {anomaly-jobs}],
+{ref}/ml-get-job-stats.html[get {anomaly-job} statistics], and
+{ref}/ml-get-overall-buckets.html[get overall buckets] APIs in 7.9.0.
+
+*Impact* +
+Use `allow_no_match` instead.
+====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -102,7 +102,7 @@ status code when the request is attempting to modify an existing repository that
 Update client code that handles creation and deletion of repositories to reflect this change.
 ====
 
-. The `allow_no_datafeeds` property has been removed from {ml} APIs.
+.The `allow_no_datafeeds` property has been removed from {ml} APIs.
 [%collapsible]
 ====
 *Details* +
@@ -116,7 +116,7 @@ The `allow_no_datafeeds` property was deprecated in the
 Use `allow_no_match` instead.
 ====
 
-. The `allow_no_jobs` property has been removed from {ml} APIs.
+.The `allow_no_jobs` property has been removed from {ml} APIs.
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/60732

This PR updates the breaking changes in https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_api_changes

### Preview

https://elasticsearch_80155.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_api_changes