### PR TITLE
Code cleanup in TransportRolloverAction and added concurrent rollover test.

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
-import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -14,11 +14,18 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.Loggers;
@@ -27,6 +34,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -34,9 +42,11 @@ import org.elasticsearch.test.MockLogAppender;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -726,4 +736,59 @@ public class RolloverIT extends ESIntegTestCase {
         // We should *NOT* have a third index, it should have rolled over *exactly* once
         expectThrows(Exception.class, () -> client().admin().indices().prepareGetIndex().addIndices(writeIndexPrefix + "000003").get());
     }
+
+    public void testRolloverConcurrently() throws Exception {
+        int numOfThreads = 5;
+        int numberOfRolloversPerThread = 20;
+
+        var putTemplateRequest = new PutComposableIndexTemplateAction.Request("my-template");
+        var template = new Template(
+            Settings.builder()
+                // Avoid index check, which gets randomly inserted by test framework. This slows down the test a bit.
+                .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), false)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build(),
+            null,
+            null
+        );
+        putTemplateRequest.indexTemplate(new ComposableIndexTemplate(List.of("test-*"), template, null, 100L, null, null));
+        assertAcked(client().execute(PutComposableIndexTemplateAction.INSTANCE, putTemplateRequest).actionGet());
+
+        Thread[] threads = new Thread[numOfThreads];
+        for (int i = 0; i < numOfThreads; i++) {
+            var aliasName = "test-" + i;
+            threads[i] = new Thread(() -> {
+                assertAcked(prepareCreate(aliasName+ "-000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
+                for (int j = 1; j <= numberOfRolloversPerThread; j++) {
+                    var response = client().admin().indices().prepareRolloverIndex(aliasName)
+                        .waitForActiveShards(ActiveShardCount.NONE)
+                        .get();
+                    assertThat(response.getOldIndex(), equalTo(aliasName + String.format("-%06d", j)));
+                    assertThat(response.getNewIndex(), equalTo(aliasName + String.format("-%06d", j + 1)));
+                    assertThat(response.isDryRun(), equalTo(false));
+                    assertThat(response.isRolledOver(), equalTo(true));
+                }
+            });
+            threads[i].start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        for (int i = 0; i < numOfThreads; i++) {
+            var aliasName = "test-" + i;
+            var response = client().admin().indices().getAliases(new GetAliasesRequest(aliasName)).get();
+            List<Map.Entry<String, List<AliasMetadata>>> actual = response.getAliases().stream().collect(Collectors.toList());
+            List<Map.Entry<String, List<AliasMetadata>>> expected = new ArrayList<>(numberOfRolloversPerThread);
+            int numOfIndices = numberOfRolloversPerThread + 1;
+            for (int j = 1; j <= numOfIndices; j++) {
+                AliasMetadata.Builder amBuilder = new AliasMetadata.Builder(aliasName);
+                amBuilder.writeIndex(j == numOfIndices);
+                expected.add(Map.entry(aliasName + String.format("-%06d", j), List.of(amBuilder.build())));
+            }
+            assertThat(actual, containsInAnyOrder(expected.toArray(Object[]::new)));
+        }
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -63,7 +63,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
     private final MetadataRolloverService rolloverService;
     private final ActiveShardsObserver activeShardsObserver;
     private final Client client;
-    private final ClusterStateTaskExecutor<RolloverTask> rolloverTaskExecutor;
+    private final RolloverExecutor rolloverTaskExecutor;
 
     @Inject
     public TransportRolloverAction(
@@ -90,33 +90,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         this.rolloverService = rolloverService;
         this.client = client;
         this.activeShardsObserver = new ActiveShardsObserver(clusterService, threadPool);
-        this.rolloverTaskExecutor = (currentState, tasks) -> {
-            ClusterStateTaskExecutor.ClusterTasksResult.Builder<RolloverTask> builder = ClusterStateTaskExecutor.ClusterTasksResult
-                .builder();
-            ClusterState state = currentState;
-            for (RolloverTask task : tasks) {
-                try {
-                    state = task.performRollover(state);
-                    builder.success(task);
-                } catch (Exception e) {
-                    builder.failure(task, e);
-                }
-            }
-
-            if (state != currentState) {
-                var reason = new StringBuilder();
-                Strings.collectionToDelimitedStringWithLimit(
-                    (Iterable<String>) () -> tasks.stream().map(t -> t.sourceIndex.get() + "->" + t.rolloverIndex.get()).iterator(),
-                    ",",
-                    "bulk rollover [",
-                    "]",
-                    1024,
-                    reason
-                );
-                state = allocationService.reroute(state, reason.toString());
-            }
-            return builder.build(state);
-        };
+        this.rolloverTaskExecutor = new RolloverExecutor(allocationService);
     }
 
     @Override
@@ -193,7 +167,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     .filter(condition -> trialConditionResults.get(condition.toString()))
                     .collect(Collectors.toList());
 
-                final RolloverResponse trailRolloverResponse = new RolloverResponse(
+                final RolloverResponse trialRolloverResponse = new RolloverResponse(
                     trialSourceIndexName,
                     trialRolloverIndexName,
                     trialConditionResults,
@@ -206,11 +180,11 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 // Pre-check the conditions to see whether we should submit a new cluster state task
                 if (trialConditionResults.size() == 0 || trialMetConditions.size() > 0) {
                     String source = "rollover_index source [" + trialRolloverIndexName + "] to target [" + trialRolloverIndexName + "]";
-                    RolloverTask rolloverTask = new RolloverTask(rolloverRequest, statsResponse, trailRolloverResponse, listener);
+                    RolloverTask rolloverTask = new RolloverTask(rolloverRequest, statsResponse, trialRolloverResponse, listener);
                     clusterService.submitStateUpdateTask(source, rolloverTask, ROLLOVER_TASK_CONFIG, rolloverTaskExecutor, rolloverTask);
                 } else {
                     // conditions not met
-                    listener.onResponse(trailRolloverResponse);
+                    listener.onResponse(trialRolloverResponse);
                 }
             }, listener::onFailure)
         );
@@ -264,7 +238,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         private final RolloverResponse trialRolloverResponse;
         private final ActionListener<RolloverResponse> listener;
 
-        private final AtomicBoolean conditionsMet = new AtomicBoolean(false);
+        private boolean clusterStateProcessed = false;
         // Holders for what our final source and rolled over index names are as well as the
         // conditions met to cause the rollover, these are needed so we wait on and report
         // the correct indices and conditions in the clusterStateProcessed method
@@ -309,7 +283,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             conditionResults.set(postConditionResults);
 
             if (postConditionResults.size() == 0 || metConditions.size() > 0) {
-                conditionsMet.set(true);
+                clusterStateProcessed = true;
                 // Perform the actual rollover
                 MetadataRolloverService.RolloverResult rolloverResult = rolloverService.rolloverClusterState(
                     currentState,
@@ -349,7 +323,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
             // Now assuming we have a new state and the name of the rolled over index, we need to wait for the
             // configured number of active shards, as well as return the names of the indices that were rolled/created
-            if (conditionsMet.get()) {
+            if (clusterStateProcessed) {
                 assert sourceIndex.get() != null : "source index missing on successful rollover";
                 assert rolloverIndex.get() != null : "rollover index missing on successful rollover";
                 assert conditionResults.get() != null : "matching rollover conditions missing on successful rollover";
@@ -375,6 +349,44 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 // We did not roll over due to conditions not being met inside the cluster state update
                 listener.onResponse(trialRolloverResponse);
             }
+        }
+    }
+
+    static class RolloverExecutor implements ClusterStateTaskExecutor<RolloverTask> {
+
+        private final AllocationService allocationService;
+
+        RolloverExecutor(AllocationService allocationService) {
+            this.allocationService = allocationService;
+        }
+
+        @Override
+        public ClusterTasksResult<RolloverTask> execute(ClusterState currentState, List<RolloverTask> tasks) throws Exception {
+            ClusterStateTaskExecutor.ClusterTasksResult.Builder<RolloverTask> builder = ClusterStateTaskExecutor.ClusterTasksResult
+                .builder();
+            ClusterState state = currentState;
+            for (RolloverTask task : tasks) {
+                try {
+                    state = task.performRollover(state);
+                    builder.success(task);
+                } catch (Exception e) {
+                    builder.failure(task, e);
+                }
+            }
+
+            if (state != currentState) {
+                var reason = new StringBuilder();
+                Strings.collectionToDelimitedStringWithLimit(
+                    (Iterable<String>) () -> tasks.stream().map(t -> t.sourceIndex.get() + "->" + t.rolloverIndex.get()).iterator(),
+                    ",",
+                    "bulk rollover [",
+                    "]",
+                    1024,
+                    reason
+                );
+                state = allocationService.reroute(state, reason.toString());
+            }
+            return builder.build(state);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**


### PR DESCRIPTION
Code cleanups around rollover executor in `TransportRolloverAction` and added an integration test that tests rollover concurrently.

Relates to #79945