### PR TITLE
[DOCS] Add actual and typical values in ML alerting docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
@@ -228,6 +228,9 @@ The list of top records.
 .Properties of `context.topRecords`
 [%collapsible%open]
 ====
+`actual`:::
+The actual value for the bucket.
+
 `by_field_value`::: 
 The value of the by field.
 
@@ -248,6 +251,9 @@ The field used to segment the analysis.
 `score`:::
 A normalized score between 0-100, which is based on the probability of the 
 anomalousness of this record.
+
+`typical`:::
+The typical value for the bucket, according to analytical modeling.
 ====
 
 [[anomaly-jobs-health-action-variables]]


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/118006

This PR adds the new actual and typical values to https://www.elastic.co/guide/en/machine-learning/master/ml-configuring-alerts.html#creating-ml-rules 


### Preview

https://elasticsearch_80571.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-configuring-alerts.html#anomaly-alert-action-variables