### PR TITLE
[8.0] [DOCS] Remove `testenv` annotations from doc snippet tests (#80023)

### DIFF
--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/RestTestsFromSnippetsTask.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/RestTestsFromSnippetsTask.groovy
@@ -264,19 +264,6 @@ class RestTestsFromSnippetsTask extends SnippetsTask {
                 current.println("        - stash_in_path")
                 current.println("        - stash_path_replace")
                 current.println("        - warnings")
-                if (test.testEnv != null) {
-                    switch (test.testEnv) {
-                    case 'basic':
-                    case 'gold':
-                    case 'platinum':
-                    case 'enterprise':
-                        current.println("        - xpack")
-                        break;
-                    default:
-                        throw new InvalidUserDataException('Unsupported testEnv: '
-                                + test.testEnv)
-                    }
-                }
             }
             if (test.skip) {
                 if (test.continued) {

--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/SnippetsTask.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/SnippetsTask.groovy
@@ -73,7 +73,6 @@ class SnippetsTask extends DefaultTask {
             Snippet snippet = null
             StringBuilder contents = null
             List substitutions = null
-            String testEnv = null
             Closure emit = {
                 snippet.contents = contents.toString()
                 contents = null
@@ -140,14 +139,10 @@ class SnippetsTask extends DefaultTask {
             }
             file.eachLine('UTF-8') { String line, int lineNumber ->
                 Matcher matcher
-                matcher = line =~ /\[testenv="([^"]+)"\]\s*/
-                if (matcher.matches()) {
-                    testEnv = matcher.group(1)
-                }
                 if (line ==~ /-{4,}\s*/) { // Four dashes looks like a snippet
                     if (snippet == null) {
                         Path path = docs.dir.toPath().relativize(file.toPath())
-                        snippet = new Snippet(path: path, start: lineNumber, testEnv: testEnv, name: name)
+                        snippet = new Snippet(path: path, start: lineNumber, name: name)
                         if (lastLanguageLine == lineNumber - 1) {
                             snippet.language = lastLanguage
                         }
@@ -333,7 +328,6 @@ class SnippetsTask extends DefaultTask {
         int start
         int end = NOT_FINISHED
         String contents
-        String testEnv
 
         Boolean console = null
         boolean test = false
@@ -362,9 +356,6 @@ class SnippetsTask extends DefaultTask {
             }
             if (test) {
                 result += '// TEST'
-                if (testEnv != null) {
-                    result += "[testenv=$testEnv]"
-                }
                 if (catchPart) {
                     result += "[catch: $catchPart]"
                 }

--- a/docs/reference/aggregations/bucket/multi-terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/multi-terms-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-bucket-multi-terms-aggregation]]
 === Multi Terms aggregation
 ++++

--- a/docs/reference/aggregations/metrics/boxplot-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/boxplot-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-metrics-boxplot-aggregation]]
 === Boxplot aggregation
 ++++

--- a/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="gold"]
 [[search-aggregations-metrics-geo-line]]
 === Geo-Line Aggregation
 ++++

--- a/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-metrics-rate-aggregation]]
 === Rate aggregation
 ++++

--- a/docs/reference/aggregations/metrics/string-stats-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/string-stats-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-metrics-string-stats-aggregation]]
 === String stats aggregation
 ++++

--- a/docs/reference/aggregations/metrics/t-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/t-test-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-metrics-ttest-aggregation]]
 === T-test aggregation
 ++++

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-metrics-top-metrics]]
 === Top metrics aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-bucket-correlation-aggregation]]
 === Bucket correlation aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-bucket-count-ks-test-aggregation]]
 === Bucket count K-S test correlation aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/cumulative-cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/cumulative-cardinality-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-pipeline-cumulative-cardinality-aggregation]]
 === Cumulative cardinality aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-pipeline-inference-bucket-aggregation]]
 === {infer-cap} bucket aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/moving-percentiles-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/moving-percentiles-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-pipeline-moving-percentiles-aggregation]]
 === Moving percentiles aggregation
 ++++

--- a/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[search-aggregations-pipeline-normalize-aggregation]]
 === Normalize aggregation
 ++++

--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-apis]]
 == Autoscaling APIs
 

--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-delete-autoscaling-policy]]
 === Delete autoscaling policy API
 ++++

--- a/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-get-autoscaling-capacity]]
 === Get autoscaling capacity API
 ++++

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-get-autoscaling-policy]]
 === Get autoscaling policy API
 ++++

--- a/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-put-autoscaling-policy]]
 === Create or update autoscaling policy API
 ++++

--- a/docs/reference/autoscaling/autoscaling-deciders.asciidoc
+++ b/docs/reference/autoscaling/autoscaling-deciders.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-deciders]]
 == Autoscaling deciders
 

--- a/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-fixed-decider]]
 === Fixed decider
 

--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-machine-learning-decider]]
 === Machine learning decider
 

--- a/docs/reference/autoscaling/deciders/proactive-storage-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/proactive-storage-decider.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[autoscaling-proactive-storage-decider]]
 === Proactive storage decider
 

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[xpack-autoscaling]]
 = Autoscaling
 

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[cat-anomaly-detectors]]
 === cat anomaly detectors API
 ++++

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[cat-datafeeds]]
 === cat {dfeeds} API
 ++++

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[cat-dfanalytics]]
 === cat {dfanalytics} API
 ++++

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[cat-trained-model]]
 === cat trained model API
 ++++

--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-delete-auto-follow-pattern]]
 === Delete auto-follow pattern API
 ++++

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-get-auto-follow-pattern]]
 === Get auto-follow pattern API
 ++++

--- a/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-pause-auto-follow-pattern]]
 === Pause auto-follow pattern API
 ++++

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-put-auto-follow-pattern]]
 === Create auto-follow pattern API
 ++++

--- a/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-resume-auto-follow-pattern]]
 === Resume auto-follow pattern API
 ++++

--- a/docs/reference/ccr/apis/ccr-apis.asciidoc
+++ b/docs/reference/ccr/apis/ccr-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-apis]]
 == {ccr-cap} APIs
 

--- a/docs/reference/ccr/apis/follow-request-body.asciidoc
+++ b/docs/reference/ccr/apis/follow-request-body.asciidoc
@@ -1,4 +1,3 @@
-[testenv="platinum"]
 `settings`::
   (object) Settings to override from the leader index. Note that certain
   settings can not be overrode (e.g., `index.number_of_shards`).

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-get-follow-info]]
 === Get follower info API
 ++++

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-get-follow-stats]]
 === Get follower stats API
 ++++

--- a/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-post-forget-follower]]
 === Forget follower API
 ++++

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-post-pause-follow]]
 === Pause follower API
 ++++

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-post-resume-follow]]
 === Resume follower API
 ++++

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-post-unfollow]]
 === Unfollow API
 ++++

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-put-follow]]
 === Create follower API
 ++++

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-get-stats]]
 === Get {ccr} stats API
 [subs="attributes"]

--- a/docs/reference/ccr/auto-follow.asciidoc
+++ b/docs/reference/ccr/auto-follow.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-auto-follow]]
 === Manage auto-follow patterns
 To replicate time series indices, you configure an auto-follow pattern so that

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-getting-started-tutorial]]
 === Tutorial: Set up {ccr}
 ++++

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[xpack-ccr]]
 == {ccr-cap}
 With {ccr}, you can replicate indices across clusters to:

--- a/docs/reference/ccr/managing.asciidoc
+++ b/docs/reference/ccr/managing.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 
 [[ccr-managing]]
 === Manage {ccr}

--- a/docs/reference/ccr/upgrading.asciidoc
+++ b/docs/reference/ccr/upgrading.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ccr-upgrading]]
 === Upgrading clusters using {ccr}
 ++++

--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [[delete-async-eql-search-api]]
 === Delete async EQL search API

--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[eql-ex-threat-detection]]
 == Example: Detect threats with EQL
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [[eql-search-api]]
 === EQL search API

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[eql]]
 = EQL search
 ++++

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[eql-function-ref]]
 == EQL function reference
 ++++

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [[get-async-eql-search-api]]
 === Get async EQL search API

--- a/docs/reference/eql/get-async-eql-status-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-status-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [[get-async-eql-status-api]]
 === Get async EQL status API

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[eql-pipe-ref]]
 == EQL pipe reference
 ++++

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[eql-syntax]]
 == EQL syntax reference
 ++++

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[graph-explore-api]]
 == Graph explore API
 

--- a/docs/reference/high-availability/backup-and-restore-security-config.asciidoc
+++ b/docs/reference/high-availability/backup-and-restore-security-config.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[security-backup]]
 === Back up a cluster's security configuration
 ++++

--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-delete-lifecycle]]
 === Delete lifecycle policy API
 ++++

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-explain-lifecycle]]
 === Explain lifecycle API
 ++++

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-get-lifecycle]]
 === Get lifecycle policy API
 ++++

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-get-status]]
 === Get {ilm} status API
 

--- a/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
+++ b/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-migrate-to-data-tiers]]
 === Migrate to data tiers routing API
 ++++

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-move-to-step]]
 === Move to lifecycle step API
 ++++

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-put-lifecycle]]
 === Create or update lifecycle policy API
 ++++

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-remove-policy]]
 === Remove policy from index API
 ++++

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-retry-policy]]
 === Retry policy execution API
 ++++

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-start]]
 === Start {ilm} API
 

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-stop]]
 === Stop {ilm} API
 

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[index-lifecycle-error-handling]]
 == Troubleshooting {ilm} errors
 

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-actions]]
 == Index lifecycle actions
 

--- a/docs/reference/ilm/ilm-and-snapshots.asciidoc
+++ b/docs/reference/ilm/ilm-and-snapshots.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[index-lifecycle-and-snapshots]]
 == Restore a managed data stream or index
 

--- a/docs/reference/ilm/ilm-concepts.asciidoc
+++ b/docs/reference/ilm/ilm-concepts.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-concepts]]
 == {ilm-init} concepts
 

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-index-lifecycle]]
 === Index lifecycle
 ++++

--- a/docs/reference/ilm/ilm-overview.asciidoc
+++ b/docs/reference/ilm/ilm-overview.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[overview-index-lifecycle-management]]
 == {ilm-init} overview
 

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[getting-started-index-lifecycle-management]]
 == Tutorial: Automate rollover with {ilm-init}
 

--- a/docs/reference/ilm/ilm-with-existing-indices.asciidoc
+++ b/docs/reference/ilm/ilm-with-existing-indices.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ilm-with-existing-indices]]
 == Manage existing indices
 

--- a/docs/reference/ilm/index-rollover.asciidoc
+++ b/docs/reference/ilm/index-rollover.asciidoc
@@ -1,5 +1,4 @@
 [[index-rollover]]
-[testenv="basic"]
 === Rollover
 
 When indexing time series data like logs or metrics, you can't write to a single index indefinitely. 

--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[index-lifecycle-management]]
 = {ilm-init}: Manage the index lifecycle
 

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[set-up-lifecycle-policy]]
 == Configure a lifecycle policy [[ilm-policy-definition]]
 

--- a/docs/reference/ilm/start-stop.asciidoc
+++ b/docs/reference/ilm/start-stop.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[start-stop-ilm]]
 == Start and stop {ilm}
 

--- a/docs/reference/ilm/update-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/update-lifecycle-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[update-lifecycle-policy]]
 === Lifecycle policy updates
 ++++

--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[indices-reload-analyzers]]
 == Reload search analyzers API
 

--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[unfreeze-index-api]]
 === Unfreeze index API
 ++++

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[delete-enrich-policy-api]]
 === Delete enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/enrich-stats.asciidoc
+++ b/docs/reference/ingest/apis/enrich/enrich-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[enrich-stats-api]]
 === Enrich stats API
 ++++

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[execute-enrich-policy-api]]
 === Execute enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-enrich-policy-api]]
 === Get enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[put-enrich-policy-api]]
 === Create enrich policy API
 ++++

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -1,4 +1,3 @@
-[testenv="basic"]
 [[ingest-enriching-data]]
 == Enrich your data
 

--- a/docs/reference/ingest/geo-match-enrich-policy-type-ex.asciidoc
+++ b/docs/reference/ingest/geo-match-enrich-policy-type-ex.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[geo-match-enrich-policy-type]]
 === Example: Enrich your data based on geolocation
 

--- a/docs/reference/ingest/match-enrich-policy-type-ex.asciidoc
+++ b/docs/reference/ingest/match-enrich-policy-type-ex.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[match-enrich-policy-type]]
 === Example: Enrich your data based on exact values
 

--- a/docs/reference/ingest/processors/circle.asciidoc
+++ b/docs/reference/ingest/processors/circle.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[ingest-circle-processor]]
 === Circle processor
 ++++

--- a/docs/reference/ingest/processors/community-id.asciidoc
+++ b/docs/reference/ingest/processors/community-id.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[community-id-processor]]
 === Community ID processor
 ++++

--- a/docs/reference/ingest/processors/enrich.asciidoc
+++ b/docs/reference/ingest/processors/enrich.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[enrich-processor]]
 === Enrich processor
 ++++

--- a/docs/reference/ingest/processors/fingerprint.asciidoc
+++ b/docs/reference/ingest/processors/fingerprint.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[fingerprint-processor]]
 === Fingerprint processor
 ++++

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[inference-processor]]
 === {infer-cap} processor
 ++++

--- a/docs/reference/ingest/processors/network-direction.asciidoc
+++ b/docs/reference/ingest/processors/network-direction.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[network-direction-processor]]
 === Network direction processor
 ++++

--- a/docs/reference/ingest/processors/registered-domain.asciidoc
+++ b/docs/reference/ingest/processors/registered-domain.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[registered-domain-processor]]
 === Registered domain processor
 ++++

--- a/docs/reference/ingest/processors/uri-parts.asciidoc
+++ b/docs/reference/ingest/processors/uri-parts.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[uri-parts-processor]]
 === URI parts processor
 ++++

--- a/docs/reference/ingest/range-enrich-policy-type-ex.asciidoc
+++ b/docs/reference/ingest/range-enrich-policy-type-ex.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[range-enrich-policy-type]]
 === Example: Enrich your data by matching a value to a range
 

--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[delete-license]]
 === Delete license API
 ++++

--- a/docs/reference/licensing/get-basic-status.asciidoc
+++ b/docs/reference/licensing/get-basic-status.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-basic-status]]
 === Get basic status API
 ++++

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-license]]
 === Get license API
 ++++

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-trial-status]]
 === Get trial status API
 ++++

--- a/docs/reference/licensing/start-basic.asciidoc
+++ b/docs/reference/licensing/start-basic.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[start-basic]]
 === Start basic API
 ++++

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[start-trial]]
 === Start trial API
 ++++

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[update-license]]
 === Update license API
 ++++

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[aggregate-metric-double]]
 === Aggregate metric field type
 ++++

--- a/docs/reference/mapping/types/constant-keyword.asciidoc
+++ b/docs/reference/mapping/types/constant-keyword.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [discrete]
 [[constant-keyword-field-type]]

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[dense-vector]]
 === Dense vector field type
 ++++

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[histogram]]
 === Histogram field type
 ++++

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -1,4 +1,3 @@
-[testenv="basic"]
 [[keyword]]
 === Keyword type family
 ++++

--- a/docs/reference/mapping/types/point.asciidoc
+++ b/docs/reference/mapping/types/point.asciidoc
@@ -1,6 +1,5 @@
 [[point]]
 [role="xpack"]
-[testenv="basic"]
 === Point field type
 ++++
 <titleabbrev>Point</titleabbrev>

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -1,6 +1,5 @@
 [[shape]]
 [role="xpack"]
-[testenv="basic"]
 === Shape field type
 ++++
 <titleabbrev>Shape</titleabbrev>

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -1,4 +1,3 @@
-[testenv="basic"]
 [[text]]
 === Text type family
 ++++

--- a/docs/reference/mapping/types/unsigned_long.asciidoc
+++ b/docs/reference/mapping/types/unsigned_long.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 
 [[unsigned-long]]
 === Unsigned long field type

--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[version]]
 === Version field type
 ++++

--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [discrete]
 [[wildcard-field-type]]
 === Wildcard field type

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[migration-api-deprecation]]
 === Deprecation info APIs
 ++++

--- a/docs/reference/migration/apis/feature_upgrade.asciidoc
+++ b/docs/reference/migration/apis/feature_upgrade.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[migration-api-feature-upgrade]]
 === Feature Upgrade APIs
 ++++

--- a/docs/reference/migration/migration.asciidoc
+++ b/docs/reference/migration/migration.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[migration-api]]
 == Migration APIs
 

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-close-job]]
 = Close {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-calendar-event]]
 = Delete events from calendar API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-calendar-job]]
 = Delete {anomaly-jobs} from calendar API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-calendar]]
 = Delete calendars API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-datafeed]]
 = Delete {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-expired-data]]
 = Delete expired data API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-filter]]
 = Delete filters API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-forecast]]
 = Delete forecasts API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-job]]
 = Delete {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-delete-snapshot]]
 = Delete model snapshots API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-estimate-model-memory]]
 = Estimate {anomaly-jobs} model memory API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-flush-job]]
 = Flush jobs API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-forecast]]
 = Forecast jobs API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-bucket]]
 = Get buckets API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-calendar-event]]
 = Get scheduled events API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-calendar]]
 = Get calendars API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-category]]
 = Get categories API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-datafeed-stats]]
 = Get {dfeed} statistics API
 

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-datafeed]]
 = Get {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-filter]]
 = Get filters API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-influencer]]
 = Get influencers API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-job-stats]]
 = Get {anomaly-job} statistics API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-job]]
 = Get {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[get-ml-info]]
 = Get machine learning info API
 

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-overall-buckets]]
 = Get overall buckets API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-record]]
 = Get records API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-get-snapshot]]
 = Get model snapshots API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/ml-apis.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/ml-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-apis]]
 = {ml-cap} {anomaly-detect} APIs
 

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-open-job]]
 = Open {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-post-calendar-event]]
 = Add events to calendar API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-post-data]]
 = Post data to jobs API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-preview-datafeed]]
 = Preview {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-put-calendar-job]]
 = Add {anomaly-jobs} to calendar API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-put-calendar]]
 = Create calendars API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-put-datafeed]]
 = Create {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-put-filter]]
 = Create filters API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-put-job]]
 = Create {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/reset-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/reset-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-reset-job]]
 = Reset {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-revert-snapshot]]
 = Revert model snapshots API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-set-upgrade-mode]]
 = Set upgrade mode API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-start-datafeed]]
 = Start {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-stop-datafeed]]
 = Stop {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-update-datafeed]]
 = Update {dfeeds} API
 

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-update-filter]]
 = Update filters API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-update-job]]
 = Update {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-update-snapshot]]
 = Update model snapshots API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-upgrade-job-model-snapshot]]
 = Upgrade model snapshots API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-valid-detector]]
 = Validate detectors API
 ++++

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-valid-job]]
 = Validate {anomaly-jobs} API
 ++++

--- a/docs/reference/ml/anomaly-detection/ml-configuring-categories.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-categories.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-configuring-categories]]
 = Detecting anomalous categories of data
 

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[delete-dfanalytics]]
 = Delete {dfanalytics-jobs} API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[delete-trained-models-aliases]]
 = Delete trained model aliases API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[delete-trained-models]]
 = Delete trained models API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[evaluate-dfanalytics]]
 = Evaluate {dfanalytics} API
 

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[explain-dfanalytics]]
 = Explain {dfanalytics} API
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[get-dfanalytics-stats]]
 = Get {dfanalytics-jobs} statistics API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[get-dfanalytics]]
 = Get {dfanalytics-jobs} API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/get-trained-model-deployment-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-model-deployment-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-trained-model-deployment-stats]]
 = Get trained model deployment statistics API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-trained-models-stats]]
 = Get trained models statistics API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-trained-models]]
 = Get trained models API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/infer-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/infer-trained-model-deployment.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[infer-trained-model-deployment]]
 = Infer trained model deployment API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[ml-df-analytics-apis]]
 = {ml-cap} {dfanalytics} APIs
 

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[preview-dfanalytics]]
 = Preview {dfanalytics} API
 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[put-dfanalytics]]
 = Create {dfanalytics-jobs} API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/put-trained-model-definition-part.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-model-definition-part.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[put-trained-model-definition-part]]
 = Create trained model definition part API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/put-trained-model-vocabulary.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-model-vocabulary.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[put-trained-model-vocabulary]]
 = Create trained model vocabulary API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[put-trained-models-aliases]]
 = Create or update trained model aliases API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[put-trained-models]]
 = Create trained models API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[start-dfanalytics]]
 = Start {dfanalytics-jobs} API
 

--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[start-trained-model-deployment]]
 = Start trained model deployment API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[stop-dfanalytics]]
 = Stop {dfanalytics-jobs} API
 

--- a/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[stop-trained-model-deployment]]
 = Stop trained model deployment API
 [subs="attributes"]

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[update-dfanalytics]]
 = Update {dfanalytics-jobs} API
 [subs="attributes"]

--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="gold"]
 [[collecting-monitoring-data]]
 == Collecting monitoring data using legacy collectors
 ++++

--- a/docs/reference/monitoring/collectors.asciidoc
+++ b/docs/reference/monitoring/collectors.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[es-monitoring-collectors]]
 == Collectors
 

--- a/docs/reference/monitoring/configuring-filebeat.asciidoc
+++ b/docs/reference/monitoring/configuring-filebeat.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[configuring-filebeat]]
 == Collecting {es} log data with {filebeat}
 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="gold"]
 [[configuring-metricbeat]]
 == Collecting {es} monitoring data with {metricbeat}
 

--- a/docs/reference/monitoring/exporters.asciidoc
+++ b/docs/reference/monitoring/exporters.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[es-monitoring-exporters]]
 == Exporters
 

--- a/docs/reference/monitoring/how-monitoring-works.asciidoc
+++ b/docs/reference/monitoring/how-monitoring-works.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[how-monitoring-works]]
 == How monitoring works
 ++++

--- a/docs/reference/monitoring/http-export.asciidoc
+++ b/docs/reference/monitoring/http-export.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[http-exporter]]
 === HTTP exporters
 

--- a/docs/reference/monitoring/index.asciidoc
+++ b/docs/reference/monitoring/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[monitor-elasticsearch-cluster]]
 = Monitor a cluster
 

--- a/docs/reference/monitoring/indices.asciidoc
+++ b/docs/reference/monitoring/indices.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[config-monitoring-indices]]
 == Configuring indices for monitoring
 

--- a/docs/reference/monitoring/local-export.asciidoc
+++ b/docs/reference/monitoring/local-export.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[local-exporter]]
 === Local exporters
 

--- a/docs/reference/monitoring/pause-export.asciidoc
+++ b/docs/reference/monitoring/pause-export.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[pause-export]]
 === Pausing data collection
 

--- a/docs/reference/query-dsl/pinned-query.asciidoc
+++ b/docs/reference/query-dsl/pinned-query.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[query-dsl-pinned-query]]
 === Pinned Query
 Promotes selected documents to rank higher than those matching a given query.

--- a/docs/reference/query-dsl/shape-queries.asciidoc
+++ b/docs/reference/query-dsl/shape-queries.asciidoc
@@ -1,6 +1,5 @@
 [[shape-queries]]
 [role="xpack"]
-[testenv="basic"]
 == Shape queries
 
 

--- a/docs/reference/query-dsl/shape-query.asciidoc
+++ b/docs/reference/query-dsl/shape-query.asciidoc
@@ -1,6 +1,5 @@
 [[query-dsl-shape-query]]
 [role="xpack"]
-[testenv="basic"]
 === Shape query
 ++++
 <titleabbrev>Shape</titleabbrev>

--- a/docs/reference/repositories-metering-api/apis/clear-repositories-metering-archive.asciidoc
+++ b/docs/reference/repositories-metering-api/apis/clear-repositories-metering-archive.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[clear-repositories-metering-archive-api]]
 === Clear repositories metering archive
 ++++

--- a/docs/reference/repositories-metering-api/apis/get-repositories-metering.asciidoc
+++ b/docs/reference/repositories-metering-api/apis/get-repositories-metering.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-repositories-metering-api]]
 === Get repositories metering information
 ++++

--- a/docs/reference/repositories-metering-api/repositories-metering-apis.asciidoc
+++ b/docs/reference/repositories-metering-api/repositories-metering-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[repositories-metering-apis]]
 == Repositories metering APIs
 

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[info-api]]
 == Info API
 

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[usage-api]]
 == Usage API
 

--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-api-quickref]]
 === {rollup-cap} API quick reference
 ++++

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-delete-job]]
 === Delete {rollup-jobs} API
 [subs="attributes"]

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-get-job]]
 === Get {rollup-jobs} API
 ++++

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-put-job]]
 === Create {rollup-jobs} API
 [subs="attributes"]

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-get-rollup-caps]]
 === Get {rollup-job} capabilities API
 ++++

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-get-rollup-index-caps]]
 === Get rollup index capabilities API
 ++++

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-search]]
 === Rollup search
 ++++

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-start-job]]
 === Start {rollup-jobs} API
 [subs="attributes"]

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-stop-job]]
 === Stop {rollup-jobs} API
 [subs="attributes"]

--- a/docs/reference/rollup/index.asciidoc
+++ b/docs/reference/rollup/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[xpack-rollup]]
 == Rolling up historical data
 

--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-overview]]
 === {rollup-cap} overview
 ++++

--- a/docs/reference/rollup/rollup-agg-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-agg-limitations.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-agg-limitations]]
 === {rollup-cap} aggregation limitations
 

--- a/docs/reference/rollup/rollup-apis.asciidoc
+++ b/docs/reference/rollup/rollup-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-apis]]
 == Rollup APIs
 

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-getting-started]]
 === Getting started with {rollups}
 ++++

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-search-limitations]]
 === {rollup-cap} search limitations
 

--- a/docs/reference/rollup/understanding-groups.asciidoc
+++ b/docs/reference/rollup/understanding-groups.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[rollup-understanding-groups]]
 === Understanding groups
 

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[async-search]]
 === Async search
 

--- a/docs/reference/search/search-your-data/long-running-searches.asciidoc
+++ b/docs/reference/search/search-your-data/long-running-searches.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[async-search-intro]]
 == Long-running searches
 

--- a/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[searchable-snapshots-api-clear-cache]]
 === Clear cache API
 ++++

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[searchable-snapshots-api-mount-snapshot]]
 === Mount snapshot API
 ++++

--- a/docs/reference/searchable-snapshots/apis/node-cache-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/node-cache-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[searchable-snapshots-api-cache-stats]]
 === Cache stats API
 ++++

--- a/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[searchable-snapshots-apis]]
 == Searchable snapshots APIs
 

--- a/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[searchable-snapshots-api-stats]]
 === Searchable snapshot statistics API
 ++++

--- a/docs/reference/shutdown/apis/shutdown-api.asciidoc
+++ b/docs/reference/shutdown/apis/shutdown-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[node-lifecycle-api]]
 == Node lifecycle APIs
 

--- a/docs/reference/slm/apis/slm-api.asciidoc
+++ b/docs/reference/slm/apis/slm-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[snapshot-lifecycle-management-api]]
 == {slm-cap} APIs
 

--- a/docs/reference/slm/apis/slm-delete.asciidoc
+++ b/docs/reference/slm/apis/slm-delete.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-delete-policy]]
 === Delete snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-execute-retention.asciidoc
+++ b/docs/reference/slm/apis/slm-execute-retention.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-execute-retention]]
 === Execute snapshot retention policy API
 ++++

--- a/docs/reference/slm/apis/slm-execute.asciidoc
+++ b/docs/reference/slm/apis/slm-execute.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-execute-lifecycle]]
 === Execute snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-get-status]]
 === Get {slm} status API
 

--- a/docs/reference/slm/apis/slm-get.asciidoc
+++ b/docs/reference/slm/apis/slm-get.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-get-policy]]
 === Get snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-start.asciidoc
+++ b/docs/reference/slm/apis/slm-start.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-start]]
 === Start {slm} API
 

--- a/docs/reference/slm/apis/slm-stats.asciidoc
+++ b/docs/reference/slm/apis/slm-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-get-stats]]
 === Get snapshot lifecycle stats API
 ++++

--- a/docs/reference/slm/apis/slm-stop.asciidoc
+++ b/docs/reference/slm/apis/slm-stop.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-api-stop]]
 === Stop {slm} API
 

--- a/docs/reference/slm/getting-started-slm.asciidoc
+++ b/docs/reference/slm/getting-started-slm.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[getting-started-snapshot-lifecycle-management]]
 === Tutorial: Automate backups with {slm-init}
 

--- a/docs/reference/slm/index.asciidoc
+++ b/docs/reference/slm/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[snapshot-lifecycle-management]]
 == {slm-init}: Manage the snapshot lifecycle
 

--- a/docs/reference/slm/slm-retention.asciidoc
+++ b/docs/reference/slm/slm-retention.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[slm-retention]]
 === Snapshot retention
 

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -1,5 +1,4 @@
 [[snapshots-register-repository]]
-[testenv="basic"]
 == Register a snapshot repository
 ++++
 <titleabbrev>Register a repository</titleabbrev>

--- a/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
+++ b/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[clear-sql-cursor-api]]
 === Clear SQL cursor API
 ++++

--- a/docs/reference/sql/apis/delete-async-sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/delete-async-sql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[delete-async-sql-search-api]]
 === Delete async SQL search API
 ++++

--- a/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-async-sql-search-api]]
 === Get async SQL search API
 ++++

--- a/docs/reference/sql/apis/get-async-sql-search-status-api.asciidoc
+++ b/docs/reference/sql/apis/get-async-sql-search-status-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-async-sql-search-status-api]]
 === Get async SQL search status API
 ++++

--- a/docs/reference/sql/apis/sql-apis.asciidoc
+++ b/docs/reference/sql/apis/sql-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-apis]]
 == SQL APIs
 

--- a/docs/reference/sql/apis/sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/sql-search-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-search-api]]
 === SQL search API
 ++++

--- a/docs/reference/sql/apis/sql-translate-api.asciidoc
+++ b/docs/reference/sql/apis/sql-translate-api.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-translate-api]]
 === SQL translate API
 ++++

--- a/docs/reference/sql/appendix/syntax-reserved.asciidoc
+++ b/docs/reference/sql/appendix/syntax-reserved.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-reserved]]
 == Reserved keywords
 

--- a/docs/reference/sql/concepts.asciidoc
+++ b/docs/reference/sql/concepts.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-concepts]]
 == Conventions and Terminology
 

--- a/docs/reference/sql/endpoints/cli.asciidoc
+++ b/docs/reference/sql/endpoints/cli.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-cli]]
 == SQL CLI
 

--- a/docs/reference/sql/endpoints/client-apps/dbeaver.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/dbeaver.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-dbeaver]]
 === DBeaver
 

--- a/docs/reference/sql/endpoints/client-apps/dbvis.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/dbvis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-dbvis]]
 === DbVisualizer
 

--- a/docs/reference/sql/endpoints/client-apps/excel.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/excel.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-excel]]
 === Microsoft Excel
 

--- a/docs/reference/sql/endpoints/client-apps/index.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps]]
 == SQL Client Applications
 

--- a/docs/reference/sql/endpoints/client-apps/microstrat.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/microstrat.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-microstrat]]
 === MicroStrategy Desktop
 

--- a/docs/reference/sql/endpoints/client-apps/powerbi.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/powerbi.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-powerbi]]
 === Microsoft Power BI Desktop
 

--- a/docs/reference/sql/endpoints/client-apps/ps1.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/ps1.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-ps1]]
 === Microsoft PowerShell
 

--- a/docs/reference/sql/endpoints/client-apps/qlik.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/qlik.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-qlik]]
 === Qlik Sense Desktop
 

--- a/docs/reference/sql/endpoints/client-apps/squirrel.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/squirrel.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-squirrel]]
 === SQuirreL SQL
 

--- a/docs/reference/sql/endpoints/client-apps/tableau-desktop.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/tableau-desktop.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-tableau-desktop]]
 === Tableau Desktop
 

--- a/docs/reference/sql/endpoints/client-apps/tableau-server.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/tableau-server.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-tableau-server]]
 === Tableau Server
 

--- a/docs/reference/sql/endpoints/client-apps/workbench.asciidoc
+++ b/docs/reference/sql/endpoints/client-apps/workbench.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-client-apps-workbench]]
 === SQL Workbench/J
 

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-jdbc]]
 == SQL JDBC
 

--- a/docs/reference/sql/endpoints/odbc.asciidoc
+++ b/docs/reference/sql/endpoints/odbc.asciidoc
@@ -1,6 +1,5 @@
 :odbc: {es-sql} ODBC Driver
 
-[testenv="platinum"]
 [[sql-odbc]]
 == SQL ODBC
 

--- a/docs/reference/sql/endpoints/odbc/configuration.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/configuration.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-odbc-setup]]
 === Configuration
 

--- a/docs/reference/sql/endpoints/odbc/installation.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/installation.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="platinum"]
 [[sql-odbc-installation]]
 === Driver installation
 

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-rest]]
 == SQL REST API
 

--- a/docs/reference/sql/endpoints/translate.asciidoc
+++ b/docs/reference/sql/endpoints/translate.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-translate]]
 == SQL Translate API
 

--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-aggs]]
 === Aggregate Functions
 

--- a/docs/reference/sql/functions/conditional.asciidoc
+++ b/docs/reference/sql/functions/conditional.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-conditional]]
 === Conditional Functions And Expressions
 

--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-datetime]]
 === Date/Time and Interval Functions and Operators
 

--- a/docs/reference/sql/functions/geo.asciidoc
+++ b/docs/reference/sql/functions/geo.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-geo]]
 === Geo Functions
 

--- a/docs/reference/sql/functions/grouping.asciidoc
+++ b/docs/reference/sql/functions/grouping.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-grouping]]
 === Grouping Functions
 

--- a/docs/reference/sql/functions/index.asciidoc
+++ b/docs/reference/sql/functions/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions]]
 == Functions and Operators
 

--- a/docs/reference/sql/functions/like-rlike.asciidoc
+++ b/docs/reference/sql/functions/like-rlike.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-like-rlike-operators]]
 === LIKE and RLIKE Operators
 

--- a/docs/reference/sql/functions/math.asciidoc
+++ b/docs/reference/sql/functions/math.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-math]]
 === Mathematical Functions
 

--- a/docs/reference/sql/functions/operators.asciidoc
+++ b/docs/reference/sql/functions/operators.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-operators]]
 === Comparison Operators
 

--- a/docs/reference/sql/functions/search.asciidoc
+++ b/docs/reference/sql/functions/search.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-search]]
 === Full-Text Search Functions
 

--- a/docs/reference/sql/functions/string.asciidoc
+++ b/docs/reference/sql/functions/string.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-string]]
 === String Functions
 

--- a/docs/reference/sql/functions/system.asciidoc
+++ b/docs/reference/sql/functions/system.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-system]]
 === System Functions
 

--- a/docs/reference/sql/functions/type-conversion.asciidoc
+++ b/docs/reference/sql/functions/type-conversion.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-functions-type-conversion]]
 === Type Conversion Functions
 

--- a/docs/reference/sql/getting-started.asciidoc
+++ b/docs/reference/sql/getting-started.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-getting-started]]
 == Getting Started with SQL
 

--- a/docs/reference/sql/index.asciidoc
+++ b/docs/reference/sql/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[xpack-sql]]
 = SQL
 

--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-data-types]]
 === Data Types
 

--- a/docs/reference/sql/language/index.asciidoc
+++ b/docs/reference/sql/language/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-spec]]
 == SQL Language
 

--- a/docs/reference/sql/language/indices.asciidoc
+++ b/docs/reference/sql/language/indices.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-index-patterns]]
 === Index patterns
 

--- a/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-describe-table]]
 === DESCRIBE TABLE
 

--- a/docs/reference/sql/language/syntax/commands/index.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-commands]]
 === SQL Commands
 

--- a/docs/reference/sql/language/syntax/commands/select.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/select.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-select]]
 === SELECT
 

--- a/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-show-columns]]
 === SHOW COLUMNS
 

--- a/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-show-functions]]
 === SHOW FUNCTIONS
 

--- a/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-syntax-show-tables]]
 === SHOW TABLES
 

--- a/docs/reference/sql/language/syntax/lexic/index.asciidoc
+++ b/docs/reference/sql/language/syntax/lexic/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-lexical-structure]]
 === Lexical Structure
 

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-limitations]]
 == SQL Limitations
 

--- a/docs/reference/sql/overview.asciidoc
+++ b/docs/reference/sql/overview.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-overview]]
 == Overview
 

--- a/docs/reference/sql/security.asciidoc
+++ b/docs/reference/sql/security.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[sql-security]]
 == Security
 

--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[find-structure]]
 = Find structure API
 

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[delete-transform]]
 = Delete {transform} API
 

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-transform-stats]]
 = Get {transform} statistics API
 

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[get-transform]]
 = Get {transforms} API
 

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[preview-transform]]
 = Preview {transform} API
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[put-transform]]
 = Create {transform} API
 

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[start-transform]]
 = Start {transform} API
 

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[stop-transform]]
 = Stop {transforms} API
 

--- a/docs/reference/transform/apis/transform-apis.asciidoc
+++ b/docs/reference/transform/apis/transform-apis.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[transform-apis]]
 = {transform-cap} APIs
 

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[update-transform]]
 = Update {transform} API
 

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[upgrade-transforms]]
 = Upgrade {transforms} API
 

--- a/docs/reference/transform/examples.asciidoc
+++ b/docs/reference/transform/examples.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[transform-examples]]
 = {transform-cap} examples
 ++++

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[transform-painless-examples]]
 = Painless examples for {transforms}
 ++++

--- a/docs/reference/transform/troubleshooting.asciidoc
+++ b/docs/reference/transform/troubleshooting.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[transform-troubleshooting]]
 = Troubleshooting {transforms}
 [subs="attributes"]

--- a/docs/reference/transform/usage.asciidoc
+++ b/docs/reference/transform/usage.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[transform-usage]]
 = When to use {transforms}
 

--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -1,4 +1,3 @@
-[testenv="platinum"]
 
 ////////////
 Take us out of upgrade mode after running any snippets on this page.

--- a/docs/reference/upgrade/open-ml.asciidoc
+++ b/docs/reference/upgrade/open-ml.asciidoc
@@ -1,4 +1,3 @@
-[testenv="platinum"]
 If you temporarily halted the tasks associated with your {ml} jobs,
 use the <<ml-set-upgrade-mode,set upgrade mode API>> to return them to active
 states:

--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[vector-functions]]
 ===== Functions for vector fields
 

--- a/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[logstash-api-delete-pipeline]]
 === Delete {ls} pipeline API
 ++++

--- a/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[logstash-api-get-pipeline]]
 === Get pipeline API
 ++++

--- a/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="basic"]
 [[logstash-api-put-pipeline]]
 === Create or update {ls} pipeline API
 ++++

--- a/x-pack/docs/en/security/operator-privileges/configure-operator-privileges.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/configure-operator-privileges.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[configure-operator-privileges]]
 === Configure operator privileges
 

--- a/x-pack/docs/en/security/operator-privileges/index.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[operator-privileges]]
 == Operator privileges
 

--- a/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[operator-only-functionality]]
 === Operator-only functionality
 

--- a/x-pack/docs/en/security/operator-privileges/operator-only-snapshot-and-restore.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-snapshot-and-restore.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="enterprise"]
 [[operator-only-snapshot-and-restore]]
 === Operator privileges for snapshot and restore
 

--- a/x-pack/docs/en/security/reference/files.asciidoc
+++ b/x-pack/docs/en/security/reference/files.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="gold"]
 [[security-files]]
 === Security files
 

--- a/x-pack/docs/en/watcher/troubleshooting.asciidoc
+++ b/x-pack/docs/en/watcher/troubleshooting.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[testenv="gold"]
 [[watcher-troubleshooting]]
 == Troubleshooting {watcher}
 [subs="attributes"]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove `testenv` annotations from doc snippet tests (#80023)