### PR TITLE
[ML] Check total_definition_length is consistent on start deployment

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -120,6 +120,8 @@ public final class Messages {
         "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =
         "Model definition truncated. Unable to deserialize trained model definition [{0}]";
+    public static final String UNABLE_TO_DEPLOY_MODEL_BAD_PARTS =
+        "Unable to deploy model, please delete and recreate the model definition";
     public static final String INFERENCE_FAILED_TO_DESERIALIZE = "Could not deserialize trained model [{0}]";
     public static final String INFERENCE_TOO_MANY_DEFINITIONS_REQUESTED =
         "Getting model definition is not supported when getting more than one model";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -120,8 +120,7 @@ public final class Messages {
         "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =
         "Model definition truncated. Unable to deserialize trained model definition [{0}]";
-    public static final String UNABLE_TO_DEPLOY_MODEL_BAD_PARTS =
-        "Unable to deploy model, please delete and recreate the model definition";
+    public static final String UNABLE_TO_DEPLOY_MODEL_BAD_PARTS = "Unable to deploy model, please delete and recreate the model definition";
     public static final String INFERENCE_FAILED_TO_DESERIALIZE = "Could not deserialize trained model [{0}]";
     public static final String INFERENCE_TOO_MANY_DEFINITIONS_REQUESTED =
         "Getting model definition is not supported when getting more than one model";

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -333,8 +332,8 @@ public class TrainedModelIT extends ESRestTestCase {
         assertThat(
             responseException.getMessage(),
             containsString(
-                "[total_definition_length] must be the same in all model definition parts. " +
-                    "The value [600] in model definition part [2] does not match the value [500] in part [0]"
+                "[total_definition_length] must be the same in all model definition parts. "
+                    + "The value [600] in model definition part [2] does not match the value [500] in part [0]"
             )
         );
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -318,6 +319,60 @@ public class TrainedModelIT extends ESRestTestCase {
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
             .setOutputAggregator(new WeightedSum(Arrays.asList(0.5, 0.5, 0.5)))
             .build();
+    }
+
+    public void testStartDeploymentWithInconsistentTotalLengths() throws IOException {
+        String modelId = "inconsistent-size-model";
+        putPyTorchModel(modelId);
+
+        putModelDefinitionPart(modelId, 500, 3, 0);
+        putModelDefinitionPart(modelId, 500, 3, 1);
+        putModelDefinitionPart(modelId, 600, 3, 2);
+
+        ResponseException responseException = expectThrows(ResponseException.class, () -> startDeployment(modelId));
+        assertThat(
+            responseException.getMessage(),
+            containsString(
+                "[total_definition_length] must be the same in all model definition parts. " +
+                    "The value [600] in model definition part [2] does not match the value [500] in part [0]"
+            )
+        );
+
+    }
+
+    private void putPyTorchModel(String modelId) throws IOException {
+        Request request = new Request("PUT", "/_ml/trained_models/" + modelId);
+        request.setJsonEntity(
+            "{  "
+                + "    \"description\": \"simple model for testing\",\n"
+                + "    \"model_type\": \"pytorch\",\n"
+                + "    \"inference_config\": {\n"
+                + "        \"pass_through\": {\n"
+                + "        }\n"
+                + "    }\n"
+                + "}"
+        );
+        client().performRequest(request);
+    }
+
+    private void putModelDefinitionPart(String modelId, int totalSize, int numParts, int partNumber) throws IOException {
+        Request request = new Request("PUT", "_ml/trained_models/" + modelId + "/definition/" + partNumber);
+        request.setJsonEntity(
+            "{  "
+                + "\"total_definition_length\": "
+                + totalSize
+                + ","
+                + "\"definition\": \"UEsDBAAACAgAAAAAAAAAAAAAAAAAAAAAAAAUAA4Ac2ltcGxlbW9kZW==\","
+                + "\"total_parts\": "
+                + numParts
+                + "}"
+        );
+        client().performRequest(request);
+    }
+
+    private void startDeployment(String modelId) throws IOException {
+        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/deployment/_start?timeout=40s");
+        client().performRequest(request);
     }
 
     @After

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -223,16 +223,20 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         );
         restorer.setSearchIndex(trainedModelConfig.getLocation().getResourceName());
         restorer.setSearchSize(1);
-        restorer.restoreModelDefinition(doc -> {
-            // The in-memory size of the model was found to be approximately equal
-            // to the size of the model on disk in experiments for BERT models. However,
-            // this might not always be the case.
-            // TODO Improve heuristic for in-memory model size.
-            listener.onResponse(doc.getTotalDefinitionLength());
+        restorer.restoreModelDefinition(
+            doc -> {
+                // The in-memory size of the model was found to be approximately equal
+                // to the size of the model on disk in experiments for BERT models. However,
+                // this might not always be the case.
+                // TODO Improve heuristic for in-memory model size.
+                listener.onResponse(doc.getTotalDefinitionLength());
 
-            // Return false to stop the restorer as we only need the first doc
-            return false;
-        }, success -> { /* nothing to do */ }, listener::onFailure);
+                // Return false to stop the restorer as we only need the first doc
+                return false;
+            },
+            success -> { /* nothing to do */ },
+            listener::onFailure
+        );
     }
 
     private void waitForDeploymentState(
@@ -316,16 +320,20 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     listener.onFailure(new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId)));
                     return;
                 }
+                long firstTotalLength = ((Number) hits[0].getSourceAsMap()
+                    .get(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())).longValue();
+
                 long summedLengths = 0;
                 for (SearchHit hit : hits) {
                     Map<String, Object> fields = hit.getSourceAsMap();
                     if (fields == null) {
                         listener.onFailure(
                             ExceptionsHelper.badRequestException(
-                                "[{}] model definition [{}] is missing required fields {}, unable to be deployed",
+                                "[{}] model definition [{}] is missing required fields {}. {}",
                                 modelId,
                                 TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hit.getId())),
-                                List.of(requiredSourceFields)
+                                List.of(requiredSourceFields),
+                                Messages.UNABLE_TO_DEPLOY_MODEL_BAD_PARTS
                             )
                         );
                         return;
@@ -334,21 +342,40 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     if (diff.isEmpty() == false) {
                         listener.onFailure(
                             ExceptionsHelper.badRequestException(
-                                "[{}] model definition [{}] is missing required fields {}, unable to be deployed",
+                                "[{}] model definition [{}] is missing required fields {}. {}",
                                 modelId,
                                 TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hit.getId())),
-                                diff
+                                diff,
+                                Messages.UNABLE_TO_DEPLOY_MODEL_BAD_PARTS
                             )
                         );
                         return;
                     }
                     summedLengths += ((Number) fields.get(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName())).longValue();
+                    long totalLength = ((Number) fields.get(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName()))
+                        .longValue();
+                    if (totalLength != firstTotalLength) {
+                        listener.onFailure(
+                            ExceptionsHelper.badRequestException(
+                                "[{}] [total_definition_length] must be the same in all model definition parts. "
+                                    + "The value [{}] in model definition part [{}] does not match the value [{}] in part [{}]. "
+                                    + Messages.UNABLE_TO_DEPLOY_MODEL_BAD_PARTS,
+                                modelId,
+                                totalLength,
+                                TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hit.getId())),
+                                firstTotalLength,
+                                TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hits[0].getId()))
+                            )
+                        );
+                        return;
+                    }
+
                 }
-                long totalLength = ((Number) hits[hits.length - 1].getSourceAsMap()
-                    .get(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())).longValue();
                 Boolean eos = (Boolean) hits[hits.length - 1].getSourceAsMap().get(TrainedModelDefinitionDoc.EOS.getPreferredName());
-                if (summedLengths != totalLength || eos == null || eos == false) {
-                    listener.onFailure(ExceptionsHelper.serverError(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId)));
+                if (summedLengths != firstTotalLength || eos == null || eos == false) {
+                    listener.onFailure(
+                        ExceptionsHelper.badRequestException(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId))
+                    );
                     return;
                 }
                 listener.onResponse(null);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -223,20 +223,16 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         );
         restorer.setSearchIndex(trainedModelConfig.getLocation().getResourceName());
         restorer.setSearchSize(1);
-        restorer.restoreModelDefinition(
-            doc -> {
-                // The in-memory size of the model was found to be approximately equal
-                // to the size of the model on disk in experiments for BERT models. However,
-                // this might not always be the case.
-                // TODO Improve heuristic for in-memory model size.
-                listener.onResponse(doc.getTotalDefinitionLength());
+        restorer.restoreModelDefinition(doc -> {
+            // The in-memory size of the model was found to be approximately equal
+            // to the size of the model on disk in experiments for BERT models. However,
+            // this might not always be the case.
+            // TODO Improve heuristic for in-memory model size.
+            listener.onResponse(doc.getTotalDefinitionLength());
 
-                // Return false to stop the restorer as we only need the first doc
-                return false;
-            },
-            success -> { /* nothing to do */ },
-            listener::onFailure
-        );
+            // Return false to stop the restorer as we only need the first doc
+            return false;
+        }, success -> { /* nothing to do */ }, listener::onFailure);
     }
 
     private void waitForDeploymentState(


### PR DESCRIPTION
Before a model deployment is started check the the individual model part documents have a consistent value for `total_definition_length`.

This is an unrecoverable error as it shows the model definition sizes are not reliable, the only solution is to delete the model and recreate it and the error message should express this to the user. 

