### PR TITLE
[7.16] Upgrade spotless gradle plugin to 6.0.0 (#80560)

### DIFF
--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     api 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
     api 'org.apache.rat:apache-rat:0.11'
     compileOnly "com.puppycrawl.tools:checkstyle:8.42"
-    api('com.diffplug.spotless:spotless-plugin-gradle:5.17.1') {
+    api('com.diffplug.spotless:spotless-plugin-gradle:6.0.0') {
       exclude module: "groovy-xml"
     }
 }

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -50,6 +50,9 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
             project.getPlugins().apply(PrecommitTaskPlugin.class);
             project.getPlugins().apply(SpotlessPlugin.class);
 
+            // Spotless resolves required dependencies from project repositories, so we need maven central
+            project.getRepositories().mavenCentral();
+
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
                 String importOrderPath = "build-conventions/elastic.importorder";
                 String formatterConfigPath = "build-conventions/formatterConfig.xml";


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Upgrade spotless gradle plugin to 6.0.0 (#80560)