### PR TITLE
[8.0] [ML] re-enable back compat tests with v7 (#80625)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -113,9 +113,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure{ task ->
   task.skipTest("indices.freeze/20_stats/Translog stats on frozen indices", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("indices.freeze/10_basic/Basic", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("indices.freeze/10_basic/Test index options", "#70192 -- the freeze index API is removed from 8.0")
-  task.skipTest("ml/categorization_agg/Test categorization aggregation with poor settings", "https://github.com/elastic/elasticsearch/pull/79586")
-  task.skipTest("ml/inference_crud/Test put with defer_definition_decompression with invalid compression definition and no memory estimate", "https://github.com/elastic/elasticsearch/pull/80554")
-  task.skipTest("ml/inference_crud/Test put with defer_definition_decompression with invalid compressed definition", "https://github.com/elastic/elasticsearch/pull/80554")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] re-enable back compat tests with v7 (#80625)