### PR TITLE
Update transient settings deprecation message

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -60,7 +60,7 @@ PUT /_cluster/settings?flat_settings=true
   }
 }
 --------------------------------------------------
-// TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
+// TEST[warning:[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings.]
 
 The response to an update returns the changed setting, as in this response to
 the transient example:
@@ -89,7 +89,7 @@ PUT /_cluster/settings
   }
 }
 --------------------------------------------------
-// TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
+// TEST[warning:[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings.]
 
 
 The response does not include settings that have been reset:
@@ -117,4 +117,4 @@ PUT /_cluster/settings
   }
 }
 --------------------------------------------------
-// TEST[warning:[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.]
+// TEST[warning:[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings.]

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -82,6 +82,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/20_terms/string profiler via map", "The profiler results aren't backwards compatible.")
   task.skipTest("search.aggregation/20_terms/numeric profiler", "The profiler results aren't backwards compatible.")
   task.skipTest("migration/10_get_feature_upgrade_status/Get feature upgrade status", "Awaits backport")
+  task.skipTest("cluster.put_settings/10_basic/Test put and reset transient settings", "Awaits backport")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -7,7 +7,7 @@
 
   - do:
       warnings:
-        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
+        - "[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings."
       cluster.put_settings:
         body:
           transient:
@@ -24,7 +24,7 @@
 
   - do:
       warnings:
-        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
+        - "[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings."
       cluster.put_settings:
         body:
           transient:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -3,11 +3,12 @@
   - skip:
       version: " - 7.15.99"
       reason:  "transient settings deprecation"
-      features: "warnings"
+      features: "allowed_warnings"
 
   - do:
-      warnings:
+      allowed_warnings:
         - "[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings."
+        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
       cluster.put_settings:
         body:
           transient:
@@ -23,8 +24,9 @@
   - match: {transient: {cluster.routing.allocation.enable: "none"}}
 
   - do:
-      warnings:
+      allowed_warnings:
         - "[transient settings removal] Updating cluster settings through transient settings is deprecated. Some Elastic products may make use of transient settings and those should not be changed. Any custom use of transient settings should be replaced by persistent settings."
+        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
       cluster.put_settings:
         body:
           transient:

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
@@ -28,8 +28,9 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestClusterUpdateSettingsAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestClusterUpdateSettingsAction.class);
-    static final String TRANSIENT_SETTINGS_DEPRECATION_MESSAGE = "[transient settings removal]"
-        + " Updating cluster settings through transientSettings is deprecated. Use persistent settings instead.";
+    static final String TRANSIENT_SETTINGS_DEPRECATION_MESSAGE = "[transient settings removal] Updating cluster settings "
+        + "through transient settings is deprecated. Some Elastic products may make use of transient settings and those "
+        + "should not be changed. Any custom use of transient settings should be replaced by persistent settings.";
 
     private static final String PERSISTENT = "persistent";
     private static final String TRANSIENT = "transient";

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -17,7 +17,9 @@ public class ClusterDeprecationChecks {
                 DeprecationIssue.Level.WARNING,
                 "Transient cluster settings are deprecated",
                 "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                "Use persistent settings to configure your cluster.",
+                "Use of transient settings is deprecated. Some Elastic products " +
+                    "may make use of transient settings and those should not be changed. " +
+                    "Any custom use of transient settings should be replaced by persistent settings.",
                 false,
                 null
             );

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -17,9 +17,9 @@ public class ClusterDeprecationChecks {
                 DeprecationIssue.Level.WARNING,
                 "Transient cluster settings are deprecated",
                 "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                "Use of transient settings is deprecated. Some Elastic products " +
-                    "may make use of transient settings and those should not be changed. " +
-                    "Any custom use of transient settings should be replaced by persistent settings.",
+                "Use of transient settings is deprecated. Some Elastic products "
+                    + "may make use of transient settings and those should not be changed. "
+                    + "Any custom use of transient settings should be replaced by persistent settings.",
                 false,
                 null
             );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -39,9 +39,9 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
                     DeprecationIssue.Level.WARNING,
                     "Transient cluster settings are deprecated",
                     "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                    "Use of transient settings is deprecated. Some Elastic products " +
-                        "may make use of transient settings and those should not be changed. " +
-                        "Any custom use of transient settings should be replaced by persistent settings.",
+                    "Use of transient settings is deprecated. Some Elastic products "
+                        + "may make use of transient settings and those should not be changed. "
+                        + "Any custom use of transient settings should be replaced by persistent settings.",
                     false,
                     null
                 )

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -39,7 +39,9 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
                     DeprecationIssue.Level.WARNING,
                     "Transient cluster settings are deprecated",
                     "https://ela.st/es-deprecation-7-transient-cluster-settings",
-                    "Use persistent settings to configure your cluster.",
+                    "Use of transient settings is deprecated. Some Elastic products " +
+                        "may make use of transient settings and those should not be changed. " +
+                        "Any custom use of transient settings should be replaced by persistent settings.",
                     false,
                     null
                 )


### PR DESCRIPTION
This PR updates the transient settings deprecation message to clarify
that the appearance of deprecations warnings that might be caused
by Elastic products.

Relates to https://github.com/elastic/elasticsearch/pull/78794

Closes https://github.com/elastic/elasticsearch/issues/79953