### PR TITLE
Easier array optimization parsing BytesReference

### DIFF
--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -71,8 +71,10 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
         try (XContentBuilder builtSample = sample.apply(createBuilder())) {
             BytesReference sampleBytes = BytesReference.bytes(builtSample);
             try (
-                XContentParser parser = getXContentType().xContent()
-                    .createParser(XContentParserConfiguration.EMPTY.withFiltering(includes, excludes), sampleBytes.streamInput())
+                XContentParser parser = sampleBytes.xContentParser(
+                    getXContentType().xContent(),
+                    XContentParserConfiguration.EMPTY.withFiltering(includes, excludes)
+                )
             ) {
                 XContentBuilder result = createBuilder();
                 if (sampleBytes.get(sampleBytes.length() - 1) == '\n') {
@@ -107,11 +109,8 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
     static void assertXContentBuilderAsBytes(final XContentBuilder expected, final XContentBuilder actual) {
         XContent xContent = XContentFactory.xContent(actual.contentType());
         try (
-            XContentParser jsonParser = xContent.createParser(
-                XContentParserConfiguration.EMPTY,
-                BytesReference.bytes(expected).streamInput()
-            );
-            XContentParser testParser = xContent.createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(actual).streamInput())
+            XContentParser jsonParser = BytesReference.bytes(expected).xContentParser(xContent, XContentParserConfiguration.EMPTY);
+            XContentParser testParser = BytesReference.bytes(actual).xContentParser(xContent, XContentParserConfiguration.EMPTY);
         ) {
             while (true) {
                 XContentParser.Token token1 = jsonParser.nextToken();

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -14,13 +14,11 @@ import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.xcontent.DeprecationHandler;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
 
@@ -75,14 +73,7 @@ public final class JsonProcessor extends AbstractProcessor {
 
     public static Object apply(Object fieldValue, boolean allowDuplicateKeys) {
         BytesReference bytesRef = fieldValue == null ? new BytesArray("null") : new BytesArray(fieldValue.toString());
-        try (
-            InputStream stream = bytesRef.streamInput();
-            XContentParser parser = JsonXContent.jsonXContent.createParser(
-                NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                stream
-            )
-        ) {
+        try (XContentParser parser = bytesRef.xContentParser(JsonXContent.jsonXContent, XContentParserConfiguration.EMPTY)) {
             parser.allowDuplicateKeys(allowDuplicateKeys);
             XContentParser.Token token = parser.nextToken();
             Object value = null;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -10,7 +10,6 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.CollectionUtils;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
@@ -20,13 +19,11 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -112,9 +109,8 @@ public final class ScriptProcessor extends AbstractProcessor {
         ) throws Exception {
             try (
                 XContentBuilder builder = XContentBuilder.builder(JsonXContent.jsonXContent).map(config);
-                InputStream stream = BytesReference.bytes(builder).streamInput();
-                XContentParser parser = XContentType.JSON.xContent()
-                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
+                XContentParser parser = BytesReference.bytes(builder)
+                    .xContentParser(JsonXContent.jsonXContent, XContentParserConfiguration.EMPTY);
             ) {
                 Script script = Script.parse(parser);
 

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -242,10 +242,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             IndicesOptions defaultOptions = searchRequest.indicesOptions();
             // now parse the action
             if (nextMarker - from > 0) {
-                try (
-                    InputStream stream = data.slice(from, nextMarker - from).streamInput();
-                    XContentParser parser = xContent.createParser(parserConfig, stream)
-                ) {
+                try (XContentParser parser = data.slice(from, nextMarker - from).xContentParser(xContent, parserConfig)) {
                     Map<String, Object> source = parser.map();
                     Object expandWildcards = null;
                     Object ignoreUnavailable = null;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -219,7 +219,7 @@ public abstract class IndexRouting {
             assert Transports.assertNotTransportThread("parsing the _source can get slow");
 
             try {
-                try (XContentParser parser = sourceType.xContent().createParser(parserConfig, source.streamInput())) {
+                try (XContentParser parser = source.xContentParser(sourceType.xContent(), parserConfig)) {
                     parser.nextToken(); // Move to first token
                     if (parser.currentToken() == null) {
                         throw new IllegalArgumentException("Error extracting routing: source didn't contain any routing fields");

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -10,6 +10,9 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xcontent.XContent;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -100,6 +103,11 @@ public final class BytesArray extends AbstractBytesReference {
     @Override
     public int arrayOffset() {
         return offset;
+    }
+
+    @Override
+    public XContentParser xContentParser(XContent xContent, XContentParserConfiguration parserConfig) throws IOException {
+        return xContent.createParser(parserConfig, bytes, offset, length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -15,7 +15,10 @@ import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -194,4 +197,15 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
     default int arrayOffset() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Build an {@link XContentParser} that parses from these bytes.
+     * This is the same as {@code xContent.createParser(parserConfig, bytes.streamInput())}
+     * but more efficient when the bytes {@code #hasArray()}.
+     */
+    default XContentParser xContentParser(XContent xContent, XContentParserConfiguration parserConfig) throws IOException {
+        assert hasArray() == false : "override xContentParser if overriding hasArray";
+        return xContent.createParser(parserConfig, streamInput());
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -15,7 +15,10 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -215,6 +218,12 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     public int arrayOffset() {
         assert refCount() > 0;
         return delegate.arrayOffset();
+    }
+
+    @Override
+    public XContentParser xContentParser(XContent xContent, XContentParserConfiguration parserConfig) throws IOException {
+        assert refCount() > 0;
+        return delegate.xContentParser(xContent, parserConfig);
     }
 
     private static final class RefCountedReleasable extends AbstractRefCounted {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -163,14 +163,14 @@ public class XContentHelper {
                 try (InputStream stream = input) {
                     return new Tuple<>(
                         Objects.requireNonNull(contentType),
-                        convertToMap(XContentFactory.xContent(contentType), stream, ordered, include, exclude)
+                        convertToMap(contentType.xContent(), stream, ordered, include, exclude)
                     );
                 }
             }
             XContentType contentType = xContentType != null ? xContentType : xContentType(bytes);
             try (
                 XContentParser parser = bytes.xContentParser(
-                    xContentType.xContent(),
+                    contentType.xContent(),
                     XContentParserConfiguration.EMPTY.withFiltering(include, exclude)
                 )
             ) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommandTests.java
@@ -66,7 +66,7 @@ public class ElasticsearchNodeCommandTests extends ESTestCase {
             ? parserConfig().withRegistry(ElasticsearchNodeCommand.namedXContentRegistry)
             : parserConfig();
         Metadata loadedMetadata;
-        try (XContentParser parser = createParser(parserConfig, JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+        try (XContentParser parser = BytesReference.bytes(builder).xContentParser(JsonXContent.jsonXContent, parserConfig)) {
             loadedMetadata = Metadata.fromXContent(parser);
         }
         assertThat(loadedMetadata.clusterUUID(), not(equalTo("_na_")));

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -50,8 +50,8 @@ public class XContentHelperTests extends ESTestCase {
     }
 
     public void testMergingListValuesAreMapsOfOne() {
-        Map<String, Object> defaults = getMap("test", getList(getNamedMap("name1", "t1", "1"), getNamedMap("name2", "t2", "2")));
-        Map<String, Object> content = getMap("test", getList(getNamedMap("name2", "t3", "3"), getNamedMap("name4", "t4", "4")));
+        Map<String, Object> defaults = getMap("test", List.of(getNamedMap("name1", "t1", "1"), getNamedMap("name2", "t2", "2")));
+        Map<String, Object> content = getMap("test", List.of(getNamedMap("name2", "t3", "3"), getNamedMap("name4", "t4", "4")));
         Map<String, Object> expected = getMap(
             "test",
             getList(getNamedMap("name2", "t2", "2", "t3", "3"), getNamedMap("name4", "t4", "4"), getNamedMap("name1", "t1", "1"))

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
 import org.junit.After;
@@ -484,10 +485,16 @@ public class RestControllerTests extends ESTestCase {
             SmileConstants.HEADER_BYTE_4 }
     );
 
+    /**
+     * Builds some random that will produce an {@link XContentParser}.
+     * We don't use the parser so the content need not be valid, but
+     * constructing the parser must work.
+     */
     private BytesReference randomContent(boolean json) {
         if (json) {
             return new BytesArray(randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.getBytes() / inFlightRequestsBreaker.getOverhead())));
         }
+        // Constructing a SMILE parser sometimes validates the head. So we include it.
         BytesReference bytes = CompositeBytesReference.of(
             SMILE_HEADER,
             new BytesArray(randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.getBytes() / inFlightRequestsBreaker.getOverhead() - 4)))

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1146,10 +1146,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
                 final Metadata loadedMetadata;
                 try (
-                    XContentParser parser = createParser(
-                        parserConfig().withRegistry(ElasticsearchNodeCommand.namedXContentRegistry),
+                    XContentParser parser = originalBytes.xContentParser(
                         SmileXContent.smileXContent,
-                        originalBytes
+                        parserConfig().withRegistry(ElasticsearchNodeCommand.namedXContentRegistry)
                     )
                 ) {
                     loadedMetadata = Metadata.fromXContent(parser);
@@ -1187,10 +1186,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
                 final IndexMetadata loadedIndexMetadata;
                 try (
-                    XContentParser parser = createParser(
-                        parserConfig().withRegistry(ElasticsearchNodeCommand.namedXContentRegistry),
+                    XContentParser parser = originalBytes.xContentParser(
                         SmileXContent.smileXContent,
-                        originalBytes
+                        parserConfig().withRegistry(ElasticsearchNodeCommand.namedXContentRegistry)
                     )
                 ) {
                     loadedIndexMetadata = IndexMetadata.fromXContent(parser);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1468,18 +1468,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContent xContent, BytesReference data) throws IOException {
-        return createParser(parserConfig(), xContent, data);
-    }
-
-    /**
-     * Create a new {@link XContentParser}.
-     */
-    protected final XContentParser createParser(XContentParserConfiguration config, XContent xContent, BytesReference data)
-        throws IOException {
-        if (data.hasArray()) {
-            return xContent.createParser(config, data.array(), data.arrayOffset(), data.length());
-        }
-        return xContent.createParser(config, data.streamInput());
+        return data.xContentParser(xContent, parserConfig());
     }
 
     protected final XContentParser createParserWithCompatibilityFor(XContent xContent, String data, RestApiVersion restApiVersion)


### PR DESCRIPTION
This adds a `BytesReference#xContentParser` method that builds the most
efficient parser for the bytes. Previously we had many calls that looked like:

```
if (data.hasArray()) {
    return xContent.createParser(config, data.array(), data.arrayOffset(), data.length());
}
return xContent.createParser(config, data.streamInput());
```

This replaces it with:
```
return data.xContentParser(xContent, config);
```

They amount to doing the same thing, but I think it's a lot more likely that folks will use the shorter version. So it's a lot more likely that we'll more consistently get the array-optimized parser. I haven't done any deep digging into the performance difference, but it seems like we went to a lot of trouble to get the array version in `BulkRequestParser` so I figure it's important.


