### PR TITLE
Mute 'Fix IndexNotFoundException error when handling remove alias action' test,

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -80,6 +80,7 @@ tasks.named("yamlRestTestV7CompatTest").configure {
             'unsigned_long/50_script_values/Scripted sort values',
             'unsigned_long/50_script_values/script_score query',
             'unsigned_long/50_script_values/Script query',
+            'data_stream/140_data_stream_aliases/Fix IndexNotFoundException error when handling remove alias action',
     ].join(',')
 }
 


### PR DESCRIPTION
when running yamlRestTestV7CompatTest

Relates to #80405