### PR TITLE
[ML] Removing redundant release note

### DIFF
--- a/docs/reference/release-notes/8.0.0-beta1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-beta1.asciidoc
@@ -12,11 +12,6 @@ Also see <<breaking-changes-8.0,Breaking changes in 8.0>>.
 [float]
 === Known issues
 
-* If you're using {ml}, it's not safe to perform a rolling upgrade from `7.16.x`
-  to `8.0.0-beta1`. Doing so might lead to cluster state propagation issues in the mixed 
-  version cluster. We recommend waiting for `8.0.0-rc1` before testing a 
-  rolling upgrade from `7.16.x`. Do not attempt to upgrade any 
-  production cluster to pre-release software.
 * If you're using {ml}, it's not safe to upgrade to `8.0.0-beta1`
   if the cluster you're upgrading was first used prior to `7.7.0`.
   If you attempt such an upgrade the filtered aliases against


### PR DESCRIPTION
The release note about not doing a rolling upgrade to 8.0.0-beta1
if using ML is no longer required because 8.0.0-beta1 was rebuilt
to include #80041.