### PR TITLE
Doc: Clarify the impact of the aggregation leak

### DIFF
--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -17,8 +17,9 @@ Authorization::
 Aggregations::
 * Possible source of leaked delayable writables {es-pull}80166[#80166]
 
-NOTE: The only arises when using <<search-search-api-query-params,allow_partial_search_results=false>> on a search with aggregations 
-AND if one of the underlying shard level search requests fail. Kibana uses `allow_partial_search_results=true` (Elasticsearch default).
+NOTE: This issue only arises when using <<search-search-api-query-params,allow_partial_search_results=false>> 
+(e.g. <<transform-overview,transforms>>) on a search with aggregations AND if one of the underlying 
+shard level search requests fail. Kibana uses `allow_partial_search_results=true` (Elasticsearch default).
 
 Authorization::
 * Marking operator user no longer depends on license state {es-pull}79595[#79595]

--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -17,6 +17,9 @@ Authorization::
 Aggregations::
 * Possible source of leaked delayable writables {es-pull}80166[#80166]
 
+NOTE: The only arises when using <<search-search-api-query-params,allow_partial_search_results=false>> on a search with aggregations 
+AND if one of the underlying shard level search requests fail. Kibana uses `allow_partial_search_results=true` (Elasticsearch default).
+
 Authorization::
 * Marking operator user no longer depends on license state {es-pull}79595[#79595]
 * Preserve request headers in a mixed version cluster {es-pull}79412[#79412] (issue: {es-issue}79354[#79354])


### PR DESCRIPTION
Clarifying the (limited) impact of https://github.com/elastic/elasticsearch/pull/80166 in release notes.

