### PR TITLE
Implement Setting Deduplication via String Interning (#80493)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -2040,7 +2040,7 @@ public class Setting<T> implements ToXContentObject {
         protected final String key;
 
         public SimpleKey(String key) {
-            this.key = key;
+            this.key = Settings.internKeyOrValue(key);
         }
 
         @Override
@@ -2131,7 +2131,7 @@ public class Setting<T> implements ToXContentObject {
                 sb.append('.');
                 sb.append(suffix);
             }
-            keyString = sb.toString();
+            keyString = Settings.internKeyOrValue(sb.toString());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
+import org.elasticsearch.common.util.StringLiteralDeduplicator;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Booleans;
@@ -99,7 +100,27 @@ public final class Settings implements ToXContentFragment {
 
     private Settings(Map<String, Object> settings, SecureSettings secureSettings) {
         // we use a sorted map for consistent serialization when using getAsMap()
-        this.settings = Collections.unmodifiableNavigableMap(new TreeMap<>(settings));
+        final TreeMap<String, Object> tree = new TreeMap<>();
+        for (Map.Entry<String, Object> settingEntry : settings.entrySet()) {
+            final Object value = settingEntry.getValue();
+            final Object internedValue;
+            if (value instanceof String) {
+                internedValue = internKeyOrValue((String) value);
+            } else if (value instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<String> valueList = (List<String>) value;
+                final int listSize = valueList.size();
+                final String[] internedArr = new String[listSize];
+                for (int i = 0; i < valueList.size(); i++) {
+                    internedArr[i] = internKeyOrValue(valueList.get(i));
+                }
+                internedValue = List.of(internedArr);
+            } else {
+                internedValue = value;
+            }
+            tree.put(internKeyOrValue(settingEntry.getKey()), internedValue);
+        }
+        this.settings = Collections.unmodifiableNavigableMap(tree);
         this.secureSettings = secureSettings;
     }
 
@@ -418,7 +439,7 @@ public final class Settings implements ToXContentFragment {
             if (valueFromPrefix instanceof List) {
                 @SuppressWarnings("unchecked")
                 final List<String> valuesAsList = (List<String>) valueFromPrefix;
-                return Collections.unmodifiableList(valuesAsList);
+                return valuesAsList;
             } else if (commaDelimited) {
                 String[] strings = Strings.splitStringByCommaToArray(get(key));
                 if (strings.length > 0) {
@@ -1189,11 +1210,19 @@ public final class Settings implements ToXContentFragment {
                 }
                 if (entry.getValue() instanceof List) {
                     @SuppressWarnings("unchecked")
-                    final ListIterator<String> li = ((List<String>) entry.getValue()).listIterator();
+                    final List<String> mutableList = new ArrayList<>((List<String>) entry.getValue());
+                    final ListIterator<String> li = mutableList.listIterator();
+                    boolean changed = false;
                     while (li.hasNext()) {
                         final String settingValueRaw = li.next();
                         final String settingValueResolved = propertyPlaceholder.replacePlaceholders(settingValueRaw, placeholderResolver);
-                        li.set(settingValueResolved);
+                        if (settingValueResolved.equals(settingValueRaw) == false) {
+                            li.set(settingValueResolved);
+                            changed = true;
+                        }
+                    }
+                    if (changed) {
+                        entry.setValue(List.copyOf(mutableList));
                     }
                     continue;
                 }
@@ -1445,4 +1474,18 @@ public final class Settings implements ToXContentFragment {
         return o == null ? null : o.toString();
     }
 
+    private static final StringLiteralDeduplicator settingLiteralDeduplicator = new StringLiteralDeduplicator();
+
+    /**
+     * Interns the given string which should be either a setting key or value or part of a setting value list. This is used to reduce the
+     * memory footprint of similar setting instances like index settings that may contain mostly the same keys and values. Interning these
+     * strings at some runtime cost is considered a reasonable trade-off here since neither setting keys nor values change frequently
+     * while duplicate keys values may consume significant amounts of memory.
+     *
+     * @param s string to intern
+     * @return interned string
+     */
+    static String internKeyOrValue(String s) {
+        return settingLiteralDeduplicator.deduplicate(s);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.common.util;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
 import java.util.Map;
@@ -19,8 +17,6 @@ import java.util.Map;
  * advisable as its performance may deteriorate to slower than outright calls to {@link String#intern()}.
  */
 public final class StringLiteralDeduplicator {
-
-    private static final Logger logger = LogManager.getLogger(StringLiteralDeduplicator.class);
 
     private static final int MAX_SIZE = 1000;
 
@@ -36,7 +32,6 @@ public final class StringLiteralDeduplicator {
         final String interned = string.intern();
         if (map.size() > MAX_SIZE) {
             map.clear();
-            logger.debug("clearing intern cache");
         }
         map.put(interned, interned);
         return interned;


### PR DESCRIPTION
This is a somewhat crude solution to #78892 that addresses
95%+ of duplicate setting entry memory consumption in large clusters.
The remaining duplicate structures (lists of all the same strings) are
comparatively cheap in their heap consumption.
In heavy benchmarking for #77466 no runtime impact of adding this extra step
to setting creation has been found despite pushing setting creation harder
than is expected in real-world usage (part of the low relative impact here is
the fact that populating a tree-map is quite expensive to begin with so adding
the string interning which is fast via the CHM cache doesn't add much overhead).
On the other hand, the heap use impact for use-cases that come with a large number
of duplicate settings (many similar indices) is significant. As an example,
10k AuditBeat indices consume about 500M of heap for duplicate settings data structures
without this change. This cahnge brings the heap consumption from duplicate settings down to
O(1M) on every node in the cluster.

Relates and addresses most of #78892
Relates #77466

backport of #80493