### PR TITLE
Unmute Kerberos integ tests

### DIFF
--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
@@ -97,10 +97,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByKeytab() throws IOException, PrivilegedActionException {
-        assumeFalse(
-            "This test fails often on Java 17 early access. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_KEYTAB_KEY);
         final String keytabPath = System.getProperty(TEST_USER_WITH_KEYTAB_PATH_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -113,10 +109,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByUsernamePassword() throws IOException, PrivilegedActionException {
-        assumeFalse(
-            "This test fails often on Java 17 early access. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -129,10 +121,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testGetOauth2TokenInExchangeForKerberosTickets() throws PrivilegedActionException, GSSException, IOException {
-        assumeFalse(
-            "This test fails often on Java 17. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));


### PR DESCRIPTION
We used to default enctypes to des3-cbc-sha1-kd but with JDK17,
weak encryption types are disabled by default. This caused our
Kerberos integration tests to fail with an
`sun.security.krb5.KrbException: no supported default etypes for
default_tkt_enctypes` exception.

We have since changed our default encryption type to
aes256-cts-hmac-sha1-96 in #78703 and we can unmute these tests
now.