### PR TITLE
[Test] Relax assertion of denial message for service account (#80389)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -85,7 +85,7 @@ teardown:
 
   - match: { "error.type": "security_exception" }
   - match:
-      error.reason: "action [cluster:admin/xpack/security/user/delete] is unauthorized for user [elastic/fleet-server], this action is granted by the cluster privileges [manage_security,all]"
+      error.reason: "/action.\\[cluster:admin/xpack/security/user/delete\\].is.unauthorized.for.*\\[elastic/fleet-server\\].*this.action.is.granted.by.the.cluster.privileges.*/"
 
   - do:
       headers:


### PR DESCRIPTION
Relax the assertion for error message so that v7RestCompat test does not
break on non-bwc'able changes.

Relates: #79809
