### PR TITLE
fix delete-auto-follow-pattern task name

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportDeleteAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportDeleteAutoFollowPatternAction.java
@@ -60,7 +60,7 @@ public class TransportDeleteAutoFollowPatternAction extends AcknowledgedTranspor
         ActionListener<AcknowledgedResponse> listener
     ) {
         clusterService.submitStateUpdateTask(
-            "put-auto-follow-pattern-" + request.getName(),
+            "delete-auto-follow-pattern-" + request.getName(),
             new AckedClusterStateUpdateTask(request, listener) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {


### PR DESCRIPTION
This pr fix the name for `delete-auto-follow-pattern` update cluster task that seems to be accidentally copied from another action