### PR TITLE
Adding two missing entries to the deprecation info api

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
@@ -76,7 +76,7 @@ public class LifecycleSettings {
         TimeValue.timeValueSeconds(30),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.Deprecated
+        Setting.Property.DeprecatedWarning
     );
     // This setting configures how much time since step_time should ILM wait for a condition to be met. After the threshold wait time has
     // elapsed ILM will likely stop waiting and go to the next step.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -82,7 +82,9 @@ public class DeprecationChecks {
         NodeDeprecationChecks::checkScriptContextCompilationsRateLimitSetting,
         NodeDeprecationChecks::checkScriptContextCacheSizeSetting,
         NodeDeprecationChecks::checkScriptContextCacheExpirationSetting,
-        NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting
+        NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting,
+        NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
+        NodeDeprecationChecks::checkEqlEnabledSetting
     );
 
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(


### PR DESCRIPTION
Adding indices.lifecycle.step.master_timeout and xpack.eql.enabled to the deprecation info API. These two checks
were also added to the 7.16 line in #80233.
