### PR TITLE
[7.16] [DOCS] Adds missing query params to GET category and GET influencer APIs (#79448)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -38,6 +38,10 @@ examine the description and examples of that category. For more information, see
 [[ml-get-category-path-parms]]
 == {api-path-parms-title}
 
+`<job_id>`::
+(Required, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+
 `<category_id>`::
 (Optional, long) Identifier for the category, which is unique in the job. If you
 specify neither the category ID nor the `partition_field_value`, the API returns
@@ -45,9 +49,20 @@ information about all categories. If you specify only the
 `partition_field_value`, it returns information about all categories for the
 specified partition.
 
-`<job_id>`::
-(Required, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+
+[[ml-get-category-query-parms]]
+== {api-query-parms-title}
+
+`from`::
+(Optional, integer) Skips the specified number of categories. Defaults to `0`.
+
+`partition_field_value`::
+(Optional, string) Only return categories for the specified partition.
+
+`size`::
+(Optional, integer) Specifies the maximum number of categories to obtain. 
+Defaults to `100`.
+
 
 [[ml-get-category-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -49,6 +49,7 @@ specified partition.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+
 [[ml-get-category-query-parms]]
 == {api-query-parms-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -38,10 +38,6 @@ examine the description and examples of that category. For more information, see
 [[ml-get-category-path-parms]]
 == {api-path-parms-title}
 
-`<job_id>`::
-(Required, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
-
 `<category_id>`::
 (Optional, long) Identifier for the category, which is unique in the job. If you
 specify neither the category ID nor the `partition_field_value`, the API returns
@@ -49,6 +45,9 @@ information about all categories. If you specify only the
 `partition_field_value`, it returns information about all categories for the
 specified partition.
 
+`<job_id>`::
+(Required, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-get-category-query-parms]]
 == {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -33,6 +33,40 @@ the anomalies. Influencer results are available only if an
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+
+[[ml-get-influencer-query-parms]]
+== {api-query-parms-title}
+
+`desc`::
+(Optional, Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
+
+`exclude_interim`::
+(Optional, Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
+
+`from`::
+(Optional, integer)
+Skips the specified number of influencers. Defaults to `0`.
+
+`influencer_score`::
+(Optional, double) Returns influencers with anomaly scores greater than or
+equal to this value. Defaults to `0.0`.
+
+`size`::
+(Optional, integer)
+Specifies the maximum number of influencers to obtain. Defaults to `100`.
+
+`sort`::
+(Optional, string) Specifies the sort field for the requested influencers. By
+default, the influencers are sorted by the `influencer_score` value.
+
+`start`::
+(Optional, string) Returns influencers with timestamps after this time. Defaults 
+to `-1`, which means it is unset and results are not limited to specific 
+timestamps.
+
+
 [[ml-get-influencer-request-body]]
 == {api-request-body-title}
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Adds missing query params to GET category and GET influencer APIs (#79448)