### PR TITLE
Mark the `keep_alive` parameter of Open Point in Time API as required

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -52,7 +52,8 @@
       },
       "keep_alive": {
         "type": "string",
-        "description": "Specific the time to live for the point in time"
+        "description": "Specific the time to live for the point in time",
+        "required": true
       }
     }
   }


### PR DESCRIPTION
This parameter isn't marked as required in the API spec, but when using the API you [always receive an error unless `keep_alive` is specified](https://github.com/elastic/elasticsearch/blob/26c86871fc091900952e88e252c36fbfedf8d5fa/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java#L104).