### PR TITLE
[master] [DOCS] Add collapsible section to `dimension` parameter (#80230)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -331,12 +331,19 @@ pipeline attempts to change the `_index` field, the indexing request will fail.
 
 [[index-mapping-dimension-fields-limit]]
 `index.mapping.dimension_fields.limit`::
-experimental:[] 
-For internal use by Elastic only. Maximum number of time series dimensions for
-the index. Defaults to `16`.
 +
+--
+experimental:[]
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+Maximum number of time series dimensions for the index. Defaults to `16`.
+
 You can mark a field as a dimension using the `time_series_dimension` mapping
 parameter.
+====
+--
 
 [[index-hidden]] `index.hidden`::
 

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -57,10 +57,21 @@ specify at least one value.
 Default metric sub-field to use for queries, scripts, and aggregations that
 don't use a sub-field. Must be a value from the `metrics` array.
 
-include::numeric.asciidoc[tag=time_series_metric]
+`time_series_metric`::
 +
+--
+experimental:[]
+(Optional, string)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+include::numeric.asciidoc[tag=time_series_metric]
+
 For `aggregate_metric_double` fields, this parameter accepts `counter`, `gauge`,
 and `summary`. You can't update this parameter for existing fields.
+====
+--
 
 [[aggregate-metric-double-uses]]
 ==== Uses

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -27,10 +27,21 @@ per document. Nested arrays are not supported.
 [[histogram-params]]
 ==== Parameters
 
-include::numeric.asciidoc[tag=time_series_metric]
+`time_series_metric`::
 +
+--
+experimental:[]
+(Optional, string)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+include::numeric.asciidoc[tag=time_series_metric]
+
 For `histogram` fields, this parameter accepts `histogram`. You can't update
 this parameter for existing fields.
+====
+--
 
 [[histogram-uses]]
 ==== Uses

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -91,7 +91,18 @@ The following parameters are accepted by `ip` fields:
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
+`time_series_dimension`::
++
+--
+experimental:[]
+(Optional, Boolean)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
 include::keyword.asciidoc[tag=dimension]
+====
+--
 
 [[query-ip-fields]]
 ==== Querying `ip` fields

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -147,22 +147,30 @@ The following parameters are accepted by `keyword` fields:
     when building a query for this field.
     Accepts `true` or `false` (default).
 
-// tag::dimension[]
 `time_series_dimension`::
-experimental:[]
-(Optional, Boolean) For internal use by Elastic only. Marks the field as a time
-series dimension. Defaults to `false`.
 +
+--
+experimental:[]
+(Optional, Boolean)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+// tag::dimension[]
+Marks the field as a time series dimension. Defaults to `false`.
+
 The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
 index setting limits the number of dimensions in an index.
-+
+
 Dimension fields have the following constraints:
-+
+
 * The `doc_values` and `index` mapping parameters must be `true`.
 * Field values cannot be an <<array,array or multi-value>>.
 // end::dimension[]
 * Field values cannot be larger than 1024 bytes.
 * The field cannot use a <<normalizer,`normalizer`>>.
+====
+--
 
 include::constant-keyword.asciidoc[]
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -170,26 +170,45 @@ The following parameters are accepted by numeric types:
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
-include::keyword.asciidoc[tag=dimension]
+`time_series_dimension`::
 +
+--
+experimental:[]
+(Optional, Boolean)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+include::keyword.asciidoc[tag=dimension]
+
 Of the numeric field types, only `byte`, `short`, `integer`, `long`, and
 `unsigned_long` fields support this parameter.
-+
-A numeric field can't be both a time series dimension and a time series metric.
 
-// tag::time_series_metric[]
+A numeric field can't be both a time series dimension and a time series metric.
+====
+--
+
 `time_series_metric`::
-experimental:[]
-(Optional, string) For internal use by Elastic only. Marks the field as a time
-series metric. The value is the metric type. Defaults to `null` (Not a time
-series metric).
-// end::time_series_metric[]
 +
+--
+experimental:[]
+(Optional, string)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+// tag::time_series_metric[]
+Marks the field as a time series metric. The value is the metric type. Defaults
+to `null` (Not a time series metric).
+// end::time_series_metric[]
+
 For numeric fields, this parameter accepts `gauge` and `counter`. You can't
 update this parameter for existing fields.
-+
+
 For a numeric time series metric, the `doc_values` parameter must be `true`. A
 numeric field can't be both a time series dimension and a time series metric.
+====
+--
 
 [[scaled-float-params]]
 ==== Parameters for `scaled_float`


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Add collapsible section to `dimension` parameter (#80230)