### PR TITLE
[DOCS] Fixes version in ML breaking change

### DIFF
--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -110,7 +110,7 @@ The `allow_no_datafeeds` property was deprecated in the
 {ref}/cat-datafeeds.html[cat {dfeeds}],
 {ref}/ml-get-datafeed.html[get {dfeeds}],
 {ref}/ml-get-datafeed-stats.html[get {dfeed} statistics], and
-{ref}/ml-stop-datafeed.html[stop {dfeeds}] APIs in 7.9.0.
+{ref}/ml-stop-datafeed.html[stop {dfeeds}] APIs in 7.10.0.
 
 *Impact* +
 Use `allow_no_match` instead.
@@ -125,7 +125,7 @@ The `allow_no_jobs` property was deprecated in the
 {ref}/ml-close-job.html[close {anomaly-jobs}],
 {ref}/ml-get-job.html[get {anomaly-jobs}],
 {ref}/ml-get-job-stats.html[get {anomaly-job} statistics], and
-{ref}/ml-get-overall-buckets.html[get overall buckets] APIs in 7.9.0.
+{ref}/ml-get-overall-buckets.html[get overall buckets] APIs in 7.10.0.
 
 *Impact* +
 Use `allow_no_match` instead.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/80155

Fixes an incorrect version number in the breaking change.