### PR TITLE
Adding .logstash-management to the list of known templates

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1742,6 +1742,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case ".snapshot-blob-cache":
             case "ilm-history":
             case "logstash-index-template":
+            case ".logstash-management":
             case "security-index-template":
             case "data-streams-mappings":
                 return true;


### PR DESCRIPTION
In #79946 we began checking that no unexpected ILM policies or templates existed after we cleaned a cluster. This
caused a test failure because in compatibility clusters we have .logstash-management as a standard template in
older clusters. This commit adds that to the list of known templates.
Relates #79946
Closes #80202