### PR TITLE
Possible source of leaked delayable writables 

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -260,9 +260,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
             // Clean up any delayed aggregations we haven't processed (because there was an error).
             Releasables.close(
-                (Iterable<DelayableWriteable<InternalAggregations>>) (() -> buffer.stream()
-                    .map(QuerySearchResult::aggregations)
-                    .iterator())
+                (Iterable<DelayableWriteable<InternalAggregations>>) (() -> buffer.stream().map(QuerySearchResult::aggregations).iterator())
             );
 
             if (hasPendingMerges()) {

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -258,14 +258,14 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                     assert circuitBreakerBytes == 0;
                     return;
                 }
-                assert circuitBreakerBytes >= 0;
-                circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
-                circuitBreakerBytes = 0;
             } finally {
                 // Clean up any delayed aggregations we haven't processed.
                 Releasables.close(
                     buffer.stream().filter(b -> b.aggregations() != null).map(b -> b.aggregations()).collect(Collectors.toList())
                 );
+                assert circuitBreakerBytes >= 0;
+                circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+                circuitBreakerBytes = 0;
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.search.SearchPhaseController.getTopDocsSize;
 import static org.elasticsearch.action.search.SearchPhaseController.mergeTopDocs;

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -264,7 +264,9 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
             } finally {
                 // Clean up any delayed aggregations we haven't processed.
                 Releasables.close(
-                    buffer.stream().filter(b -> b.aggregations() != null).map(b -> b.aggregations()).collect(Collectors.toList())
+                    (Iterable<DelayableWriteable<InternalAggregations>>) (() -> buffer.stream()
+                        .map(QuerySearchResult::aggregations)
+                        .iterator())
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -377,7 +377,9 @@ public final class QuerySearchResult extends SearchPhaseResult {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         // we do not know that it is being sent over transport, but this at least protects all writes from happening, including sending.
-        assert aggregations == null || aggregations.isSerialized() == false : "cannot send serialized version since it will leak";
+        if (aggregations != null && aggregations.isSerialized()) {
+            throw new IllegalStateException("cannot send serialized version since it will leak");
+        }
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeBoolean(isNull);
         }

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -461,8 +461,11 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         request.setWaitForCompletionTimeout(TimeValue.timeValueMinutes(10));
         request.getSearchRequest().allowPartialSearchResults(false);
         request.getSearchRequest()
-            .source(new SearchSourceBuilder().query(new ThrowingQueryBuilder(randomLong(), new AlreadyClosedException("boom"),
-                between(0, numShards - 1))));
+            .source(
+                new SearchSourceBuilder().query(
+                    new ThrowingQueryBuilder(randomLong(), new AlreadyClosedException("boom"), between(0, numShards - 1))
+                )
+            );
         request.getSearchRequest().source().aggregation(terms("f").field("f").size(between(1, 10)));
 
         AsyncSearchResponse response = submitAsyncSearch(request);

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.search.SearchService.MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -446,6 +447,24 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         request.getSearchRequest().allowPartialSearchResults(false);
         request.getSearchRequest()
             .source(new SearchSourceBuilder().query(new ThrowingQueryBuilder(randomLong(), new AlreadyClosedException("boom"), 0)));
+        AsyncSearchResponse response = submitAsyncSearch(request);
+        assertFalse(response.isRunning());
+        assertTrue(response.isPartial());
+        assertThat(response.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
+        assertNotNull(response.getFailure());
+        ensureTaskNotRunning(response.getId());
+    }
+
+    public void testSearchPhaseFailureLeak() throws Exception {
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(indexName);
+        request.setKeepOnCompletion(true);
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMinutes(10));
+        request.getSearchRequest().allowPartialSearchResults(false);
+        request.getSearchRequest()
+            .source(new SearchSourceBuilder().query(new ThrowingQueryBuilder(randomLong(), new AlreadyClosedException("boom"),
+                between(0, numShards - 1))));
+        request.getSearchRequest().source().aggregation(terms("f").field("f").size(between(1, 10)));
+
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertFalse(response.isRunning());
         assertTrue(response.isPartial());


### PR DESCRIPTION
In a couple of error paths, it's possible that `QueryPhaseResultsConsumer#PendingMerges` might not have consumed all the aggregations it's trying to merge.  It is never the less important to release those aggregations so that we don't leak memory or hold references to them.  This PR achieves that by using the `Releasables.close()` mechanism, which will execute each close action, even if earlier actions had exceptions.  This ensures that all of the aggregations get released and that the circuit breaker gets cleaned up.


ORIGINAL DESCRIPTION:
@DaveCTurner So, I haven't written a test for it yet, but I saw a path that might cause the leak we were looking for.  In `QueryPhaseResultConsumer`, we iterate all the `QuerySearchResult` instances and call `consumeAggs` on them.  But, `consumeAggs` can throw an unchecked exception if the aggregation fails to deserialize correctly (which definitely can happen, especially with pipeline aggs).  In that case, any unconsumed aggs would leak, I think.

While I was touching it, I turned a couple of related `asserts` into `exceptions`.  I don't think either is expensive to evaluate, and I'd rather know we don't do that in production than know we didn't write a test case that does that.

/cc @nik9000 