### PR TITLE
[DOCS] Fixes typo in start trained models API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -12,7 +12,7 @@ Starts a new trained model deployment.
 [[start-trained-model-deployment-request]]
 == {api-request-title}
 
-`POST _ml/trained_models/<model_id>/deployent/_start`
+`POST _ml/trained_models/<model_id>/deployment/_start`
 
 [[start-trained-model-deployment-prereq]]
 == {api-prereq-title}


### PR DESCRIPTION
Fixes a typo in the API reference page (https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-trained-model-deployment.html).