### PR TITLE
[ML] Model snapshot version too old is not server error

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -196,7 +196,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                             return;
                         }
                         listener.onFailure(
-                            ExceptionsHelper.serverError(
+                            ExceptionsHelper.badRequestException(
                                 "[{}] job snapshot [{}] has min version before [{}], "
                                     + "please revert to a newer model snapshot or reset the job",
                                 jobParams.getJobId(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -390,9 +390,8 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                         return;
                     }
                     listener.onFailure(
-                        ExceptionsHelper.serverError(
-                            "[{}] job snapshot [{}] has min version before [{}], "
-                                + "please revert to a newer model snapshot or reset the job",
+                        ExceptionsHelper.badRequestException(
+                            "[{}] job snapshot [{}] has min version before [{}], please revert to a newer model snapshot or reset the job",
                             jobId,
                             jobSnapshotId,
                             MIN_SUPPORTED_SNAPSHOT_VERSION.toString()


### PR DESCRIPTION
If a job cannot be opened because its model snapshot is too
old then this should not be reported as a server error (status
500). It's a user error because the user did not upgrade their
old model snapshots as the deprecation info API and upgrade
assistant told them to. Instead we should report the attempt
to open the job with the old snapshot as a bad request (status
400).