### PR TITLE
Fix HiddenField checkstyle problems in client/

### DIFF
--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     api 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
     api 'org.apache.rat:apache-rat:0.11'
     compileOnly "com.puppycrawl.tools:checkstyle:8.42"
-    api('com.diffplug.spotless:spotless-plugin-gradle:5.16.0') {
+    api('com.diffplug.spotless:spotless-plugin-gradle:5.17.1') {
       exclude module: "groovy-xml"
     }
 }

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/HiddenFieldCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/HiddenFieldCheck.java
@@ -1,0 +1,570 @@
+/*
+ * @notice
+ * checkstyle: Checks Java source code for adherence to a set of rules.
+ * Copyright (C) 2001-2021 the original author or authors.
+
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package org.elasticsearch.gradle.internal.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Scope;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * This is a copy of Checkstyle's {@link com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck}. See
+ * the original class for full documentation.
+ */
+@FileStatefulCheck
+public class HiddenFieldCheck extends AbstractCheck {
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY = "hidden.field";
+
+    /**
+     * Stack of sets of field names,
+     * one for each class of a set of nested classes.
+     */
+    private FieldFrame frame;
+
+    /** Define the RegExp for names of variables and parameters to ignore. */
+    private Pattern ignoreFormat;
+
+    /**
+     * Allow to ignore the parameter of a property setter method.
+     */
+    private boolean ignoreSetter;
+
+    /**
+     * Allow to expand the definition of a setter method to include methods
+     * that return the class' instance.
+     */
+    private boolean setterCanReturnItsClass;
+
+    /** Control whether to ignore constructor parameters. */
+    private boolean ignoreConstructorParameter;
+
+    /** Control whether to ignore parameters of abstract methods. */
+    private boolean ignoreAbstractMethods;
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.PATTERN_VARIABLE_DEF,
+            TokenTypes.LAMBDA,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.RECORD_COMPONENT_DEF, };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] { TokenTypes.CLASS_DEF, TokenTypes.ENUM_DEF, TokenTypes.ENUM_CONSTANT_DEF, TokenTypes.RECORD_DEF, };
+    }
+
+    @Override
+    public void beginTree(DetailAST rootAST) {
+        frame = new FieldFrame(null, true, null);
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        final int type = ast.getType();
+        switch (type) {
+            case TokenTypes.VARIABLE_DEF:
+            case TokenTypes.PARAMETER_DEF:
+            case TokenTypes.PATTERN_VARIABLE_DEF:
+            case TokenTypes.RECORD_COMPONENT_DEF:
+                processVariable(ast);
+                break;
+            case TokenTypes.LAMBDA:
+                processLambda(ast);
+                break;
+            default:
+                visitOtherTokens(ast, type);
+        }
+    }
+
+    /**
+     * Process a lambda token.
+     * Checks whether a lambda parameter shadows a field.
+     * Note, that when parameter of lambda expression is untyped,
+     * ANTLR parses the parameter as an identifier.
+     *
+     * @param ast the lambda token.
+     */
+    private void processLambda(DetailAST ast) {
+        final DetailAST firstChild = ast.getFirstChild();
+        if (firstChild != null && firstChild.getType() == TokenTypes.IDENT) {
+            final String untypedLambdaParameterName = firstChild.getText();
+            if (frame.containsStaticField(untypedLambdaParameterName) || isInstanceField(firstChild, untypedLambdaParameterName)) {
+                log(firstChild, MSG_KEY, untypedLambdaParameterName);
+            }
+        }
+    }
+
+    /**
+     * Called to process tokens other than {@link TokenTypes#VARIABLE_DEF}
+     * and {@link TokenTypes#PARAMETER_DEF}.
+     *
+     * @param ast token to process
+     * @param type type of the token
+     */
+    private void visitOtherTokens(DetailAST ast, int type) {
+        // A more thorough check of enum constant class bodies is
+        // possible (checking for hidden fields against the enum
+        // class body in addition to enum constant class bodies)
+        // but not attempted as it seems out of the scope of this
+        // check.
+        final DetailAST typeMods = ast.findFirstToken(TokenTypes.MODIFIERS);
+        final boolean isStaticInnerType = typeMods != null && typeMods.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+        final String frameName;
+
+        if (type == TokenTypes.CLASS_DEF || type == TokenTypes.ENUM_DEF) {
+            frameName = ast.findFirstToken(TokenTypes.IDENT).getText();
+        } else {
+            frameName = null;
+        }
+        final FieldFrame newFrame = new FieldFrame(frame, isStaticInnerType, frameName);
+
+        // add fields to container
+        final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
+        // enum constants may not have bodies
+        if (objBlock != null) {
+            DetailAST child = objBlock.getFirstChild();
+            while (child != null) {
+                if (child.getType() == TokenTypes.VARIABLE_DEF) {
+                    final String name = child.findFirstToken(TokenTypes.IDENT).getText();
+                    final DetailAST mods = child.findFirstToken(TokenTypes.MODIFIERS);
+                    if (mods.findFirstToken(TokenTypes.LITERAL_STATIC) == null) {
+                        newFrame.addInstanceField(name);
+                    } else {
+                        newFrame.addStaticField(name);
+                    }
+                }
+                child = child.getNextSibling();
+            }
+        }
+        if (ast.getType() == TokenTypes.RECORD_DEF) {
+            final DetailAST recordComponents = ast.findFirstToken(TokenTypes.RECORD_COMPONENTS);
+
+            // For each record component definition, we will add it to this frame.
+            TokenUtil.forEachChild(recordComponents, TokenTypes.RECORD_COMPONENT_DEF, node -> {
+                final String name = node.findFirstToken(TokenTypes.IDENT).getText();
+                newFrame.addInstanceField(name);
+            });
+        }
+        // push container
+        frame = newFrame;
+    }
+
+    @Override
+    public void leaveToken(DetailAST ast) {
+        if (ast.getType() == TokenTypes.CLASS_DEF
+            || ast.getType() == TokenTypes.ENUM_DEF
+            || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF
+            || ast.getType() == TokenTypes.RECORD_DEF) {
+            // pop
+            frame = frame.getParent();
+        }
+    }
+
+    /**
+     * Process a variable token.
+     * Check whether a local variable or parameter shadows a field.
+     * Store a field for later comparison with local variables and parameters.
+     *
+     * @param ast the variable token.
+     */
+    private void processVariable(DetailAST ast) {
+        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast) == false
+            && CheckUtil.isReceiverParameter(ast) == false
+            && (ScopeUtil.isLocalVariableDef(ast)
+                || ast.getType() == TokenTypes.PARAMETER_DEF
+                || ast.getType() == TokenTypes.PATTERN_VARIABLE_DEF)) {
+            // local variable or parameter. Does it shadow a field?
+            final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
+            final String name = nameAST.getText();
+
+            if ((frame.containsStaticField(name) || isInstanceField(ast, name))
+                && isMatchingRegexp(name) == false
+                && isIgnoredParam(ast, name) == false) {
+                log(nameAST, MSG_KEY, name);
+            }
+        }
+    }
+
+    /**
+     * Checks whether method or constructor parameter is ignored.
+     *
+     * @param ast the parameter token.
+     * @param name the parameter name.
+     * @return true if parameter is ignored.
+     */
+    private boolean isIgnoredParam(DetailAST ast, String name) {
+        return isIgnoredSetterParam(ast, name) || isIgnoredConstructorParam(ast) || isIgnoredParamOfAbstractMethod(ast);
+    }
+
+    /**
+     * Check for instance field.
+     *
+     * @param ast token
+     * @param name identifier of token
+     * @return true if instance field
+     */
+    private boolean isInstanceField(DetailAST ast, String name) {
+        return isInStatic(ast) == false && frame.containsInstanceField(name);
+    }
+
+    /**
+     * Check name by regExp.
+     *
+     * @param name string value to check
+     * @return true is regexp is matching
+     */
+    private boolean isMatchingRegexp(String name) {
+        return ignoreFormat != null && ignoreFormat.matcher(name).find();
+    }
+
+    /**
+     * Determines whether an AST node is in a static method or static
+     * initializer.
+     *
+     * @param ast the node to check.
+     * @return true if ast is in a static method or a static block;
+     */
+    private static boolean isInStatic(DetailAST ast) {
+        DetailAST parent = ast.getParent();
+        boolean inStatic = false;
+
+        while (parent != null && inStatic == false) {
+            if (parent.getType() == TokenTypes.STATIC_INIT) {
+                inStatic = true;
+            } else if (parent.getType() == TokenTypes.METHOD_DEF && ScopeUtil.isInScope(parent, Scope.ANONINNER) == false
+                || parent.getType() == TokenTypes.VARIABLE_DEF) {
+                    final DetailAST mods = parent.findFirstToken(TokenTypes.MODIFIERS);
+                    inStatic = mods.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+                    break;
+                } else {
+                    parent = parent.getParent();
+                }
+        }
+        return inStatic;
+    }
+
+    /**
+     * Decides whether to ignore an AST node that is the parameter of a
+     * setter method, where the property setter method for field 'xyz' has
+     * name 'setXyz', one parameter named 'xyz', and return type void
+     * (default behavior) or return type is name of the class in which
+     * such method is declared (allowed only if
+     * {@link #setSetterCanReturnItsClass(boolean)} is called with
+     * value <em>true</em>).
+     *
+     * @param ast the AST to check.
+     * @param name the name of ast.
+     * @return true if ast should be ignored because check property
+     *     ignoreSetter is true and ast is the parameter of a setter method.
+     */
+    private boolean isIgnoredSetterParam(DetailAST ast, String name) {
+        boolean isIgnoredSetterParam = false;
+        if (ignoreSetter && ast.getType() == TokenTypes.PARAMETER_DEF) {
+            final DetailAST parametersAST = ast.getParent();
+            final DetailAST methodAST = parametersAST.getParent();
+            if (parametersAST.getChildCount() == 1 && methodAST.getType() == TokenTypes.METHOD_DEF && isSetterMethod(methodAST, name)) {
+                isIgnoredSetterParam = true;
+            }
+        }
+        return isIgnoredSetterParam;
+    }
+
+    /**
+     * Determine if a specific method identified by methodAST and a single
+     * variable name aName is a setter. This recognition partially depends
+     * on setterCanReturnItsClass property.
+     *
+     * @param aMethodAST AST corresponding to a method call
+     * @param aName name of single parameter of this method.
+     * @return true of false indicating of method is a setter or not.
+     */
+    private boolean isSetterMethod(DetailAST aMethodAST, String aName) {
+        final String methodName = aMethodAST.findFirstToken(TokenTypes.IDENT).getText();
+        boolean isSetterMethod = false;
+
+        // ES also allows setters with the same name as a property, and builder-style settings that start with "with".
+        if (("set" + capitalize(aName)).equals(methodName) || ("with" + capitalize(aName)).equals(methodName) || aName.equals(methodName)) {
+            // method name did match set${Name}(${anyType} ${aName})
+            // where ${Name} is capitalized version of ${aName}
+            // therefore this method is potentially a setter
+            final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
+            final String returnType = typeAST.getFirstChild().getText();
+            if (typeAST.findFirstToken(TokenTypes.LITERAL_VOID) != null || setterCanReturnItsClass && frame.isEmbeddedIn(returnType)) {
+                // this method has signature
+                //
+                // void set${Name}(${anyType} ${name})
+                //
+                // and therefore considered to be a setter
+                //
+                // or
+                //
+                // return type is not void, but it is the same as the class
+                // where method is declared and and mSetterCanReturnItsClass
+                // is set to true
+                isSetterMethod = true;
+            }
+        }
+
+        return isSetterMethod;
+    }
+
+    /**
+     * Capitalizes a given property name the way we expect to see it in
+     * a setter name.
+     *
+     * @param name a property name
+     * @return capitalized property name
+     */
+    private static String capitalize(final String name) {
+        String setterName = name;
+        // we should not capitalize the first character if the second
+        // one is a capital one, since according to JavaBeans spec
+        // setXYzz() is a setter for XYzz property, not for xYzz one.
+        if (name.length() == 1 || Character.isUpperCase(name.charAt(1)) == false) {
+            setterName = name.substring(0, 1).toUpperCase(Locale.ENGLISH) + name.substring(1);
+        }
+        return setterName;
+    }
+
+    /**
+     * Decides whether to ignore an AST node that is the parameter of a
+     * constructor.
+     *
+     * @param ast the AST to check.
+     * @return true if ast should be ignored because check property
+     *     ignoreConstructorParameter is true and ast is a constructor parameter.
+     */
+    private boolean isIgnoredConstructorParam(DetailAST ast) {
+        boolean result = false;
+        if (ignoreConstructorParameter && ast.getType() == TokenTypes.PARAMETER_DEF) {
+            final DetailAST parametersAST = ast.getParent();
+            final DetailAST constructorAST = parametersAST.getParent();
+            result = constructorAST.getType() == TokenTypes.CTOR_DEF;
+        }
+        return result;
+    }
+
+    /**
+     * Decides whether to ignore an AST node that is the parameter of an
+     * abstract method.
+     *
+     * @param ast the AST to check.
+     * @return true if ast should be ignored because check property
+     *     ignoreAbstractMethods is true and ast is a parameter of abstract methods.
+     */
+    private boolean isIgnoredParamOfAbstractMethod(DetailAST ast) {
+        boolean result = false;
+        if (ignoreAbstractMethods && ast.getType() == TokenTypes.PARAMETER_DEF) {
+            final DetailAST method = ast.getParent().getParent();
+            if (method.getType() == TokenTypes.METHOD_DEF) {
+                final DetailAST mods = method.findFirstToken(TokenTypes.MODIFIERS);
+                result = mods.findFirstToken(TokenTypes.ABSTRACT) != null;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Setter to define the RegExp for names of variables and parameters to ignore.
+     *
+     * @param pattern a pattern.
+     */
+    public void setIgnoreFormat(Pattern pattern) {
+        ignoreFormat = pattern;
+    }
+
+    /**
+     * Setter to allow to ignore the parameter of a property setter method.
+     *
+     * @param ignoreSetter decide whether to ignore the parameter of
+     *     a property setter method.
+     */
+    public void setIgnoreSetter(boolean ignoreSetter) {
+        this.ignoreSetter = ignoreSetter;
+    }
+
+    /**
+     * Setter to allow to expand the definition of a setter method to include methods
+     * that return the class' instance.
+     *
+     * @param aSetterCanReturnItsClass if true then setter can return
+     *        either void or class in which it is declared. If false then
+     *        in order to be recognized as setter method (otherwise
+     *        already recognized as a setter) must return void.  Later is
+     *        the default behavior.
+     */
+    public void setSetterCanReturnItsClass(boolean aSetterCanReturnItsClass) {
+        setterCanReturnItsClass = aSetterCanReturnItsClass;
+    }
+
+    /**
+     * Setter to control whether to ignore constructor parameters.
+     *
+     * @param ignoreConstructorParameter decide whether to ignore
+     *     constructor parameters.
+     */
+    public void setIgnoreConstructorParameter(boolean ignoreConstructorParameter) {
+        this.ignoreConstructorParameter = ignoreConstructorParameter;
+    }
+
+    /**
+     * Setter to control whether to ignore parameters of abstract methods.
+     *
+     * @param ignoreAbstractMethods decide whether to ignore
+     *     parameters of abstract methods.
+     */
+    public void setIgnoreAbstractMethods(boolean ignoreAbstractMethods) {
+        this.ignoreAbstractMethods = ignoreAbstractMethods;
+    }
+
+    /**
+     * Holds the names of static and instance fields of a type.
+     */
+    private static class FieldFrame {
+
+        /** Name of the frame, such name of the class or enum declaration. */
+        private final String frameName;
+
+        /** Is this a static inner type. */
+        private final boolean staticType;
+
+        /** Parent frame. */
+        private final FieldFrame parent;
+
+        /** Set of instance field names. */
+        private final Set<String> instanceFields = new HashSet<>();
+
+        /** Set of static field names. */
+        private final Set<String> staticFields = new HashSet<>();
+
+        /**
+         * Creates new frame.
+         *
+         * @param parent parent frame.
+         * @param staticType is this a static inner type (class or enum).
+         * @param frameName name associated with the frame, which can be a
+         */
+        /* package */ FieldFrame(FieldFrame parent, boolean staticType, String frameName) {
+            this.parent = parent;
+            this.staticType = staticType;
+            this.frameName = frameName;
+        }
+
+        /**
+         * Adds an instance field to this FieldFrame.
+         *
+         * @param field  the name of the instance field.
+         */
+        public void addInstanceField(String field) {
+            instanceFields.add(field);
+        }
+
+        /**
+         * Adds a static field to this FieldFrame.
+         *
+         * @param field  the name of the instance field.
+         */
+        public void addStaticField(String field) {
+            staticFields.add(field);
+        }
+
+        /**
+         * Determines whether this FieldFrame contains an instance field.
+         *
+         * @param field the field to check.
+         * @return true if this FieldFrame contains instance field field.
+         */
+        public boolean containsInstanceField(String field) {
+            return instanceFields.contains(field) || parent != null && staticType == false && parent.containsInstanceField(field);
+        }
+
+        /**
+         * Determines whether this FieldFrame contains a static field.
+         *
+         * @param field the field to check.
+         * @return true if this FieldFrame contains static field field.
+         */
+        public boolean containsStaticField(String field) {
+            return staticFields.contains(field) || parent != null && parent.containsStaticField(field);
+        }
+
+        /**
+         * Getter for parent frame.
+         *
+         * @return parent frame.
+         */
+        public FieldFrame getParent() {
+            return parent;
+        }
+
+        /**
+         * Check if current frame is embedded in class or enum with
+         * specific name.
+         *
+         * @param classOrEnumName name of class or enum that we are looking
+         *     for in the chain of field frames.
+         *
+         * @return true if current frame is embedded in class or enum
+         *     with name classOrNameName
+         */
+        private boolean isEmbeddedIn(String classOrEnumName) {
+            FieldFrame currentFrame = this;
+            boolean isEmbeddedIn = false;
+            while (currentFrame != null) {
+                if (Objects.equals(currentFrame.frameName, classOrEnumName)) {
+                    isEmbeddedIn = true;
+                    break;
+                }
+                currentFrame = currentFrame.parent;
+            }
+            return isEmbeddedIn;
+        }
+
+    }
+
+}

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
@@ -75,6 +75,7 @@ public class PublishPlugin implements Plugin<Project> {
                 publication.from(project.getComponents().getByName("java"));
             }
         });
+        @SuppressWarnings("unchecked")
         var projectLicenses = (MapProperty<String, String>) project.getExtensions().getExtraProperties().get("projectLicenses");
         publication.getPom().withXml(xml -> {
             var node = xml.asNode();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -82,6 +82,7 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
                 addNoticeGeneration(p, extension);
             }
 
+            @SuppressWarnings("unchecked")
             NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
                 .getExtensions()
                 .getByName(TestClustersPlugin.EXTENSION_NAME);

--- a/build-tools-internal/src/main/resources/checkstyle.xml
+++ b/build-tools-internal/src/main/resources/checkstyle.xml
@@ -106,13 +106,15 @@
     <module name="PackageDeclaration" />
 
     <!-- Checks that a local variable or a parameter does not shadow a field that is defined in the same class. -->
+    <!-- Use a forked version that understands setters that don't start with "set". -->
     <!-- Disabled until existing violations are fixed -->
     <!--
-    <module name="HiddenField">
+    <module name="org.elasticsearch.gradle.internal.checkstyle.HiddenFieldCheck">
         <property name="ignoreConstructorParameter" value="true" />
         <property name="ignoreSetter" value="true" />
         <property name="setterCanReturnItsClass" value="true"/>
         <property name="ignoreFormat" value="^(threadPool)$"/>
+        <message key="hidden.field" value="''{0}'' hides a field." />
     </module>
     -->
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/BroadcastResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/BroadcastResponse.java
@@ -60,8 +60,8 @@ public class BroadcastResponse {
         return PARSER.parse(parser, null);
     }
 
-    protected static <T extends BroadcastResponse> void declareShardsField(ConstructingObjectParser<T, Void> PARSER) {
-        PARSER.declareObject(ConstructingObjectParser.constructorArg(), Shards.SHARDS_PARSER, SHARDS_FIELD);
+    protected static <T extends BroadcastResponse> void declareShardsField(ConstructingObjectParser<T, Void> parser) {
+        parser.declareObject(ConstructingObjectParser.constructorArg(), Shards.SHARDS_PARSER, SHARDS_FIELD);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
@@ -156,36 +156,36 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
     /**
      * Sets whether to request term positions
      */
-    public void setPositions(boolean requestPositions) {
-        this.requestPositions = requestPositions;
+    public void setPositions(boolean positions) {
+        this.requestPositions = positions;
     }
 
     /**
      * Sets whether to request term payloads
      */
-    public void setPayloads(boolean requestPayloads) {
-        this.requestPayloads = requestPayloads;
+    public void setPayloads(boolean payloads) {
+        this.requestPayloads = payloads;
     }
 
     /**
      * Sets whether to request term offsets
      */
-    public void setOffsets(boolean requestOffsets) {
-        this.requestOffsets = requestOffsets;
+    public void setOffsets(boolean offsets) {
+        this.requestOffsets = offsets;
     }
 
     /**
      * Sets whether to request field statistics
      */
-    public void setFieldStatistics(boolean requestFieldStatistics) {
-        this.requestFieldStatistics = requestFieldStatistics;
+    public void setFieldStatistics(boolean fieldStatistics) {
+        this.requestFieldStatistics = fieldStatistics;
     }
 
     /**
      * Sets whether to request term statistics
      */
-    public void setTermStatistics(boolean requestTermStatistics) {
-        this.requestTermStatistics = requestTermStatistics;
+    public void setTermStatistics(boolean termStatistics) {
+        this.requestTermStatistics = termStatistics;
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
@@ -77,11 +77,11 @@ public class GetIndexRequest extends TimedRequest {
         return this;
     }
 
-    public GetIndexRequest addFeatures(Feature... features) {
+    public GetIndexRequest addFeatures(Feature... featuresToAdd) {
         if (this.features == DEFAULT_FEATURES) {
-            return features(features);
+            return features(featuresToAdd);
         } else {
-            return features(ArrayUtils.concat(features(), features, Feature.class));
+            return features(ArrayUtils.concat(features(), featuresToAdd, Feature.class));
         }
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/IndexTemplateMetadata.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/IndexTemplateMetadata.java
@@ -222,8 +222,8 @@ public class IndexTemplateMetadata {
             return this;
         }
 
-        public Builder patterns(List<String> indexPatterns) {
-            this.indexPatterns = indexPatterns;
+        public Builder patterns(List<String> patterns) {
+            this.indexPatterns = patterns;
             return this;
         }
 
@@ -237,8 +237,8 @@ public class IndexTemplateMetadata {
             return this;
         }
 
-        public Builder mapping(MappingMetadata mappings) {
-            this.mappings = mappings;
+        public Builder mapping(MappingMetadata mappingMetadata) {
+            this.mappings = mappingMetadata;
             return this;
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutIndexTemplateRequest.java
@@ -85,11 +85,11 @@ public class PutIndexTemplateRequest extends TimedRequest implements ToXContentF
         return this.name;
     }
 
-    public PutIndexTemplateRequest patterns(List<String> indexPatterns) {
-        if (indexPatterns == null || indexPatterns.size() == 0) {
+    public PutIndexTemplateRequest patterns(List<String> patterns) {
+        if (patterns == null || patterns.size() == 0) {
             throw new IllegalArgumentException("index patterns are missing");
         }
-        this.indexPatterns = indexPatterns;
+        this.indexPatterns = patterns;
         return this;
     }
 
@@ -255,8 +255,8 @@ public class PutIndexTemplateRequest extends TimedRequest implements ToXContentF
     public PutIndexTemplateRequest source(Map<String, Object> templateSource) {
         Map<String, Object> source = templateSource;
         for (Map.Entry<String, Object> entry : source.entrySet()) {
-            String name = entry.getKey();
-            if (name.equals("index_patterns")) {
+            String entryName = entry.getKey();
+            if (entryName.equals("index_patterns")) {
                 if (entry.getValue() instanceof String) {
                     patterns(Collections.singletonList((String) entry.getValue()));
                 } else if (entry.getValue() instanceof List) {
@@ -265,25 +265,24 @@ public class PutIndexTemplateRequest extends TimedRequest implements ToXContentF
                 } else {
                     throw new IllegalArgumentException("Malformed [index_patterns] value, should be a string or a list of strings");
                 }
-            } else if (name.equals("order")) {
+            } else if (entryName.equals("order")) {
                 order(XContentMapValues.nodeIntegerValue(entry.getValue(), order()));
-            } else if ("version".equals(name)) {
+            } else if ("version".equals(entryName)) {
                 if ((entry.getValue() instanceof Integer) == false) {
                     throw new IllegalArgumentException("Malformed [version] value, should be an integer");
                 }
                 version((Integer) entry.getValue());
-            } else if (name.equals("settings")) {
+            } else if (entryName.equals("settings")) {
                 if ((entry.getValue() instanceof Map) == false) {
                     throw new IllegalArgumentException("Malformed [settings] section, should include an inner object");
                 }
                 settings((Map<String, Object>) entry.getValue());
-            } else if (name.equals("mappings")) {
-                Map<String, Object> mappings = (Map<String, Object>) entry.getValue();
-                mapping(mappings);
-            } else if (name.equals("aliases")) {
+            } else if (entryName.equals("mappings")) {
+                mapping((Map<String, Object>) entry.getValue());
+            } else if (entryName.equals("aliases")) {
                 aliases((Map<String, Object>) entry.getValue());
             } else {
-                throw new ElasticsearchParseException("unknown key [{}] in the template ", name);
+                throw new ElasticsearchParseException("unknown key [{}] in the template ", entryName);
             }
         }
         return this;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
@@ -99,9 +99,9 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      *
      * Note that the definition should *not* be nested under a type name.
      */
-    public PutMappingRequest source(String mappingSource, XContentType xContentType) {
+    public PutMappingRequest source(String mappingSource, XContentType type) {
         this.source = new BytesArray(mappingSource);
-        this.xContentType = xContentType;
+        this.xContentType = type;
         return this;
     }
 
@@ -121,9 +121,9 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      *
      * Note that the definition should *not* be nested under a type name.
      */
-    public PutMappingRequest source(BytesReference source, XContentType xContentType) {
-        this.source = source;
-        this.xContentType = xContentType;
+    public PutMappingRequest source(BytesReference bytesReference, XContentType type) {
+        this.source = bytesReference;
+        this.xContentType = type;
         return this;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
@@ -34,6 +34,7 @@ public class DatafeedTimingStats implements ToXContentObject {
 
     public static final ConstructingObjectParser<DatafeedTimingStats, Void> PARSER = createParser();
 
+    @SuppressWarnings("HiddenField")
     private static ConstructingObjectParser<DatafeedTimingStats, Void> createParser() {
         ConstructingObjectParser<DatafeedTimingStats, Void> parser = new ConstructingObjectParser<>("datafeed_timing_stats", true, args -> {
             String jobId = (String) args[0];

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
@@ -209,8 +209,8 @@ public class OutlierDetection implements DataFrameAnalysis {
 
         private Builder() {}
 
-        public Builder setNNeighbors(Integer nNeighbors) {
-            this.nNeighbors = nNeighbors;
+        public Builder setNNeighbors(Integer nNeighborsValue) {
+            this.nNeighbors = nNeighborsValue;
             return this;
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/FrequencyEncoding.java
@@ -122,8 +122,8 @@ public class FrequencyEncoding implements PreProcessor {
         return Objects.hash(field, featureName, frequencyMap, custom);
     }
 
-    public Builder builder(String field) {
-        return new Builder(field);
+    public Builder builder(String fieldName) {
+        return new Builder(fieldName);
     }
 
     public static class Builder {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -135,8 +135,8 @@ public class TargetMeanEncoding implements PreProcessor {
         return Objects.hash(field, featureName, meanMap, defaultValue, custom);
     }
 
-    public Builder builder(String field) {
-        return new Builder(field);
+    public Builder builder(String fieldName) {
+        return new Builder(fieldName);
     }
 
     public static class Builder {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -537,8 +537,8 @@ public class Job implements ToXContentObject {
             return this;
         }
 
-        public Builder setDataDescription(DataDescription.Builder description) {
-            dataDescription = Objects.requireNonNull(description, DATA_DESCRIPTION.getPreferredName()).build();
+        public Builder setDataDescription(DataDescription.Builder descriptionBuilder) {
+            dataDescription = Objects.requireNonNull(descriptionBuilder, DATA_DESCRIPTION.getPreferredName()).build();
             return this;
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/results/AnomalyRecord.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/results/AnomalyRecord.java
@@ -341,8 +341,8 @@ public class AnomalyRecord implements ToXContentObject {
         return isInterim;
     }
 
-    void setInterim(boolean isInterim) {
-        this.isInterim = isInterim;
+    void setInterim(boolean interim) {
+        this.isInterim = interim;
     }
 
     public String getFieldName() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/results/Bucket.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/results/Bucket.java
@@ -174,8 +174,8 @@ public class Bucket implements ToXContentObject {
         return isInterim;
     }
 
-    void setInterim(boolean isInterim) {
-        this.isInterim = isInterim;
+    void setInterim(boolean interim) {
+        this.isInterim = interim;
     }
 
     public long getProcessingTimeMs() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/HasPrivilegesResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/HasPrivilegesResponse.java
@@ -149,17 +149,17 @@ public final class HasPrivilegesResponse {
      *                                  {@link HasPrivilegesRequest#getIndexPrivileges() included in the request}.
      */
     public boolean hasIndexPrivilege(String indexName, String privilegeName) {
-        Map<String, Boolean> indexPrivileges = this.indexPrivileges.get(indexName);
-        if (indexPrivileges == null) {
+        Map<String, Boolean> privilegesForIndex = this.indexPrivileges.get(indexName);
+        if (privilegesForIndex == null) {
             throw new IllegalArgumentException("No privileges for index [" + indexName + "] were included in this response");
         }
-        Boolean has = indexPrivileges.get(privilegeName);
-        if (has == null) {
+        Boolean hasPrivilege = privilegesForIndex.get(privilegeName);
+        if (hasPrivilege == null) {
             throw new IllegalArgumentException(
                 "Privilege [" + privilegeName + "] was not included in the response for index [" + indexName + "]"
             );
         }
-        return has;
+        return hasPrivilege;
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/user/privileges/ApplicationPrivilege.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/user/privileges/ApplicationPrivilege.java
@@ -129,13 +129,13 @@ public final class ApplicationPrivilege implements ToXContentObject {
 
         private Builder() {}
 
-        public Builder application(String applicationName) {
-            this.applicationName = Objects.requireNonNull(applicationName, "application name must be provided");
+        public Builder application(String name) {
+            this.applicationName = Objects.requireNonNull(name, "application name must be provided");
             return this;
         }
 
-        public Builder privilege(String privilegeName) {
-            this.privilegeName = Objects.requireNonNull(privilegeName, "privilege name must be provided");
+        public Builder privilege(String name) {
+            this.privilegeName = Objects.requireNonNull(name, "privilege name must be provided");
             return this;
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/CancelTasksRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/CancelTasksRequest.java
@@ -110,6 +110,7 @@ public class CancelTasksRequest implements Validatable {
             + '}';
     }
 
+    @SuppressWarnings("HiddenField")
     public static class Builder {
         private Optional<TimeValue> timeout = Optional.empty();
         private Optional<TaskId> taskId = Optional.empty();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/ElasticsearchException.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/ElasticsearchException.java
@@ -61,8 +61,8 @@ public class ElasticsearchException {
         return suppressed;
     }
 
-    void addSuppressed(List<ElasticsearchException> suppressed) {
-        this.suppressed.addAll(suppressed);
+    void addSuppressed(List<ElasticsearchException> suppressedExceptions) {
+        this.suppressed.addAll(suppressedExceptions);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/ListTasksResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/ListTasksResponse.java
@@ -40,18 +40,18 @@ public class ListTasksResponse {
     }
 
     private List<TaskGroup> buildTaskGroups() {
-        Map<TaskId, TaskGroup.Builder> taskGroups = new HashMap<>();
+        Map<TaskId, TaskGroup.Builder> taskIdToBuilderMap = new HashMap<>();
         List<TaskGroup.Builder> topLevelTasks = new ArrayList<>();
         // First populate all tasks
         for (TaskInfo taskInfo : this.tasks) {
-            taskGroups.put(taskInfo.getTaskId(), TaskGroup.builder(taskInfo));
+            taskIdToBuilderMap.put(taskInfo.getTaskId(), TaskGroup.builder(taskInfo));
         }
 
         // Now go through all task group builders and add children to their parents
-        for (TaskGroup.Builder taskGroup : taskGroups.values()) {
+        for (TaskGroup.Builder taskGroup : taskIdToBuilderMap.values()) {
             TaskId parentTaskId = taskGroup.getTaskInfo().getParentTaskId();
             if (parentTaskId != null) {
-                TaskGroup.Builder parentTask = taskGroups.get(parentTaskId);
+                TaskGroup.Builder parentTask = taskIdToBuilderMap.get(parentTaskId);
                 if (parentTask != null) {
                     // we found parent in the list of tasks - add it to the parent list
                     parentTask.addGroup(taskGroup);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
@@ -178,11 +178,11 @@ public class SettingsConfig implements ToXContentObject {
          * This setting throttles transform by issuing queries less often, however processing still happens in
          * batches. A value of 0 disables throttling (default).
          *
-         * @param docsPerSecond Integer value
+         * @param documentsPerSecond Integer value
          * @return the {@link Builder} with requestsPerSecond set.
          */
-        public Builder setRequestsPerSecond(Float docsPerSecond) {
-            this.docsPerSecond = docsPerSecond == null ? DEFAULT_DOCS_PER_SECOND : docsPerSecond;
+        public Builder setRequestsPerSecond(Float documentsPerSecond) {
+            this.docsPerSecond = documentsPerSecond == null ? DEFAULT_DOCS_PER_SECOND : documentsPerSecond;
             return this;
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/pivot/GeoTileGroupSource.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/pivot/GeoTileGroupSource.java
@@ -153,7 +153,7 @@ public class GeoTileGroupSource extends SingleGroupSource implements ToXContentO
          * @param precision The precision
          * @return The {@link Builder} with the precision set.
          */
-        public Builder setPrecission(Integer precision) {
+        public Builder setPrecision(Integer precision) {
             this.precision = precision;
             return this;
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/AckWatchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/AckWatchRequest.java
@@ -27,6 +27,7 @@ public class AckWatchRequest implements Validatable {
         this.actionIds = actionIds;
     }
 
+    @SuppressWarnings("HiddenField")
     private void validateIds(String watchId, String... actionIds) {
         ValidationException exception = new ValidationException();
         if (watchId == null) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/GetWatchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/GetWatchRequest.java
@@ -22,11 +22,11 @@ public final class GetWatchRequest implements Validatable {
         this.id = watchId;
     }
 
-    private void validateId(String id) {
+    private void validateId(String watchId) {
         ValidationException exception = new ValidationException();
-        if (id == null) {
+        if (watchId == null) {
             exception.addValidationError("watch id is missing");
-        } else if (PutWatchRequest.isValidId(id) == false) {
+        } else if (PutWatchRequest.isValidId(watchId) == false) {
             exception.addValidationError("watch id contains whitespace");
         }
         if (exception.validationErrors().isEmpty() == false) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -381,7 +381,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         {
             TrackingActionListener trackingActionListener = new TrackingActionListener();
             restHighLevelClient.performRequestAsync(request, null, RequestOptions.DEFAULT, null, trackingActionListener, null);
-            assertSame(validationException, trackingActionListener.exception.get());
+            assertSame(validationException, trackingActionListener.lastException.get());
         }
     }
 
@@ -707,8 +707,8 @@ public class RestHighLevelClientTests extends ESTestCase {
             RestStatus restStatus = randomFrom(RestStatus.values());
             HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
             responseListener.onSuccess(new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse));
-            assertNull(trackingActionListener.exception.get());
-            assertEquals(restStatus.getStatus(), trackingActionListener.statusCode.get());
+            assertNull(trackingActionListener.lastException.get());
+            assertEquals(restStatus.getStatus(), trackingActionListener.lastStatusCode.get());
         }
         {
             TrackingActionListener trackingActionListener = new TrackingActionListener();
@@ -720,8 +720,8 @@ public class RestHighLevelClientTests extends ESTestCase {
             RestStatus restStatus = randomFrom(RestStatus.values());
             HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
             responseListener.onSuccess(new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse));
-            assertThat(trackingActionListener.exception.get(), instanceOf(IOException.class));
-            IOException ioe = (IOException) trackingActionListener.exception.get();
+            assertThat(trackingActionListener.lastException.get(), instanceOf(IOException.class));
+            IOException ioe = (IOException) trackingActionListener.lastException.get();
             assertEquals(
                 "Unable to parse response body for Response{requestLine=GET / http/1.1, host=http://localhost:9200, "
                     + "response=http/1.1 "
@@ -744,7 +744,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         );
         IllegalStateException exception = new IllegalStateException();
         responseListener.onFailure(exception);
-        assertSame(exception, trackingActionListener.exception.get());
+        assertSame(exception, trackingActionListener.lastException.get());
     }
 
     public void testWrapResponseListenerOnResponseExceptionWithoutEntity() throws IOException {
@@ -759,8 +759,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(response);
         responseListener.onFailure(responseException);
-        assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+        assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
         assertEquals(responseException.getMessage(), elasticsearchException.getMessage());
         assertEquals(restStatus, elasticsearchException.status());
         assertSame(responseException, elasticsearchException.getCause());
@@ -781,8 +781,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(response);
         responseListener.onFailure(responseException);
-        assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+        assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
         assertEquals("Elasticsearch exception [type=exception, reason=test error message]", elasticsearchException.getMessage());
         assertEquals(restStatus, elasticsearchException.status());
         assertSame(responseException, elasticsearchException.getSuppressed()[0]);
@@ -802,8 +802,8 @@ public class RestHighLevelClientTests extends ESTestCase {
             Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
             ResponseException responseException = new ResponseException(response);
             responseListener.onFailure(responseException);
-            assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-            ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+            assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+            ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
             assertEquals("Unable to parse response body", elasticsearchException.getMessage());
             assertEquals(restStatus, elasticsearchException.status());
             assertSame(responseException, elasticsearchException.getCause());
@@ -822,8 +822,8 @@ public class RestHighLevelClientTests extends ESTestCase {
             Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
             ResponseException responseException = new ResponseException(response);
             responseListener.onFailure(responseException);
-            assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-            ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+            assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+            ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
             assertEquals("Unable to parse response body", elasticsearchException.getMessage());
             assertEquals(restStatus, elasticsearchException.status());
             assertSame(responseException, elasticsearchException.getCause());
@@ -843,8 +843,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         ResponseException responseException = new ResponseException(response);
         responseListener.onFailure(responseException);
         // although we got an exception, we turn it into a successful response because the status code was provided among ignores
-        assertNull(trackingActionListener.exception.get());
-        assertEquals(404, trackingActionListener.statusCode.get());
+        assertNull(trackingActionListener.lastException.get());
+        assertEquals(404, trackingActionListener.lastStatusCode.get());
     }
 
     public void testWrapResponseListenerOnResponseExceptionWithIgnoresErrorNoBody() throws IOException {
@@ -860,8 +860,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(response);
         responseListener.onFailure(responseException);
-        assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+        assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
         assertEquals(RestStatus.NOT_FOUND, elasticsearchException.status());
         assertSame(responseException, elasticsearchException.getCause());
         assertEquals(responseException.getMessage(), elasticsearchException.getMessage());
@@ -881,8 +881,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         Response response = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(response);
         responseListener.onFailure(responseException);
-        assertThat(trackingActionListener.exception.get(), instanceOf(ElasticsearchException.class));
-        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.exception.get();
+        assertThat(trackingActionListener.lastException.get(), instanceOf(ElasticsearchException.class));
+        ElasticsearchException elasticsearchException = (ElasticsearchException) trackingActionListener.lastException.get();
         assertEquals(RestStatus.NOT_FOUND, elasticsearchException.status());
         assertSame(responseException, elasticsearchException.getSuppressed()[0]);
         assertEquals("Elasticsearch exception [type=exception, reason=test error message]", elasticsearchException.getMessage());
@@ -1314,7 +1314,7 @@ public class RestHighLevelClientTests extends ESTestCase {
 
     public void testProductCompatibilityRequestFailure() throws Exception {
 
-        RestClient restClient = mock(RestClient.class);
+        RestClient client = mock(RestClient.class);
 
         // An endpoint different from "/" that returns a boolean
         GetSourceRequest apiRequest = new GetSourceRequest("foo", "bar");
@@ -1322,28 +1322,28 @@ public class RestHighLevelClientTests extends ESTestCase {
         when(apiStatus.getStatusCode()).thenReturn(200);
         Response apiResponse = mock(Response.class);
         when(apiResponse.getStatusLine()).thenReturn(apiStatus);
-        when(restClient.performRequest(argThat(new RequestMatcher("HEAD", "/foo/_source/bar")::matches))).thenReturn(apiResponse);
+        when(client.performRequest(argThat(new RequestMatcher("HEAD", "/foo/_source/bar")::matches))).thenReturn(apiResponse);
 
         // Have the verification request fail
-        when(restClient.performRequestAsync(argThat(new RequestMatcher("GET", "/")::matches), any())).thenAnswer(i -> {
+        when(client.performRequestAsync(argThat(new RequestMatcher("GET", "/")::matches), any())).thenAnswer(i -> {
             ((ResponseListener) i.getArguments()[1]).onFailure(new IOException("Something bad happened"));
             return Cancellable.NO_OP;
         });
 
-        RestHighLevelClient highLevelClient = new RestHighLevelClient(restClient, RestClient::close, Collections.emptyList());
+        RestHighLevelClient highLevelClient = new RestHighLevelClient(client, RestClient::close, Collections.emptyList());
 
         expectThrows(ElasticsearchException.class, () -> { highLevelClient.existsSource(apiRequest, RequestOptions.DEFAULT); });
 
         // Now have the validation request succeed
         Build build = new Build(Build.Flavor.DEFAULT, Build.Type.UNKNOWN, "hash", "date", false, "7.14.0");
-        mockGetRoot(restClient, build, true);
+        mockGetRoot(client, build, true);
 
         // API request should now succeed as validation has been retried
         assertTrue(highLevelClient.existsSource(apiRequest, RequestOptions.DEFAULT));
     }
 
     public void testProductCompatibilityWithForbiddenInfoEndpoint() throws Exception {
-        RestClient restClient = mock(RestClient.class);
+        RestClient client = mock(RestClient.class);
 
         // An endpoint different from "/" that returns a boolean
         GetSourceRequest apiRequest = new GetSourceRequest("foo", "bar");
@@ -1351,10 +1351,10 @@ public class RestHighLevelClientTests extends ESTestCase {
         when(apiStatus.getStatusCode()).thenReturn(200);
         Response apiResponse = mock(Response.class);
         when(apiResponse.getStatusLine()).thenReturn(apiStatus);
-        when(restClient.performRequest(argThat(new RequestMatcher("HEAD", "/foo/_source/bar")::matches))).thenReturn(apiResponse);
+        when(client.performRequest(argThat(new RequestMatcher("HEAD", "/foo/_source/bar")::matches))).thenReturn(apiResponse);
 
         // Have the info endpoint used for verification return a 403 (forbidden)
-        when(restClient.performRequestAsync(argThat(new RequestMatcher("GET", "/")::matches), any())).thenAnswer(i -> {
+        when(client.performRequestAsync(argThat(new RequestMatcher("GET", "/")::matches), any())).thenAnswer(i -> {
             StatusLine infoStatus = mock(StatusLine.class);
             when(apiStatus.getStatusCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
             Response infoResponse = mock(Response.class);
@@ -1363,11 +1363,11 @@ public class RestHighLevelClientTests extends ESTestCase {
             return Cancellable.NO_OP;
         });
 
-        RestHighLevelClient highLevelClient = new RestHighLevelClient(restClient, RestClient::close, Collections.emptyList());
+        RestHighLevelClient highLevelClient = new RestHighLevelClient(client, RestClient::close, Collections.emptyList());
 
         // API request should succeed
         Build build = new Build(Build.Flavor.DEFAULT, Build.Type.UNKNOWN, "hash", "date", false, "7.14.0");
-        mockGetRoot(restClient, build, true);
+        mockGetRoot(client, build, true);
 
         assertTrue(highLevelClient.existsSource(apiRequest, RequestOptions.DEFAULT));
     }
@@ -1655,17 +1655,17 @@ public class RestHighLevelClientTests extends ESTestCase {
     }
 
     private static class TrackingActionListener implements ActionListener<Integer> {
-        private final AtomicInteger statusCode = new AtomicInteger(-1);
-        private final AtomicReference<Exception> exception = new AtomicReference<>();
+        private final AtomicInteger lastStatusCode = new AtomicInteger(-1);
+        private final AtomicReference<Exception> lastException = new AtomicReference<>();
 
         @Override
         public void onResponse(Integer statusCode) {
-            assertTrue(this.statusCode.compareAndSet(-1, statusCode));
+            assertTrue(this.lastStatusCode.compareAndSet(-1, statusCode));
         }
 
         @Override
         public void onFailure(Exception e) {
-            assertTrue(exception.compareAndSet(null, e));
+            assertTrue(lastException.compareAndSet(null, e));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
@@ -128,7 +128,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
             }
         }
 
-        final int numDocs = bulkRequest.numberOfActions();
+        final int numberOfDocs = bulkRequest.numberOfActions();
 
         BulkResponse bulkResponse = highLevelClient().bulk(bulkRequest, RequestOptions.DEFAULT);
         assertEquals(RestStatus.OK, bulkResponse.status());
@@ -143,7 +143,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
 
         RefreshResponse refreshResponse = highLevelClient().indices().refresh(new RefreshRequest("docs"), RequestOptions.DEFAULT);
         assertEquals(0, refreshResponse.getFailedShards());
-        return numDocs;
+        return numberOfDocs;
     }
 
     public void testDeleteRollupJob() throws Exception {
@@ -263,6 +263,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
         assertThat(getResponse.getJobs(), empty());
     }
 
+    @SuppressWarnings("HiddenField")
     public void testGetRollupCaps() throws Exception {
         final Set<Integer> values = new HashSet<>();
         double sum = 0.0d;
@@ -295,7 +296,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
             }
         }
 
-        final int numDocs = bulkRequest.numberOfActions();
+        final int numberOfDocs = bulkRequest.numberOfActions();
 
         BulkResponse bulkResponse = highLevelClient().bulk(bulkRequest, RequestOptions.DEFAULT);
         assertEquals(RestStatus.OK, bulkResponse.status());
@@ -315,7 +316,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
         final String indexPattern = randomFrom("docs", "d*", "doc*");
         final String rollupIndex = randomFrom("rollup", "test");
         final String cron = "*/1 * * * * ?";
-        final int pageSize = randomIntBetween(numDocs, numDocs * 10);
+        final int pageSize = randomIntBetween(numberOfDocs, numberOfDocs * 10);
         // TODO expand this to also test with histogram and terms?
         final GroupConfig groups = new GroupConfig(new DateHistogramGroupConfig.CalendarInterval("date", DateHistogramInterval.DAY));
         final List<MetricConfig> metrics = Collections.singletonList(new MetricConfig("value", SUPPORTED_METRICS));
@@ -376,6 +377,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
         assertThat(valueCaps.size(), equalTo(SUPPORTED_METRICS.size()));
     }
 
+    @SuppressWarnings("HiddenField")
     public void testGetRollupIndexCaps() throws Exception {
         final Set<Integer> values = new HashSet<>();
         double sum = 0.0d;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleRequestTests.java
@@ -51,9 +51,9 @@ public class PutRoleRequestTests extends AbstractXContentTestCase<PutRoleRequest
         return false;
     }
 
-    private static Role randomRole(String roleName) {
+    private static Role randomRole(String name) {
         final Role.Builder roleBuilder = Role.builder()
-            .name(roleName)
+            .name(name)
             .clusterPrivileges(randomSubsetOf(randomInt(3), Role.ClusterPrivilegeName.ALL_ARRAY))
             .indicesPrivileges(
                 randomArray(3, IndicesPrivileges[]::new, () -> IndicesPrivilegesTests.createNewRandom(randomAlphaOfLength(3)))


### PR DESCRIPTION
Part of #19752.

Fix a number of cases of shadows vars under `client/rest-high-level`. As
part of this, fork the Checkstyle `HiddeFieldCheck` class so that it
understand the pattern of settings with no "set" prefix.