### PR TITLE
Improve Slow Inbound Handling to Include Response Type

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -271,20 +271,22 @@ public class InboundHandlerTests extends ESTestCase {
     public void testLogsSlowInboundProcessing() throws Exception {
         final MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "expected message",
-                InboundHandler.class.getCanonicalName(),
-                Level.WARN,
-                "handling inbound transport message "
-            )
-        );
         final Logger inboundHandlerLogger = LogManager.getLogger(InboundHandler.class);
         Loggers.addAppender(inboundHandlerLogger, mockAppender);
 
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
         try {
             final Version remoteVersion = Version.CURRENT;
+
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "expected slow request",
+                    InboundHandler.class.getCanonicalName(),
+                    Level.WARN,
+                    "handling request "
+                )
+            );
+
             final long requestId = randomNonNegativeLong();
             final Header requestHeader = new Header(
                 between(0, 100),
@@ -292,7 +294,7 @@ public class InboundHandlerTests extends ESTestCase {
                 TransportStatus.setRequest(TransportStatus.setHandshake((byte) 0)),
                 remoteVersion
             );
-            final InboundMessage requestMessage = new InboundMessage(requestHeader, ReleasableBytesReference.wrap(BytesArray.EMPTY), () -> {
+            final InboundMessage requestMessage = new InboundMessage(requestHeader, ReleasableBytesReference.empty(), () -> {
                 try {
                     TimeUnit.SECONDS.sleep(1L);
                 } catch (InterruptedException e) {
@@ -303,6 +305,34 @@ public class InboundHandlerTests extends ESTestCase {
             requestHeader.headers = Tuple.tuple(Map.of(), Map.of());
             handler.inboundMessage(channel, requestMessage);
             assertNotNull(channel.getMessageCaptor().get());
+            mockAppender.assertAllExpectationsMatched();
+
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "expected slow response",
+                    InboundHandler.class.getCanonicalName(),
+                    Level.WARN,
+                    "handling response "
+                )
+            );
+
+            final long responseId = randomNonNegativeLong();
+            final Header responseHeader = new Header(between(0, 100), responseId, TransportStatus.setResponse((byte) 0), remoteVersion);
+            responseHeader.headers = Tuple.tuple(Map.of(), Map.of());
+            handler.setMessageListener(new TransportMessageListener() {
+                @Override
+                @SuppressWarnings("rawtypes")
+                public void onResponseReceived(long requestId, Transport.ResponseContext context) {
+                    assertEquals(responseId, requestId);
+                    try {
+                        TimeUnit.SECONDS.sleep(1L);
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            });
+            handler.inboundMessage(channel, new InboundMessage(responseHeader, ReleasableBytesReference.empty(), () -> {}));
+
             mockAppender.assertAllExpectationsMatched();
         } finally {
             Loggers.removeAppender(inboundHandlerLogger, mockAppender);


### PR DESCRIPTION
The slow logging for responses is often relatively useless when debugging
because it does not contain the type of the response. Tracking down the type
from the message size and response id is not possible in most cases.
This commit adds the handler to the log message which gives us that type information.
