### PR TITLE
remove nullable annotation in IndexShard constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -300,7 +300,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final IndexCache indexCache,
         final MapperService mapperService,
         final SimilarityService similarityService,
-        final @Nullable EngineFactory engineFactory,
+        final EngineFactory engineFactory,
         final IndexEventListener indexEventListener,
         final CheckedFunction<DirectoryReader, DirectoryReader, IOException> indexReaderWrapper,
         final ThreadPool threadPool,


### PR DESCRIPTION
In PR [#26827](https://github.com/elastic/elasticsearch/pull/26827),  @jasontedor  enabled engine factory to be pluggable. `engineFactory` parameter of IndexShard constructor became not nullable,   so `@nullable` annotation for this parameter was removed in that PR. 
However, `@nullable` annotaion was still there after the PR was merged, maybe a merge operation mistake.
This PR remove the `@nullable` annotaion of `engineFactory`  in IndexShard constructor, in order to solve the conflict between `@nullable` annotaion and `Objects.requireNonNull(engineFactory)`.