### PR TITLE
[7.16] Reformat XContentHelperTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -63,13 +63,19 @@ public class XContentHelperTests extends ESTestCase {
     }
 
     public void testMergingListsWithSameContent() {
-        Map<String, Object> defaults = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
-        Map<String, Object> content = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
+        Map<String, Object> defaults = getMap(
+            "dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z")
+        );
+        Map<String, Object> content = getMap(
+            "dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z")
+        );
 
-        Map<String, Object> expected = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"));
+        Map<String, Object> expected = getMap(
+            "dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z")
+        );
 
         XContentHelper.mergeDefaults(content, defaults);
 
@@ -77,13 +83,13 @@ public class XContentHelperTests extends ESTestCase {
     }
 
     public void testMergingListsWithDifferentContent() {
-        Map<String, Object> defaults = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z"));
-        Map<String, Object> content = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "dd-MMM-yyyy HH:mm:ss Z"));
+        Map<String, Object> defaults = getMap("dynamic_date_formats", getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z"));
+        Map<String, Object> content = getMap("dynamic_date_formats", getList("strict_date_optional_time", "dd-MMM-yyyy HH:mm:ss Z"));
 
-        Map<String, Object> expected = getMap("dynamic_date_formats",
-            getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z", "dd-MMM-yyyy HH:mm:ss Z"));
+        Map<String, Object> expected = getMap(
+            "dynamic_date_formats",
+            getList("strict_date_optional_time", "yyyy.MM.dd HH:mm:ss Z", "dd-MMM-yyyy HH:mm:ss Z")
+        );
 
         XContentHelper.mergeDefaults(content, defaults);
 
@@ -94,8 +100,7 @@ public class XContentHelperTests extends ESTestCase {
         Map<String, Object> defaults = getMap("tags", getList("cluster_id", "cluster_region"));
         Map<String, Object> content = getMap("tags", getList("cluster_id", "cluster_name"));
 
-        Map<String, Object> expected = getMap("tags",
-            getList("cluster_id", "cluster_region", "cluster_name"));
+        Map<String, Object> expected = getMap("tags", getList("cluster_id", "cluster_region", "cluster_name"));
 
         XContentHelper.mergeDefaults(content, defaults);
 


### PR DESCRIPTION
XContentHelperTests was modified in #80336, but wasn't formatted with spotless, which is now mandatory.