### PR TITLE
[+DOC] Tasks' Queue backup

### DIFF
--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -673,38 +673,68 @@ If you regularly trigger circuit breaker errors, see <<circuit-breaker-errors>>
 for tips on diagnosing and preventing them.
 
 [discrete]
-[[task-throughput]]
-=== Task Queue Backup
+[[task-queue-backlog]]
+=== Task queue backlog
 
-{es} tracks its node task's <<modules-threadpool,thread pools>>. You can see 
-an overview by using the <<cat-thread-pool,cat thread pool API>>.
+A backlogged task queue can prevent tasks from completing and 
+put the cluster into an unhealthy state. 
+Resource constraints, a large number of tasks being triggered at once,
+and long running tasks can all contribute to a backlogged task queue.
+
+[discrete]
+[[diagnose-task-queue-backlog]]
+==== Diagnose a task queue backlog
+
+**Check the thread pool status**
+
+A <<high-cpu-usage,depleted thread pool>> can result in <<rejected-requests,rejected requests>>. 
+
+You can use the <<cat-thread-pool,cat thread pool API>> to 
+see the number of active threads in each thread pool and
+how many tasks are queued, how many have been rejected, and how many have completed. 
 
 [source,console]
 ---
 GET /_cat/thread_pool?v&s=t,n&h=type,name,node_name,active,queue,rejected,completed
 ---
 
-Tasks run per thread pool grouped by `name` and `node_name` which request CPU resources
-to process. They can therefore be effected by <<high-cpu-usage,depleted thread pool>> 
-resulting in <<rejected-requests,rejected requests>>. You may alternatively find a high
-queue correlating to a long running task, checked via the <<tasks,Task Management API>>
-looking for `running_time_in_nanos`.
+**Inspect the hot threads on each node**
 
-[source,console]
-----
-GET /_tasks?filter_path=nodes.*.tasks
-----
-
-If you find a particular thread pool queue is backed up, you'll want to inspect your 
-cluster node's <<cluster-nodes-hot-threads,Hot Threads>>. Polled periodically, 
-this will inform you if the thread has sufficient resources to progress and how 
-quickly its processing.
+If a particular thread pool queue is backed up, 
+you can periodically poll the <<cluster-nodes-hot-threads,Nodes hot threads>> API 
+to determine if the thread has sufficient 
+resources to progress and gauge how quickly it is progressing.
 
 [source,console]
 ---
 GET /_nodes/hot_threads
 ---
 
-If you find the active task's hot thread isn't progressing, you may consider cancelling
-the task. More frequently, you'll find it slowly progressing, in which case should
-review related feature settings to tune performance.
+**Look for long running tasks**
+
+Long-running tasks can also cause a backlog. 
+You can use the <<tasks,task management>> API to get information about the tasks that are running. 
+Check the `running_time_in_nanos` to identify tasks that are taking an excessive amount of time to complete. 
+
+[source,console]
+----
+GET /_tasks?filter_path=nodes.*.tasks
+----
+
+[discrete]
+[[resolve-task-queue-backlog]]
+==== Resolve a task queue backlog
+
+**Increase available resources** 
+
+If tasks are progressing slowly and the queue is backing up, 
+you might need to take steps to <<reduce-cpu-usage>>. 
+
+In some cases, increasing the thread pool size might help.
+For example, the `force_merge` thread pool defaults to a single thread.
+Increasing the size to 2 might help reduce a backlog of force merge requests.
+
+**Cancel stuck tasks**
+
+If you find the active task's hot thread isn't progressing and there's a backlog, 
+consider canceling the task. 

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -676,8 +676,8 @@ for tips on diagnosing and preventing them.
 [[task-throughput]]
 === Task Queue Backup
 
-{es} tracks its node task's thread pools. You can see an overview by using the 
-<<cat-thread-pool,cat thread pool API>>.
+{es} tracks its node task's <<modules-threadpool,thread pools>>. You can see 
+an overview by using the <<cat-thread-pool,cat thread pool API>>.
 
 [source,console]
 ---

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -671,3 +671,40 @@ CPU usage or high JVM memory pressure. For tips, see <<high-cpu-usage>> and
 
 If you regularly trigger circuit breaker errors, see <<circuit-breaker-errors>>
 for tips on diagnosing and preventing them.
+
+[discrete]
+[[task-throughput]]
+=== Task Queue Backup
+
+{es} tracks its node task's thread pools. You can see an overview by using the 
+<<cat-thread-pool,cat thread pool API>>.
+
+[source,console]
+---
+GET /_cat/thread_pool?v&s=t,n&h=type,name,node_name,active,queue,rejected,completed
+---
+
+Tasks run per thread pool grouped by `name` and `node_name` which request CPU resources
+to process. They can therefore be effected by <<high-cpu-usage,depleted thread pool>> 
+resulting in <<rejected-requests,rejected requests>>. You may alternatively find a high
+queue correlating to a long running task, checked via the <<tasks,Task Management API>>
+looking for `running_time_in_nanos`.
+
+[source,console]
+----
+GET /_tasks?filter_path=nodes.*.tasks
+----
+
+If you find a particular thread pool queue is backed up, you'll want to inspect your 
+cluster node's <<cluster-nodes-hot-threads,Hot Threads>>. Polled periodically, 
+this will inform you if the thread has sufficient resources to progress and how 
+quickly its processing.
+
+[source,console]
+---
+GET /_nodes/hot_threads
+---
+
+If you find the active task's hot thread isn't progressing, you may consider cancelling
+the task. More frequently, you'll find it slowly progressing, in which case should
+review related feature settings to tune performance.


### PR DESCRIPTION
Hiya, @debadair! Adds in task queue backup troubleshooting to [this page](https://www.elastic.co/guide/en/elasticsearch/reference/current/fix-common-cluster-issues.html). I think it miss-formats hierarchy a bit to the rest of the page feel, so free to change as you deem best. Thanks again for your help on this!