### PR TITLE
Undeprecate the auto complete thread pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -210,7 +210,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
         builders.put(
             Names.AUTO_COMPLETE,
-            new FixedExecutorBuilder(settings, Names.AUTO_COMPLETE, Math.max(allocatedProcessors / 4, 1), 100, true)
+            new FixedExecutorBuilder(settings, Names.AUTO_COMPLETE, Math.max(allocatedProcessors / 4, 1), 100, false)
         );
         builders.put(
             Names.MANAGEMENT,


### PR DESCRIPTION
The auto complete thread pool was incorrectly marked as deprecated when it was backported to 7.x. This PR undeprecates the properties associated with the thread pool.