### PR TITLE
Add plumbing so each mapped typed can be converted to a script in

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -41,6 +42,7 @@ import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField.ToScaledFloatField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -262,7 +264,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             return (cache, breakerService) -> {
                 final IndexNumericFieldData scaledValues = new SortedNumericIndexFieldData.Builder(
                     name(),
-                    IndexNumericFieldData.NumericType.LONG
+                    NumericType.LONG,
+                    ToScaledFloatField.INSTANCE
                 ).build(cache, breakerService);
                 return new ScaledFloatIndexFieldData(scaledValues, scalingFactor);
             };

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToParentIdScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -69,7 +70,7 @@ public final class ParentIdFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, ToParentIdScriptField.INSTANCE);
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToParentJoinScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -160,7 +161,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, ToParentJoinScriptField.INSTANCE);
         }
 
         @Override

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.TestDocumentParserContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.script.field.BinaryDocValuesField.ToBinaryScriptField;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.test.ESTestCase;
@@ -77,7 +78,7 @@ public class QueryBuilderStoreTests extends ESTestCase {
             when(searchExecutionContext.getWriteableRegistry()).thenReturn(writableRegistry());
             when(searchExecutionContext.getXContentRegistry()).thenReturn(xContentRegistry());
             when(searchExecutionContext.getForField(fieldMapper.fieldType())).thenReturn(
-                new BytesBinaryIndexFieldData(fieldMapper.name(), CoreValuesSourceType.KEYWORD)
+                new BytesBinaryIndexFieldData(fieldMapper.name(), CoreValuesSourceType.KEYWORD, ToBinaryScriptField.INSTANCE)
             );
             when(searchExecutionContext.getFieldType(Mockito.anyString())).thenAnswer(invocation -> {
                 final String fieldName = (String) invocation.getArguments()[0];

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.mapper.TextParams;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToICUCollationKeywordScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -107,7 +108,11 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(
+                name(),
+                CoreValuesSourceType.KEYWORD,
+                ToICUCollationKeywordScriptField.INSTANCE
+            );
         }
 
         @Override

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToMurmur3ScriptField;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -90,7 +91,7 @@ public class Murmur3FieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG);
+            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG, ToMurmur3ScriptField.INSTANCE);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/DateScriptFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/DateScriptFieldData.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.index.fielddata.plain.LeafLongFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.DateFieldScript;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
@@ -22,24 +23,28 @@ public final class DateScriptFieldData extends IndexNumericFieldData {
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final DateFieldScript.LeafFactory leafFactory;
+        private final ToScriptField toScriptField;
 
-        public Builder(String name, DateFieldScript.LeafFactory leafFactory) {
+        public Builder(String name, DateFieldScript.LeafFactory leafFactory, ToScriptField toScriptField) {
             this.name = name;
             this.leafFactory = leafFactory;
+            this.toScriptField = toScriptField;
         }
 
         @Override
         public DateScriptFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-            return new DateScriptFieldData(name, leafFactory);
+            return new DateScriptFieldData(name, leafFactory, toScriptField);
         }
     }
 
     private final String fieldName;
     private final DateFieldScript.LeafFactory leafFactory;
+    protected final ToScriptField toScriptField;
 
-    private DateScriptFieldData(String fieldName, DateFieldScript.LeafFactory leafFactory) {
+    private DateScriptFieldData(String fieldName, DateFieldScript.LeafFactory leafFactory, ToScriptField toScriptField) {
         this.fieldName = fieldName;
         this.leafFactory = leafFactory;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -63,7 +68,7 @@ public final class DateScriptFieldData extends IndexNumericFieldData {
 
     @Override
     public DateScriptLeafFieldData loadDirect(LeafReaderContext context) {
-        return new DateScriptLeafFieldData(new LongScriptDocValues(leafFactory.newInstance(context)));
+        return new DateScriptLeafFieldData(new LongScriptDocValues(leafFactory.newInstance(context)), toScriptField);
     }
 
     @Override
@@ -79,8 +84,8 @@ public final class DateScriptFieldData extends IndexNumericFieldData {
     public static class DateScriptLeafFieldData extends LeafLongFieldData {
         private final LongScriptDocValues longScriptDocValues;
 
-        DateScriptLeafFieldData(LongScriptDocValues longScriptDocValues) {
-            super(0, NumericType.DATE);
+        DateScriptLeafFieldData(LongScriptDocValues longScriptDocValues, ToScriptField toScriptField) {
+            super(0, toScriptField);
             this.longScriptDocValues = longScriptDocValues;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/DoubleScriptFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/DoubleScriptFieldData.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.index.fielddata.plain.LeafDoubleFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
@@ -21,24 +22,28 @@ public final class DoubleScriptFieldData extends IndexNumericFieldData {
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final DoubleFieldScript.LeafFactory leafFactory;
+        private final ToScriptField toScriptField;
 
-        public Builder(String name, DoubleFieldScript.LeafFactory leafFactory) {
+        public Builder(String name, DoubleFieldScript.LeafFactory leafFactory, ToScriptField toScriptField) {
             this.name = name;
             this.leafFactory = leafFactory;
+            this.toScriptField = toScriptField;
         }
 
         @Override
         public DoubleScriptFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-            return new DoubleScriptFieldData(name, leafFactory);
+            return new DoubleScriptFieldData(name, leafFactory, toScriptField);
         }
     }
 
     private final String fieldName;
     DoubleFieldScript.LeafFactory leafFactory;
+    protected ToScriptField toScriptField;
 
-    private DoubleScriptFieldData(String fieldName, DoubleFieldScript.LeafFactory leafFactory) {
+    private DoubleScriptFieldData(String fieldName, DoubleFieldScript.LeafFactory leafFactory, ToScriptField toScriptField) {
         this.fieldName = fieldName;
         this.leafFactory = leafFactory;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -62,7 +67,7 @@ public final class DoubleScriptFieldData extends IndexNumericFieldData {
 
     @Override
     public DoubleScriptLeafFieldData loadDirect(LeafReaderContext context) {
-        return new DoubleScriptLeafFieldData(new DoubleScriptDocValues(leafFactory.newInstance(context)));
+        return new DoubleScriptLeafFieldData(new DoubleScriptDocValues(leafFactory.newInstance(context)), toScriptField);
     }
 
     @Override
@@ -78,8 +83,8 @@ public final class DoubleScriptFieldData extends IndexNumericFieldData {
     public static class DoubleScriptLeafFieldData extends LeafDoubleFieldData {
         private final DoubleScriptDocValues doubleScriptDocValues;
 
-        DoubleScriptLeafFieldData(DoubleScriptDocValues doubleScriptDocValues) {
-            super(0);
+        DoubleScriptLeafFieldData(DoubleScriptDocValues doubleScriptDocValues, ToScriptField toScriptField) {
+            super(0, toScriptField);
             this.doubleScriptDocValues = doubleScriptDocValues;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -19,6 +19,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.N
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -38,25 +39,33 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
      * The type of number.
      */
     public enum NumericType {
-        BOOLEAN(false, SortField.Type.LONG, CoreValuesSourceType.BOOLEAN),
-        BYTE(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
-        SHORT(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
-        INT(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
-        LONG(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
-        DATE(false, SortField.Type.LONG, CoreValuesSourceType.DATE),
-        DATE_NANOSECONDS(false, SortField.Type.LONG, CoreValuesSourceType.DATE),
-        HALF_FLOAT(true, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
-        FLOAT(true, SortField.Type.FLOAT, CoreValuesSourceType.NUMERIC),
-        DOUBLE(true, SortField.Type.DOUBLE, CoreValuesSourceType.NUMERIC);
+        BOOLEAN(false, SortField.Type.LONG, CoreValuesSourceType.BOOLEAN, ToScriptField.ToBooleanScriptField.INSTANCE),
+        BYTE(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC, ToScriptField.ToByteScriptField.INSTANCE),
+        SHORT(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC, ToScriptField.ToShortScriptField.INSTANCE),
+        INT(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC, ToScriptField.ToIntScriptField.INSTANCE),
+        LONG(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC, ToScriptField.ToLongScriptField.INSTANCE),
+        DATE(false, SortField.Type.LONG, CoreValuesSourceType.DATE, ToScriptField.ToDateMillisScriptField.INSTANCE),
+        DATE_NANOSECONDS(false, SortField.Type.LONG, CoreValuesSourceType.DATE, ToScriptField.ToDateNanosScriptField.INSTANCE),
+        HALF_FLOAT(true, SortField.Type.LONG, CoreValuesSourceType.NUMERIC, ToScriptField.ToHalfFloatScriptField.INSTANCE),
+        FLOAT(true, SortField.Type.FLOAT, CoreValuesSourceType.NUMERIC, ToScriptField.ToFloatScriptField.INSTANCE),
+        DOUBLE(true, SortField.Type.DOUBLE, CoreValuesSourceType.NUMERIC, ToScriptField.ToDoubleScriptField.INSTANCE);
 
         private final boolean floatingPoint;
         private final ValuesSourceType valuesSourceType;
         private final SortField.Type sortFieldType;
+        private final ToScriptField defaultToScriptField;
 
-        NumericType(boolean floatingPoint, SortField.Type sortFieldType, ValuesSourceType valuesSourceType) {
+        NumericType(
+            boolean floatingPoint,
+            SortField.Type sortFieldType,
+            ValuesSourceType valuesSourceType,
+            ToScriptField defaultToScriptField
+        ) {
+
             this.floatingPoint = floatingPoint;
             this.sortFieldType = sortFieldType;
             this.valuesSourceType = valuesSourceType;
+            this.defaultToScriptField = defaultToScriptField;
         }
 
         public final boolean isFloatingPoint() {
@@ -65,6 +74,10 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
 
         public final ValuesSourceType getValuesSourceType() {
             return valuesSourceType;
+        }
+
+        public final ToScriptField getDefaultToScriptField() {
+            return defaultToScriptField;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -19,15 +19,15 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.script.field.ToScriptField;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * Utility class to build global ordinals.
@@ -43,7 +43,7 @@ public enum GlobalOrdinalsBuilder {
         IndexOrdinalsFieldData indexFieldData,
         CircuitBreakerService breakerService,
         Logger logger,
-        Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction
+        ToScriptField toScriptField
     ) throws IOException {
         assert indexReader.leaves().size() > 1;
         long startTimeNS = System.nanoTime();
@@ -72,7 +72,7 @@ public enum GlobalOrdinalsBuilder {
             atomicFD,
             ordinalMap,
             memorySizeInBytes,
-            scriptFunction
+            toScriptField
         );
     }
 
@@ -82,7 +82,7 @@ public enum GlobalOrdinalsBuilder {
         final LeafOrdinalsFieldData[] atomicFD = new LeafOrdinalsFieldData[indexReader.leaves().size()];
         final SortedSetDocValues[] subs = new SortedSetDocValues[indexReader.leaves().size()];
         for (int i = 0; i < indexReader.leaves().size(); ++i) {
-            atomicFD[i] = new AbstractLeafOrdinalsFieldData(AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION) {
+            atomicFD[i] = new AbstractLeafOrdinalsFieldData(ToKeywordScriptField.INSTANCE) {
                 @Override
                 public SortedSetDocValues getOrdinalsValues() {
                     return DocValues.emptySortedSet();
@@ -110,7 +110,7 @@ public enum GlobalOrdinalsBuilder {
             atomicFD,
             ordinalMap,
             0,
-            AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
+            ToKeywordScriptField.INSTANCE
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -19,8 +19,8 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 
 /**
  * Concrete implementation of {@link IndexOrdinalsFieldData} for global ordinals.
@@ -50,7 +49,7 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
 
     private final OrdinalMap ordinalMap;
     private final LeafOrdinalsFieldData[] segmentAfd;
-    private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
+    private final ToScriptField toScriptField;
 
     protected GlobalOrdinalsIndexFieldData(
         String fieldName,
@@ -58,14 +57,14 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
         LeafOrdinalsFieldData[] segmentAfd,
         OrdinalMap ordinalMap,
         long memorySizeInBytes,
-        Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction
+        ToScriptField toScriptField
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.memorySizeInBytes = memorySizeInBytes;
         this.ordinalMap = ordinalMap;
         this.segmentAfd = segmentAfd;
-        this.scriptFunction = scriptFunction;
+        this.toScriptField = toScriptField;
     }
 
     public IndexOrdinalsFieldData newConsumer(DirectoryReader source) {
@@ -228,7 +227,7 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
         @Override
         public LeafOrdinalsFieldData load(LeafReaderContext context) {
             assert source.getReaderCacheHelper().getKey() == context.parent.reader().getReaderCacheHelper().getKey();
-            return new AbstractLeafOrdinalsFieldData(scriptFunction) {
+            return new AbstractLeafOrdinalsFieldData(toScriptField) {
                 @Override
                 public SortedSetDocValues getOrdinalsValues() {
                     final SortedSetDocValues values = segmentAfd[context.ord].getOrdinalsValues();

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBinaryDVLeafFieldData.java
@@ -14,17 +14,22 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
 abstract class AbstractBinaryDVLeafFieldData implements LeafFieldData {
-    private final BinaryDocValues values;
 
-    AbstractBinaryDVLeafFieldData(BinaryDocValues values) {
+    private final BinaryDocValues values;
+    private final ToScriptField toScriptField;
+
+    AbstractBinaryDVLeafFieldData(BinaryDocValues values, ToScriptField toScriptField) {
         super();
         this.values = values;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -73,6 +78,11 @@ abstract class AbstractBinaryDVLeafFieldData implements LeafFieldData {
             }
 
         };
+    }
+
+    @Override
+    public DocValuesField<?> getScriptField(String name) {
+        return toScriptField.getScriptField(getBytesValues(), name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.OrdinalMap;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
@@ -21,14 +20,13 @@ import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.RamAccountingTermsEnum;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsIndexFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFieldData {
     private static final Logger logger = LogManager.getLogger(AbstractIndexOrdinalsFieldData.class);
@@ -37,20 +35,20 @@ public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFie
     private final ValuesSourceType valuesSourceType;
     private final IndexFieldDataCache cache;
     protected final CircuitBreakerService breakerService;
-    protected final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
+    protected final ToScriptField toScriptField;
 
     protected AbstractIndexOrdinalsFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
         IndexFieldDataCache cache,
         CircuitBreakerService breakerService,
-        Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction
+        ToScriptField toScriptField
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.cache = cache;
         this.breakerService = breakerService;
-        this.scriptFunction = scriptFunction;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -137,7 +135,7 @@ public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFie
 
     @Override
     public IndexOrdinalsFieldData loadGlobalDirect(DirectoryReader indexReader) throws Exception {
-        return GlobalOrdinalsBuilder.build(indexReader, this, breakerService, logger, scriptFunction);
+        return GlobalOrdinalsBuilder.build(indexReader, this, breakerService, logger, toScriptField);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLeafOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLeafOrdinalsFieldData.java
@@ -13,30 +13,25 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 
 public abstract class AbstractLeafOrdinalsFieldData implements LeafOrdinalsFieldData {
 
-    public static final Function<SortedSetDocValues, ScriptDocValues<?>> DEFAULT_SCRIPT_FUNCTION = ((Function<
-        SortedSetDocValues,
-        SortedBinaryDocValues>) FieldData::toString).andThen(ScriptDocValues.Strings::new);
+    private final ToScriptField toScriptField;
 
-    private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
-
-    protected AbstractLeafOrdinalsFieldData(Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) {
-        this.scriptFunction = scriptFunction;
+    protected AbstractLeafOrdinalsFieldData(ToScriptField toScriptField) {
+        this.toScriptField = toScriptField;
     }
 
     @Override
     public final DocValuesField<?> getScriptField(String name) {
-        return new DelegateDocValuesField(scriptFunction.apply(getOrdinalsValues()), name);
+        return toScriptField.getScriptField(getOrdinalsValues(), name);
     }
 
     @Override
@@ -45,7 +40,7 @@ public abstract class AbstractLeafOrdinalsFieldData implements LeafOrdinalsField
     }
 
     public static LeafOrdinalsFieldData empty() {
-        return new AbstractLeafOrdinalsFieldData(DEFAULT_SCRIPT_FUNCTION) {
+        return new AbstractLeafOrdinalsFieldData(ToKeywordScriptField.INSTANCE) {
 
             @Override
             public long ramBytesUsed() {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVLeafFieldData.java
@@ -9,16 +9,10 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.BinaryDocValues;
-import org.elasticsearch.script.field.BinaryDocValuesField;
-import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 
 final class BytesBinaryDVLeafFieldData extends AbstractBinaryDVLeafFieldData {
-    BytesBinaryDVLeafFieldData(BinaryDocValues values) {
-        super(values);
-    }
-
-    @Override
-    public DocValuesField<?> getScriptField(String name) {
-        return new BinaryDocValuesField(getBytesValues(), name);
+    BytesBinaryDVLeafFieldData(BinaryDocValues values, ToScriptField toScriptField) {
+        super(values, toScriptField);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -17,6 +17,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.script.field.BinaryDocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -29,10 +31,12 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
 
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
+    protected final ToScriptField toScriptField;
 
-    public BytesBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+    public BytesBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType, ToScriptField toScriptField) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -67,7 +71,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
     @Override
     public BytesBinaryDVLeafFieldData load(LeafReaderContext context) {
         try {
-            return new BytesBinaryDVLeafFieldData(DocValues.getBinary(context.reader(), fieldName));
+            return new BytesBinaryDVLeafFieldData(DocValues.getBinary(context.reader(), fieldName), toScriptField);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }
@@ -90,7 +94,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             // Ignore breaker
-            return new BytesBinaryIndexFieldData(name, valuesSourceType);
+            return new BytesBinaryIndexFieldData(name, valuesSourceType, BinaryDocValuesField.ToBinaryScriptField.INSTANCE);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -42,16 +43,18 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
         private final String constantValue;
         private final String name;
         private final ValuesSourceType valuesSourceType;
+        private final ToScriptField toScriptField;
 
-        public Builder(String constantValue, String name, ValuesSourceType valuesSourceType) {
+        public Builder(String constantValue, String name, ValuesSourceType valuesSourceType, ToScriptField toScriptField) {
             this.constantValue = constantValue;
             this.name = name;
             this.valuesSourceType = valuesSourceType;
+            this.toScriptField = toScriptField;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-            return new ConstantIndexFieldData(name, constantValue, valuesSourceType);
+            return new ConstantIndexFieldData(name, constantValue, valuesSourceType, toScriptField);
         }
     }
 
@@ -59,8 +62,8 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
         private final String value;
 
-        ConstantLeafFieldData(String value) {
-            super(DEFAULT_SCRIPT_FUNCTION);
+        ConstantLeafFieldData(String value, ToScriptField toScriptField) {
+            super(toScriptField);
             this.value = value;
         }
 
@@ -120,9 +123,9 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
     private final ConstantLeafFieldData atomicFieldData;
 
-    private ConstantIndexFieldData(String name, String value, ValuesSourceType valuesSourceType) {
-        super(name, valuesSourceType, null, null, AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
-        atomicFieldData = new ConstantLeafFieldData(value);
+    private ConstantIndexFieldData(String name, String value, ValuesSourceType valuesSourceType, ToScriptField toScriptField) {
+        super(name, valuesSourceType, null, null, toScriptField);
+        atomicFieldData = new ConstantLeafFieldData(value, toScriptField);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
@@ -13,11 +13,10 @@ import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -30,9 +29,11 @@ import java.util.Collections;
 public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
 
     private final long ramBytesUsed;
+    protected final ToScriptField toScriptField;
 
-    protected LeafDoubleFieldData(long ramBytesUsed) {
+    protected LeafDoubleFieldData(long ramBytesUsed, ToScriptField toScriptField) {
         this.ramBytesUsed = ramBytesUsed;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -42,7 +43,7 @@ public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
 
     @Override
     public final DocValuesField<?> getScriptField(String name) {
-        return new DelegateDocValuesField(new ScriptDocValues.Doubles(getDoubleValues()), name);
+        return toScriptField.getScriptField(getDoubleValues(), name);
     }
 
     @Override
@@ -56,7 +57,7 @@ public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
     }
 
     public static LeafNumericFieldData empty(final int maxDoc) {
-        return new LeafDoubleFieldData(0) {
+        return new LeafDoubleFieldData(0, ToScriptField.ToDoubleScriptField.INSTANCE) {
 
             @Override
             public SortedNumericDoubleValues getDoubleValues() {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
@@ -11,13 +11,11 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -28,14 +26,11 @@ import java.io.IOException;
 public abstract class LeafLongFieldData implements LeafNumericFieldData {
 
     private final long ramBytesUsed;
-    /**
-     * Type of this field. Used to expose appropriate types in {@link #getScriptField(String)}}.
-     */
-    private final NumericType numericType;
+    protected final ToScriptField toScriptField;
 
-    protected LeafLongFieldData(long ramBytesUsed, NumericType numericType) {
+    protected LeafLongFieldData(long ramBytesUsed, ToScriptField toScriptField) {
         this.ramBytesUsed = ramBytesUsed;
-        this.numericType = numericType;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -44,22 +39,8 @@ public abstract class LeafLongFieldData implements LeafNumericFieldData {
     }
 
     @Override
-    public final DocValuesField<?> getScriptField(String name) {
-        switch (numericType) {
-            // for now, dates and nanoseconds are treated the same, which also means, that the precision is only on millisecond level
-            case DATE:
-                return new DelegateDocValuesField(new ScriptDocValues.Dates(getLongValues(), false), name);
-            case DATE_NANOSECONDS:
-                assert this instanceof SortedNumericIndexFieldData.NanoSecondFieldData;
-                return new DelegateDocValuesField(
-                    new ScriptDocValues.Dates(((SortedNumericIndexFieldData.NanoSecondFieldData) this).getLongValuesAsNanos(), true),
-                    name
-                );
-            case BOOLEAN:
-                return new DelegateDocValuesField(new ScriptDocValues.Booleans(getLongValues()), name);
-            default:
-                return new DelegateDocValuesField(new ScriptDocValues.Longs(getLongValues()), name);
-        }
+    public DocValuesField<?> getScriptField(String name) {
+        return toScriptField.getScriptField(getLongValues(), name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesLeafFieldData.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PagedBytes;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+import org.elasticsearch.script.field.ToScriptField;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,8 +25,13 @@ public class PagedBytesLeafFieldData extends AbstractLeafOrdinalsFieldData {
     private final PackedLongValues termOrdToBytesOffset;
     protected final Ordinals ordinals;
 
-    public PagedBytesLeafFieldData(PagedBytes.Reader bytes, PackedLongValues termOrdToBytesOffset, Ordinals ordinals) {
-        super(DEFAULT_SCRIPT_FUNCTION);
+    public PagedBytesLeafFieldData(
+        PagedBytes.Reader bytes,
+        PackedLongValues termOrdToBytesOffset,
+        Ordinals ordinals,
+        ToScriptField toScriptField
+    ) {
+        super(toScriptField);
         this.bytes = bytes;
         this.termOrdToBytesOffset = termOrdToBytesOffset;
         this.ordinals = ordinals;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetBytesLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetBytesLeafFieldData.java
@@ -13,12 +13,11 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.LeafFieldData;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.field.ToScriptField;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 
 /**
  * An {@link LeafFieldData} implementation that uses Lucene {@link SortedSetDocValues}.
@@ -28,8 +27,8 @@ public final class SortedSetBytesLeafFieldData extends AbstractLeafOrdinalsField
     private final LeafReader reader;
     private final String field;
 
-    SortedSetBytesLeafFieldData(LeafReader reader, String field, Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) {
-        super(scriptFunction);
+    SortedSetBytesLeafFieldData(LeafReader reader, String field, ToScriptField toScriptField) {
+        super(toScriptField);
         this.reader = reader;
         this.field = field;
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryDVLeafFieldData.java
@@ -9,17 +9,10 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.BinaryDocValues;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.script.field.DelegateDocValuesField;
-import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 
 final class StringBinaryDVLeafFieldData extends AbstractBinaryDVLeafFieldData {
-    StringBinaryDVLeafFieldData(BinaryDocValues values) {
-        super(values);
-    }
-
-    @Override
-    public DocValuesField<?> getScriptField(String name) {
-        return new DelegateDocValuesField(new ScriptDocValues.Strings(getBytesValues()), name);
+    StringBinaryDVLeafFieldData(BinaryDocValues values, ToScriptField toScriptField) {
+        super(values, toScriptField);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -27,10 +28,12 @@ public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDV
 
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
+    protected final ToScriptField toScriptField;
 
-    public StringBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+    public StringBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType, ToScriptField toScriptField) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -52,7 +55,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDV
     @Override
     public StringBinaryDVLeafFieldData load(LeafReaderContext context) {
         try {
-            return new StringBinaryDVLeafFieldData(DocValues.getBinary(context.reader(), fieldName));
+            return new StringBinaryDVLeafFieldData(DocValues.getBinary(context.reader(), fieldName), toScriptField);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.script.field.ToScriptField.ToBooleanScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -226,7 +227,7 @@ public class BooleanFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), NumericType.BOOLEAN);
+            return new SortedNumericIndexFieldData.Builder(name(), NumericType.BOOLEAN, ToBooleanScriptField.INSTANCE);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.field.ToScriptField.ToBooleanScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.BooleanScriptFieldExistsQuery;
@@ -105,7 +106,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
 
     @Override
     public BooleanScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-        return new BooleanScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
+        return new BooleanScriptFieldData.Builder(name(), leafFactory(searchLookup.get()), ToBooleanScriptField.INSTANCE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -39,6 +39,8 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.script.field.ToScriptField.ToDateMillisScriptField;
+import org.elasticsearch.script.field.ToScriptField.ToDateNanosScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -672,7 +674,13 @@ public final class DateFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), resolution.numericType());
+            return new SortedNumericIndexFieldData.Builder(
+                name(),
+                resolution.numericType(),
+                resolution.numericType() == NumericType.DATE_NANOSECONDS
+                    ? ToDateNanosScriptField.INSTANCE
+                    : ToDateMillisScriptField.INSTANCE
+            );
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.field.ToScriptField.ToDateMillisScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
@@ -158,7 +159,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
 
     @Override
     public DateScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
-        return new DateScriptFieldData.Builder(name(), leafFactory(lookup.get()));
+        return new DateScriptFieldData.Builder(name(), leafFactory(lookup.get()), ToDateMillisScriptField.INSTANCE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.field.ToScriptField.ToDoubleScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.DoubleScriptFieldExistsQuery;
@@ -98,7 +99,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
 
     @Override
     public DoubleScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-        return new DoubleScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
+        return new DoubleScriptFieldData.Builder(name(), leafFactory(searchLookup.get()), ToDoubleScriptField.INSTANCE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField.ToIdScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -151,7 +152,8 @@ public class IdFieldMapper extends MetadataFieldMapper {
                 TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE,
-                CoreValuesSourceType.KEYWORD
+                CoreValuesSourceType.KEYWORD,
+                ToIdScriptField.INSTANCE
             );
             return new IndexFieldData.Builder() {
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToIndexField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
@@ -63,7 +64,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-            return new ConstantIndexFieldData.Builder(fullyQualifiedIndexName, name(), CoreValuesSourceType.KEYWORD);
+            return new ConstantIndexFieldData.Builder(fullyQualifiedIndexName, name(), CoreValuesSourceType.KEYWORD, ToIndexField.INSTANCE);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.script.field.ToScriptField.ToIpScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
@@ -398,7 +399,7 @@ public class IpFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), IpScriptDocValues::new, CoreValuesSourceType.IP);
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.IP, ToIpScriptField.INSTANCE);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.StringFieldScript;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -397,7 +398,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, ToKeywordScriptField.INSTANCE);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.field.ToScriptField.ToLongScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldExistsQuery;
@@ -93,7 +94,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
 
     @Override
     public LongScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-        return new LongScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
+        return new LongScriptFieldData.Builder(name(), leafFactory(searchLookup.get()), ToLongScriptField.INSTANCE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1165,7 +1165,7 @@ public class NumberFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), type.numericType());
+            return new SortedNumericIndexFieldData.Builder(name(), type.numericType(), type.numericType().getDefaultToScriptField());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.script.field.ToScriptField.ToSeqNoScriptField;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -183,7 +184,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG);
+            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG, ToSeqNoScriptField.INSTANCE);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -58,6 +58,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.script.field.ToScriptField.ToTextScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.ToXContent;
@@ -875,7 +876,8 @@ public class TextFieldMapper extends FieldMapper {
                 filter.minFreq,
                 filter.maxFreq,
                 filter.minSegmentSize,
-                CoreValuesSourceType.KEYWORD
+                CoreValuesSourceType.KEYWORD,
+                ToTextScriptField.INSTANCE
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToVersionScriptField;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
@@ -57,7 +58,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG);
+            return new SortedNumericIndexFieldData.Builder(name(), NumericType.LONG, ToVersionScriptField.INSTANCE);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
@@ -16,9 +16,8 @@ import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
-import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -37,10 +36,12 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
 
     private final String key;
     private final LeafOrdinalsFieldData delegate;
+    private final ToScriptField toScriptField;
 
-    KeyedFlattenedLeafFieldData(String key, LeafOrdinalsFieldData delegate) {
+    KeyedFlattenedLeafFieldData(String key, LeafOrdinalsFieldData delegate, ToScriptField toScriptField) {
         this.key = key;
         this.delegate = delegate;
+        this.toScriptField = toScriptField;
     }
 
     @Override
@@ -80,7 +81,7 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
 
     @Override
     public DocValuesField<?> getScriptField(String name) {
-        return new DelegateDocValuesField(AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION.apply(getOrdinalsValues()), name);
+        return toScriptField.getScriptField(getOrdinalsValues(), name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/field/BinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/BinaryDocValuesField.java
@@ -22,6 +22,20 @@ import java.util.NoSuchElementException;
 
 public class BinaryDocValuesField implements DocValuesField<ByteBuffer> {
 
+    public static class ToBinaryScriptField extends ToScriptField {
+
+        public static final ToBinaryScriptField INSTANCE = new ToBinaryScriptField();
+
+        private ToBinaryScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new BinaryDocValuesField(sortedBinaryDocValues, name);
+        }
+    }
+
     private final SortedBinaryDocValues input;
     private final String name;
 

--- a/server/src/main/java/org/elasticsearch/script/field/ToScriptField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/ToScriptField.java
@@ -1,0 +1,478 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues.Booleans;
+import org.elasticsearch.index.fielddata.ScriptDocValues.Dates;
+import org.elasticsearch.index.fielddata.ScriptDocValues.Doubles;
+import org.elasticsearch.index.fielddata.ScriptDocValues.Longs;
+import org.elasticsearch.index.fielddata.ScriptDocValues.Strings;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.IpFieldMapper.IpFieldType.IpScriptDocValues;
+
+public abstract class ToScriptField {
+
+    // TODO: move these to appropriate field types as they are created (https://github.com/elastic/elasticsearch/issues/79105)
+    public static final class ToBooleanScriptField extends ToScriptField {
+
+        public static final ToBooleanScriptField INSTANCE = new ToBooleanScriptField();
+
+        private ToBooleanScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Booleans(sortedNumericDocValues), name);
+        }
+    }
+
+    public static final class ToByteScriptField extends ToScriptField {
+
+        public static final ToByteScriptField INSTANCE = new ToByteScriptField();
+
+        private ToByteScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToShortScriptField extends ToScriptField {
+
+        public static final ToShortScriptField INSTANCE = new ToShortScriptField();
+
+        private ToShortScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToIntScriptField extends ToScriptField {
+
+        public static final ToIntScriptField INSTANCE = new ToIntScriptField();
+
+        private ToIntScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToLongScriptField extends ToScriptField {
+
+        public static final ToLongScriptField INSTANCE = new ToLongScriptField();
+
+        private ToLongScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToDateMillisScriptField extends ToScriptField {
+
+        public static final ToDateMillisScriptField INSTANCE = new ToDateMillisScriptField();
+
+        private ToDateMillisScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Dates(sortedNumericDocValues, false), name);
+        }
+    }
+
+    public static class ToDateNanosScriptField extends ToScriptField {
+
+        public static final ToDateNanosScriptField INSTANCE = new ToDateNanosScriptField();
+
+        private ToDateNanosScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Dates(sortedNumericDocValues, true), name);
+        }
+    }
+
+    public static class ToHalfFloatScriptField extends ToScriptField {
+
+        public static final ToHalfFloatScriptField INSTANCE = new ToHalfFloatScriptField();
+
+        private ToHalfFloatScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDoubleValues sortedNumericDoubleValues, String name) {
+            return new DelegateDocValuesField(new Doubles(sortedNumericDoubleValues), name);
+        }
+    }
+
+    public static class ToScaledFloatField extends ToScriptField {
+
+        public static final ToScaledFloatField INSTANCE = new ToScaledFloatField();
+
+        private ToScaledFloatField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToFloatScriptField extends ToScriptField {
+
+        public static final ToFloatScriptField INSTANCE = new ToFloatScriptField();
+
+        private ToFloatScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDoubleValues sortedNumericDoubleValues, String name) {
+            return new DelegateDocValuesField(new Doubles(sortedNumericDoubleValues), name);
+        }
+    }
+
+    public static class ToDoubleScriptField extends ToScriptField {
+
+        public static final ToDoubleScriptField INSTANCE = new ToDoubleScriptField();
+
+        private ToDoubleScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDoubleValues sortedNumericDoubleValues, String name) {
+            return new DelegateDocValuesField(new Doubles(sortedNumericDoubleValues), name);
+        }
+    }
+
+    public static class ToSeqNoScriptField extends ToScriptField {
+
+        public static final ToSeqNoScriptField INSTANCE = new ToSeqNoScriptField();
+
+        private ToSeqNoScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToVersionScriptField extends ToScriptField {
+
+        public static final ToVersionScriptField INSTANCE = new ToVersionScriptField();
+
+        private ToVersionScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToKeywordScriptField extends ToScriptField {
+
+        public static final ToKeywordScriptField INSTANCE = new ToKeywordScriptField();
+
+        private ToKeywordScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToConstantKeywordScriptField extends ToScriptField {
+
+        public static final ToConstantKeywordScriptField INSTANCE = new ToConstantKeywordScriptField();
+
+        private ToConstantKeywordScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToWildcardScriptField extends ToScriptField {
+
+        public static final ToWildcardScriptField INSTANCE = new ToWildcardScriptField();
+
+        private ToWildcardScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToICUCollationKeywordScriptField extends ToScriptField {
+
+        public static final ToICUCollationKeywordScriptField INSTANCE = new ToICUCollationKeywordScriptField();
+
+        private ToICUCollationKeywordScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToIpScriptField extends ToScriptField {
+
+        public static final ToIpScriptField INSTANCE = new ToIpScriptField();
+
+        private ToIpScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return new DelegateDocValuesField(new IpScriptDocValues(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToIdScriptField extends ToScriptField {
+
+        public static final ToIdScriptField INSTANCE = new ToIdScriptField();
+
+        private ToIdScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToParentIdScriptField extends ToScriptField {
+
+        public static final ToParentIdScriptField INSTANCE = new ToParentIdScriptField();
+
+        private ToParentIdScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToParentJoinScriptField extends ToScriptField {
+
+        public static final ToParentJoinScriptField INSTANCE = new ToParentJoinScriptField();
+
+        private ToParentJoinScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToIndexField extends ToScriptField {
+
+        public static final ToIndexField INSTANCE = new ToIndexField();
+
+        private ToIndexField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToMurmur3ScriptField extends ToScriptField {
+
+        public static final ToMurmur3ScriptField INSTANCE = new ToMurmur3ScriptField();
+
+        private ToMurmur3ScriptField() {
+
+        }
+
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+        }
+    }
+
+    public static class ToTextScriptField extends ToScriptField {
+
+        public static final ToTextScriptField INSTANCE = new ToTextScriptField();
+
+        private ToTextScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToFlattenedScriptField extends ToScriptField {
+
+        public static final ToFlattenedScriptField INSTANCE = new ToFlattenedScriptField();
+
+        private ToFlattenedScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToKeyedFlattenedScriptField extends ToScriptField {
+
+        public static final ToKeyedFlattenedScriptField INSTANCE = new ToKeyedFlattenedScriptField();
+
+        private ToKeyedFlattenedScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public static class ToRootFlattenedScriptField extends ToScriptField {
+
+        public static final ToRootFlattenedScriptField INSTANCE = new ToRootFlattenedScriptField();
+
+        private ToRootFlattenedScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+            return new DelegateDocValuesField(new Strings(sortedBinaryDocValues), name);
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+            return getScriptField(FieldData.toString(sortedSetDocValues), name);
+        }
+    }
+
+    public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+        return new DelegateDocValuesField(new Longs(sortedNumericDocValues), name);
+    }
+
+    public DocValuesField<?> getScriptField(SortedNumericDoubleValues sortedNumericDoubleValues, String name) {
+        return new DelegateDocValuesField(new Doubles(sortedNumericDoubleValues), name);
+    }
+
+    public DocValuesField<?> getScriptField(SortedBinaryDocValues sortedBinaryDocValues, String name) {
+        return new BinaryDocValuesField(sortedBinaryDocValues, name);
+    }
+
+    public DocValuesField<?> getScriptField(SortedSetDocValues sortedSetDocValues, String name) {
+        return new DelegateDocValuesField(new Strings(FieldData.toString(sortedSetDocValues)), name);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
@@ -20,12 +20,13 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
-import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
+import org.elasticsearch.script.field.ToScriptField.ToTextScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.FieldMaskingReader;
@@ -78,7 +79,7 @@ public class FieldDataCacheTests extends ESTestCase {
             fieldName,
             CoreValuesSourceType.KEYWORD,
             new NoneCircuitBreakerService(),
-            AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
+            ToKeywordScriptField.INSTANCE
         );
     }
 
@@ -88,6 +89,7 @@ public class FieldDataCacheTests extends ESTestCase {
             CoreValuesSourceType.KEYWORD,
             indexFieldDataCache,
             new NoneCircuitBreakerService(),
+            ToTextScriptField.INSTANCE,
             TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE

--- a/server/src/test/java/org/elasticsearch/index/fielddata/plain/HalfFloatFielddataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/plain/HalfFloatFielddataTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.script.field.ToScriptField;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -37,8 +38,11 @@ public class HalfFloatFielddataTests extends ESTestCase {
         w.addDocument(doc);
         final DirectoryReader dirReader = DirectoryReader.open(w);
         LeafReader reader = getOnlyLeafReader(dirReader);
-        SortedNumericDoubleValues values = new SortedNumericIndexFieldData.SortedNumericHalfFloatFieldData(reader, "half_float")
-            .getDoubleValues();
+        SortedNumericDoubleValues values = new SortedNumericIndexFieldData.SortedNumericHalfFloatFieldData(
+            reader,
+            "half_float",
+            ToScriptField.ToHalfFloatScriptField.INSTANCE
+        ).getDoubleValues();
         assertNotNull(FieldData.unwrapSingleton(values));
         assertTrue(values.advanceExact(0));
         assertEquals(1, values.docValueCount());
@@ -59,8 +63,11 @@ public class HalfFloatFielddataTests extends ESTestCase {
         w.addDocument(doc);
         final DirectoryReader dirReader = DirectoryReader.open(w);
         LeafReader reader = getOnlyLeafReader(dirReader);
-        SortedNumericDoubleValues values = new SortedNumericIndexFieldData.SortedNumericHalfFloatFieldData(reader, "half_float")
-            .getDoubleValues();
+        SortedNumericDoubleValues values = new SortedNumericIndexFieldData.SortedNumericHalfFloatFieldData(
+            reader,
+            "half_float",
+            ToScriptField.ToHalfFloatScriptField.INSTANCE
+        ).getDoubleValues();
         assertNull(FieldData.unwrapSingleton(values));
         assertTrue(values.advanceExact(0));
         assertEquals(2, values.docValueCount());

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.query.DateRangeIncludingNowQuery;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToDateNanosScriptField;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -335,7 +336,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         // Create the doc values reader
         SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData(
             "my_date",
-            IndexNumericFieldData.NumericType.DATE_NANOSECONDS
+            IndexNumericFieldData.NumericType.DATE_NANOSECONDS,
+            ToDateNanosScriptField.INSTANCE
         );
         // Read index and check the doc values
         DirectoryReader reader = DirectoryReader.open(w);

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldDataTests.java
@@ -13,6 +13,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
+import org.elasticsearch.script.field.ToScriptField.ToKeyedFlattenedScriptField;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -100,18 +102,22 @@ public class KeyedFlattenedLeafFieldDataTests extends ESTestCase {
     }
 
     public void testAdvanceExact() throws IOException {
-        LeafOrdinalsFieldData avocadoFieldData = new KeyedFlattenedLeafFieldData("avocado", delegate);
+        LeafOrdinalsFieldData avocadoFieldData = new KeyedFlattenedLeafFieldData("avocado", delegate, ToKeyedFlattenedScriptField.INSTANCE);
         assertFalse(avocadoFieldData.getOrdinalsValues().advanceExact(0));
 
-        LeafOrdinalsFieldData bananaFieldData = new KeyedFlattenedLeafFieldData("banana", delegate);
+        LeafOrdinalsFieldData bananaFieldData = new KeyedFlattenedLeafFieldData("banana", delegate, ToKeyedFlattenedScriptField.INSTANCE);
         assertTrue(bananaFieldData.getOrdinalsValues().advanceExact(0));
 
-        LeafOrdinalsFieldData nonexistentFieldData = new KeyedFlattenedLeafFieldData("berry", delegate);
+        LeafOrdinalsFieldData nonexistentFieldData = new KeyedFlattenedLeafFieldData(
+            "berry",
+            delegate,
+            ToKeyedFlattenedScriptField.INSTANCE
+        );
         assertFalse(nonexistentFieldData.getOrdinalsValues().advanceExact(0));
     }
 
     public void testNextOrd() throws IOException {
-        LeafOrdinalsFieldData fieldData = new KeyedFlattenedLeafFieldData("banana", delegate);
+        LeafOrdinalsFieldData fieldData = new KeyedFlattenedLeafFieldData("banana", delegate, ToKeyedFlattenedScriptField.INSTANCE);
         SortedSetDocValues docValues = fieldData.getOrdinalsValues();
         docValues.advanceExact(0);
 
@@ -129,15 +135,23 @@ public class KeyedFlattenedLeafFieldDataTests extends ESTestCase {
     }
 
     public void testLookupOrd() throws IOException {
-        LeafOrdinalsFieldData appleFieldData = new KeyedFlattenedLeafFieldData("apple", delegate);
+        LeafOrdinalsFieldData appleFieldData = new KeyedFlattenedLeafFieldData("apple", delegate, ToKeyedFlattenedScriptField.INSTANCE);
         SortedSetDocValues appleDocValues = appleFieldData.getOrdinalsValues();
         assertEquals(new BytesRef("value0"), appleDocValues.lookupOrd(0));
 
-        LeafOrdinalsFieldData cantaloupeFieldData = new KeyedFlattenedLeafFieldData("cantaloupe", delegate);
+        LeafOrdinalsFieldData cantaloupeFieldData = new KeyedFlattenedLeafFieldData(
+            "cantaloupe",
+            delegate,
+            ToKeyedFlattenedScriptField.INSTANCE
+        );
         SortedSetDocValues cantaloupeDocValues = cantaloupeFieldData.getOrdinalsValues();
         assertEquals(new BytesRef("value40"), cantaloupeDocValues.lookupOrd(0));
 
-        LeafOrdinalsFieldData cucumberFieldData = new KeyedFlattenedLeafFieldData("cucumber", delegate);
+        LeafOrdinalsFieldData cucumberFieldData = new KeyedFlattenedLeafFieldData(
+            "cucumber",
+            delegate,
+            ToKeyedFlattenedScriptField.INSTANCE
+        );
         SortedSetDocValues cucumberDocValues = cucumberFieldData.getOrdinalsValues();
         assertEquals(new BytesRef("value41"), cucumberDocValues.lookupOrd(0));
     }
@@ -146,7 +160,7 @@ public class KeyedFlattenedLeafFieldDataTests extends ESTestCase {
         private final SortedSetDocValues docValues;
 
         MockLeafOrdinalsFieldData(BytesRef[] allTerms, long[] documentOrds) {
-            super(AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
+            super(ToKeywordScriptField.INSTANCE);
             this.docValues = new MockSortedSetDocValues(allTerms, documentOrds);
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.script.field.ToScriptField.ToDoubleScriptField;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -162,7 +163,11 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
     ) throws IOException {
         MappedFieldType idFieldType = new KeywordFieldMapper.KeywordFieldType("id");
 
-        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData("price", IndexNumericFieldData.NumericType.DOUBLE);
+        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData(
+            "price",
+            IndexNumericFieldData.NumericType.DOUBLE,
+            ToDoubleScriptField.INSTANCE
+        );
         FunctionScoreQuery query = new FunctionScoreQuery(
             new MatchAllDocsQuery(),
             new FieldValueFactorFunction("price", 1, FieldValueFactorFunction.Modifier.RECIPROCAL, null, fieldData)

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToConstantKeywordScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.XContentParser;
@@ -130,7 +131,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-            return new ConstantIndexFieldData.Builder(value, name(), CoreValuesSourceType.KEYWORD);
+            return new ConstantIndexFieldData.Builder(value, name(), CoreValuesSourceType.KEYWORD, ToConstantKeywordScriptField.INSTANCE);
         }
 
         @Override

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
@@ -11,6 +11,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.script.field.DocValuesField;
+import org.elasticsearch.script.field.ToScriptField;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -24,6 +25,20 @@ import static org.elasticsearch.search.DocValueFormat.MASK_2_63;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.BIGINTEGER_2_64_MINUS_ONE;
 
 public class UnsignedLongDocValuesField implements UnsignedLongField, DocValuesField<Long> {
+
+    public static class ToUnsignedLongScriptField extends ToScriptField {
+
+        public static final ToUnsignedLongScriptField INSTANCE = new ToUnsignedLongScriptField();
+
+        private ToUnsignedLongScriptField() {
+
+        }
+
+        @Override
+        public DocValuesField<?> getScriptField(SortedNumericDocValues sortedNumericDocValues, String name) {
+            return new UnsignedLongDocValuesField(sortedNumericDocValues, name);
+        }
+    }
 
     private final SortedNumericDocValues input;
     private final String name;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.unsignedlong.UnsignedLongDocValuesField.ToUnsignedLongScriptField;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -286,7 +287,8 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             return (cache, breakerService) -> {
                 final IndexNumericFieldData signedLongValues = new SortedNumericIndexFieldData.Builder(
                     name(),
-                    IndexNumericFieldData.NumericType.LONG
+                    IndexNumericFieldData.NumericType.LONG,
+                    ToUnsignedLongScriptField.INSTANCE
                 ).build(cache, breakerService);
                 return new UnsignedLongIndexFieldData(signedLongValues);
             };

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.QueryParsers;
+import org.elasticsearch.script.field.ToScriptField.ToVersionScriptField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -279,7 +280,7 @@ public class VersionStringFieldMapper extends FieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), VersionScriptDocValues::new, CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, ToVersionScriptField.INSTANCE);
         }
 
         @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/FieldDataCacheWithFieldSubsetReaderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/FieldDataCacheWithFieldSubsetReaderTests.java
@@ -26,13 +26,13 @@ import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
-import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.script.field.ToScriptField.ToKeywordScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.FieldSubsetReader;
@@ -63,13 +63,14 @@ public class FieldDataCacheWithFieldSubsetReaderTests extends ESTestCase {
             name,
             CoreValuesSourceType.KEYWORD,
             circuitBreakerService,
-            AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
+            ToKeywordScriptField.INSTANCE
         );
         pagedBytesIndexFieldData = new PagedBytesIndexFieldData(
             name,
             CoreValuesSourceType.KEYWORD,
             indexFieldDataCache,
             circuitBreakerService,
+            ToKeywordScriptField.INSTANCE,
             TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -64,6 +64,7 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.field.ToScriptField.ToWildcardScriptField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.XContentParser;
@@ -832,7 +833,11 @@ public class WildcardFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return (cache, breakerService) -> new StringBinaryIndexFieldData(name(), CoreValuesSourceType.KEYWORD);
+            return (cache, breakerService) -> new StringBinaryIndexFieldData(
+                name(),
+                CoreValuesSourceType.KEYWORD,
+                ToWildcardScriptField.INSTANCE
+            );
         }
 
         @Override


### PR DESCRIPTION
This plumbs a ToScriptField class from each appropriate builder within a FieldMapper all the way down to the LeafFieldData. This allows getScriptField to return a field based on the mapped type rather than indexed data as identified as a requirement for the scripting fields api project. (https://github.com/elastic/elasticsearch/issues/79105)

This design was copied from ordinals field data which already had a script function. ToScriptField replaces this script function and adds it to the other types of indexed data. This design helps keep the mapped type separate from the indexed data and how it's loaded.

I understand that for reading data, families of types make sense, but I included each individual mapped type for now as I think that may have relevance to writing the data for ingest and update.

@jtibshirani and @romseygeek I marked this as a WIP as I was hoping for feedback regarding this design strategy as opposed to one adding new field data classes to match mapped types. I'm fully open to any design that gets the information necessary for the scripting fields api. This one just seemed like the cleanest based on what's already there and the precedent set by the existing script function.