### PR TITLE
Expose only_expunge_deletes parameter to ForceMergeAction of ILM

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ForceMergeAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ForceMergeAction.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.client.ilm;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -20,31 +22,61 @@ import java.util.Objects;
 public class ForceMergeAction implements LifecycleAction, ToXContentObject {
     public static final String NAME = "forcemerge";
     private static final ParseField MAX_NUM_SEGMENTS_FIELD = new ParseField("max_num_segments");
+    public static final ParseField CODEC = new ParseField("index_codec");
+    public static final ParseField ONLY_EXPUNGE_DELETES = new ParseField("only_expunge_deletes");
 
     private static final ConstructingObjectParser<ForceMergeAction, Void> PARSER = new ConstructingObjectParser<>(NAME, true, a -> {
-        int maxNumSegments = (int) a[0];
-        return new ForceMergeAction(maxNumSegments);
+        Integer maxNumSegments = (Integer) a[0];
+        String codec = a[1] != null ? (String) a[1] : null;
+        boolean onlyExpungeDeletes = a[2] != null && (boolean) a[2];
+        return new ForceMergeAction(maxNumSegments, codec, onlyExpungeDeletes);
     });
 
     static {
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_NUM_SEGMENTS_FIELD);
+        PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_NUM_SEGMENTS_FIELD);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), CODEC);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), ONLY_EXPUNGE_DELETES);
     }
 
-    private final int maxNumSegments;
+    private final Integer maxNumSegments;
+    private final String codec;
+    private final boolean onlyExpungeDeletes;
 
     public static ForceMergeAction parse(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 
-    public ForceMergeAction(int maxNumSegments) {
-        if (maxNumSegments <= 0) {
+    public ForceMergeAction(@Nullable Integer maxNumSegments, @Nullable String codec, boolean onlyExpungeDeletes) {
+        if (maxNumSegments != null && onlyExpungeDeletes) {
+            throw new IllegalArgumentException(
+                "cannot set [max_num_segments] and [only_expunge_deletes] at the same time,"
+                    + " those two parameters are mutually exclusive"
+            );
+        }
+        if (maxNumSegments == null && onlyExpungeDeletes == false) {
+            throw new IllegalArgumentException("Either [max_num_segments] or [only_expunge_deletes] must be set");
+        }
+        if (maxNumSegments != null && maxNumSegments <= 0) {
             throw new IllegalArgumentException("[" + MAX_NUM_SEGMENTS_FIELD.getPreferredName() + "] must be a positive integer");
         }
         this.maxNumSegments = maxNumSegments;
+        if (codec != null && CodecService.BEST_COMPRESSION_CODEC.equals(codec) == false) {
+            throw new IllegalArgumentException("unknown index codec: [" + codec + "]");
+        }
+        this.codec = codec;
+        this.onlyExpungeDeletes = onlyExpungeDeletes;
     }
 
-    public int getMaxNumSegments() {
+    public Integer getMaxNumSegments() {
         return maxNumSegments;
+    }
+
+    public String getCodec() {
+        return this.codec;
+    }
+
+    public boolean getOnlyExpungeDeletes() {
+        return this.onlyExpungeDeletes;
     }
 
     @Override
@@ -55,14 +87,20 @@ public class ForceMergeAction implements LifecycleAction, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(MAX_NUM_SEGMENTS_FIELD.getPreferredName(), maxNumSegments);
+        if (maxNumSegments != null) {
+            builder.field(MAX_NUM_SEGMENTS_FIELD.getPreferredName(), maxNumSegments);
+        }
+        if (codec != null) {
+            builder.field(CODEC.getPreferredName(), codec);
+        }
+        builder.field(ONLY_EXPUNGE_DELETES.getPreferredName(), onlyExpungeDeletes);
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxNumSegments);
+        return Objects.hash(maxNumSegments, codec, onlyExpungeDeletes);
     }
 
     @Override
@@ -74,7 +112,9 @@ public class ForceMergeAction implements LifecycleAction, ToXContentObject {
             return false;
         }
         ForceMergeAction other = (ForceMergeAction) obj;
-        return Objects.equals(maxNumSegments, other.maxNumSegments);
+        return Objects.equals(this.maxNumSegments, other.maxNumSegments)
+            && Objects.equals(this.codec, other.codec)
+            && Objects.equals(this.onlyExpungeDeletes, other.onlyExpungeDeletes);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleIT.java
@@ -177,7 +177,7 @@ public class IndexLifecycleIT extends ESRestHighLevelClientTestCase {
         warmActions.put(UnfollowAction.NAME, new UnfollowAction());
         warmActions.put(AllocateAction.NAME, new AllocateAction(null, null, null, Collections.singletonMap("_name", "node-1")));
         warmActions.put(ShrinkAction.NAME, new ShrinkAction(1, null));
-        warmActions.put(ForceMergeAction.NAME, new ForceMergeAction(1000));
+        warmActions.put(ForceMergeAction.NAME, new ForceMergeAction(1000, null, false));
         lifecyclePhases.put("warm", new Phase("warm", TimeValue.timeValueSeconds(1000), warmActions));
 
         Map<String, LifecycleAction> coldActions = new HashMap<>();

--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -4,13 +4,13 @@
 
 Phases allowed: hot, warm.
 
-<<indices-forcemerge,Force merges>> the index into 
+<<indices-forcemerge,Force merges>> the index into
 the specified maximum number of <<indices-segments,segments>>.
 
 This action makes the index <<dynamic-index-settings,read-only>>.
 
 To use the `forcemerge` action in the `hot` phase, the `rollover` action *must* be present.
-If no rollover action is configured, {ilm-init} will reject the policy. 
+If no rollover action is configured, {ilm-init} will reject the policy.
 
 [NOTE]
 The `forcemerge` action is best effort. It might happen that some of the
@@ -20,8 +20,19 @@ shards are relocating, in which case they will not be merged.
 ==== Options
 
 `max_num_segments`::
-(Required, integer) 
-Number of segments to merge to. To fully merge the index, set to `1`.
+(Optional, integer)
+Number of segments to merge to. To fully merge the index, set to `1`. This parameter conflicts with
+`only_expunge_deletes`, cannot be set if `only_expunge_deletes` is set to `true`.
+
+`only_expunge_deletes`::
++
+--
+(Optional, boolean)
+If `true`,
+expunge all segments containing more than `index.merge.policy.expunge_deletes_allowed`
+(default to 10) percents of deleted documents. Defaults to `false`. This parameter conflicts with
+`max_num_segments`, cannot be set to `true` if `max_num_segments` has been set.
+--
 
 `index_codec`::
 (Optional, string)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
@@ -30,11 +30,13 @@ public class ForceMergeStep extends AsyncActionStep {
 
     public static final String NAME = "forcemerge";
     private static final Logger logger = LogManager.getLogger(ForceMergeStep.class);
-    private final int maxNumSegments;
+    private final Integer maxNumSegments;
+    private final boolean onlyExpungeDeletes;
 
-    public ForceMergeStep(StepKey key, StepKey nextStepKey, Client client, int maxNumSegments) {
+    public ForceMergeStep(StepKey key, StepKey nextStepKey, Client client, Integer maxNumSegments, boolean onlyExpungeDeletes) {
         super(key, nextStepKey, client);
         this.maxNumSegments = maxNumSegments;
+        this.onlyExpungeDeletes = onlyExpungeDeletes;
     }
 
     @Override
@@ -42,8 +44,12 @@ public class ForceMergeStep extends AsyncActionStep {
         return true;
     }
 
-    public int getMaxNumSegments() {
+    public Integer getMaxNumSegments() {
         return maxNumSegments;
+    }
+
+    public boolean getOnlyExpungeDeletes() {
+        return onlyExpungeDeletes;
     }
 
     @Override
@@ -55,7 +61,11 @@ public class ForceMergeStep extends AsyncActionStep {
     ) {
         String indexName = indexMetadata.getIndex().getName();
         ForceMergeRequest request = new ForceMergeRequest(indexName);
-        request.maxNumSegments(maxNumSegments);
+        if (maxNumSegments != null) {
+            request.maxNumSegments(maxNumSegments);
+        } else {
+            request.onlyExpungeDeletes(onlyExpungeDeletes);
+        }
         getClient().admin().indices().forceMerge(request, ActionListener.wrap(response -> {
             if (response.getFailedShards() == 0) {
                 listener.onResponse(null);
@@ -84,7 +94,7 @@ public class ForceMergeStep extends AsyncActionStep {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), maxNumSegments);
+        return Objects.hash(super.hashCode(), maxNumSegments, onlyExpungeDeletes);
     }
 
     @Override
@@ -96,6 +106,8 @@ public class ForceMergeStep extends AsyncActionStep {
             return false;
         }
         ForceMergeStep other = (ForceMergeStep) obj;
-        return super.equals(obj) && Objects.equals(maxNumSegments, other.maxNumSegments);
+        return super.equals(obj)
+            && Objects.equals(maxNumSegments, other.maxNumSegments)
+            && Objects.equals(onlyExpungeDeletes, other.onlyExpungeDeletes);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -247,7 +247,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         );
 
         // If a new snapshot is needed, these steps are executed
-        ForceMergeStep forceMergeStep = new ForceMergeStep(forceMergeStepKey, waitForSegmentCountKey, client, 1);
+        ForceMergeStep forceMergeStep = new ForceMergeStep(forceMergeStepKey, waitForSegmentCountKey, client, 1, false);
         SegmentCountStep segmentCountStep = new SegmentCountStep(waitForSegmentCountKey, generateSnapshotNameKey, client, 1);
         GenerateSnapshotNameStep generateSnapshotNameStep = new GenerateSnapshotNameStep(
             generateSnapshotNameKey,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -264,7 +264,7 @@ public class PhaseCacheManagementTests extends ESTestCase {
         );
 
         Map<String, LifecycleAction> actions = new HashMap<>();
-        actions.put("forcemerge", new ForceMergeAction(5, null));
+        actions.put("forcemerge", new ForceMergeAction(5, null, false));
         actions.put("allocate", new AllocateAction(1, 20, null, null, null));
         PhaseExecutionInfo pei = new PhaseExecutionInfo("policy", new Phase("wonky", TimeValue.ZERO, actions), 1, 1);
         String phaseDef = Strings.toString(pei);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -64,7 +64,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     private static final DeleteAction TEST_DELETE_ACTION = DeleteAction.WITH_SNAPSHOT_DELETE;
 
     private static final WaitForSnapshotAction TEST_WAIT_FOR_SNAPSHOT_ACTION = new WaitForSnapshotAction("policy");
-    private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1, null);
+    private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1, null, false);
     private static final RolloverAction TEST_ROLLOVER_ACTION = new RolloverAction(new ByteSizeValue(1), null, null, null);
     private static final ShrinkAction TEST_SHRINK_ACTION = new ShrinkAction(1, null);
     private static final ReadOnlyAction TEST_READ_ONLY_ACTION = new ReadOnlyAction();
@@ -305,7 +305,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
                     new SearchableSnapshotAction(randomAlphaOfLengthBetween(4, 10))
                 )
             );
-            Phase warm = new Phase("warm", TimeValue.ZERO, Map.of(ForceMergeAction.NAME, new ForceMergeAction(1, null)));
+            Phase warm = new Phase("warm", TimeValue.ZERO, Map.of(ForceMergeAction.NAME, new ForceMergeAction(1, null, false)));
             Phase cold = new Phase("cold", TimeValue.ZERO, Map.of(FreezeAction.NAME, FreezeAction.INSTANCE));
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
@@ -1070,7 +1070,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
                 case DeleteAction.NAME:
                     return DeleteAction.WITH_SNAPSHOT_DELETE;
                 case ForceMergeAction.NAME:
-                    return new ForceMergeAction(1, null);
+                    return new ForceMergeAction(1, null, false);
                 case ReadOnlyAction.NAME:
                     return new ReadOnlyAction();
                 case RolloverAction.NAME:


### PR DESCRIPTION
Relates to #77979.
The main changes are:
1. Expose `only_expunge_deletes` parameter to ILM's ForceMergeAction and high level rest client.
2. Add some tests.
3. Add the parameter in the ForceMergeAction's document.