### PR TITLE
[7.16] [DOCS] Clarify manage indices privileges (#80284)

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -259,8 +259,8 @@ No privilege to read or write index data or otherwise manage the index.
 
 `manage`::
 All `monitor` privileges plus index and data stream administration (aliases,
-analyze, cache clear, close, delete, exists, flush, mapping, open, field capabilties,
-force merge, refresh, settings, search shards, templates, validate query).
+analyze, cache clear, close, delete, exists, flush, mapping, open, field capabilities,
+force merge, refresh, settings, search shards, validate query).
 
 `manage_follow_index`::
 All actions that are required to manage the lifecycle of a follower index, which


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Clarify manage indices privileges (#80284)