### PR TITLE
[8.0] [ML] Model snapshot version too old is not server error (#80588)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -196,7 +196,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                             return;
                         }
                         listener.onFailure(
-                            ExceptionsHelper.serverError(
+                            ExceptionsHelper.badRequestException(
                                 "[{}] job snapshot [{}] has min version before [{}], "
                                     + "please revert to a newer model snapshot or reset the job",
                                 jobParams.getJobId(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -390,9 +390,8 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                         return;
                     }
                     listener.onFailure(
-                        ExceptionsHelper.serverError(
-                            "[{}] job snapshot [{}] has min version before [{}], "
-                                + "please revert to a newer model snapshot or reset the job",
+                        ExceptionsHelper.badRequestException(
+                            "[{}] job snapshot [{}] has min version before [{}], please revert to a newer model snapshot or reset the job",
                             jobId,
                             jobSnapshotId,
                             MIN_SUPPORTED_SNAPSHOT_VERSION.toString()


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Model snapshot version too old is not server error (#80588)