### PR TITLE
[ML] Fix mocking failure in MlDailyMaintenanceServiceTests

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -154,7 +154,6 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
         verify(client, Mockito.atLeast(1)).execute(same(DeleteExpiredDataAction.INSTANCE), any(), any());
         verify(client, Mockito.atLeast(1)).execute(same(GetJobsAction.INSTANCE), any(), any());
         verify(mlAssignmentNotifier, Mockito.atLeast(1)).auditUnassignedMlTasks(any(), any());
-        verifyNoMoreInteractions(client, mlAssignmentNotifier);
     }
 
     public void testJobInDeletingStateAlreadyHasDeletionTask() throws InterruptedException {


### PR DESCRIPTION
First fixed in #80000 now a different failure with `verifyNoMoreInteractions` occurs very rarely. This verification is not important, the preceding ones check the behaviour. The [Mockito docs](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#finding_redundant_invocations) offer this advice on `verifyNoMoreInteractions` which I've taken to heart:

> Use it only when it's relevant. Abusing it leads to overspecified, less maintainable tests


Closes #79971