### PR TITLE
[DOCS] Changes title of transform alert docs

### DIFF
--- a/docs/reference/transform/transform-alerts.asciidoc
+++ b/docs/reference/transform/transform-alerts.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[transform-alerts]]
-= {transform-cap} alerts
+= Generating alerts for {transforms}
 
 beta::[]
 


### PR DESCRIPTION
## Overview

This PR changes the title of the page about transform alerts to be in line with the anomaly detection alert documentation page.

### Preview

[Generating alerts for transforms](https://elasticsearch_80362.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-alerts.html)