### PR TITLE
Handle exceptions thrown from RestCompatibleVersionHelper (#80253)

### DIFF
--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4BadRequestIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4BadRequestIT.java
@@ -89,6 +89,6 @@ public class Netty4BadRequestIT extends ESRestTestCase {
         final ObjectPath objectPath = ObjectPath.createFromResponse(response);
         final Map<String, Object> map = objectPath.evaluate("error");
         assertThat(map.get("type"), equalTo("media_type_header_exception"));
-        assertThat(map.get("reason"), equalTo("Invalid media-type value on header [Content-Type]"));
+        assertThat(map.get("reason"), equalTo("Invalid media-type value on headers [Content-Type]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -197,7 +197,7 @@ public class RestRequestTests extends ESTestCase {
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), equalTo("invalid media-type [" + type + "]"));
-        assertThat(e.getMessage(), equalTo("Invalid media-type value on header [Content-Type]"));
+        assertThat(e.getMessage(), equalTo("Invalid media-type value on headers [Content-Type]"));
     }
 
     public void testNoContentTypeHeader() {
@@ -214,7 +214,7 @@ public class RestRequestTests extends ESTestCase {
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf((IllegalArgumentException.class)));
         assertThat(e.getCause().getMessage(), equalTo("Incorrect header [Content-Type]. Only one value should be provided"));
-        assertThat(e.getMessage(), equalTo("Invalid media-type value on header [Content-Type]"));
+        assertThat(e.getMessage(), equalTo("Invalid media-type value on headers [Content-Type]"));
     }
 
     public void testRequiredContent() {


### PR DESCRIPTION
RestCompatibleVersionHelper is used to validate versions on Accept and Content-Type headers
When a validation fails, an exception is being thrown indicating which headers are incorrect.
That exception was not handled in RestRequest where the helper was used.
This commit gracefully handles the exception from validation failure. A bad request response is returned to a user.

closes #79060
closes #78214

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
