### PR TITLE
[7.16] Fix IndexNotFoundException error when handling remove alias action. (#80312)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -120,10 +120,10 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                     action.indices()
                 );
                 List<Index> nonBackingIndices = Arrays.stream(unprocessedConcreteIndices).filter(index -> {
-                    var ia = state.metadata().getIndicesLookup().get(index.getName());
+                    IndexAbstraction ia = state.metadata().getIndicesLookup().get(index.getName());
                     return ia.getParentDataStream() == null;
                 }).collect(Collectors.toList());
-                concreteIndices = nonBackingIndices.toArray(Index[]::new);
+                concreteIndices = nonBackingIndices.toArray(Index.EMPTY_ARRAY);
                 switch (action.actionType()) {
                     case ADD:
                         // Fail if parameters are used that data stream aliases don't support:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -111,18 +111,19 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                 request.indicesOptions(),
                 action.indices()
             );
+            final Index[] concreteIndices;
             if (concreteDataStreams.size() != 0) {
-                String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
+                Index[] unprocessedConcreteIndices = indexNameExpressionResolver.concreteIndices(
                     state,
                     request.indicesOptions(),
                     true,
                     action.indices()
                 );
-                List<String> nonBackingIndices = Arrays.stream(concreteIndices)
-                    .map(resolvedIndex -> state.metadata().getIndicesLookup().get(resolvedIndex))
-                    .filter(ia -> ia.getParentDataStream() == null)
-                    .map(IndexAbstraction::getName)
-                    .collect(Collectors.toList());
+                List<Index> nonBackingIndices = Arrays.stream(unprocessedConcreteIndices).filter(index -> {
+                    var ia = state.metadata().getIndicesLookup().get(index.getName());
+                    return ia.getParentDataStream() == null;
+                }).collect(Collectors.toList());
+                concreteIndices = nonBackingIndices.toArray(Index[]::new);
                 switch (action.actionType()) {
                     case ADD:
                         // Fail if parameters are used that data stream aliases don't support:
@@ -168,14 +169,10 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                     default:
                         throw new IllegalArgumentException("Unsupported action [" + action.actionType() + "]");
                 }
+            } else {
+                concreteIndices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), false, action.indices());
             }
 
-            final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(
-                state,
-                request.indicesOptions(),
-                false,
-                action.indices()
-            );
             for (Index concreteIndex : concreteIndices) {
                 IndexAbstraction indexAbstraction = state.metadata().getIndicesLookup().get(concreteIndex.getName());
                 assert indexAbstraction != null : "invalid cluster metadata. index [" + concreteIndex.getName() + "] was not found";

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -197,8 +197,8 @@
 ---
 "Fix IndexNotFoundException error when handling remove alias action":
   - skip:
-      version: " - 8.0.99"
-      reason: "backport pending"
+      version: " - 7.15.99"
+      reason: "Fix available from 7.16.0"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -193,3 +193,70 @@
   - do:
       indices.get_alias: {}
   - match: {log-foobar.aliases.my-alias: {}}
+
+---
+"Fix IndexNotFoundException error when handling remove alias action":
+  - skip:
+      version: " - 8.0.99"
+      reason: "backport pending"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [log-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ log-* ]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream: { }
+
+  - do:
+      indices.create_data_stream:
+        name: log-foobar
+  - is_true: acknowledged
+
+  - do:
+      indices.create:
+        index: test1
+        body:
+          aliases:
+            test: {}
+
+  - do:
+      indices.create:
+        index: test2
+        body:
+          aliases:
+            test: {}
+
+  - do:
+      indices.create:
+        index: test3
+        body:
+          aliases:
+            test: {}
+
+  - do:
+      indices.get_alias: { }
+  - match: { test1.aliases.test: { } }
+  - match: { test2.aliases.test: { } }
+  - match: { test3.aliases.test: { } }
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: '*'
+                alias: test
+  - is_true: acknowledged
+
+  - do:
+      indices.get_alias: {}
+  - match: {test1.aliases: {}}
+  - match: {test2.aliases: {}}
+  - match: {test3.aliases: {}}
+


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Fix IndexNotFoundException error when handling remove alias action. (#80312)