### PR TITLE
Correct description in kNN search rest spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
@@ -21,7 +21,7 @@
           "parts":{
             "index":{
               "type":"list",
-              "description":"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
+              "description":"A comma-separated list of index names to search; use `_all` to perform the operation on all indices"
             }
           }
         }


### PR DESCRIPTION
The `_knn_search` endpoint does not accept an empty `index` parameter.

Follow-up to #79013.