### PR TITLE
Add extra round trip to aggs tests (backport of #79638)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -332,6 +332,26 @@ public interface DocValueFormat extends NamedWriteable {
         public String toString() {
             return "DocValueFormat.DateTime(" + formatter + ", " + timeZone + ", " + resolution + ")";
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DateTime that = (DateTime) o;
+            return formatter.equals(that.formatter)
+                && timeZone.equals(that.timeZone)
+                && resolution == that.resolution
+                && formatSortValues == that.formatSortValues;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(formatter, timeZone, resolution, formatSortValues);
+        }
     }
 
     DocValueFormat GEOHASH = GeoHashDocValueFormat.INSTANCE;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -52,7 +53,12 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         long subsetSize;
         long supersetDf;
         long supersetSize;
-        long bucketOrd;
+        /**
+         * Ordinal of the bucket while it is being built. Not used after it is
+         * returned from {@link Aggregator#buildAggregations(long[])} and not
+         * serialized.
+         */
+        transient long bucketOrd;
         double score;
         protected InternalAggregations aggregations;
         final transient DocValueFormat format;
@@ -134,15 +140,14 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
             }
 
             Bucket<?> that = (Bucket<?>) o;
-            return bucketOrd == that.bucketOrd
-                && Double.compare(that.score, score) == 0
+            return Double.compare(that.score, score) == 0
                 && Objects.equals(aggregations, that.aggregations)
                 && Objects.equals(format, that.format);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getClass(), bucketOrd, aggregations, score, format);
+            return Objects.hash(getClass(), aggregations, score, format);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -142,17 +142,23 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
                 return false;
             }
             Bucket<?> that = (Bucket<?>) obj;
-            // No need to take format and showDocCountError, they are attributes
-            // of the parent terms aggregation object that are only copied here
-            // for serialization purposes
+            if (showDocCountError && docCountError != that.docCountError) {
+                /*
+                 * docCountError doesn't matter if not showing it and
+                 * serialization sets it to -1 no matter what it was
+                 * before.
+                 */
+                return false;
+            }
             return Objects.equals(docCount, that.docCount)
-                && Objects.equals(docCountError, that.docCountError)
+                && Objects.equals(showDocCountError, that.showDocCountError)
+                && Objects.equals(format, that.format)
                 && Objects.equals(aggregations, that.aggregations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getClass(), docCount, docCountError, aggregations);
+            return Objects.hash(getClass(), docCount, format, showDocCountError, showDocCountError ? docCountError : -1, aggregations);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -101,7 +101,7 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), counts.hashCode(0));
+        return Objects.hash(super.hashCode(), counts == null ? 0 : counts.hashCode(0));
     }
 
     @Override
@@ -111,6 +111,9 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
         if (super.equals(obj) == false) return false;
 
         InternalCardinality other = (InternalCardinality) obj;
+        if (counts == null) {
+            return other.counts == null;
+        }
         return counts.equals(0, other.counts, 0);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -200,7 +200,6 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
             ScoreDoc otherDoc = other.topDocs.topDocs.scoreDocs[d];
             if (thisDoc.doc != otherDoc.doc) return false;
             if (Double.compare(thisDoc.score, otherDoc.score) != 0) return false;
-            if (thisDoc.shardIndex != otherDoc.shardIndex) return false;
             if (thisDoc instanceof FieldDoc) {
                 if (false == (otherDoc instanceof FieldDoc)) return false;
                 FieldDoc thisFieldDoc = (FieldDoc) thisDoc;
@@ -225,7 +224,6 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
             ScoreDoc doc = topDocs.topDocs.scoreDocs[d];
             hashCode = 31 * hashCode + doc.doc;
             hashCode = 31 * hashCode + Float.floatToIntBits(doc.score);
-            hashCode = 31 * hashCode + doc.shardIndex;
             if (doc instanceof FieldDoc) {
                 FieldDoc fieldDoc = (FieldDoc) doc;
                 hashCode = 31 * hashCode + Arrays.hashCode(fieldDoc.fields);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -75,7 +75,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
             randomLongBetween(0, utcMillis("2050-01-01")),
             roundingInfos,
             roundingIndex,
-            randomNumericDocValueFormat()
+            randomDateDocValueFormat()
         );
     }
 
@@ -112,7 +112,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         long startingDate = randomLongBetween(0, utcMillis("2050-01-01"));
         RoundingInfo[] roundingInfos = AutoDateHistogramAggregationBuilder.buildRoundings(null, null);
         int roundingIndex = between(0, roundingInfos.length - 1);
-        DocValueFormat format = randomNumericDocValueFormat();
+        DocValueFormat format = randomDateDocValueFormat();
         List<InternalAutoDateHistogram> result = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             long thisResultStart = startingDate;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -12,11 +12,13 @@ import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.Rounding.DateTimeUnit;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +43,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
     public void setUp() throws Exception {
         super.setUp();
         keyed = randomBoolean();
-        format = randomNumericDocValueFormat();
+        format = randomDateDocValueFormat();
         // in order for reduction to work properly (and be realistic) we need to use the same interval, minDocCount, emptyBucketInfo
         // and base in all randomly created aggs as part of the same test run. This is particularly important when minDocCount is
         // set to 0 as empty buckets need to be added to fill the holes.
@@ -69,6 +71,26 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
 
     @Override
     protected InternalDateHistogram createTestInstance(String name, Map<String, Object> metadata, InternalAggregations aggregations) {
+        return createTestInstance(name, metadata, aggregations, format);
+    }
+
+    @Override
+    protected InternalDateHistogram createTestInstanceForXContent(String name, Map<String, Object> metadata, InternalAggregations subAggs) {
+        // We have to force a format that won't throw away precision and cause duplicate fields
+        DocValueFormat xContentCompatibleFormat = new DocValueFormat.DateTime(
+            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            ZoneOffset.UTC,
+            Resolution.MILLISECONDS
+        );
+        return createTestInstance(name, metadata, subAggs, xContentCompatibleFormat);
+    }
+
+    private InternalDateHistogram createTestInstance(
+        String name,
+        Map<String, Object> metadata,
+        InternalAggregations aggregations,
+        DocValueFormat format
+    ) {
         int nbBuckets = randomNumberOfBuckets();
         List<InternalDateHistogram.Bucket> buckets = new ArrayList<>(nbBuckets);
         // avoid having different random instance start from exactly the same base

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -31,7 +31,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        format = randomNumericDocValueFormat();
+        format = randomDateDocValueFormat();
 
         Function<DateTime, DateTime> interval = randomFrom(
             dateTime -> dateTime.plusSeconds(1),

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -470,11 +470,11 @@ public class RangeAggregatorTests extends AggregatorTestCase {
     public void testSubAggCollectsFromSingleBucketIfOneRange() throws IOException {
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("test").field(NUMBER_FIELD_NAME)
             .addRange(0d, 10d)
-            .subAggregation(aggCardinality("c"));
+            .subAggregation(aggCardinalityUpperBound("c"));
 
         simpleTestCase(aggregationBuilder, new MatchAllDocsQuery(), range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
-            InternalAggCardinality pc = ranges.get(0).getAggregations().get("c");
+            InternalAggCardinalityUpperBound pc = ranges.get(0).getAggregations().get("c");
             assertThat(pc.cardinality(), equalTo(CardinalityUpperBound.ONE));
         });
     }
@@ -483,11 +483,11 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("test").field(NUMBER_FIELD_NAME)
             .addRange(0d, 10d)
             .addRange(10d, 100d)
-            .subAggregation(aggCardinality("c"));
+            .subAggregation(aggCardinalityUpperBound("c"));
 
         simpleTestCase(aggregationBuilder, new MatchAllDocsQuery(), range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
-            InternalAggCardinality pc = ranges.get(0).getAggregations().get("c");
+            InternalAggCardinalityUpperBound pc = ranges.get(0).getAggregations().get("c");
             assertThat(pc.cardinality().map(i -> i), equalTo(2));
             pc = ranges.get(1).getAggregations().get("c");
             assertThat(pc.cardinality().map(i -> i), equalTo(2));

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -13,10 +13,12 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -551,10 +553,14 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         final boolean humanReadable = randomBoolean();
 
         final BytesReference originalBytes;
-        if (shuffled) {
-            originalBytes = toShuffledXContent(aggregation, xContentType, params, humanReadable);
-        } else {
-            originalBytes = toXContent(aggregation, xContentType, params, humanReadable);
+        try {
+            if (shuffled) {
+                originalBytes = toShuffledXContent(aggregation, xContentType, params, humanReadable);
+            } else {
+                originalBytes = toXContent(aggregation, xContentType, params, humanReadable);
+            }
+        } catch (IOException e) {
+            throw new IOException("error converting " + aggregation, e);
         }
         BytesReference mutated;
         if (addRandomFields) {
@@ -615,7 +621,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     /**
-     * @return a random {@link DocValueFormat} that can be used in aggregations which
+     * A random {@link DocValueFormat} that can be used in aggregations which
      * compute numbers.
      */
     public static DocValueFormat randomNumericDocValueFormat() {
@@ -623,6 +629,22 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         formats.add(() -> DocValueFormat.RAW);
         formats.add(() -> new DocValueFormat.Decimal(randomFrom("###.##", "###,###.##")));
         return randomFrom(formats).get();
+    }
+
+    /**
+     * A random {@link DocValueFormat} that can be used in aggregations which
+     * compute dates.
+     */
+    public static DocValueFormat randomDateDocValueFormat() {
+        DocValueFormat.DateTime format = new DocValueFormat.DateTime(
+            DateFormatter.forPattern(randomDateFormatterPattern()),
+            randomZone(),
+            randomFrom(Resolution.values())
+        );
+        if (randomBoolean()) {
+            return DocValueFormat.enableFormatSortValues(format);
+        }
+        return format;
     }
 
     public static void assertMultiBucketConsumer(Aggregation agg, MultiBucketConsumer bucketConsumer) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
@@ -73,7 +73,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
                 final int numAggregations = randomIntBetween(1, 3);
                 List<InternalAggregation> aggs = new ArrayList<>();
                 for (int i = 0; i < numAggregations; i++) {
-                    aggs.add(createTestInstance(randomAlphaOfLength(5), emptyMap(), InternalAggregations.EMPTY));
+                    aggs.add(createTestInstanceForXContent(randomAlphaOfLength(5), emptyMap(), InternalAggregations.EMPTY));
                 }
                 return InternalAggregations.from(aggs);
             };
@@ -97,8 +97,17 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
         assertMultiBucketsAggregations(aggregation, parsedAggregation, false);
     }
 
+    @Override
+    public final T createTestInstanceForXContent() {
+        return createTestInstanceForXContent(randomAlphaOfLength(5), createTestMetadata(), createSubAggregations());
+    }
+
+    protected T createTestInstanceForXContent(String name, Map<String, Object> metadata, InternalAggregations subAggs) {
+        return createTestInstance(name, metadata, subAggs);
+    }
+
     public void testIterators() throws IOException {
-        final T aggregation = createTestInstance();
+        final T aggregation = createTestInstanceForXContent();
         assertMultiBucketsAggregations(aggregation, parseAndAssert(aggregation, false, false), true);
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.analytics.aggregations.AnalyticsAggregatorFactory
 import org.elasticsearch.xpack.analytics.boxplot.BoxplotAggregationBuilder;
 import org.elasticsearch.xpack.analytics.boxplot.InternalBoxplot;
 import org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityPipelineAggregationBuilder;
+import org.elasticsearch.xpack.analytics.cumulativecardinality.InternalSimpleLongValue;
 import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
 import org.elasticsearch.xpack.analytics.movingPercentiles.MovingPercentilesPipelineAggregationBuilder;
 import org.elasticsearch.xpack.analytics.multiterms.InternalMultiTerms;
@@ -79,7 +80,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
                 CumulativeCardinalityPipelineAggregationBuilder.NAME,
                 CumulativeCardinalityPipelineAggregationBuilder::new,
                 usage.track(AnalyticsStatsAction.Item.CUMULATIVE_CARDINALITY, CumulativeCardinalityPipelineAggregationBuilder.PARSER)
-            )
+            ).addResultReader(InternalSimpleLongValue.NAME, InternalSimpleLongValue::new)
         );
         pipelineAggs.add(
             new PipelineAggregationSpec(

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.analytics.multiterms;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
@@ -32,7 +33,7 @@ import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.D
 
 public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms, InternalMultiTerms.Bucket> {
 
-    public static TermsComparator TERMS_COMPARATOR = new TermsComparator();
+    public static final TermsComparator TERMS_COMPARATOR = new TermsComparator();
 
     public static class Bucket extends AbstractInternalTerms.AbstractTermsBucket implements KeyComparable<Bucket> {
 
@@ -159,6 +160,27 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         @Override
         public int compareKey(Bucket other) {
             return TERMS_COMPARATOR.compare(terms, other.terms);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Bucket other = (Bucket) obj;
+            if (showDocCountError && docCountError != other.docCountError) {
+                return false;
+            }
+            return docCount == other.docCount
+                && aggregations.equals(other.aggregations)
+                && showDocCountError == other.showDocCountError
+                && terms.equals(other.terms)
+                && keyConverters.equals(other.keyConverters);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(docCount, aggregations, showDocCountError, showDocCountError ? docCountError : -1, terms, keyConverters);
         }
     }
 
@@ -607,5 +629,10 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
             buckets,
             docCountError
         );
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
@@ -16,11 +16,13 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -30,6 +32,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -163,5 +166,10 @@ public class CumulativeCardinalityAggregatorTests extends AggregatorTestCase {
 
     private static long asLong(String dateTime) {
         return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+    }
+
+    @Override
+    protected List<SearchPlugin> getSearchPlugins() {
+        return org.elasticsearch.core.List.of(new AnalyticsPlugin(Settings.EMPTY));
     }
 }


### PR DESCRIPTION
This tries to automatically detect problems seriealization aggregation
results by round tripping the results in our usual `AggregatorTestCase`.
It's "free" testing in that we already have the tests written and we'll
get round trip testing "on the side". But it's kind of sneaky because we
aren't *trying* to test serialization here. So they failures can be
surprising. But surprising test failures are better than bugs. At least
that is what I tell myself so I can sleep at night. Closes #73680
