### PR TITLE
Don't apply the spotless plugin to non-applicable projects

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -14,8 +14,6 @@ import com.diffplug.gradle.spotless.SpotlessPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-import java.util.List;
-
 /**
  * This plugin configures formatting for Java source using Spotless
  * for Gradle. Since the act of formatting existing source can interfere
@@ -43,10 +41,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        final boolean shouldFormatProject = PROJECT_PATHS_TO_EXCLUDE.contains(project.getPath()) == false
-            || project.getProviders().systemProperty("es.format.everything").forUseAtConfigurationTime().isPresent();
-
-        if (shouldFormatProject) {
+        project.getPluginManager().withPlugin("java-base", javaBasePlugin -> {
             project.getPlugins().apply(PrecommitTaskPlugin.class);
             project.getPlugins().apply(SpotlessPlugin.class);
 
@@ -83,14 +78,6 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
             });
 
             project.getTasks().named("precommit").configure(precommitTask -> precommitTask.dependsOn("spotlessJavaCheck"));
-        }
+        });
     }
-
-    // Do not add new sub-projects here!
-    private static final List<String> PROJECT_PATHS_TO_EXCLUDE = List.of(
-        ":distribution:bwc:bugfix",
-        ":distribution:bwc:maintenance",
-        ":distribution:bwc:minor",
-        ":distribution:bwc:staged"
-    );
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ import org.elasticsearch.gradle.internal.ResolveAllDependencies
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
+buildscript {
+  repositories {
+    mavenLocal()
+  }
+}
+
 plugins {
   id 'lifecycle-base'
   id 'elasticsearch.docker-support'
@@ -430,7 +436,7 @@ tasks.register("buildReleaseArtifacts").configure {
     .findAll { it != null }
 }
 
-tasks.named("spotlessApply").configure {
+tasks.register("spotlessApply").configure {
   dependsOn gradle.includedBuild('build-tools').task(':spotlessApply')
   dependsOn gradle.includedBuild('build-tools').task(':reaper:spotlessApply')
   dependsOn gradle.includedBuild('build-tools-internal').task(':spotlessApply')

--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,6 @@ import org.elasticsearch.gradle.internal.ResolveAllDependencies
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-buildscript {
-  repositories {
-    mavenLocal()
-  }
-}
-
 plugins {
   id 'lifecycle-base'
   id 'elasticsearch.docker-support'


### PR DESCRIPTION
This is an attempt at resolving, or at least reducing the prevalence of #77837. A more robust solution is probably required, but this should help reduce this problem since we now apply spotless to about 90 fewer subprojects.