### PR TITLE
[ML] Report start_time for trained model deployments and allocations

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-trained-model-deployment-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-model-deployment-stats.asciidoc
@@ -73,6 +73,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 (<<byte-units,byte value>>)
 The size of the loaded model in bytes.
 
+`start_time`:::
+(long)
+The epoch timestamp when the deployment started.
+
 `state`:::
 (string)
 The overall state of the deployment. The values may be:
@@ -170,6 +174,10 @@ The current routing state and reason for the current routing state for this allo
 `reason`:::
 (string)
 The reason for the current state. Usually only populated when the `routing_state` is `failed`.
+
+`start_time`:::
+(long)
+The epoch timestamp when the allocation started.
 
 =====
 ====

--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -96,7 +96,8 @@ The API returns the following results:
                 "reason": ""
             }
         },
-        "allocation_state": "started"
+        "allocation_state": "started",
+        "start_time": "2021-11-02T11:50:34.766591Z"
     }
 }
 ----

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
@@ -9,25 +9,18 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.allocation.RoutingState;
-import org.elasticsearch.xpack.core.ml.inference.allocation.RoutingStateAndReason;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.hasSize;
 
 public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializingTestCase<GetDeploymentStatsAction.Response> {
     @Override
@@ -37,6 +30,10 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
 
     @Override
     protected GetDeploymentStatsAction.Response createTestInstance() {
+        return createRandom();
+    }
+
+    public static GetDeploymentStatsAction.Response createRandom() {
         int numStats = randomIntBetween(0, 2);
         var stats = new ArrayList<GetDeploymentStatsAction.Response.AllocationStats>(numStats);
         for (var i = 0; i < numStats; i++) {
@@ -46,153 +43,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
         return new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), stats, stats.size());
     }
 
-    public void testAddFailedRoutes_GivenNoFailures() throws UnknownHostException {
-        var response = createTestInstance();
-        var modifed = GetDeploymentStatsAction.Response.addFailedRoutes(response, Collections.emptyMap(), buildNodes("node_foo"));
-        assertEquals(response, modifed);
-    }
-
-    public void testAddFailedRoutes_GivenNoTaskResponses() throws UnknownHostException {
-        var emptyResponse = new GetDeploymentStatsAction.Response(
-            Collections.emptyList(),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            0
-        );
-
-        Map<String, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
-        for (var modelId : new String[] { "model1", "model2" }) {
-            Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
-            for (var nodeId : new String[] { "nodeA", "nodeB" }) {
-                nodeRoutes.put(nodeId, new RoutingStateAndReason(RoutingState.FAILED, "failure reason"));
-            }
-            badRoutes.put(modelId, nodeRoutes);
-        }
-
-        DiscoveryNodes nodes = buildNodes("nodeA", "nodeB");
-        var modified = GetDeploymentStatsAction.Response.addFailedRoutes(emptyResponse, badRoutes, nodes);
-        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
-        assertThat(results, hasSize(2));
-        assertEquals("model1", results.get(0).getModelId());
-        assertThat(results.get(0).getNodeStats(), hasSize(2));
-        assertEquals("nodeA", results.get(0).getNodeStats().get(0).getNode().getId());
-        assertEquals("nodeB", results.get(0).getNodeStats().get(1).getNode().getId());
-        assertEquals("nodeA", results.get(1).getNodeStats().get(0).getNode().getId());
-        assertEquals("nodeB", results.get(1).getNodeStats().get(1).getNode().getId());
-    }
-
-    public void testAddFailedRoutes_GivenMixedResponses() throws UnknownHostException {
-        DiscoveryNodes nodes = buildNodes("node1", "node2", "node3");
-
-        List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
-        nodeStatsList.add(
-            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
-                nodes.get("node1"),
-                randomNonNegativeLong(),
-                randomDoubleBetween(0.0, 100.0, true),
-                randomIntBetween(0, 100),
-                Instant.now()
-            )
-        );
-        nodeStatsList.add(
-            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
-                nodes.get("node2"),
-                randomNonNegativeLong(),
-                randomDoubleBetween(0.0, 100.0, true),
-                randomIntBetween(0, 100),
-                Instant.now()
-            )
-        );
-
-        var model1 = new GetDeploymentStatsAction.Response.AllocationStats(
-            "model1",
-            ByteSizeValue.ofBytes(randomNonNegativeLong()),
-            randomBoolean() ? null : randomIntBetween(1, 8),
-            randomBoolean() ? null : randomIntBetween(1, 8),
-            randomBoolean() ? null : randomIntBetween(1, 10000),
-            nodeStatsList
-        );
-
-        Map<String, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
-        Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
-        nodeRoutes.put("node3", new RoutingStateAndReason(RoutingState.FAILED, "failed on node3"));
-        badRoutes.put("model1", nodeRoutes);
-
-        var response = new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), List.of(model1), 1);
-
-        var modified = GetDeploymentStatsAction.Response.addFailedRoutes(response, badRoutes, nodes);
-        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
-        assertThat(results, hasSize(1));
-        assertThat(results.get(0).getNodeStats(), hasSize(3));
-        assertEquals("node1", results.get(0).getNodeStats().get(0).getNode().getId());
-        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(0).getRoutingState().getState());
-        assertEquals("node2", results.get(0).getNodeStats().get(1).getNode().getId());
-        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(1).getRoutingState().getState());
-        assertEquals("node3", results.get(0).getNodeStats().get(2).getNode().getId());
-        assertEquals(RoutingState.FAILED, results.get(0).getNodeStats().get(2).getRoutingState().getState());
-    }
-
-    public void testAddFailedRoutes_TaskResultIsOverwritten() throws UnknownHostException {
-        DiscoveryNodes nodes = buildNodes("node1", "node2");
-
-        List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
-        nodeStatsList.add(
-            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
-                nodes.get("node1"),
-                randomNonNegativeLong(),
-                randomDoubleBetween(0.0, 100.0, true),
-                randomIntBetween(0, 100),
-                Instant.now()
-            )
-        );
-        nodeStatsList.add(
-            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
-                nodes.get("node2"),
-                randomNonNegativeLong(),
-                randomDoubleBetween(0.0, 100.0, true),
-                randomIntBetween(0, 100),
-                Instant.now()
-            )
-        );
-
-        var model1 = new GetDeploymentStatsAction.Response.AllocationStats(
-            "model1",
-            ByteSizeValue.ofBytes(randomNonNegativeLong()),
-            randomBoolean() ? null : randomIntBetween(1, 8),
-            randomBoolean() ? null : randomIntBetween(1, 8),
-            randomBoolean() ? null : randomIntBetween(1, 10000),
-            nodeStatsList
-        );
-        var response = new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), List.of(model1), 1);
-
-        // failed state for node 2 conflicts with the task response
-        Map<String, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
-        Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
-        nodeRoutes.put("node2", new RoutingStateAndReason(RoutingState.FAILED, "failed on node3"));
-        badRoutes.put("model1", nodeRoutes);
-
-        var modified = GetDeploymentStatsAction.Response.addFailedRoutes(response, badRoutes, nodes);
-        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
-        assertThat(results, hasSize(1));
-        assertThat(results.get(0).getNodeStats(), hasSize(2));
-        assertEquals("node1", results.get(0).getNodeStats().get(0).getNode().getId());
-        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(0).getRoutingState().getState());
-        assertEquals("node2", results.get(0).getNodeStats().get(1).getNode().getId());
-        // routing state from the bad routes map is chosen to resolve teh conflict
-        assertEquals(RoutingState.FAILED, results.get(0).getNodeStats().get(1).getRoutingState().getState());
-    }
-
-    private DiscoveryNodes buildNodes(String... nodeIds) throws UnknownHostException {
-        InetAddress inetAddress = InetAddress.getByAddress(new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
-        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
-        int port = 9200;
-        for (String nodeId : nodeIds) {
-            builder.add(new DiscoveryNode(nodeId, new TransportAddress(inetAddress, port++), Version.CURRENT));
-        }
-        return builder.build();
-    }
-
-    private GetDeploymentStatsAction.Response.AllocationStats randomDeploymentStats() {
+    private static GetDeploymentStatsAction.Response.AllocationStats randomDeploymentStats() {
         List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
         int numNodes = randomIntBetween(1, 4);
         for (int i = 0; i < numNodes; i++) {
@@ -204,6 +55,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
                         randomNonNegativeLong(),
                         randomBoolean() ? randomDoubleBetween(0.0, 100.0, true) : null,
                         randomIntBetween(0, 100),
+                        Instant.now(),
                         Instant.now()
                     )
                 );
@@ -226,6 +78,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 10000),
+            Instant.now(),
             nodeStatsList
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
@@ -36,6 +37,7 @@ import org.elasticsearch.xpack.ml.inference.deployment.TrainedModelDeploymentTas
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -100,14 +102,15 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         GetDeploymentStatsAction.Request request,
         ActionListener<GetDeploymentStatsAction.Response> listener
     ) {
+        final ClusterState clusterState = clusterService.state();
+        final TrainedModelAllocationMetadata allocation = TrainedModelAllocationMetadata.fromState(clusterState);
 
         String[] tokenizedRequestIds = Strings.tokenizeToStringArray(request.getDeploymentId(), ",");
         ExpandedIdsMatcher.SimpleIdsMatcher idsMatcher = new ExpandedIdsMatcher.SimpleIdsMatcher(tokenizedRequestIds);
 
-        TrainedModelAllocationMetadata allocation = TrainedModelAllocationMetadata.fromState(clusterService.state());
         List<String> matchedDeploymentIds = new ArrayList<>();
         Set<String> taskNodes = new HashSet<>();
-        Map<String, Map<String, RoutingStateAndReason>> nonStartedAllocationsForModel = new HashMap<>();
+        Map<TrainedModelAllocation, Map<String, RoutingStateAndReason>> allocationNonStartedRoutes = new HashMap<>();
         for (var allocationEntry : allocation.modelAllocations().entrySet()) {
             String modelId = allocationEntry.getKey();
             if (idsMatcher.idMatches(modelId)) {
@@ -122,7 +125,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
                     .filter(routingEntry -> RoutingState.STARTED.equals(routingEntry.getValue().getState()) == false)
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-                nonStartedAllocationsForModel.put(modelId, routings);
+                allocationNonStartedRoutes.put(allocationEntry.getValue(), routings);
             }
         }
 
@@ -144,11 +147,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         request.setExpandedIds(matchedDeploymentIds);
 
         ActionListener<GetDeploymentStatsAction.Response> addFailedListener = listener.delegateFailure((l, response) -> {
-            var updatedResponse = GetDeploymentStatsAction.Response.addFailedRoutes(
-                response,
-                nonStartedAllocationsForModel,
-                clusterService.state().nodes()
-            );
+            var updatedResponse = addFailedRoutes(response, allocationNonStartedRoutes, clusterState.nodes());
             ClusterState latestState = clusterService.state();
             Set<String> nodesShuttingDown = TransportStartTrainedModelDeploymentAction.nodesShuttingDown(latestState);
             List<DiscoveryNode> nodes = latestState.getNodes()
@@ -174,6 +173,135 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         super.doExecute(task, request, addFailedListener);
     }
 
+    /**
+     * Update the collected task responses with the non-started
+     * allocation information. The result is the task responses
+     * merged with the non-started model allocations.
+     *
+     * Where there is a merge collision for the pair {@code <model_id, node_id>}
+     * the non-started allocations are used.
+     *
+     * @param tasksResponse All the responses from the tasks
+     * @param allocationNonStartedRoutes Non-started routes
+     * @param nodes current cluster nodes
+     * @return The result of merging tasksResponse and the non-started routes
+     */
+    static GetDeploymentStatsAction.Response addFailedRoutes(
+        GetDeploymentStatsAction.Response tasksResponse,
+        Map<TrainedModelAllocation, Map<String, RoutingStateAndReason>> allocationNonStartedRoutes,
+        DiscoveryNodes nodes
+    ) {
+        final Map<String, TrainedModelAllocation> modelToAllocationWithNonStartedRoutes = allocationNonStartedRoutes.keySet()
+            .stream()
+            .collect(Collectors.toMap(TrainedModelAllocation::getModelId, Function.identity()));
+
+        final List<GetDeploymentStatsAction.Response.AllocationStats> updatedAllocationStats = new ArrayList<>();
+
+        for (GetDeploymentStatsAction.Response.AllocationStats stat : tasksResponse.getStats().results()) {
+            if (modelToAllocationWithNonStartedRoutes.containsKey(stat.getModelId())) {
+                // there is merging to be done
+                Map<String, RoutingStateAndReason> nodeToRoutingStates = allocationNonStartedRoutes.get(
+                    modelToAllocationWithNonStartedRoutes.get(stat.getModelId())
+                );
+                List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> updatedNodeStats = new ArrayList<>();
+
+                Set<String> visitedNodes = new HashSet<>();
+                for (var nodeStat : stat.getNodeStats()) {
+                    if (nodeToRoutingStates.containsKey(nodeStat.getNode().getId())) {
+                        // conflict as there is both a task response for the model/node pair
+                        // and we have a non-started routing entry.
+                        // Prefer the entry from allocationNonStartedRoutes as we cannot be sure
+                        // of the state of the task - it may be starting, started, stopping, or stopped.
+                        RoutingStateAndReason stateAndReason = nodeToRoutingStates.get(nodeStat.getNode().getId());
+                        updatedNodeStats.add(
+                            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forNotStartedState(
+                                nodeStat.getNode(),
+                                stateAndReason.getState(),
+                                stateAndReason.getReason()
+                            )
+                        );
+                    } else {
+                        updatedNodeStats.add(nodeStat);
+                    }
+
+                    visitedNodes.add(nodeStat.getNode().getId());
+                }
+
+                // add nodes from the failures that were not in the task responses
+                for (var nodeRoutingState : nodeToRoutingStates.entrySet()) {
+                    if (visitedNodes.contains(nodeRoutingState.getKey()) == false) {
+                        updatedNodeStats.add(
+                            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forNotStartedState(
+                                nodes.get(nodeRoutingState.getKey()),
+                                nodeRoutingState.getValue().getState(),
+                                nodeRoutingState.getValue().getReason()
+                            )
+                        );
+                    }
+                }
+
+                updatedNodeStats.sort(Comparator.comparing(n -> n.getNode().getId()));
+                updatedAllocationStats.add(
+                    new GetDeploymentStatsAction.Response.AllocationStats(
+                        stat.getModelId(),
+                        stat.getModelSize(),
+                        stat.getInferenceThreads(),
+                        stat.getModelThreads(),
+                        stat.getQueueCapacity(),
+                        stat.getStartTime(),
+                        updatedNodeStats
+                    )
+                );
+            } else {
+                updatedAllocationStats.add(stat);
+            }
+        }
+
+        // Merge any models in the non-started that were not in the task responses
+        for (var nonStartedEntries : allocationNonStartedRoutes.entrySet()) {
+            final TrainedModelAllocation allocation = nonStartedEntries.getKey();
+            final String modelId = allocation.getTaskParams().getModelId();
+            if (tasksResponse.getStats().results().stream().anyMatch(e -> modelId.equals(e.getModelId())) == false) {
+
+                // no tasks for this model so build the allocation stats from the non-started states
+                List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStats = new ArrayList<>();
+
+                for (var routingEntry : nonStartedEntries.getValue().entrySet()) {
+                    nodeStats.add(
+                        GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forNotStartedState(
+                            nodes.get(routingEntry.getKey()),
+                            routingEntry.getValue().getState(),
+                            routingEntry.getValue().getReason()
+                        )
+                    );
+                }
+
+                nodeStats.sort(Comparator.comparing(n -> n.getNode().getId()));
+
+                updatedAllocationStats.add(
+                    new GetDeploymentStatsAction.Response.AllocationStats(
+                        modelId,
+                        null,
+                        null,
+                        null,
+                        null,
+                        allocation.getStartTime(),
+                        nodeStats
+                    )
+                );
+            }
+        }
+
+        updatedAllocationStats.sort(Comparator.comparing(GetDeploymentStatsAction.Response.AllocationStats::getModelId));
+
+        return new GetDeploymentStatsAction.Response(
+            tasksResponse.getTaskFailures(),
+            tasksResponse.getNodeFailures(),
+            updatedAllocationStats,
+            updatedAllocationStats.size()
+        );
+    }
+
     @Override
     protected void taskOperation(
         GetDeploymentStatsAction.Request request,
@@ -192,7 +320,8 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
                     // avoid reporting the average time as 0 if count < 1
                     (stats.get().getTimingStats().getCount() > 0) ? stats.get().getTimingStats().getAverage() : null,
                     stats.get().getPendingCount(),
-                    stats.get().getLastUsed()
+                    stats.get().getLastUsed(),
+                    stats.get().getStartTime()
                 )
             );
         } else {
@@ -214,6 +343,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
                 task.getParams().getInferenceThreads(),
                 task.getParams().getModelThreads(),
                 task.getParams().getQueueCapacity(),
+                TrainedModelAllocationMetadata.fromState(clusterService.state()).getModelAllocation(task.getModelId()).getStartTime(),
                 nodeStats
             )
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
@@ -12,14 +12,20 @@ import java.util.LongSummaryStatistics;
 
 public class ModelStats {
 
+    private final Instant startTime;
     private final LongSummaryStatistics timingStats;
     private final Instant lastUsed;
     private final int pendingCount;
 
-    ModelStats(LongSummaryStatistics timingStats, Instant lastUsed, int pendingCount) {
+    ModelStats(Instant startTime, LongSummaryStatistics timingStats, Instant lastUsed, int pendingCount) {
+        this.startTime = startTime;
         this.timingStats = timingStats;
         this.lastUsed = lastUsed;
         this.pendingCount = pendingCount;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
     }
 
     public LongSummaryStatistics getTimingStats() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsActionResponseTests;
+import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
+import org.elasticsearch.xpack.core.ml.inference.allocation.RoutingState;
+import org.elasticsearch.xpack.core.ml.inference.allocation.RoutingStateAndReason;
+import org.elasticsearch.xpack.core.ml.inference.allocation.TrainedModelAllocation;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasSize;
+
+public class TransportGetDeploymentStatsActionTests extends ESTestCase {
+
+    public void testAddFailedRoutes_GivenNoFailures() throws UnknownHostException {
+        var response = GetDeploymentStatsActionResponseTests.createRandom();
+        var modified = TransportGetDeploymentStatsAction.addFailedRoutes(response, Collections.emptyMap(), buildNodes("node_foo"));
+        assertEquals(response, modified);
+    }
+
+    public void testAddFailedRoutes_GivenNoTaskResponses() throws UnknownHostException {
+        var emptyResponse = new GetDeploymentStatsAction.Response(
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0
+        );
+
+        Map<TrainedModelAllocation, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
+        for (var modelId : new String[] { "model1", "model2" }) {
+            TrainedModelAllocation allocation = createAllocation(modelId);
+            Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
+            for (var nodeId : new String[] { "nodeA", "nodeB" }) {
+                nodeRoutes.put(nodeId, new RoutingStateAndReason(RoutingState.FAILED, "failure reason"));
+            }
+            badRoutes.put(allocation, nodeRoutes);
+        }
+
+        DiscoveryNodes nodes = buildNodes("nodeA", "nodeB");
+        var modified = TransportGetDeploymentStatsAction.addFailedRoutes(emptyResponse, badRoutes, nodes);
+        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
+        assertThat(results, hasSize(2));
+        assertEquals("model1", results.get(0).getModelId());
+        assertThat(results.get(0).getNodeStats(), hasSize(2));
+        assertEquals("nodeA", results.get(0).getNodeStats().get(0).getNode().getId());
+        assertEquals("nodeB", results.get(0).getNodeStats().get(1).getNode().getId());
+        assertEquals("nodeA", results.get(1).getNodeStats().get(0).getNode().getId());
+        assertEquals("nodeB", results.get(1).getNodeStats().get(1).getNode().getId());
+    }
+
+    public void testAddFailedRoutes_GivenMixedResponses() throws UnknownHostException {
+        DiscoveryNodes nodes = buildNodes("node1", "node2", "node3");
+
+        List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
+        nodeStatsList.add(
+            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
+                nodes.get("node1"),
+                randomNonNegativeLong(),
+                randomDoubleBetween(0.0, 100.0, true),
+                randomIntBetween(1, 100),
+                Instant.now(),
+                Instant.now()
+            )
+        );
+        nodeStatsList.add(
+            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
+                nodes.get("node2"),
+                randomNonNegativeLong(),
+                randomDoubleBetween(0.0, 100.0, true),
+                randomIntBetween(1, 100),
+                Instant.now(),
+                Instant.now()
+            )
+        );
+
+        var model1 = new GetDeploymentStatsAction.Response.AllocationStats(
+            "model1",
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
+            Instant.now(),
+            nodeStatsList
+        );
+
+        Map<TrainedModelAllocation, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
+        Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
+        nodeRoutes.put("node3", new RoutingStateAndReason(RoutingState.FAILED, "failed on node3"));
+        badRoutes.put(createAllocation("model1"), nodeRoutes);
+
+        var response = new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), List.of(model1), 1);
+
+        var modified = TransportGetDeploymentStatsAction.addFailedRoutes(response, badRoutes, nodes);
+        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getNodeStats(), hasSize(3));
+        assertEquals("node1", results.get(0).getNodeStats().get(0).getNode().getId());
+        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(0).getRoutingState().getState());
+        assertEquals("node2", results.get(0).getNodeStats().get(1).getNode().getId());
+        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(1).getRoutingState().getState());
+        assertEquals("node3", results.get(0).getNodeStats().get(2).getNode().getId());
+        assertEquals(RoutingState.FAILED, results.get(0).getNodeStats().get(2).getRoutingState().getState());
+    }
+
+    public void testAddFailedRoutes_TaskResultIsOverwritten() throws UnknownHostException {
+        DiscoveryNodes nodes = buildNodes("node1", "node2");
+
+        List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
+        nodeStatsList.add(
+            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
+                nodes.get("node1"),
+                randomNonNegativeLong(),
+                randomDoubleBetween(0.0, 100.0, true),
+                randomIntBetween(1, 100),
+                Instant.now(),
+                Instant.now()
+            )
+        );
+        nodeStatsList.add(
+            GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
+                nodes.get("node2"),
+                randomNonNegativeLong(),
+                randomDoubleBetween(0.0, 100.0, true),
+                randomIntBetween(1, 100),
+                Instant.now(),
+                Instant.now()
+            )
+        );
+
+        var model1 = new GetDeploymentStatsAction.Response.AllocationStats(
+            "model1",
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
+            Instant.now(),
+            nodeStatsList
+        );
+        var response = new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), List.of(model1), 1);
+
+        // failed state for node 2 conflicts with the task response
+        Map<TrainedModelAllocation, Map<String, RoutingStateAndReason>> badRoutes = new HashMap<>();
+        Map<String, RoutingStateAndReason> nodeRoutes = new HashMap<>();
+        nodeRoutes.put("node2", new RoutingStateAndReason(RoutingState.FAILED, "failed on node3"));
+        badRoutes.put(createAllocation("model1"), nodeRoutes);
+
+        var modified = TransportGetDeploymentStatsAction.addFailedRoutes(response, badRoutes, nodes);
+        List<GetDeploymentStatsAction.Response.AllocationStats> results = modified.getStats().results();
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getNodeStats(), hasSize(2));
+        assertEquals("node1", results.get(0).getNodeStats().get(0).getNode().getId());
+        assertEquals(RoutingState.STARTED, results.get(0).getNodeStats().get(0).getRoutingState().getState());
+        assertEquals("node2", results.get(0).getNodeStats().get(1).getNode().getId());
+        // routing state from the bad routes map is chosen to resolve teh conflict
+        assertEquals(RoutingState.FAILED, results.get(0).getNodeStats().get(1).getRoutingState().getState());
+    }
+
+    private DiscoveryNodes buildNodes(String... nodeIds) throws UnknownHostException {
+        InetAddress inetAddress = InetAddress.getByAddress(new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        int port = 9200;
+        for (String nodeId : nodeIds) {
+            builder.add(new DiscoveryNode(nodeId, new TransportAddress(inetAddress, port++), Version.CURRENT));
+        }
+        return builder.build();
+    }
+
+    private GetDeploymentStatsAction.Response.AllocationStats randomDeploymentStats() {
+        List<GetDeploymentStatsAction.Response.AllocationStats.NodeStats> nodeStatsList = new ArrayList<>();
+        int numNodes = randomIntBetween(1, 4);
+        for (int i = 0; i < numNodes; i++) {
+            var node = new DiscoveryNode("node_" + i, new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
+            if (randomBoolean()) {
+                nodeStatsList.add(
+                    GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forStartedState(
+                        node,
+                        randomNonNegativeLong(),
+                        randomDoubleBetween(0.0, 100.0, true),
+                        randomIntBetween(1, 100),
+                        Instant.now(),
+                        Instant.now()
+                    )
+                );
+            } else {
+                nodeStatsList.add(
+                    GetDeploymentStatsAction.Response.AllocationStats.NodeStats.forNotStartedState(
+                        node,
+                        randomFrom(RoutingState.values()),
+                        randomBoolean() ? null : "a good reason"
+                    )
+                );
+            }
+        }
+
+        nodeStatsList.sort(Comparator.comparing(n -> n.getNode().getId()));
+
+        return new GetDeploymentStatsAction.Response.AllocationStats(
+            randomAlphaOfLength(5),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 8),
+            randomBoolean() ? null : randomIntBetween(1, 10000),
+            Instant.now(),
+            nodeStatsList
+        );
+    }
+
+    private static TrainedModelAllocation createAllocation(String modelId) {
+        return TrainedModelAllocation.Builder.empty(new StartTrainedModelDeploymentAction.TaskParams(modelId, 1024, 1, 1, 1)).build();
+    }
+}


### PR DESCRIPTION
Adds `start_time` to the get deployment stats API for the deployment
and each allocation.
