### PR TITLE
[8.0] Bump bundled JDK to 17.0.1 (#80034)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -69,7 +69,7 @@ import static org.elasticsearch.gradle.internal.vagrant.VagrantMachine.convertWi
  * This class defines gradle tasks for testing our various distribution artifacts.
  */
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "17+35";
+    private static final String SYSTEM_JDK_VERSION = "17.0.1+12";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
     private static final String GRADLE_JDK_VERSION = "16.0.2+7";
     private static final String GRADLE_JDK_VENDOR = "adoptium";

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.0.0
 lucene            = 9.0.0-snapshot-cc2a31f2be8
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17+35
+bundled_jdk = 17.0.1+12
 
 checkstyle = 8.42
 

--- a/docs/changelog/80034.yaml
+++ b/docs/changelog/80034.yaml
@@ -1,0 +1,6 @@
+pr: 80034
+summary: Bump bundled JDK to 17.0.1
+area: Packaging
+type: upgrade
+issues:
+ - 80001


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Bump bundled JDK to 17.0.1 (#80034)