### PR TITLE
[DOCS] Clarify parameters in delete expired data, forecast, and flush job APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -54,8 +54,8 @@ The default value is `8h` (8 hours).
 [[ml-delete-expired-data-request-body]]
 == {api-request-body-title}
 
-You can specify the same parameters (`requests_per_second` and `timeout`) in the
-request body.
+You can alternatively specify the query parameters (`requests_per_second` and
+`timeout`) in the request body.
 
 [[ml-delete-expired-data-example]]
 == {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -54,7 +54,7 @@ The default value is `8h` (8 hours).
 [[ml-delete-expired-data-request-body]]
 == {api-request-body-title}
 
-You can alternatively specify the query parameters (`requests_per_second` and
+You can also specify the query parameters (`requests_per_second` and
 `timeout`) in the request body.
 
 [[ml-delete-expired-data-example]]

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -40,8 +40,8 @@ by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
 Identifier for an {anomaly-job}. It can be a job identifier, a group name, or a
 wildcard expression.
 
-[[ml-delete-expired-data-request-body]]
-== {api-request-body-title}
+[[ml-delete-expired-data-query-parms]]
+== {api-query-parms-title}
 
 `requests_per_second`::
 (Optional, float) The desired requests per second for the deletion processes.
@@ -51,14 +51,18 @@ The default behavior is no throttling.
 (Optional, string) How long can the underlying delete processes run until they are canceled.
 The default value is `8h` (8 hours).
 
+[[ml-delete-expired-data-request-body]]
+== {api-request-body-title}
+
+You can specify the same parameters (`requests_per_second` and `timeout`) in the
+request body.
+
 [[ml-delete-expired-data-example]]
 == {api-examples-title}
 
-The endpoint takes no arguments:
-
 [source,console]
 --------------------------------------------------
-DELETE _ml/_delete_expired_data
+DELETE _ml/_delete_expired_data?timeout=1h
 --------------------------------------------------
 // TEST
 

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -62,6 +62,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   (string) Optional. When used in conjunction with `calc_interim`, specifies the
   range of buckets on which to calculate interim results.
 
+[[ml-flush-job-request-body]]
+== {api-request-body-title}
+
+You can alternatively specify the query parameters (such as `advance_time` and `calc_interim`) in the request body.
+
 [[ml-flush-job-example]]
 == {api-examples-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -50,8 +50,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   recent bucket or all buckets within the latency period.
 
 `end`::
-  (string) Optional. When used in conjunction with `calc_interim`, specifies the
-  range of buckets on which to calculate interim results.
+  (string) Optional. When used in conjunction with `calc_interim` and `start`,
+  specifies the range of buckets on which to calculate interim results.
 
 `skip_time`::
   (string) Optional. Specifies to skip to a particular time value. Results are

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -65,7 +65,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 [[ml-flush-job-request-body]]
 == {api-request-body-title}
 
-You can alternatively specify the query parameters (such as `advance_time` and `calc_interim`) in the request body.
+You can also specify the query parameters (such as `advance_time` and
+`calc_interim`) in the request body.
 
 [[ml-flush-job-example]]
 == {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -34,8 +34,9 @@ You can delete a forecast by using the
 [NOTE]
 ===============================
 
-* If you use an `over_field_name` property in your job, you cannot create a
-forecast. For more information about this property, see <<ml-put-job>>.
+* Forecasts are not supported for jobs that perform population analysis; an
+error occurs if you try to create a forecast for a job that has an
+`over_field_name` property in its configuration.
 * The job must be open when you create a forecast. Otherwise, an error occurs.
 ===============================
 
@@ -46,8 +47,8 @@ forecast. For more information about this property, see <<ml-put-job>>.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-[[ml-forecast-request-body]]
-== {api-request-body-title}
+[[ml-forecast-query-parms]]
+== {api-query-parms-title}
 
 `duration`::
   (Optional, <<time-units, time units>>) A period of time that indicates how far 
@@ -67,6 +68,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   disk. Default is 20mb, maximum is 500mb and minimum is 1mb. If set to 40% or
   more of the job's configured memory limit, it is automatically reduced to
   below that amount.
+
+[[ml-forecast-request-body]]
+== {api-request-body-title}
+
+You can also specify the query parameters (such as `duration` and
+`expires_in`) in the request body.
 
 [[ml-forecast-example]]
 == {api-examples-title}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/1013 and https://github.com/elastic/elasticsearch-specification/pull/1014

Clarify that the query parameters can be used in the request body (and vice versa) for the machine learning "delete expired data", "flush anomaly detection jobs", and "forecast" APIs.

### Preview

* https://elasticsearch_80517.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html
* https://elasticsearch_80517.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-flush-job.html
* https://elasticsearch_80517.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-forecast.html