### PR TITLE
[7.13][DOCS] Adds deprecated allow_no_jobs and allow_no_datafeeds ML API…(#80163)

### DIFF
--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -40,6 +40,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 [[cat-anomaly-detectors-query-params]]
 ==== {api-query-parms-title}
 
+`allow_no_jobs`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -29,7 +29,7 @@ Returns configuration and usage information about {dfeeds}.
 {dfeeds-cap} retrieve data from {es} for analysis by {anomaly-jobs}. For more 
 information, see {ml-docs}/ml-dfeeds.html[{dfeeds-cap}].
 
-NOTE: This API returns a maximum of 10,000 jobs.
+NOTE: This API returns a maximum of 10,000 {dfeeds}.
 
 [[cat-datafeeds-path-params]]
 ==== {api-path-parms-title}
@@ -40,6 +40,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[cat-datafeeds-query-params]]
 ==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
 
 `allow_no_match`::
 (Optional, Boolean)

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -65,6 +65,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildca
 [[ml-close-job-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_jobs`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -55,6 +55,9 @@ all {dfeeds}.
 [[ml-get-datafeed-stats-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_datafeeds`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -52,6 +52,9 @@ all {dfeeds}.
 [[ml-get-datafeed-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_datafeeds`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -45,6 +45,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 [[ml-get-job-stats-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_jobs`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -45,6 +45,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 [[ml-get-job-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_jobs`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -58,6 +58,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildca
 [[ml-get-overall-buckets-request-body]]
 == {api-request-body-title}
 
+`allow_no_jobs`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -45,6 +45,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 [[ml-stop-datafeed-query-parms]]
 == {api-query-parms-title}
 
+`allow_no_datafeeds`::
+(Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
+
 `allow_no_match`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]


### PR DESCRIPTION
Backports #80163 
