### PR TITLE
[Test] Fix and enhance testServiceAccountDenial

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -146,6 +146,7 @@ import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivileg
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.Privilege;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.ElasticUser;
@@ -865,7 +866,6 @@ public class AuthorizationServiceTests extends ESTestCase {
         verifyNoMoreInteractions(auditTrail);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/80243")
     public void testServiceAccountDenial() {
         Tuple<String, TransportRequest> tuple = randomFrom(
             asList(new Tuple<>(SearchAction.NAME, new SearchRequest()), new Tuple<>(SqlQueryAction.NAME, new SqlQueryRequest()))
@@ -878,6 +878,9 @@ public class AuthorizationServiceTests extends ESTestCase {
         final User serviceUser = new User(randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8));
         final User finalUser;
         final boolean isRunAs = randomBoolean();
+        // If testing run-as, randomize whether the service account actually has the run-as permission
+        // This makes a difference in the auditing logs (runAsDenied vs accessDenied)
+        final boolean canRunAs = isRunAs && randomBoolean();
         if (isRunAs) {
             finalUser = new User(new User(randomAlphaOfLengthBetween(3, 8)), serviceUser);
         } else {
@@ -892,10 +895,18 @@ public class AuthorizationServiceTests extends ESTestCase {
             Map.of()
         );
         Mockito.reset(rolesStore);
+        final Role role;
+        if (canRunAs) {
+            role = Role.builder(RESTRICTED_INDICES_AUTOMATON, "can_run_as")
+                .runAs(new Privilege(finalUser.principal(), finalUser.principal()))
+                .build();
+        } else {
+            role = Role.EMPTY;
+        }
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Role> listener = (ActionListener<Role>) invocationOnMock.getArguments()[2];
-            listener.onResponse(Role.EMPTY);
+            listener.onResponse(role);
             return null;
         }).when(rolesStore).getRoles(any(User.class), any(Authentication.class), anyActionListener());
 
@@ -910,10 +921,17 @@ public class AuthorizationServiceTests extends ESTestCase {
             )
         );
         if (isRunAs) {
-            assertThat(securityException, throwableWithMessage(containsString("run as [" + finalUser.principal() + "]with roles [")));
+            assertThat(securityException, throwableWithMessage(containsString("run as [" + finalUser.principal() + "] with roles [")));
         }
         assertThat(securityException, throwableWithMessage(containsString("this action is granted by the index privileges [read,all]")));
-        verify(auditTrail).accessDenied(eq(requestId), eq(authentication), eq(action), eq(request), authzInfoRoles(Role.EMPTY.names()));
+        if (isRunAs && false == canRunAs) {
+            verify(auditTrail).runAsDenied(eq(requestId), eq(authentication), eq(action), eq(request), authzInfoRoles(role.names()));
+        } else {
+            if (canRunAs) {
+                verify(auditTrail).runAsGranted(eq(requestId), eq(authentication), eq(action), eq(request), authzInfoRoles(role.names()));
+            }
+            verify(auditTrail).accessDenied(eq(requestId), eq(authentication), eq(action), eq(request), authzInfoRoles(role.names()));
+        }
         verifyNoMoreInteractions(auditTrail);
     }
 


### PR DESCRIPTION
The test has been expanded to cover the following three cases:
* The service account tries to execute the action itself
* The service account runs-as other user and tries to execute the action
* The service account runs-as other user but does not have permission

Resolves: #80243

