### PR TITLE
Change ESRestTestCase#getAllUnexpectedTemplates() to remove v2 style templates if nodes are in 7.8.0 or later

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -846,9 +846,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         Set<String> unexpectedTemplates = new HashSet<>();
         if (preserveDataStreamsUponCompletion() == false && preserveTemplatesUponCompletion() == false) {
             if (hasXPack) {
-                // In case of bwc testing, if all nodes are before 7.7.0 then no need to attempt to delete component and composable
-                // index templates, because these were introduced in 7.7.0:
-                if (nodeVersions.stream().allMatch(version -> version.onOrAfter(Version.V_7_7_0))) {
+                // In case of bwc testing, if all nodes are before 7.8.0 then no need to attempt to delete component and composable
+                // index templates, because these were introduced in 7.8.0:
+                if (nodeVersions.stream().allMatch(version -> version.onOrAfter(Version.V_7_8_0))) {
                     Request getTemplatesRequest = new Request("GET", "_index_template");
                     Map<String, Object> composableIndexTemplates = XContentHelper.convertToMap(
                         JsonXContent.jsonXContent,


### PR DESCRIPTION
Forwardport #80330 to master.

Composable index templates were introduced in 7.8.0 and component templates in 7.7.0 (but not the rest action iirc).

Some bwc tests fail during teardown,
because APIs get invoked that don't exist
in particular versions.

I will forward port this to 8.0 and master branches if build is successful (including full bwc tests).

Closes #80323, #80322