### PR TITLE
Re-enable transient settings tests

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -82,7 +82,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/20_terms/string profiler via map", "The profiler results aren't backwards compatible.")
   task.skipTest("search.aggregation/20_terms/numeric profiler", "The profiler results aren't backwards compatible.")
   task.skipTest("migration/10_get_feature_upgrade_status/Get feature upgrade status", "Awaits backport")
-  task.skipTest("cluster.put_settings/10_basic/Test put and reset transient settings", "Awaits backport")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -1,13 +1,6 @@
 ---
 "Test put and reset transient settings":
-  - skip:
-      version: " - 7.99.99"
-      reason:  "transient settings deprecation"
-      features: "allowed_warnings"
-
   - do:
-      allowed_warnings:
-        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
       cluster.put_settings:
         body:
           transient:
@@ -23,8 +16,6 @@
   - match: {transient: {cluster.routing.allocation.enable: "none"}}
 
   - do:
-      allowed_warnings:
-        - "[transient settings removal] Updating cluster settings through transientSettings is deprecated. Use persistent settings instead."
       cluster.put_settings:
         body:
           transient:


### PR DESCRIPTION
The undoing of transient settings deprecation is
merged in 7.16 now. This PR removes the test warnings
and re-enables the v7 compatibility test.

Relates to https://github.com/elastic/elasticsearch/pull/80558 and https://github.com/elastic/elasticsearch/issues/80556