### PR TITLE
[8.0] Don't include associated indices when checking Feature migration status (#80051)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -27,12 +27,10 @@ import org.elasticsearch.upgrades.FeatureMigrationResults;
 import org.elasticsearch.upgrades.SingleFeatureMigrationResult;
 import org.elasticsearch.upgrades.SystemIndexMigrationTaskState;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.ERROR;
 import static org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusResponse.UpgradeStatus.IN_PROGRESS;
@@ -148,8 +146,8 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
         final String failedFeatureName = featureStatus == null ? null : featureStatus.getFailedIndexName();
         final Exception exception = featureStatus == null ? null : featureStatus.getException();
 
-        return Stream.of(feature.getIndexDescriptors(), feature.getAssociatedIndexDescriptors())
-            .flatMap(Collection::stream)
+        return feature.getIndexDescriptors()
+            .stream()
             .flatMap(descriptor -> descriptor.getMatchingIndices(state.metadata()).stream())
             .sorted(String::compareTo)
             .map(index -> state.metadata().index(index))


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Don't include associated indices when checking Feature migration status (#80051)