### PR TITLE
Autoscaling use adjusted total memory

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -181,7 +181,7 @@ public class AutoscalingMemoryInfoService {
     private void addNodeStats(ImmutableOpenMap.Builder<String, Long> builder, NodeStats nodeStats) {
         // we might add nodes that already died here, but those will be removed on next cluster state update anyway and is only a small
         // waste.
-        builder.put(nodeStats.getNode().getEphemeralId(), nodeStats.getOs().getMem().getTotal().getBytes());
+        builder.put(nodeStats.getNode().getEphemeralId(), nodeStats.getOs().getMem().getAdjustedTotal().getBytes());
     }
 
     public AutoscalingMemoryInfo snapshot() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
@@ -331,7 +331,7 @@ public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
             n -> {
                 assertThat(
                     service.snapshot().get(n),
-                    equalTo(response.getNodesMap().get(n.getId()).getOs().getMem().getTotal().getBytes())
+                    equalTo(response.getNodesMap().get(n.getId()).getOs().getMem().getAdjustedTotal().getBytes())
                 );
             }
         );
@@ -347,7 +347,7 @@ public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
         OsStats osStats = new OsStats(
             randomNonNegativeLong(),
             new OsStats.Cpu(randomShort(), null),
-            new OsStats.Mem(memory, memory, randomLongBetween(0, memory)),
+            new OsStats.Mem(memory, randomLongBetween(0, memory), randomLongBetween(0, memory)),
             new OsStats.Swap(randomNonNegativeLong(), randomNonNegativeLong()),
             null
         );


### PR DESCRIPTION
The current capacity in use in autoscaling would use the full container
memory and not the adjusted total memory. ES sometimes responds with
`current_capacity` as `required_capacity` and the `current_capacity`
therefore need to use the adjusted capacity instead (since the
orchestration should add the memory reservation on top).

Relates #78750
