### PR TITLE
[Transform] Ignore deletions during upgrade

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -50,7 +51,8 @@ public class TransformUpdater {
         public enum Status {
             NONE, // all checks passed, no action taken
             UPDATED, // updated
-            NEEDS_UPDATE // special dry run status
+            NEEDS_UPDATE, // special dry run status
+            DELETED // internal status if a transform got deleted during upgrade
         }
 
         // the new config after the update
@@ -68,6 +70,7 @@ public class TransformUpdater {
             return status;
         }
 
+        @Nullable
         public TransformConfig getConfig() {
             return config;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.action;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -166,7 +167,14 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
                 timeout,
                 listener
             );
-        }, listener::onFailure));
+        }, failure -> {
+            // ignore if transform got deleted while upgrade was running
+            if (failure instanceof ResourceNotFoundException) {
+                listener.onResponse(new UpdateResult(null, UpdateResult.Status.DELETED));
+            } else {
+                listener.onFailure(failure);
+            }
+        }));
     }
 
     private void recursiveUpdate(
@@ -185,11 +193,11 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
         }
 
         updateOneTransform(next, dryRun, timeout, ActionListener.wrap(updateResponse -> {
-            TransformConfig updatedConfig = updateResponse.getConfig();
-            auditor.info(updatedConfig.getId(), "Updated transform.");
-            logger.debug("[{}] Updated transform [{}]", updatedConfig.getId(), updateResponse.getStatus());
-            updatesByStatus.compute(updateResponse.getStatus(), (k, v) -> (v == null) ? 1 : v + 1L);
-
+            if (UpdateResult.Status.DELETED.equals(updateResponse.getStatus()) == false) {
+                auditor.info(next, "Updated transform.");
+                logger.debug("[{}] Updated transform [{}]", next, updateResponse.getStatus());
+                updatesByStatus.compute(updateResponse.getStatus(), (k, v) -> (v == null) ? 1 : v + 1L);
+            }
             if (transformsToUpgrade.isEmpty() == false) {
                 recursiveUpdate(transformsToUpgrade, updatesByStatus, dryRun, timeout, listener);
             } else {


### PR DESCRIPTION
ignore if a transform gets deleted during upgrade

fixes #80321

Severity: This fixes a rare scenario and as upgrade can be called again not a dramatic failure scenario. However test automation sometimes triggers on this issue.
Risk: low, its a small change and can not affect other components
non-issue: The upgrade endpoint has not been part of a release yet