### PR TITLE
[8.0] Prevent NullPointerException in SourceConfirmedTextQuery (#80472)

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQueryTests.java
@@ -417,4 +417,16 @@ public class SourceConfirmedTextQueryTests extends ESTestCase {
         ).build();
         assertEquals(approximation, SourceConfirmedTextQuery.approximate(phrasePrefixQuery));
     }
+
+    public void testEmptyIndex() throws Exception {
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                PhraseQuery query = new PhraseQuery("body", "a", "b");
+                Query sourceConfirmedPhraseQuery = new SourceConfirmedTextQuery(query, SOURCE_FETCHER_PROVIDER, Lucene.STANDARD_ANALYZER);
+                assertEquals(0, searcher.count(sourceConfirmedPhraseQuery));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Prevent NullPointerException in SourceConfirmedTextQuery (#80472)