### PR TITLE
[7.16] Document _key tag added on the agg layer features (#80205)

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -423,7 +423,10 @@ include::search-vector-tile-api.asciidoc[tag=geometry]
 [%collapsible%open]
 ======
 `_count`::
-(string) Count of the cell's documents.
+(long) Count of the cell's documents.
+
+`_key`::
+(string) Bucket key of the cell in the format `<zoom>/<x>/<y>`.
 
 `<sub-aggregation>.value`::
 Sub-aggregation results for the cell. Only returned for sub-aggregations in the


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Document _key tag added on the agg layer features (#80205)