### PR TITLE
[8.0] Fix "outer" max_docs documentation (#80436)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -509,15 +509,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=max_docs]
 (Optional, enum) Set to `proceed` to continue reindexing even if there are conflicts.
 Defaults to `abort`.
 
+`max_docs`::
+(Optional, integer) The maximum number of documents to reindex. If <<conflicts, conflicts>> is equal to
+`proceed`, reindex could attempt to reindex more documents from the source than `max_docs` until it has successfully
+indexed `max_docs` documents into the target, or it has gone through every document in the source query.
+
 `source`::
 `index`:::
 (Required, string) The name of the data stream, index, or alias you are copying
 _from_. Also accepts a comma-separated list to reindex from multiple sources.
-
-`max_docs`:::
-(Optional, integer) The maximum number of documents to reindex. If <<conflicts, conflicts>> is equal to
-`proceed`, reindex could attempt to reindex more documents from the source than `max_docs` until it has successfully
-indexed `max_docs` documents into the target, or it has gone through every document in the source query.
 
 `query`:::
 (Optional, <<query-dsl, query object>>) Specifies the documents to reindex using the Query DSL.


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix "outer" max_docs documentation (#80436)