### PR TITLE
[ML] Set estimated memory usage for PyTorch models

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -173,6 +173,10 @@ public class TrainedModelProvider {
     }
 
     public void storeTrainedModelConfig(TrainedModelConfig trainedModelConfig, ActionListener<Boolean> listener) {
+        storeTrainedModelConfig(trainedModelConfig, false, listener);
+    }
+
+    public void storeTrainedModelConfig(TrainedModelConfig trainedModelConfig, boolean allowOverwrite, ActionListener<Boolean> listener) {
         if (MODELS_STORED_AS_RESOURCE.contains(trainedModelConfig.getModelId())) {
             listener.onFailure(
                 new ResourceAlreadyExistsException(
@@ -189,6 +193,9 @@ public class TrainedModelProvider {
             trainedModelConfig
         );
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        if (allowOverwrite) {
+            request.opType(DocWriteRequest.OpType.INDEX);
+        }
 
         executeAsyncWithOrigin(
             client,


### PR DESCRIPTION
PyTorch models incorrectly report their `estimated_heap_memory_usage_bytes` as `0`. The true value is available from the model definition docs and is now set when a definition doc is PUT.
