### PR TITLE
[ML] fix bug in model snapshot upgrader where task never exits

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
@@ -139,6 +139,10 @@ public class JobSnapshotUpgraderResultProcessor {
         processKilled = true;
     }
 
+    public boolean isProcessKilled() {
+        return processKilled;
+    }
+
     private void logUnexpectedResult(String resultType) {
         String msg = "[" + jobId + "] [" + snapshotId + "] unexpected result read [" + resultType + "]";
         // This should never happen, but we definitely want to fail if -ea is provided (e.g. during tests)


### PR DESCRIPTION
It is possible that the model snapshot upgrader task is never fully shutdown.

This could occur in the following two scenarios:

 - The task state is failed being set to failed (we should kill the task in that situation)
 - The executor doesn't fire in time to initiate the shutdown before we shutdown the executor. This is caused by a race condition between scheduling the shutdown and closing the executor.

To the user, the failure looks like the REST request NEVER returning. In tests, it looks like:

```
13:10:20     ElasticsearchStatusException[Elasticsearch exception [type=status_exception, reason=Cannot upgrade job [ml-snapshots-upgrade-job] snapshot [1613739961] as there is currently a snapshot for this job being upgraded]]
```
As the request is spuriously retried and thus fails as the previous task never shutdown.

closes https://github.com/elastic/elasticsearch/issues/69276