### PR TITLE
[7.16] Bump bundled JDK to 17.0.1 (#80034)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 7.16.0
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17+35
+bundled_jdk = 17.0.1+12
 
 checkstyle = 8.39
 

--- a/docs/changelog/80034.yaml
+++ b/docs/changelog/80034.yaml
@@ -1,0 +1,6 @@
+pr: 80034
+summary: Bump bundled JDK to 17.0.1
+area: Packaging
+type: upgrade
+issues:
+ - 80001


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Bump bundled JDK to 17.0.1 (#80034)