### PR TITLE
Clarify same indices requests are blocked

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -6,9 +6,13 @@ API. The merge relates to the number of segments a Lucene index holds within
 each shard. The force merge operation allows to reduce the number of segments by
 merging them.
 
-This call will block until the merge is complete. If the http connection is
-lost, the request will continue in the background, and any new requests will
-block until the previous force merge is complete.
+=== Blocks during a force merge
+
+Calls to this API block until the merge is complete. If the client 
+connection is lost before completion then the force merge process 
+will continue in the background. Any new requests to force merge the 
+same indices will also block until the ongoing force merge is 
+complete.
 
 WARNING: Force merge should only be called against *read-only indices*. Running 
 force merge against a read-write index can cause very large segments to be produced 


### PR DESCRIPTION
Make it clear that requests to force merge _the same indices_ will be blocked.
(Used the same language from current release, v7.15.)
