### PR TITLE
[7.16] add description to shard changes action request (#80275)

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -170,6 +170,11 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
         }
 
         @Override
+        public String getDescription() {
+            return "shardId[" + shardId + "]";
+        }
+
+        @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -274,4 +274,12 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         assertThat(reference.get(), instanceOf(ShardNotFoundException.class));
     }
 
+    public void testShardChangesActionRequestHasDescription() {
+        Index index = new Index("index", "uuid");
+        ShardId shardId = new ShardId(index, 0);
+
+        String description = new ShardChangesAction.Request(shardId, "uuid").getDescription();
+
+        assertThat(description, equalTo("shardId[[index][0]]"));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - add description to shard changes action request (#80275)