### PR TITLE
Increase Docker packaging test startup time to account for auto-config

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -68,7 +68,7 @@ public class Docker {
     public static final Shell sh = new Shell();
     public static final DockerShell dockerShell = new DockerShell();
     public static final int STARTUP_SLEEP_INTERVAL_MILLISECONDS = 1000;
-    public static final int STARTUP_ATTEMPTS_MAX = 20;
+    public static final int STARTUP_ATTEMPTS_MAX = 30;
 
     /**
      * Tracks the currently running Docker image. An earlier implementation used a fixed container name,


### PR DESCRIPTION
Security auto-configuration adds some overhead to node startup. We're seeing increasing failures with our Docker packaging tests due to us waiting on node startup and `AutoConfigureNode` is still running. Let's increase this a bit more.

Closes #80176