### PR TITLE
[ML] Force stop deployment in use (#80431)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
@@ -30,10 +30,18 @@ experimental::[]
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
-////
+
 [[stop-trained-model-deployment-query-params]]
 == {api-query-parms-title}
-////
+
+`allow_no_match`::
+(Optional, Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+
+
+`force`::
+  (Optional, Boolean) If true, the deployment is stopped even if it is referenced by
+  ingest pipelines.
 
 ////
 [role="child_attributes"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
@@ -26,6 +26,21 @@
           }
         }
       ]
+    },
+    "params":{
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no deployments. (This includes `_all` string or when no deployments have been specified)"
+      },
+      "force":{
+        "type":"boolean",
+        "required":false,
+        "description":"True if the deployment should be forcefully stopped"
+      }
+    },
+    "body":{
+      "description":"The stop deployment parameters"
     }
   }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopTrainedModelDeploymentRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopTrainedModelDeploymentRequestTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.action.StopTrainedModelDeploymentAction.Request;
+
+import java.io.IOException;
+
+public class StopTrainedModelDeploymentRequestTests extends AbstractSerializingTestCase<Request> {
+
+    @Override
+    protected Request doParseInstance(XContentParser parser) throws IOException {
+        return Request.parseRequest(null, parser);
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLength(10));
+        if (randomBoolean()) {
+            request.setAllowNoMatch(randomBoolean());
+        }
+        if (randomBoolean()) {
+            request.setForce(randomBoolean());
+        }
+        return request;
+    }
+}

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -484,6 +484,42 @@ public class PyTorchModelIT extends ESRestTestCase {
         );
     }
 
+    public void testStopUsedDeploymentByIngestProcessor() throws IOException {
+        String modelId = "test_stop_used_deployment_by_ingest_processor";
+        createTrainedModel(modelId);
+        putModelDefinition(modelId);
+        putVocabulary(List.of("these", "are", "my", "words"), modelId);
+        startDeployment(modelId);
+
+        client().performRequest(
+            putPipeline(
+                "my_pipeline",
+                "{"
+                    + "\"processors\": [\n"
+                    + "      {\n"
+                    + "        \"inference\": {\n"
+                    + "          \"model_id\": \""
+                    + modelId
+                    + "\"\n"
+                    + "        }\n"
+                    + "      }\n"
+                    + "    ]\n"
+                    + "}"
+            )
+        );
+        ResponseException ex = expectThrows(ResponseException.class, () -> stopDeployment(modelId));
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(409));
+        assertThat(
+            EntityUtils.toString(ex.getResponse().getEntity()),
+            containsString(
+                "Cannot stop deployment for model [test_stop_used_deployment_by_ingest_processor] as it is referenced by"
+                    + " ingest processors; use force to stop the deployment"
+            )
+        );
+
+        stopDeployment(modelId, true);
+    }
+
     private int sumInferenceCountOnNodes(List<Map<String, Object>> nodes) {
         int inferenceCount = 0;
         for (var node : nodes) {
@@ -554,7 +590,15 @@ public class PyTorchModelIT extends ESRestTestCase {
     }
 
     private void stopDeployment(String modelId) throws IOException {
-        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/deployment/_stop");
+        stopDeployment(modelId, false);
+    }
+
+    private void stopDeployment(String modelId, boolean force) throws IOException {
+        String endpoint = "/_ml/trained_models/" + modelId + "/deployment/_stop";
+        if (force) {
+            endpoint += "?force=true";
+        }
+        Request request = new Request("POST", endpoint);
         client().performRequest(request);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStopTrainedModelDeploymentAction.java
@@ -38,7 +38,21 @@ public class RestStopTrainedModelDeploymentAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String modelId = restRequest.param(TrainedModelConfig.MODEL_ID.getPreferredName());
-        StopTrainedModelDeploymentAction.Request request = new StopTrainedModelDeploymentAction.Request(modelId);
+        StopTrainedModelDeploymentAction.Request request;
+        if (restRequest.hasContentOrSourceParam()) {
+            request = StopTrainedModelDeploymentAction.Request.parseRequest(modelId, restRequest.contentOrSourceParamParser());
+        } else {
+            request = new StopTrainedModelDeploymentAction.Request(modelId);
+            request.setAllowNoMatch(
+                restRequest.paramAsBoolean(
+                    StopTrainedModelDeploymentAction.Request.ALLOW_NO_MATCH.getPreferredName(),
+                    request.isAllowNoMatch()
+                )
+            );
+            request.setForce(
+                restRequest.paramAsBoolean(StopTrainedModelDeploymentAction.Request.FORCE.getPreferredName(), request.isForce())
+            );
+        }
         return channel -> client.execute(StopTrainedModelDeploymentAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }


### PR DESCRIPTION
Implements a `force` parameter to the stop deployment API.
This allows a user to forcefully stop a deployment. Currently,
this specifically allows stopping a deployment that is in use
by ingest processors.

Co-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>
