### PR TITLE
[ML] fix tokenization around common punctuation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizer.java
@@ -101,36 +101,23 @@ public class BasicTokenizer {
             // At this point text has been tokenized by whitespace
             // but one of the special never split tokens could be adjacent
             // to one or more punctuation characters.
-            if (isCommonPunctuation(token.codePointAt(token.length() - 1))) {
-                int lastNonPunctuationIndex = findLastNonPunctuationIndex(token);
-                if (lastNonPunctuationIndex >= 0 && neverSplit.contains(token.substring(0, lastNonPunctuationIndex + 1))) {
-                    processedTokens.add(token.substring(0, lastNonPunctuationIndex + 1));
-                    processedTokens.addAll(splitOnPunctuation(token.substring(lastNonPunctuationIndex + 1)));
-                    continue;
+            List<String> splitOnCommonTokens = splitOnPredicate(token, BasicTokenizer::isCommonPunctuation);
+            for (String splitOnCommon : splitOnCommonTokens) {
+                if (neverSplit.contains(splitOnCommon)) {
+                    processedTokens.add(splitOnCommon);
+                } else {
+                    if (isLowerCase) {
+                        splitOnCommon = splitOnCommon.toLowerCase(Locale.ROOT);
+                    }
+                    if (isStripAccents) {
+                        splitOnCommon = stripAccents(splitOnCommon);
+                    }
+                    processedTokens.addAll(splitOnPunctuation(splitOnCommon));
                 }
             }
-
-            if (isLowerCase) {
-                token = token.toLowerCase(Locale.ROOT);
-            }
-            if (isStripAccents) {
-                token = stripAccents(token);
-            }
-            processedTokens.addAll(splitOnPunctuation(token));
         }
 
         return processedTokens;
-    }
-
-    private int findLastNonPunctuationIndex(String token) {
-        int i = token.length() - 1;
-        while (i >= 0) {
-            if (isCommonPunctuation(token.codePointAt(i)) == false) {
-                break;
-            }
-            i--;
-        }
-        return i;
     }
 
     public boolean isLowerCase() {
@@ -313,10 +300,6 @@ public class BasicTokenizer {
      * @return true if codepoint is punctuation
      */
     static boolean isCommonPunctuation(int codePoint) {
-        if ((codePoint >= 33 && codePoint <= 47) || (codePoint >= 58 && codePoint <= 64)) {
-            return true;
-        }
-
-        return false;
+        return (codePoint >= 33 && codePoint <= 47) || (codePoint >= 58 && codePoint <= 64);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
@@ -161,6 +162,16 @@ public class BertTokenizerTests extends ESTestCase {
         assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", ",", "fun", "[MASK]", "."));
         assertArrayEquals(new int[] { 0, 1, 11, 3, 14, 10 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1, 2, 3, 4 }, tokenization.getTokenMap());
+    }
+
+    public void testPunctuationWithMask() {
+        BertTokenizer tokenizer = BertTokenizer.builder(
+            List.of("[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"),
+            Tokenization.createDefault()
+        ).setWithSpecialTokens(true).setNeverSplit(Set.of("[MASK]")).build();
+
+        TokenizationResult.Tokenization tokenization = tokenizer.tokenize("This is [MASK]-tastic!", Tokenization.Truncate.NONE);
+        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"));
     }
 
     public void testBatchInput() {


### PR DESCRIPTION
Our BERT style word-piece tokenization does not handle sequences like `This is [MASK]-tastic!` well. 

It used to ignore the `[MASK]` token and tokenize all the punctuations individually.

It should be tokenized like:
```
"[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"
```

And this commit corrects this.