### PR TITLE
[Security Solution] Add proper permissions to fleet server for Endpoint response index

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -74,7 +74,8 @@ GET /_security/service/elastic/fleet-server
             "metrics-*",
             "traces-*",
             "synthetics-*",
-            ".logs-endpoint.diagnostic.collection-*"
+            ".logs-endpoint.diagnostic.collection-*",
+            ".logs-endpoint.action.responses-*"
           ],
           "privileges": [
             "write",

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -90,7 +90,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "            \"metrics-*\",\n"
         + "            \"traces-*\",\n"
         + "            \"synthetics-*\",\n"
-        + "            \".logs-endpoint.diagnostic.collection-*\"\n"
+        + "            \".logs-endpoint.diagnostic.collection-*\",\n"
         + "            \".logs-endpoint.action.responses-*\"\n"
         + "          ],\n"
         + "          \"privileges\": [\n"

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -91,6 +91,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "            \"traces-*\",\n"
         + "            \"synthetics-*\",\n"
         + "            \".logs-endpoint.diagnostic.collection-*\"\n"
+        + "            \".logs-endpoint.action.responses-*\"\n"
         + "          ],\n"
         + "          \"privileges\": [\n"
         + "            \"write\",\n"

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -29,7 +29,14 @@ final class ElasticServiceAccounts {
             new String[] { "monitor", "manage_own_api_key" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-*", "metrics-*", "traces-*", "synthetics-*", ".logs-endpoint.diagnostic.collection-*", ".logs-endpoint.action.responses-*")
+                    .indices(
+                        "logs-*",
+                        "metrics-*",
+                        "traces-*",
+                        "synthetics-*",
+                        ".logs-endpoint.diagnostic.collection-*",
+                        ".logs-endpoint.action.responses-*"
+                    )
                     .privileges("write", "create_index", "auto_configure")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -29,7 +29,7 @@ final class ElasticServiceAccounts {
             new String[] { "monitor", "manage_own_api_key" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-*", "metrics-*", "traces-*", "synthetics-*", ".logs-endpoint.diagnostic.collection-*")
+                    .indices("logs-*", "metrics-*", "traces-*", "synthetics-*", ".logs-endpoint.diagnostic.collection-*", ".logs-endpoint.action.responses-*")
                     .privileges("write", "create_index", "auto_configure")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -163,7 +163,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "metrics-" + randomAlphaOfLengthBetween(1, 20),
             "traces-" + randomAlphaOfLengthBetween(1, 20),
             "synthetics-" + randomAlphaOfLengthBetween(1, 20),
-            ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(1, 20)
+            ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(1, 20),
+            ".logs-endpoint.action.responses-" + randomAlphaOfLengthBetween(1, 20)
         ).stream().map(this::mockIndexAbstraction).forEach(index -> {
             assertThat(role.indices().allowedIndicesMatcher(AutoPutMappingAction.NAME).test(index), is(true));
             assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(index), is(true));


### PR DESCRIPTION
This PR adds the proper permissions for fleet server to create and write documents to the `.logs-endpoint.action.responses-*` index.  The Security Endpoint, run by the Agent, streams action responses to this index which is used by the Security app to determine if actions are complete, etc.

This was initially missed during testing because of using locally running fleet servers that were given `superuser` permissions, hence bypassing the fleet server user.

This PR adds the index to fleet server so that the Endpoint gets the key that it needs to write to the index properly.

For more information, see this ticket: https://github.com/elastic/kibana/issues/116715
