### PR TITLE
[7.16] [DOCS] Changes title of transform alert docs. (#80362)

### DIFF
--- a/docs/reference/transform/transform-alerts.asciidoc
+++ b/docs/reference/transform/transform-alerts.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[transform-alerts]]
-= {transform-cap} alerts
+= Generating alerts for {transforms}
 
 beta::[]
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Changes title of transform alert docs. (#80362)