### PR TITLE
Document _key tag added on the agg layer features

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -423,7 +423,10 @@ include::search-vector-tile-api.asciidoc[tag=geometry]
 [%collapsible%open]
 ======
 `_count`::
-(string) Count of the cell's documents.
+(long) Count of the cell's documents.
+
+`_key`::
+(string) Bucket key of the cell in the format `{z}/{x}/{y}`.
 
 `<sub-aggregation>.value`::
 Sub-aggregation results for the cell. Only returned for sub-aggregations in the

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -426,7 +426,7 @@ include::search-vector-tile-api.asciidoc[tag=geometry]
 (long) Count of the cell's documents.
 
 `_key`::
-(string) Bucket key of the cell in the format `{z}/{x}/{y}`.
+(string) Bucket key of the cell in the format `<zoom>/<x>/<y>`.
 
 `<sub-aggregation>.value`::
 Sub-aggregation results for the cell. Only returned for sub-aggregations in the


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/79634 we added a new tag to the features in the aggregation layer. The feature is called `_key` and contains the bucket key. This PR adds such information to the docs.

In addition changes the datatype of the _count tag as it is currently a long.