### PR TITLE
[8.0] Don't apply the spotless plugin to non-applicable projects (#80679)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -14,8 +14,6 @@ import com.diffplug.gradle.spotless.SpotlessPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-import java.util.List;
-
 /**
  * This plugin configures formatting for Java source using Spotless
  * for Gradle. Since the act of formatting existing source can interfere
@@ -43,10 +41,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        final boolean shouldFormatProject = PROJECT_PATHS_TO_EXCLUDE.contains(project.getPath()) == false
-            || project.getProviders().systemProperty("es.format.everything").forUseAtConfigurationTime().isPresent();
-
-        if (shouldFormatProject) {
+        project.getPluginManager().withPlugin("java-base", javaBasePlugin -> {
             project.getPlugins().apply(PrecommitTaskPlugin.class);
             project.getPlugins().apply(SpotlessPlugin.class);
 
@@ -83,14 +78,6 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
             });
 
             project.getTasks().named("precommit").configure(precommitTask -> precommitTask.dependsOn("spotlessJavaCheck"));
-        }
+        });
     }
-
-    // Do not add new sub-projects here!
-    private static final List<String> PROJECT_PATHS_TO_EXCLUDE = List.of(
-        ":distribution:bwc:bugfix",
-        ":distribution:bwc:maintenance",
-        ":distribution:bwc:minor",
-        ":distribution:bwc:staged"
-    );
 }

--- a/build.gradle
+++ b/build.gradle
@@ -424,7 +424,7 @@ tasks.register("buildReleaseArtifacts").configure {
     .findAll { it != null }
 }
 
-tasks.named("spotlessApply").configure {
+tasks.register("spotlessApply").configure {
   dependsOn gradle.includedBuild('build-tools').task(':spotlessApply')
   dependsOn gradle.includedBuild('build-tools').task(':reaper:spotlessApply')
   dependsOn gradle.includedBuild('build-tools-internal').task(':spotlessApply')


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Don't apply the spotless plugin to non-applicable projects (#80679)