### PR TITLE
Use UBI8 image from Docker Hub for building IronBank image

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -354,8 +354,8 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
 
       if (base == DockerBase.IRON_BANK) {
         Map<String, String> buildArgsMap = [
-          'BASE_REGISTRY': 'docker.elastic.co',
-          'BASE_IMAGE'   : 'ubi8/ubi',
+          'BASE_REGISTRY': 'registry.hub.docker.com',
+          'BASE_IMAGE'   : 'redhat/ubi8',
           'BASE_TAG'     : 'latest'
         ]
 


### PR DESCRIPTION
The UBI image on docker.elastic.co seems to have stopped working. Not sure why it exists anyway when we can just grab it form the source.

Closes https://github.com/elastic/elasticsearch/issues/80636