### PR TITLE
[8.0] Add debug logging to SchedulerEngine. (#80592)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngine.java
@@ -158,6 +158,7 @@ public class SchedulerEngine {
             if (previousSchedule != null) {
                 previousSchedule.cancel();
             }
+            logger.debug(() -> new ParameterizedMessage("added job [{}]", job.getId()));
             return schedule;
         });
     }
@@ -165,6 +166,7 @@ public class SchedulerEngine {
     public boolean remove(String jobId) {
         ActiveSchedule removedSchedule = schedules.remove(jobId);
         if (removedSchedule != null) {
+            logger.debug(() -> new ParameterizedMessage("removed job [{}]", jobId));
             removedSchedule.cancel();
         }
         return removedSchedule != null;
@@ -214,6 +216,7 @@ public class SchedulerEngine {
         public void run() {
             final long triggeredTime = clock.millis();
             try {
+                logger.debug(() -> new ParameterizedMessage("job [{}] triggered with triggeredTime=[{}]", name, triggeredTime));
                 notifyListeners(name, triggeredTime, scheduledTime);
             } catch (final Throwable t) {
                 /*
@@ -236,6 +239,14 @@ public class SchedulerEngine {
                 try {
                     synchronized (this) {
                         if (future == null || future.isCancelled() == false) {
+                            logger.debug(
+                                () -> new ParameterizedMessage(
+                                    "schedule job [{}] with scheduleTime=[{}] and delay=[{}]",
+                                    name,
+                                    scheduledTime,
+                                    delay
+                                )
+                            );
                             future = scheduler.schedule(this, delay, TimeUnit.MILLISECONDS);
                         }
                     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.scheduler;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.MessageSupplier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -99,6 +101,9 @@ public class SchedulerEngineTests extends ESTestCase {
             if (numberOfFailingListeners > 0) {
                 assertFailedListenerLogMessage(mockLogger, numberOfFailingListeners);
             }
+            // Verify the debug logging:
+            verifyDebugLogging(mockLogger);
+
             verifyNoMoreInteractions(mockLogger);
         } finally {
             engine.stop();
@@ -145,6 +150,9 @@ public class SchedulerEngineTests extends ESTestCase {
             assertTrue(listeners.stream().map(Tuple::v2).allMatch(count -> count.get() == numberOfSchedules));
             latch.await();
             assertFailedListenerLogMessage(mockLogger, numberOfSchedules * numberOfListeners);
+            // Verify the debug logging:
+            verifyDebugLogging(mockLogger);
+
             verifyNoMoreInteractions(mockLogger);
         } finally {
             engine.stop();
@@ -220,6 +228,10 @@ public class SchedulerEngineTests extends ESTestCase {
             assertThat(throwable, instanceOf(RuntimeException.class));
             assertThat(throwable.getMessage(), equalTo(getTestName()));
         }
+    }
+
+    private static void verifyDebugLogging(Logger mockLogger) {
+        verify(mockLogger, atLeastOnce()).debug(any(MessageSupplier.class));
     }
 
 }

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/core/scheduler/EvilSchedulerEngineTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/core/scheduler/EvilSchedulerEngineTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.scheduler;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.MessageSupplier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
@@ -21,7 +22,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class EvilSchedulerEngineTests extends ESTestCase {
@@ -70,6 +74,7 @@ public class EvilSchedulerEngineTests extends ESTestCase {
                 assertNotNull(maybeThread.get());
                 assertThat(maybeThread.get(), not(equalTo(Thread.currentThread()))); // the error should be rethrown on another thread
                 schedulerLatch.await();
+                verify(mockLogger, atLeastOnce()).debug(any(MessageSupplier.class));
                 verifyNoMoreInteractions(mockLogger); // we never logged anything
             } finally {
                 engine.stop();


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add debug logging to SchedulerEngine. (#80592)