### PR TITLE
[8.0] Consider only the document fields when extracting fields for LAST/FIRST (#80655)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -46,7 +46,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
 
     /*
      *    "text_field": {
-     *       "text": "keyword"
+     *       "type": "text"
      *    }
      */
     public void testTextField() throws IOException {
@@ -647,6 +647,36 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             expectSourceDisabledError(query);
             expectSourceDisabledError("SELECT " + subFieldName + " FROM test");
         }
+    }
+
+    /*
+     *      "keyword_field": {
+     *          "type": "keyword",
+     *          "ignore_above": 10
+     *      },
+     *      "date": {
+     *          "type": "date"
+     *      }
+     *      Test for bug https://github.com/elastic/elasticsearch/issues/80653
+     */
+    public void testTopHitsAggBug_With_IgnoreAbove_Subfield() throws IOException {
+        String text = randomAlphaOfLength(10) + " " + randomAlphaOfLength(10);
+        String function = randomFrom("FIRST", "LAST");
+        String query = "select keyword_field from test group by keyword_field order by " + function + "(date)";
+
+        Map<String, Map<String, Object>> fieldProps = new HashMap<>(1);
+        Map<String, Object> fieldProp = new HashMap<>(1);
+        fieldProp.put("ignore_above", 10);
+        fieldProps.put("keyword_field", fieldProp);
+
+        createIndexWithFieldTypeAndProperties("keyword", fieldProps, null);
+        index("{\"keyword_field\":\"" + text + "\",\"date\":\"2021-11-11T11:11:11.000Z\"}");
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", singletonList(columnInfo("plain", "keyword_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+
+        expected.put("rows", singletonList(singletonList(null)));
+        assertResponse(expected, runSql(query));
     }
 
     /*

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractor.java
@@ -78,7 +78,7 @@ public class TopHitsAggExtractor implements BucketExtractor {
             return null;
         }
 
-        Object value = agg.getHits().getAt(0).getFields().values().iterator().next().getValue();
+        Object value = agg.getHits().getAt(0).getDocumentFields().values().iterator().next().getValue();
         if (fieldDataType == DATETIME || fieldDataType == DATE) {
             return DateUtils.asDateTimeWithNanos(value.toString()).withZoneSameInstant(zoneId());
         } else if (SqlDataTypes.isTimeBased(fieldDataType)) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
@@ -110,8 +110,11 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
                 new SearchHit(
                     1,
                     "docId",
-                    null,
-                    Collections.singletonMap("topHitsAgg", new DocumentField("field", Collections.singletonList(value)))
+                    Collections.singletonMap("topHitsAgg", new DocumentField("field", Collections.singletonList(value))),
+                    Collections.singletonMap(
+                        "topHitsAgg",
+                        new DocumentField("_ignored", Collections.singletonList(randomValueOtherThan(value, () -> randomAlphaOfLength(5))))
+                    )
                 ) },
             totalHits,
             0.0f


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Consider only the document fields when extracting fields for LAST/FIRST (#80655)