### PR TITLE
[7.16] Prepopulate the system's security manager setters map

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -60,12 +60,14 @@ class Elasticsearch extends EnvironmentAwareCommand {
      */
     public static void main(final String[] args) throws Exception {
         overrideDnsCachePolicyProperties();
+        org.elasticsearch.bootstrap.Security.prepopulateSecurityCaller();
+
         /*
          * We want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on the
          * presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy). This
          * forces such policies to take effect immediately.
          */
-        System.setSecurityManager(new SecurityManager() {
+        org.elasticsearch.bootstrap.Security.setSecurityManager(new SecurityManager() {
 
             @Override
             public void checkPermission(Permission perm) {

--- a/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.jdk.JavaVersion;
+
+import static org.hamcrest.Matchers.is;
+
+public class NoSecurityManagerTests extends LuceneTestCase {
+
+    public void testPrepopulateSecurityCaller() {
+        assumeTrue("Unexpected security manager:" + System.getSecurityManager(), System.getSecurityManager() == null);
+        boolean isAtLeastJava17 = JavaVersion.current().compareTo(JavaVersion.parse("17")) >= 0;
+        boolean isPrepopulated = Security.prepopulateSecurityCaller();
+        if (isAtLeastJava17) {
+            assertThat(isPrepopulated, is(true));
+        } else {
+            assertThat(isPrepopulated, is(false));
+        }
+    }
+}


### PR DESCRIPTION
Backport of #80462

Given that 7.16 builds with `--release 8` the code has been restructured
to avoid Java 9+ APIs. 