### PR TITLE
[DOCS] Adds missing query parameters to datafeed APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -78,6 +78,21 @@ you created or updated the {dfeed}, those credentials are used instead.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
+[[ml-start-datafeed-query-parms]]
+== {api-query-parms-title}
+
+`end`::
+  (Optional, string) The time that the {dfeed} should end. This value is
+  exclusive. The default value is an empty string.
+
+`start`::
+  (Optional, string) The time that the {dfeed} should begin. This value is
+  inclusive. The default value is an empty string.
+
+`timeout`::
+  (Optional, time) Controls the amount of time to wait until a {dfeed} starts.
+  The default value is 20 seconds.
+
 [[ml-start-datafeed-request-body]]
 == {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -49,6 +49,13 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
+`force`::
+  (Optional, Boolean) If true, the {dfeed} is stopped forcefully.
+
+`timeout`::
+  (Optional, time) Controls the amount of time to wait until a {dfeed} stops.
+  The default value is 20 seconds.
+
 [[ml-stop-datafeed-request-body]]
 == {api-request-body-title}
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/983