### PR TITLE
[7.16] Unmute Kerberos integ tests (#80538)

### DIFF
--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
@@ -104,6 +104,7 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByKeytab() throws IOException, PrivilegedActionException {
+        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_KEYTAB_KEY);
         final String keytabPath = System.getProperty(TEST_USER_WITH_KEYTAB_PATH_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -116,6 +117,7 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByUsernamePassword() throws IOException, PrivilegedActionException {
+        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -128,6 +130,7 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testGetOauth2TokenInExchangeForKerberosTickets() throws PrivilegedActionException, GSSException, IOException {
+        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));

--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
@@ -104,11 +104,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByKeytab() throws IOException, PrivilegedActionException {
-        assumeFalse(
-            "This test fails often on Java 17 early access. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
-        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_KEYTAB_KEY);
         final String keytabPath = System.getProperty(TEST_USER_WITH_KEYTAB_PATH_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -121,11 +116,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testLoginByUsernamePassword() throws IOException, PrivilegedActionException {
-        assumeFalse(
-            "This test fails often on Java 17 early access. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
-        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));
@@ -138,11 +128,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     }
 
     public void testGetOauth2TokenInExchangeForKerberosTickets() throws PrivilegedActionException, GSSException, IOException {
-        assumeFalse(
-            "This test fails often on Java 17 early access. See: https://github.com/elastic/elasticsearch/issues/72120",
-            "17".equals(System.getProperty("java.version"))
-        );
-        testSuppressedOnJDK8u262();
         final String userPrincipalName = System.getProperty(TEST_USER_WITH_PWD_KEY);
         final String password = System.getProperty(TEST_USER_WITH_PWD_PASSWD_KEY);
         final boolean enabledDebugLogs = Boolean.parseBoolean(System.getProperty(ENABLE_KERBEROS_DEBUG_LOGS_KEY));


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Unmute Kerberos integ tests (#80538)