### PR TITLE
New field mapping flag - allow_multiple_values

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -112,7 +112,7 @@ as-you-type completion.
 === Arrays
 In {es}, arrays do not require a dedicated field data type. Any field can contain
 zero or more values by default, however, all values in the array must be of the
-same field type. See <<array>>.
+same field type. See <<array>> for more detail (including how to reject array values).
 
 [discrete]
 [[types-multi-fields]]

--- a/docs/reference/mapping/types/array.asciidoc
+++ b/docs/reference/mapping/types/array.asciidoc
@@ -81,3 +81,14 @@ GET my-index-000001/_search
 <3> The second document contains no arrays, but can be indexed into the same fields.
 <4> The query looks for `elasticsearch` in the `tags` field, and matches both documents.
 
+.Rejecting documents with arrays
+[NOTE]
+====================================================
+
+It is possible to reject documents with array values for a field
+by using the `allow_multiple_values` setting in the field's index mapping.
+The default value for fields is `true`, meaning arrays are accepted.
+When this property is set to `false` documents that present arrays instead of single
+values are rejected with an error.
+
+====================================================

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -166,7 +166,7 @@ The following parameters are accepted by `boolean` fields:
 
 [horizontal]
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -166,6 +166,12 @@ The following parameters are accepted by `boolean` fields:
 
 [horizontal]
 
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -112,7 +112,7 @@ The following parameters are accepted by `date` fields:
 
 [horizontal]
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -112,6 +112,12 @@ The following parameters are accepted by `date` fields:
 
 [horizontal]
 
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -60,6 +60,10 @@ and reject the whole document.
 |`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
 | `false`
 
+|`allow_multiple_values` |If `false` will reject with an error documents presenting arrays of shapes
+| `true`
+
+
 |=======================================================================
 
 

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -60,10 +60,6 @@ and reject the whole document.
 |`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
 | `false`
 
-|`allow_multiple_values` |If `false` will reject with an error documents presenting arrays of shapes
-| `true`
-
-
 |=======================================================================
 
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -43,7 +43,7 @@ NOTE: You can also store ip ranges in a single field using an <<range,ip_range d
 
 The following parameters are accepted by `ip` fields:
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -43,6 +43,12 @@ NOTE: You can also store ip ranges in a single field using an <<range,ip_range d
 
 The following parameters are accepted by `ip` fields:
 
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -53,6 +53,12 @@ include::numeric.asciidoc[tag=map-ids-as-keyword]
 
 The following parameters are accepted by `keyword` fields:
 
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -53,7 +53,7 @@ include::numeric.asciidoc[tag=map-ids-as-keyword]
 
 The following parameters are accepted by `keyword` fields:
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -111,6 +111,12 @@ the data as both a `keyword` _and_ a numeric data type.
 
 The following parameters are accepted by numeric types:
 
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<coerce,`coerce`>>::
 
     Try to convert strings to numbers and truncate fractions for integers.

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -111,7 +111,7 @@ the data as both a `keyword` _and_ a numeric data type.
 
 The following parameters are accepted by numeric types:
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -79,7 +79,7 @@ You are not required to set the field `type` to `object` explicitly, as this is 
 The following parameters are accepted by `object` fields:
 
 [horizontal]
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -79,6 +79,12 @@ You are not required to set the field `type` to `object` explicitly, as this is 
 The following parameters are accepted by `object` fields:
 
 [horizontal]
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
+
 <<dynamic,`dynamic`>>::
 
     Whether or not new `properties` should be added dynamically

--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -214,6 +214,11 @@ PUT range_index/_doc/2
 The following parameters are accepted by range types:
 
 [horizontal]
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
 
 <<coerce,`coerce`>>::
 

--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -214,7 +214,7 @@ PUT range_index/_doc/2
 The following parameters are accepted by range types:
 
 [horizontal]
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -52,6 +52,8 @@ and reject the whole document.
 |`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
 | `false`
 
+|`allow_multiple_values` |If `false` will reject with an error documents presenting arrays of shapes
+| `true`
 |=======================================================================
 
 [[shape-indexing-approach]]

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -52,8 +52,6 @@ and reject the whole document.
 |`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
 | `false`
 
-|`allow_multiple_values` |If `false` will reject with an error documents presenting arrays of shapes
-| `true`
 |=======================================================================
 
 [[shape-indexing-approach]]

--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -9,7 +9,7 @@ The `version` field type is a specialization of the `keyword` field for
 handling software version values and to support specialized precedence
 rules for them. Precedence is defined following the rules outlined by
 https://semver.org/[Semantic Versioning], which for example means that
-major, minor and patch version parts are sorted numerically (i.e. 
+major, minor and patch version parts are sorted numerically (i.e.
 "2.1.0" < "2.4.1" < "2.11.2") and pre-release versions are sorted before
 release versions (i.e. "1.0.0-alpha" < "1.0.0").
 
@@ -30,7 +30,7 @@ PUT my-index-000001
 
 --------------------------------------------------
 
-The field offers the same search capabilities as a regular keyword field. It 
+The field offers the same search capabilities as a regular keyword field. It
 can e.g. be searched for exact matches using `match` or `term` queries and
 supports prefix and wildcard searches. The main benefit is that `range` queries
 will honor Semver ordering, so a `range` query between "1.0.0" and "1.5.0"
@@ -55,6 +55,12 @@ invalid ones.
 The following parameters are accepted by `version` fields:
 
 [horizontal]
+
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
 
 <<mapping-field-meta,`meta`>>::
 

--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -56,7 +56,7 @@ The following parameters are accepted by `version` fields:
 
 [horizontal]
 
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -114,6 +114,11 @@ GET my-index-000001/_search
 The following parameters are accepted by `wildcard` fields:
 
 [horizontal]
+<<allow-multiple-values,`allow_multiple_values`>>::
+
+    Should the field permit arrays of values?  Accepts `true`
+    (default) or `false`. When `false`, documents presenting arrays
+    of values for this field will be rejected with an error.
 
 <<null-value,`null_value`>>::
 

--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -114,7 +114,7 @@ GET my-index-000001/_search
 The following parameters are accepted by `wildcard` fields:
 
 [horizontal]
-<<allow-multiple-values,`allow_multiple_values`>>::
+`allow_multiple_values`::
 
     Should the field permit arrays of values?  Accepts `true`
     (default) or `false`. When `false`, documents presenting arrays

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -563,6 +563,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
             builder.orientation.get(),
             multiFields,
             copyTo,
+            builder.getAllowMultipleValues(),
             parser
         );
         this.indexCreatedVersion = builder.indexCreatedVersion;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
@@ -75,6 +75,12 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // We don't allow users to redefine if multiple values are allowed - they are never allowed.
+            return false;
+        }
+
+        @Override
         public RankFeatureFieldMapper build(MapperBuilderContext context) {
             return new RankFeatureFieldMapper(
                 name,

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
@@ -60,6 +60,12 @@ public class RankFeaturesFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // We don't allow users to redefine if multiple values are allowed - they are never allowed.
+            return false;
+        }
+
+        @Override
         public RankFeaturesFieldMapper build(MapperBuilderContext context) {
             return new RankFeaturesFieldMapper(
                 name,

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -646,7 +646,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         ShingleFieldMapper[] shingleFields,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, MultiFields.empty(), copyTo, false, null);
+        super(simpleName, mappedFieldType, indexAnalyzers, MultiFields.empty(), copyTo, builder.getAllowMultipleValues(), false, null);
         this.prefixField = prefixField;
         this.shingleFields = shingleFields;
         this.maxShingleSize = builder.maxShingleSize.getValue();

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -141,6 +141,12 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
+        @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // We don't allow users to redefine if multiple values are allowed - they are always allowed.
+            return false;
+        }
+
         public Builder(String name, IndexAnalyzers indexAnalyzers) {
             super(name);
             this.analyzers = new TextParams.Analyzers(
@@ -646,7 +652,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         ShingleFieldMapper[] shingleFields,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, MultiFields.empty(), copyTo, builder.getAllowMultipleValues(), false, null);
+        super(simpleName, mappedFieldType, indexAnalyzers, MultiFields.empty(), copyTo, true, false, null);
         this.prefixField = prefixField;
         this.shingleFields = shingleFields;
         this.maxShingleSize = builder.maxShingleSize.getValue();

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -73,6 +73,12 @@ public class TokenCountFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
+        @Override
         public TokenCountFieldMapper build(MapperBuilderContext context) {
             if (analyzer.getValue() == null) {
                 throw new MapperParsingException("Analyzer must be set for field [" + name + "] but wasn't.");

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -120,6 +120,12 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
+        @Override
         public ParentJoinFieldMapper build(MapperBuilderContext context) {
             checkObjectOrNested(context, name);
             final Map<String, ParentIdFieldMapper> parentIdFields = new HashMap<>();
@@ -208,6 +214,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         boolean eagerGlobalOrdinals,
         List<Relations> relations
     ) {
+        // TODO pass allowMultipleValues = false here? DocumentParser would then reject any arrays
         super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, MultiFields.empty(), CopyTo.empty());
         this.parentIdFields = parentIdFields;
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -531,7 +531,14 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, wrapAnalyzer(builder.analyzers.getIndexAnalyzer()), multiFields, copyTo);
+        super(
+            simpleName,
+            mappedFieldType,
+            wrapAnalyzer(builder.analyzers.getIndexAnalyzer()),
+            multiFields,
+            copyTo,
+            builder.getAllowMultipleValues()
+        );
         assert fieldType.tokenized();
         this.fieldType = fieldType;
         this.builder = builder;

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -123,9 +123,10 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         Explicit<Boolean> ignoreZValue,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo, false, null);
+        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo, allowMultipleValues, false, null);
         this.ignoreMalformed = ignoreMalformed;
         this.ignoreZValue = ignoreZValue;
         this.parser = parser;
@@ -138,9 +139,20 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         Explicit<Boolean> ignoreZValue,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser
     ) {
-        this(simpleName, mappedFieldType, Collections.emptyMap(), ignoreMalformed, ignoreZValue, multiFields, copyTo, parser);
+        this(
+            simpleName,
+            mappedFieldType,
+            Collections.emptyMap(),
+            ignoreMalformed,
+            ignoreZValue,
+            multiFields,
+            copyTo,
+            allowMultipleValues,
+            parser
+        );
     }
 
     protected AbstractGeometryFieldMapper(
@@ -148,10 +160,11 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser,
         String onScriptError
     ) {
-        super(simpleName, mappedFieldType, Collections.emptyMap(), multiFields, copyTo, true, onScriptError);
+        super(simpleName, mappedFieldType, Collections.emptyMap(), multiFields, copyTo, allowMultipleValues, true, onScriptError);
         this.ignoreMalformed = new Explicit<>(false, true);
         this.ignoreZValue = new Explicit<>(false, true);
         this.parser = parser;

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -40,9 +40,10 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
         Explicit<Boolean> ignoreZValue,
         T nullValue,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser
     ) {
-        super(simpleName, mappedFieldType, ignoreMalformed, ignoreZValue, multiFields, copyTo, parser);
+        super(simpleName, mappedFieldType, ignoreMalformed, ignoreZValue, multiFields, copyTo, allowMultipleValues, parser);
         this.nullValue = nullValue;
     }
 
@@ -51,10 +52,11 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser,
         String onScriptError
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, parser, onScriptError);
+        super(simpleName, mappedFieldType, multiFields, copyTo, allowMultipleValues, parser, onScriptError);
         this.nullValue = null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -40,10 +40,9 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
         Explicit<Boolean> ignoreZValue,
         T nullValue,
         CopyTo copyTo,
-        boolean allowMultipleValues,
         Parser<T> parser
     ) {
-        super(simpleName, mappedFieldType, ignoreMalformed, ignoreZValue, multiFields, copyTo, allowMultipleValues, parser);
+        super(simpleName, mappedFieldType, ignoreMalformed, ignoreZValue, multiFields, copyTo, true, parser);
         this.nullValue = nullValue;
     }
 
@@ -52,11 +51,10 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
-        boolean allowMultipleValues,
         Parser<T> parser,
         String onScriptError
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, allowMultipleValues, parser, onScriptError);
+        super(simpleName, mappedFieldType, multiFields, copyTo, true, parser, onScriptError);
         this.nullValue = null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -69,9 +69,10 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
         Explicit<Orientation> orientation,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, ignoreMalformed, ignoreZValue, multiFields, copyTo, parser);
+        super(simpleName, mappedFieldType, indexAnalyzers, ignoreMalformed, ignoreZValue, multiFields, copyTo, allowMultipleValues, parser);
         this.coerce = coerce;
         this.orientation = orientation;
     }
@@ -85,6 +86,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
         Explicit<Orientation> orientation,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         Parser<T> parser
     ) {
         this(
@@ -97,6 +99,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             orientation,
             multiFields,
             copyTo,
+            allowMultipleValues,
             parser
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -142,7 +142,7 @@ public class BinaryFieldMapper extends FieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.allowMultipleValues);
         this.stored = builder.stored.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -277,6 +277,7 @@ public class BooleanFieldMapper extends FieldMapper {
             Lucene.KEYWORD_ANALYZER,
             multiFields,
             copyTo,
+            builder.allowMultipleValues,
             builder.script.get() != null,
             builder.onScriptError.getValue()
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -720,7 +720,15 @@ public final class DateFieldMapper extends FieldMapper {
         Resolution resolution,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, builder.script.get() != null, builder.onScriptError.get());
+        super(
+            simpleName,
+            mappedFieldType,
+            multiFields,
+            copyTo,
+            builder.allowMultipleValues,
+            builder.script.get() != null,
+            builder.onScriptError.get()
+        );
         this.store = builder.store.getValue();
         this.indexed = builder.index.getValue();
         this.hasDocValues = builder.docValues.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1394,7 +1394,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             }
             validate();
         }
-        
+
         protected boolean supportsAllowMultipleValuesChoice() {
             return true;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1312,6 +1312,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     continue;
                 }
                 if (Objects.equals("allow_multiple_values", propName)) {
+                    if (supportsAllowMultipleValuesChoice() == false) {
+                        throw new MapperParsingException("Parameter [allow_multiple_values] not supported on mapper [" + name + "]");
+                    }
                     allowMultipleValues = Booleans.parseBoolean(propNode.toString());
                     iterator.remove();
                     continue;
@@ -1390,6 +1393,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 iterator.remove();
             }
             validate();
+        }
+        
+        protected boolean supportsAllowMultipleValuesChoice() {
+            return true;
         }
 
         protected static ContentPath parentPath(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -193,14 +193,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     }
 
     public GeoPointFieldMapper(String simpleName, MappedFieldType mappedFieldType, Parser<GeoPoint> parser, Builder builder) {
-        super(
-            simpleName,
-            mappedFieldType,
-            MultiFields.empty(),
-            CopyTo.empty(),
-            parser,
-            builder.onScriptError.get()
-        );
+        super(simpleName, mappedFieldType, MultiFields.empty(), CopyTo.empty(), parser, builder.onScriptError.get());
         this.builder = builder;
         this.scriptValues = builder.scriptValues();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -103,6 +103,12 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             return this;
         }
 
+        @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
         private static GeoPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed) {
             if (nullValue == null) {
                 return null;
@@ -180,7 +186,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             builder.ignoreZValue.get(),
             builder.nullValue.get(),
             copyTo,
-            builder.allowMultipleValues,
             parser
         );
         this.builder = builder;
@@ -193,7 +198,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             mappedFieldType,
             MultiFields.empty(),
             CopyTo.empty(),
-            builder.allowMultipleValues,
             parser,
             builder.onScriptError.get()
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -180,6 +180,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             builder.ignoreZValue.get(),
             builder.nullValue.get(),
             copyTo,
+            builder.allowMultipleValues,
             parser
         );
         this.builder = builder;
@@ -187,7 +188,15 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     }
 
     public GeoPointFieldMapper(String simpleName, MappedFieldType mappedFieldType, Parser<GeoPoint> parser, Builder builder) {
-        super(simpleName, mappedFieldType, MultiFields.empty(), CopyTo.empty(), parser, builder.onScriptError.get());
+        super(
+            simpleName,
+            mappedFieldType,
+            MultiFields.empty(),
+            CopyTo.empty(),
+            builder.allowMultipleValues,
+            parser,
+            builder.onScriptError.get()
+        );
         this.builder = builder;
         this.scriptValues = builder.scriptValues();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -184,6 +184,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
             builder.orientation.get(),
             multiFields,
             copyTo,
+            builder.allowMultipleValues,
             parser
         );
         this.builder = builder;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -392,7 +392,15 @@ public class IpFieldMapper extends FieldMapper {
     private final ScriptCompiler scriptCompiler;
 
     private IpFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, builder.script.get() != null, builder.onScriptError.get());
+        super(
+            simpleName,
+            mappedFieldType,
+            multiFields,
+            copyTo,
+            builder.allowMultipleValues,
+            builder.script.get() != null,
+            builder.onScriptError.get()
+        );
         this.ignoreMalformedByDefault = builder.ignoreMalformedByDefault;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -544,6 +544,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             mappedFieldType.normalizer,
             multiFields,
             copyTo,
+            builder.allowMultipleValues,
             builder.script.get() != null,
             builder.onScriptError.getValue()
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -49,6 +49,19 @@ public class NestedObjectMapper extends ObjectMapper {
         }
 
         @Override
+        public Builder allowMultipleValues(boolean allowMultipleValues) {
+            if (allowMultipleValues == false) {
+                // The whole raison d'etre of nested fields is to deal with multi-value objects.
+                // Prevent users from disabling multi-values.
+                throw new MapperParsingException(
+                    "Nested object field [" + name() + "] cannot have \"allow_multiple_values\" set to false."
+                );
+            }
+            super.allowMultipleValues(allowMultipleValues);
+            return this;
+        }
+
+        @Override
         public NestedObjectMapper build(MapperBuilderContext context) {
             return new NestedObjectMapper(name, context.buildFullName(name), buildMappers(false, context), this);
         }
@@ -93,7 +106,7 @@ public class NestedObjectMapper extends ObjectMapper {
     private final Query nestedTypeFilter;
 
     NestedObjectMapper(String name, String fullPath, Map<String, Mapper> mappers, Builder builder) {
-        super(name, fullPath, builder.enabled, builder.dynamic, mappers);
+        super(name, fullPath, builder.enabled, builder.dynamic, mappers, builder.allowMultipleValues);
         if (builder.indexCreatedVersion.before(Version.V_8_0_0)) {
             this.nestedTypePath = "__" + fullPath;
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1298,7 +1298,15 @@ public class NumberFieldMapper extends FieldMapper {
     private final MetricType metricType;
 
     private NumberFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, builder.script.get() != null, builder.onScriptError.getValue());
+        super(
+            simpleName,
+            mappedFieldType,
+            multiFields,
+            copyTo,
+            builder.allowMultipleValues,
+            builder.script.get() != null,
+            builder.onScriptError.getValue()
+        );
         this.type = builder.type;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -164,7 +164,7 @@ public class RangeFieldMapper extends FieldMapper {
         @Override
         public RangeFieldMapper build(MapperBuilderContext context) {
             RangeFieldType ft = setupFieldType(context);
-            return new RangeFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), type, this);
+            return new RangeFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), allowMultipleValues, type, this);
         }
     }
 
@@ -336,10 +336,11 @@ public class RangeFieldMapper extends FieldMapper {
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         RangeType type,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, allowMultipleValues);
         this.type = type;
         this.index = builder.index.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -252,7 +252,7 @@ public class RootObjectMapper extends ObjectMapper {
         Explicit<Boolean> dateDetection,
         Explicit<Boolean> numericDetection
     ) {
-        super(name, name, enabled, dynamic, mappers);
+        super(name, name, enabled, dynamic, mappers, true);
         this.runtimeFields = runtimeFields;
         this.dynamicTemplates = dynamicTemplates;
         this.dynamicDateTimeFormatters = dynamicDateTimeFormatters;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -918,7 +918,7 @@ public class TextFieldMapper extends FieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo, false, null);
+        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo, builder.allowMultipleValues, false, null);
         assert mappedFieldType.getTextSearchInfo().isTokenized();
         assert mappedFieldType.hasDocValues() == false;
         if (fieldType.indexOptions() == IndexOptions.NONE && fieldType().fielddata()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -271,7 +271,7 @@ public class TextFieldMapper extends FieldMapper {
         @Override
         protected boolean supportsAllowMultipleValuesChoice() {
             // Disable the default of parsing `allow_multiple_values` setting.
-            // I'm not sure when/why it makes sense to allow users to control if multi-values are allowed. 
+            // I'm not sure when/why it makes sense to allow users to control if multi-values are allowed.
             // Text fields are inherently "multi-valued" anyway because analyzers create multiple tokens
             // from a given input string. We can revisit this override if required but for now it seems
             // like the right thing to do.

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -268,6 +268,16 @@ public class TextFieldMapper extends FieldMapper {
             this(name, Version.CURRENT, indexAnalyzers);
         }
 
+        @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            // I'm not sure when/why it makes sense to allow users to control if multi-values are allowed. 
+            // Text fields are inherently "multi-valued" anyway because analyzers create multiple tokens
+            // from a given input string. We can revisit this override if required but for now it seems
+            // like the right thing to do.
+            return false;
+        }
+
         public Builder(String name, Version indexCreatedVersion, IndexAnalyzers indexAnalyzers) {
             super(name);
             this.indexCreatedVersion = indexCreatedVersion;

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -126,6 +126,11 @@ public final class FlattenedFieldMapper extends FieldMapper {
             }
         });
 
+        @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            return false;
+        }
+
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> builder(m).indexed.get(), true);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> builder(m).hasDocValues.get(), true);
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Base64;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class BinaryFieldMapperTests extends MapperTestCase {
@@ -118,6 +119,18 @@ public class BinaryFieldMapperTests extends MapperTestCase {
             Object originalValue = fieldType.valueForDisplay(indexedValue);
             assertEquals(new BytesArray(value), originalValue);
         }
+    }
+
+    public void testNoArrays() throws IOException {
+        // A simple binary value
+        final byte[] binaryValue1 = new byte[100];
+        binaryValue1[56] = 1;
+        SourceToParse sourceWithArrays = source(b -> b.array("field", binaryValue1, binaryValue1));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "binary").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "binary")));
+        okmapper.parse(sourceWithArrays);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class BooleanFieldMapperTests extends MapperTestCase {
@@ -65,6 +66,15 @@ public class BooleanFieldMapperTests extends MapperTestCase {
             assertEquals(1, values.docValueCount());
             assertEquals(1, values.nextValue());
         });
+    }
+
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", true, false));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "boolean").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "boolean")));
+        okmapper.parse(sourceWithArrays);
     }
 
     public void testSerialization() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -96,6 +96,15 @@ public class DateFieldMapperTests extends MapperTestCase {
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
     }
 
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", "2016-03-11", "2016-03-12"));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date")));
+        okmapper.parse(sourceWithArrays);
+    }
+
     public void testNoDocValues() throws Exception {
 
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date").field("doc_values", false)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -162,7 +162,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
     }
 
     private static ObjectMapper createObjectMapper(String name) {
-        return new ObjectMapper(name, name, new Explicit<>(true, false), ObjectMapper.Dynamic.FALSE, emptyMap());
+        return new ObjectMapper(name, name, new Explicit<>(true, false), ObjectMapper.Dynamic.FALSE, emptyMap(), true);
     }
 
     private static NestedObjectMapper createNestedObjectMapper(String name) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -115,6 +115,17 @@ public class IpFieldMapperTests extends MapperTestCase {
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "field")), existsQuery);
     }
 
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", "::1", "::1"));
+
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "ip").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+
+        DocumentMapper okMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "ip")));
+        okMapper.parse(sourceWithArrays);
+    }
+
     public void testStore() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip");

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -230,6 +230,16 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertEquals("field", fields[0].stringValue());
     }
 
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", "foo", "bar"));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword")));
+        okmapper.parse(sourceWithArrays);
+    }
+
     public void testNullValue() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -78,7 +78,8 @@ public class MappingLookupTests extends ESTestCase {
             "object",
             new Explicit<>(true, true),
             ObjectMapper.Dynamic.TRUE,
-            Collections.singletonMap("object.subfield", fieldMapper)
+            Collections.singletonMap("object.subfield", fieldMapper),
+            true
         );
         MappingLookup mappingLookup = createMappingLookup(
             Collections.singletonList(fieldMapper),

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -730,6 +730,16 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         assertThat(fields.size(), equalTo(new HashSet<>(fields).size()));
     }
 
+    public void testNoArraysNotAllowed() throws IOException {
+        // The whole point of nested is to deal with arrays of objects. Check that base class ObjectMapper's setting
+        // for disabling arrays is not enabled.
+        Exception e = expectThrows(
+            MapperParsingException.class,
+            () -> createDocumentMapper(fieldMapping(b -> b.field("type", "nested").field("allow_multiple_values", false)))
+        );
+        assertThat(e.getMessage(), containsString("Nested object field [field] cannot have \"allow_multiple_values\" set to false."));
+    }
+
     public void testNestedArrayStrict() throws Exception {
         DocumentMapper docMapper = createDocumentMapper(mapping(b -> {
             b.startObject("nested1");

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -126,6 +126,19 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         assertEquals(123, pointField.numericValue().doubleValue(), 0d);
     }
 
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArray = source(b -> b.array("field", 122, 123));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("allow_multiple_values", false);
+        }));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArray));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> { minimalMapping(b); }));
+        okmapper.parse(sourceWithArray);
+    }
+
     public void testStore() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -111,6 +111,35 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
         assertEquals(2, pointField.fieldType().pointIndexDimensionCount());
     }
 
+    public final void testNoArrays() throws Exception {
+        SourceToParse sourceWithArrays = source(b -> {
+            b.startArray("field");
+            b.startObject();
+            b.field("gte", rangeValue());
+            b.field("lte", rangeValue());
+            b.endObject();
+
+            b.startObject();
+            b.field("gte", rangeValue());
+            b.field("lte", rangeValue());
+            b.endObject();
+
+            b.endArray();
+        });
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("allow_multiple_values", false);
+        }));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("allow_multiple_values", true);
+        }));
+        okmapper.parse(sourceWithArrays);
+    }
+
     protected abstract String storedValue();
 
     public final void testStore() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -310,6 +310,15 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
     }
 
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", "Hello", "World"));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
+        okmapper.parse(sourceWithArrays);
+    }
+
     public void testDefaultPositionIncrementGap() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", new String[] { "a", "b" })));

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -310,15 +310,6 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
     }
 
-    public void testNoArrays() throws IOException {
-        SourceToParse sourceWithArrays = source(b -> b.array("field", "Hello", "World"));
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text").field("allow_multiple_values", false)));
-        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
-        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
-        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
-        okmapper.parse(sourceWithArrays);
-    }
-
     public void testDefaultPositionIncrementGap() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", new String[] { "a", "b" })));

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -27,7 +27,16 @@ public class MockFieldMapper extends FieldMapper {
     }
 
     public MockFieldMapper(MappedFieldType fieldType, Map<String, NamedAnalyzer> indexAnalyzers) {
-        super(findSimpleName(fieldType.name()), fieldType, indexAnalyzers, MultiFields.empty(), new CopyTo.Builder().build(), false, null);
+        super(
+            findSimpleName(fieldType.name()),
+            fieldType,
+            indexAnalyzers,
+            MultiFields.empty(),
+            new CopyTo.Builder().build(),
+            true,
+            false,
+            null
+        );
     }
 
     public MockFieldMapper(String fullName, MappedFieldType fieldType, MultiFields multifields, CopyTo copyTo) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -93,6 +93,12 @@ public class HistogramFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
+        @Override
         protected List<Parameter<?>> getParameters() {
             return List.of(ignoreMalformed, meta, metric);
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -480,7 +480,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.getAllowMultipleValues());
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
         this.stored = builder.stored.getValue();

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -234,6 +235,17 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", outOfRangeValue)));
             expectThrows(MapperParsingException.class, runnable);
         }
+    }
+
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", 1L, 2L));
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "unsigned_long").field("allow_multiple_values", false))
+        );
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "unsigned_long")));
+        okmapper.parse(sourceWithArrays);
     }
 
     public void testExistsQueryDocValuesDisabled() throws IOException {

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -110,7 +110,8 @@ public class VersionStringFieldMapper extends FieldMapper {
                 fieldtype,
                 buildFieldType(context, fieldtype),
                 multiFieldsBuilder.build(this, context),
-                copyTo.build()
+                copyTo.build(),
+                allowMultipleValues
             );
         }
 
@@ -324,9 +325,10 @@ public class VersionStringFieldMapper extends FieldMapper {
         FieldType fieldType,
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
-        CopyTo copyTo
+        CopyTo copyTo,
+        boolean allowMultipleValues
     ) {
-        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo, allowMultipleValues);
         this.fieldType = fieldType;
     }
 

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VersionStringFieldMapperTests extends MapperTestCase {
@@ -106,6 +107,15 @@ public class VersionStringFieldMapperTests extends MapperTestCase {
             "failed to parse field [field] of type [version] in document with id '1'. " + "Preview of field's value: '{}'",
             ex.getMessage()
         );
+    }
+
+    public void testNoArrays() throws IOException {
+        SourceToParse sourceWithArrays = source(b -> b.array("field", randomVersionNumber(), randomVersionNumber()));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "version").field("allow_multiple_values", false)));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(sourceWithArrays));
+        assertThat(e.getMessage(), containsString("Field [field] cannot be a multi-valued field"));
+        DocumentMapper okmapper = createDocumentMapper(fieldMapping(b -> b.field("type", "version")));
+        okmapper.parse(sourceWithArrays);
     }
 
     public void testFailsParsingNestedList() throws IOException {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -286,6 +286,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
             builder.orientation.get(),
             multiFields,
             copyTo,
+            builder.getAllowMultipleValues(),
             parser
         );
         this.builder = builder;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -136,6 +136,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
             builder.ignoreZValue.get(),
             builder.nullValue.get(),
             copyTo,
+            builder.getAllowMultipleValues(),
             parser
         );
         this.builder = builder;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -91,6 +91,12 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
         }
 
         @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
+        @Override
         public FieldMapper build(MapperBuilderContext context) {
             if (multiFieldsBuilder.hasMultiFields()) {
                 DEPRECATION_LOGGER.warn(
@@ -136,7 +142,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
             builder.ignoreZValue.get(),
             builder.nullValue.get(),
             copyTo,
-            builder.getAllowMultipleValues(),
             parser
         );
         this.builder = builder;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -153,6 +153,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
             builder.orientation.get(),
             multiFields,
             copyTo,
+            builder.getAllowMultipleValues(),
             parser
         );
         this.builder = builder;

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -89,6 +89,12 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
             }
         });
 
+        @Override
+        protected boolean supportsAllowMultipleValuesChoice() {
+            // Disable the default of parsing `allow_multiple_values` setting.
+            return false;
+        }
+
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, false);
         private final Parameter<VectorSimilarity> similarity = Parameter.enumParam(
             "similarity",

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -234,6 +234,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 ignoreAbove.get(),
                 multiFieldsBuilder.build(this, context),
                 copyTo.build(),
+                allowMultipleValues,
                 nullValue.get(),
                 indexVersionCreated
             );
@@ -863,10 +864,11 @@ public class WildcardFieldMapper extends FieldMapper {
         int ignoreAbove,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean allowMultipleValues,
         String nullValue,
         Version indexVersionCreated
     ) {
-        super(simpleName, mappedFieldType, mappedFieldType.analyzer, multiFields, copyTo);
+        super(simpleName, mappedFieldType, mappedFieldType.analyzer, multiFields, copyTo, allowMultipleValues);
         this.nullValue = nullValue;
         this.ignoreAbove = ignoreAbove;
         this.indexVersionCreated = indexVersionCreated;


### PR DESCRIPTION
When set to false documents that present arrays instead of single values are rejected at ingest time.
TODO - docs

Closes #58523