### PR TITLE
Avoiding 0 ns because it gets normalized to 0s

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -2178,11 +2178,11 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         Map<Setting<?>, Object> settingToTestValueMap = new HashMap<>();
         settingToTestValueMap.put(HttpTransportSettings.OLD_SETTING_HTTP_TCP_NO_DELAY, randomBoolean());
         /*
-         * Note: Limiting time values to between 0 and 23 because the downstream code will normalize them so that 100 hours becomes 4.2
+         * Note: Limiting time values to between 1 and 23 because the downstream code will normalize them so that 100 hours becomes 4.2
          * days, so the expected values would not match the actual.
          */
-        settingToTestValueMap.put(NetworkService.TCP_CONNECT_TIMEOUT, randomTimeValue(0, 23));
-        settingToTestValueMap.put(TransportSettings.TCP_CONNECT_TIMEOUT, randomTimeValue(0, 23));
+        settingToTestValueMap.put(NetworkService.TCP_CONNECT_TIMEOUT, randomTimeValue(1, 23));
+        settingToTestValueMap.put(TransportSettings.TCP_CONNECT_TIMEOUT, randomTimeValue(1, 23));
         settingToTestValueMap.put(TransportSettings.OLD_PORT, randomAlphaOfLength(10));
         settingToTestValueMap.put(TransportSettings.OLD_TCP_NO_DELAY, randomBoolean());
         settingToTestValueMap.put(


### PR DESCRIPTION
NodeDeprecationChecksTests.testTransportSettings() uses random TimeValue objects. The test was failing if the
random TimeValue was 0ns because that gets normalized to 0s, so the expected value does not match. Since the
purpose of this test is not to test TimeValue normalization logic, I'm avoiding the problem by not every allowing 0
to be used.
Closes #80325