### PR TITLE
[7.16] [ML] Fix mocking failure in MlDailyMaintenanceServiceTests #80657 (#80657)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -154,7 +154,6 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
         verify(client, Mockito.atLeast(1)).execute(same(DeleteExpiredDataAction.INSTANCE), any(), any());
         verify(client, Mockito.atLeast(1)).execute(same(GetJobsAction.INSTANCE), any(), any());
         verify(mlAssignmentNotifier, Mockito.atLeast(1)).auditUnassignedMlTasks(any(), any());
-        verifyNoMoreInteractions(client, mlAssignmentNotifier);
     }
 
     public void testJobInDeletingStateAlreadyHasDeletionTask() throws InterruptedException {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [ML] Fix mocking failure in MlDailyMaintenanceServiceTests #80657 (#80657)