### PR TITLE
Remove publish plugin from HLRC

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -11,16 +11,12 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.rest-test'
-apply plugin: 'elasticsearch.publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 group = 'org.elasticsearch.client'
 archivesBaseName = 'elasticsearch-rest-high-level-client'
-
-// HLRC is published under the Elastic License
-projectLicenses.set(['Elastic License 2.0': ext.elasticLicenseUrl.get()])
 
 restResources {
   //we need to copy the yaml spec so we can check naming (see RestHighlevelClientTests#testApiNamingConventions)


### PR DESCRIPTION
Starting with 8.0 we are no longer publishing the HLRC so no need to configure the module for artifact publication.

Closes #77602