### PR TITLE
[8.0] Mark the keep_alive parameter of Open Point in Time API as required (#80449)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -52,7 +52,8 @@
       },
       "keep_alive": {
         "type": "string",
-        "description": "Specific the time to live for the point in time"
+        "description": "Specific the time to live for the point in time",
+        "required": true
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Mark the `keep_alive` parameter of Open Point in Time API as required (#80449)