### PR TITLE
[8.0] Increase Docker packaging test startup time to account for auto-config (#80376)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -68,7 +68,7 @@ public class Docker {
     public static final Shell sh = new Shell();
     public static final DockerShell dockerShell = new DockerShell();
     public static final int STARTUP_SLEEP_INTERVAL_MILLISECONDS = 1000;
-    public static final int STARTUP_ATTEMPTS_MAX = 20;
+    public static final int STARTUP_ATTEMPTS_MAX = 30;
 
     /**
      * Tracks the currently running Docker image. An earlier implementation used a fixed container name,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Increase Docker packaging test startup time to account for auto-config (#80376)