### PR TITLE
[8.0] Reenable data stream tests after backport of #79916

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -113,8 +113,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure{ task ->
   task.skipTest("indices.freeze/10_basic/Basic", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("indices.freeze/10_basic/Test index options", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("ml/categorization_agg/Test categorization aggregation with poor settings", "https://github.com/elastic/elasticsearch/pull/79586")
-  task.skipTest("data_stream/50_delete_backing_indices/Delete backing index on data stream", "pending backport of https://github.com/elastic/elasticsearch/pull/79916")
-  task.skipTest("data_stream/170_modify_data_stream/Modify a data stream", "pending backport of https://github.com/elastic/elasticsearch/pull/79916")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")


### PR DESCRIPTION
Completes the backport of #79916

Backport of #80488
