### PR TITLE
Updates tsdb/90_unsupported_operations.yml noop REST API test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/90_unsupported_operations.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/90_unsupported_operations.yml
@@ -141,10 +141,10 @@ noop update:
       catch: /update is not supported because the destination index \[test\] is in time series mode/
       update:
         index:   test
-        id:      $body.hits.hits.0._id
+        id:      1
         body:
           doc:
-            $body.hits.hits.0._source
+            {}
 
 ---
 update:


### PR DESCRIPTION
When I run this REST API test on the Elasticsearch Ruby client's build, it fails with the following error:
```
[UpdateRequest] doc doesn't support values of type: VALUE_STRING
```
This update has a `$body` variable which is not being set before, so my Test Runner sends "`$body.hits.hits.0._source`" as a String since it doesn't find a value to replace it with. If I understand correctly, what's in id or body here is not necessarily important, it's going to fail and catch the expected exception anyway, right?

The test passes for me if I replace `$body.hits.hits.0._source` with `{}`, (and the id is being sent as a String), but let me know if this is correct or it should be reworked. Thanks!
