### PR TITLE
[8.0] Prevent infinite recursion for RBACEngineAuthorizationInfo#hashCode (#80244)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -801,7 +801,12 @@ public class RBACEngine implements AuthorizationEngine {
 
         @Override
         public int hashCode() {
-            return Objects.hash(role, authenticatedUserAuthorizationInfo);
+            // Since authenticatedUserAuthorizationInfo can self reference, we handle it specially to avoid infinite recursion.
+            if (this.authenticatedUserAuthorizationInfo == this) {
+                return Objects.hashCode(role);
+            } else {
+                return Objects.hash(role, authenticatedUserAuthorizationInfo);
+            }
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -1450,6 +1450,13 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(authorizedIndices.isEmpty(), is(true));
     }
 
+    public void testNoInfiniteRecursionForRBACAuthorizationInfoHashCode() {
+        final Role role = Role.builder(RESTRICTED_INDICES_AUTOMATON, "role").build();
+        // No assertion is needed, the test is successful as long as hashCode calls do not throw error
+        new RBACAuthorizationInfo(role, Role.builder(RESTRICTED_INDICES_AUTOMATON, "authenticated_role").build()).hashCode();
+        new RBACAuthorizationInfo(role, null).hashCode();
+    }
+
     private GetUserPrivilegesResponse.Indices findIndexPrivilege(Set<GetUserPrivilegesResponse.Indices> indices, String name) {
         return indices.stream().filter(i -> i.getIndices().contains(name)).findFirst().get();
     }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Prevent infinite recursion for RBACEngineAuthorizationInfo#hashCode (#80244)