### PR TITLE
Reduce invalid duplicate search request after parent search has been cancelled.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -513,7 +513,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                 new SearchPhaseExecutionException(getName(), "Shard failures", null, buildShardFailures())
             );
         } else {
-            if (lastShard == false) {
+            if (lastShard == false && isTaskCancelledException(e) == false) {
                 performPhaseOnShard(shardIndex, shardIt, nextShard);
             }
         }


### PR DESCRIPTION
With this commit, we try to avoid duplicate search request on rest replica if parent search task has been cancelled.

We have a cluster in 7.10.1 version, 30 data nodes, single index `test_esdb` has 1 primary (50MB) with 29 replicas (search scenario), each node has single shard. If client timeout for 100ms, channel will be closed between client and ES, this time the running search request will be cancelled on the channel closed event. And `AbstractSearchAsyncAction.onShardFailure` would be called due to task has been cancelled. It will try to continue to perform search request on the next replica:
https://github.com/elastic/elasticsearch/blob/05dfe880d61edf50b908e38901c9df1c69493f39/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java#L516-L518
Since parent task has been cancelled, each replica search would be failed in sending search request to its target node.
We have lots of replicas in this case, it's costly to perform the invalid duplicate search request. During this time cpu got really high (almost 95%+), and caused more timeout requests, they will be cancelled and case huge exception stacks has been logged.

Herer is the unreasonable exception logs:
```
[2021-11-11T00:00:10,240][WARN ][r.suppressed             ] [node-1] path: /test_esdb/_search, params: {preference=_local, index=test_esdb}
org.elasticsearch.action.search.SearchPhaseExecutionException: all shards failed
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onPhaseFailure(AbstractSearchAsyncAction.java:623) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.executeNextPhase(AbstractSearchAsyncAction.java:355) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onPhaseDone(AbstractSearchAsyncAction.java:658) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:434) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:683) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendChildRequest(TransportService.java:725) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService.sendExecuteQuery(SearchTransportService.java:149) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.executePhaseOnShard(SearchQueryThenFetchAsyncAction.java:85) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.lambda$performPhaseOnShard$3(AbstractSearchAsyncAction.java:255) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.performPhaseOnShard(AbstractSearchAsyncAction.java:310) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:440) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction.access$700(AbstractSearchAsyncAction.java:75) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:289) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:73) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:59) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:418) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService$6.handleException(TransportService.java:653) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1194) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:1308) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1282) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:61) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportChannel.sendErrorResponse(TransportChannel.java:56) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.support.ChannelActionListener.onFailure(ChannelActionListener.java:51) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.action.ActionRunnable.onFailure(ActionRunnable.java:88) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:39) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:44) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:737) [elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.10.1.jar:7.10.1]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:1.8.0_181]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]
Caused by: org.elasticsearch.tasks.TaskCancelledException: The parent task was cancelled, shouldn't start any child tasks
	at org.elasticsearch.tasks.TaskManager$CancellableTaskHolder.registerChildNode(TaskManager.java:522) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.tasks.TaskManager.registerChildNode(TaskManager.java:213) ~[elasticsearch-7.10.1.jar:7.10.1]
	at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:642) ~[elasticsearch-7.10.1.jar:7.10.1]
	... 434 more
```