### PR TITLE
[8.0] [DOCS] Fixes typo in start trained models API (#80368)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -12,7 +12,7 @@ Starts a new trained model deployment.
 [[start-trained-model-deployment-request]]
 == {api-request-title}
 
-`POST _ml/trained_models/<model_id>/deployent/_start`
+`POST _ml/trained_models/<model_id>/deployment/_start`
 
 [[start-trained-model-deployment-prereq]]
 == {api-prereq-title}


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fixes typo in start trained models API (#80368)