### PR TITLE
Fix "outer" max_docs documentation

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -509,15 +509,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=max_docs]
 (Optional, enum) Set to `proceed` to continue reindexing even if there are conflicts.
 Defaults to `abort`.
 
+`max_docs`::
+(Optional, integer) The maximum number of documents to reindex. If <<conflicts, conflicts>> is equal to
+`proceed`, reindex could attempt to reindex more documents from the source than `max_docs` until it has successfully
+indexed `max_docs` documents into the target, or it has gone through every document in the source query.
+
 `source`::
 `index`:::
 (Required, string) The name of the data stream, index, or alias you are copying
 _from_. Also accepts a comma-separated list to reindex from multiple sources.
-
-`max_docs`:::
-(Optional, integer) The maximum number of documents to reindex. If <<conflicts, conflicts>> is equal to
-`proceed`, reindex could attempt to reindex more documents from the source than `max_docs` until it has successfully
-indexed `max_docs` documents into the target, or it has gone through every document in the source query.
 
 `query`:::
 (Optional, <<query-dsl, query object>>) Specifies the documents to reindex using the Query DSL.


### PR DESCRIPTION
This commit fixes a documentation bug that lists 'max_docs' 
nested under `source` it should live at the same level as `source`

related: https://github.com/elastic/elasticsearch/pull/43373

---

Note - I have set auto-back port to all branches that this will apply cleanly. It looks like the change could be applied back to 7.3, but anything prior to 7.13 I don't think will merge cleanly without manual intervention. 

Preview: https://elasticsearch_80436.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-reindex.html#docs-reindex-api-request-body