### PR TITLE
[8.0] [DOCS] Changes title of transform alert docs. (#80362)

### DIFF
--- a/docs/reference/transform/transform-alerts.asciidoc
+++ b/docs/reference/transform/transform-alerts.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[transform-alerts]]
-= {transform-cap} alerts
+= Generating alerts for {transforms}
 
 beta::[]
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Changes title of transform alert docs. (#80362)