### PR TITLE
Fix execution of exists query within nested queries on field with doc…

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/161_exists_query_within_nested_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/161_exists_query_within_nested_query.yml
@@ -1,0 +1,840 @@
+setup:
+  - skip:
+      features: ["headers", "allowed_warnings"]
+
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              dynamic: false
+              properties:
+                nested:
+                  type: nested
+                  properties:
+                    binary:
+                      type: binary
+                      doc_values: true
+                    boolean:
+                      type: boolean
+                    date:
+                      type: date
+                    geo_point:
+                      type: geo_point
+                    ip:
+                      type: ip
+                    keyword:
+                      type: keyword
+                    byte:
+                      type: byte
+                    double:
+                      type: double
+                    float:
+                      type: float
+                    half_float:
+                      type: half_float
+                    integer:
+                      type: integer
+                    long:
+                      type: long
+                    short:
+                      type: short
+                    object:
+                      type: object
+                      properties:
+                        inner1:
+                          type: keyword
+                        inner2:
+                          type: keyword
+                    text:
+                      type: text
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test"
+          id:     1
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: true
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner1: "foo"
+                  inner2: "bar"
+                text: "foo bar"
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test"
+          id:     2
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: false
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner1: "foo"
+                text: "foo bar"
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test"
+          id:     3
+          routing: "route_me"
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: true
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner2: "bar"
+                text: "foo bar"
+
+  - do:
+      index:
+          index:  "test"
+          id:     4
+          body: {}
+
+  - do:
+      indices.create:
+          index:  test-no-dv
+          body:
+            mappings:
+              dynamic: false
+              properties:
+                nested:
+                  type: nested
+                  properties:
+                    binary:
+                      type: binary
+                      doc_values: false
+                      store: true
+                    boolean:
+                      type: boolean
+                      doc_values: false
+                    date:
+                      type: date
+                      doc_values: false
+                    geo_point:
+                      type: geo_point
+                      doc_values: false
+                    ip:
+                      type: ip
+                      doc_values: false
+                    keyword:
+                      type: keyword
+                      doc_values: false
+                    byte:
+                      type: byte
+                      doc_values: false
+                    double:
+                      type: double
+                      doc_values: false
+                    float:
+                      type: float
+                      doc_values: false
+                    half_float:
+                      type: half_float
+                      doc_values: false
+                    integer:
+                      type: integer
+                      doc_values: false
+                    long:
+                      type: long
+                      doc_values: false
+                    short:
+                      type: short
+                      doc_values: false
+                    object:
+                      type: object
+                      properties:
+                        inner1:
+                          type: keyword
+                          doc_values: false
+                        inner2:
+                          type: keyword
+                          doc_values: false
+                    text:
+                      type: text
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test-no-dv"
+          id:     1
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: true
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner1: "foo"
+                  inner2: "bar"
+                text: "foo bar"
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test-no-dv"
+          id:     2
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: false
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner1: "foo"
+                text: "foo bar"
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+          index:  "test-no-dv"
+          id:     3
+          routing: "route_me"
+          body:
+            nested:
+              - binary: "YWJjZGUxMjM0"
+                boolean: true
+                date: "2017-01-01"
+                geo_point: [0.0, 20.0]
+                ip: "192.168.0.1"
+                keyword: "foo"
+              - byte: 1
+                double: 1.0
+                float: 1.0
+                half_float: 1.0
+                integer: 1
+              - long: 1
+                short: 1
+                object:
+                  inner2: "bar"
+                text: "foo bar"
+
+  - do:
+      index:
+          index:  "test-no-dv"
+          id:     4
+          body: {}
+
+  - do:
+      indices.refresh:
+          index: [test, test-no-dv]
+
+---
+"Test exists query within nested query on mapped binary field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.binary
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped boolean field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.boolean
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped date field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.date
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped geo_point field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.geo_point
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped ip field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.ip
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped keyword field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.keyword
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped byte field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.byte
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped double field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.double
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped float field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped half_float field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.half_float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped integer field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.integer
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped long field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.long
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped short field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.short
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped object field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.object
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped object inner field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.object.inner1
+
+  - match: {hits.total: 2}
+
+---
+"Test exists query within nested query on mapped text field":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.text
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped binary field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.binary
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped boolean field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.boolean
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped date field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.date
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped geo_point field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.geo_point
+
+  - match: {hits.total: 3}
+
+
+---
+"Test exists query within nested query on mapped ip field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.ip
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped keyword field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.keyword
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped byte field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.byte
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped double field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.double
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped float field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped half_float field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.half_float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped integer field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.integer
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped long field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.long
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped short field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.short
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped object field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.object
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query within nested query on mapped object inner field with no doc values":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Fixed in 7.16 (backport pending)"
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.object.inner1
+
+  - match: {hits.total: 2}
+
+---
+"Test exists query within nested query on mapped text field with no doc values":
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test-no-dv
+          body:
+            query:
+              nested:
+                path: nested
+                query:
+                  exists:
+                    field: nested.text
+
+  - match: {hits.total: 3}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -93,7 +93,6 @@ public abstract class DocumentParserContext {
     private final Function<DateFormatter, MappingParserContext> parserContextFunction;
     private final SourceToParse sourceToParse;
     private final Set<String> ignoredFields;
-    private final Set<String> fieldNameFields;
     private final List<Mapper> dynamicMappers;
     private final Set<String> newFieldsSeen;
     private final Map<String, ObjectMapper> dynamicObjectMappers;
@@ -108,7 +107,6 @@ public abstract class DocumentParserContext {
         this.parserContextFunction = in.parserContextFunction;
         this.sourceToParse = in.sourceToParse;
         this.ignoredFields = in.ignoredFields;
-        this.fieldNameFields = in.fieldNameFields;
         this.dynamicMappers = in.dynamicMappers;
         this.newFieldsSeen = in.newFieldsSeen;
         this.dynamicObjectMappers = in.dynamicObjectMappers;
@@ -128,7 +126,6 @@ public abstract class DocumentParserContext {
         this.parserContextFunction = parserContextFunction;
         this.sourceToParse = source;
         this.ignoredFields = new HashSet<>();
-        this.fieldNameFields = new HashSet<>();
         this.dynamicMappers = new ArrayList<>();
         this.newFieldsSeen = new HashSet<>();
         this.dynamicObjectMappers = new HashMap<>();
@@ -185,14 +182,10 @@ public abstract class DocumentParserContext {
      * or norms.
      */
     public final void addToFieldNames(String field) {
-        fieldNameFields.add(field);
-    }
-
-    /**
-     * Return the collection of fields to be added to the _field_names field
-     */
-    public final Collection<String> getFieldNames() {
-        return Collections.unmodifiableCollection(fieldNameFields);
+        FieldNamesFieldMapper fieldNamesFieldMapper = (FieldNamesFieldMapper) getMetadataMapper(FieldNamesFieldMapper.NAME);
+        if (fieldNamesFieldMapper != null) {
+            fieldNamesFieldMapper.addFieldNames( this, field );
+        }
     }
 
     public final Field version() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -177,15 +177,15 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
                     document.add(new Field(fieldType().name(), path, Defaults.FIELD_TYPE));
                 }
             }
-        } else {
-            if (enabled.value() == false) {
-                return;
-            }
-            for (String field : context.getFieldNames()) {
-                assert noDocValues(field, context) : "Field " + field + " should not have docvalues";
-                context.doc().add(new Field(NAME, field, Defaults.FIELD_TYPE));
-            }
         }
+    }
+
+    public void addFieldNames(DocumentParserContext context, String field) {
+        if (enabled.value() == false) {
+            return;
+        }
+        assert noDocValues(field, context) : "Field " + field + " should not have docvalues";
+        context.doc().add(new Field(NAME, field, Defaults.FIELD_TYPE));
     }
 
     private static boolean noDocValues(String field, DocumentParserContext context) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
@@ -136,4 +136,13 @@ public class LuceneDocument implements Iterable<IndexableField> {
         return null;
     }
 
+    public Number getNumericValue(String name) {
+        for (IndexableField f : fields) {
+            if (f.name().equals(name) && f.numericValue() != null) {
+                return f.numericValue();
+            }
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
…_values disabled (#78841) (#79462)

The FieldNamesFieldMapper adds non-indexed fields to a special metadata
field so that exists queries can be run efficiently.  This is built in a postParse
method that is run once per document.  However, this means that nested
documents are not handled correctly - non-indexed field names are added to
the parent document's metadata field rather than to the nested document's
field.

This commit fixes things to add non-indexed field names directly to the
nested documents.

Co-authored-by: Yoann Rodière <yoann@hibernate.org>