### PR TITLE
Fixing SearchWithMinCompatibleSearchNodeIT

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1742,6 +1742,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case ".snapshot-blob-cache":
             case "ilm-history":
             case "logstash-index-template":
+            case ".logstash-management":
             case "security-index-template":
             case "data-streams-mappings":
                 return true;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -21,6 +21,8 @@ import org.elasticsearch.index.SearchSlowLog;
 import org.elasticsearch.index.SlowLogLevel;
 import org.elasticsearch.index.engine.frozen.FrozenEngine;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.store.Store;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
@@ -573,5 +575,28 @@ public class IndexDeprecationChecks {
             }
         }
         return null;
+    }
+
+    static DeprecationIssue checkSettingNoReplacement(IndexMetadata indexMetadata, Setting<?> deprecatedSetting, String url) {
+        assert deprecatedSetting.isDeprecated() : deprecatedSetting;
+        if (deprecatedSetting.exists(indexMetadata.getSettings()) == false) {
+            return null;
+        }
+        final String deprecatedSettingKey = deprecatedSetting.getKey();
+        final String message = String.format(Locale.ROOT, "Setting [%s] is deprecated", deprecatedSettingKey);
+        final String details = String.format(Locale.ROOT, "Remove the [%s] setting.", deprecatedSetting.getKey());
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
+    }
+
+    static DeprecationIssue httpContentTypeRequiredSettingCheck(IndexMetadata indexMetadata) {
+        Setting<Boolean> deprecatedSetting = Store.FORCE_RAM_TERM_DICT;
+        String url = "https://ela.st/es-deprecation-7-force-memory-term-dictionary-setting";
+        return checkSettingNoReplacement(indexMetadata, deprecatedSetting, url);
+    }
+
+    static DeprecationIssue mapperDyamicSettingCheck(IndexMetadata indexMetadata) {
+        Setting<Boolean> deprecatedSetting = MapperService.INDEX_MAPPER_DYNAMIC_SETTING;
+        String url = "https://ela.st/es-deprecation-7-mapper-dynamic-setting";
+        return checkSettingNoReplacement(indexMetadata, deprecatedSetting, url);
     }
 }


### PR DESCRIPTION
In #79946 we began checking that no unexpected ILM policies or templates existed after we cleaned a cluster. This
caused a test failure because in compatibility clusters we have .logstash-management as a standard template in
older clusters. This commit adds that to the list of known templates.
Relates #79946
Closes #80202