### PR TITLE
[7.15] [DOCS] Fix HOSTNAME quotes (#80115)

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -100,7 +100,7 @@ Values for environment variables must be simple strings. Use a comma-separated s
 
 [source,yaml]
 ----
-export HOSTNAME=“host1,host2"
+export HOSTNAME="host1,host2"
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Fix HOSTNAME quotes (#80115)