### PR TITLE
[7.15] Correctly merge lists with primitives (#80336)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -289,18 +289,20 @@ public class XContentHelper {
                 if (content.get(defaultEntry.getKey()) instanceof Map && defaultEntry.getValue() instanceof Map) {
                     mergeDefaults((Map<String, Object>) content.get(defaultEntry.getKey()), (Map<String, Object>) defaultEntry.getValue());
                 } else if (content.get(defaultEntry.getKey()) instanceof List && defaultEntry.getValue() instanceof List) {
-                    List<Map<String, Object>> defaultList = (List<Map<String, Object>>) defaultEntry.getValue();
-                    List<Map<String, Object>> contentList = (List<Map<String, Object>>) content.get(defaultEntry.getKey());
+                    List<Object> defaultList = (List<Object>) defaultEntry.getValue();
+                    List<Object> contentList = (List<Object>) content.get(defaultEntry.getKey());
 
-                    List<Map<String, Object>> mergedList = new ArrayList<>();
+                    List<Object> mergedList = new ArrayList<>();
                     if (allListValuesAreMapsOfOne(defaultList) && allListValuesAreMapsOfOne(contentList)) {
                         // all are in the form of [ {"key1" : {}}, {"key2" : {}} ], merge based on keys
                         Map<String, Map<String, Object>> processed = new LinkedHashMap<>();
-                        for (Map<String, Object> map : contentList) {
+                        for (Object e : contentList) {
+                            Map<String, Object> map = (Map<String, Object>) e;
                             Map.Entry<String, Object> entry = map.entrySet().iterator().next();
                             processed.put(entry.getKey(), map);
                         }
-                        for (Map<String, Object> map : defaultList) {
+                        for (Object e : defaultList) {
+                            Map<String, Object> map = (Map<String, Object>) e;
                             Map.Entry<String, Object> entry = map.entrySet().iterator().next();
                             if (processed.containsKey(entry.getKey())) {
                                 mergeDefaults(processed.get(entry.getKey()), map);
@@ -316,7 +318,7 @@ public class XContentHelper {
                         // if both are lists, simply combine them, first the defaults, then the content
                         // just make sure not to add the same value twice
                         mergedList.addAll(defaultList);
-                        for (Map<String, Object> o : contentList) {
+                        for (Object o : contentList) {
                             if (mergedList.contains(o) == false) {
                                 mergedList.add(o);
                             }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -60,6 +60,46 @@ public class XContentHelperTests extends ESTestCase {
         assertThat(content, Matchers.equalTo(expected));
     }
 
+    public void testMergingListsWithSameContent() {
+        Map<String, Object> defaults = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
+        Map<String, Object> content = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
+
+        Map<String, Object> expected = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
+
+        XContentHelper.mergeDefaults(content, defaults);
+
+        assertThat(content, Matchers.equalTo(expected));
+    }
+
+    public void testMergingListsWithDifferentContent() {
+        Map<String, Object> defaults = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z"));
+        Map<String, Object> content = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "dd-MMM-yyyy HH:mm:ss Z"));
+
+        Map<String, Object> expected = getMap("dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z", "dd-MMM-yyyy HH:mm:ss Z"));
+
+        XContentHelper.mergeDefaults(content, defaults);
+
+        assertThat(content, Matchers.equalTo(expected));
+    }
+
+    public void testMergingListsRemovesDuplicates() {
+        Map<String, Object> defaults = getMap("tags", getList("cluster_id", "cluster_region"));
+        Map<String, Object> content = getMap("tags", getList("cluster_id", "cluster_name"));
+
+        Map<String, Object> expected = getMap("tags",
+            getList("cluster_id", "cluster_region", "cluster_name"));
+
+        XContentHelper.mergeDefaults(content, defaults);
+
+        assertThat(content, Matchers.equalTo(expected));
+    }
+
     public void testToXContent() throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
         final ToXContent toXContent;


### PR DESCRIPTION
When merging plain lists we shouldn't cast them to `List<Map<String, V>>. If we do that we get a `ClassCastException` in runtime, e.g. if the list contains strings, not maps.

This issue has been already fixed in 8.0 during one of the refactorings, but it hasn't been fixed in 7.x.

Backports #80336