### PR TITLE
Track remote as InetSocketAddress

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
@@ -238,7 +237,7 @@ public class InboundHandler {
                     assert reg != null;
                     final T request = reg.newRequest(stream);
                     try {
-                        request.remoteAddress(new TransportAddress(channel.getRemoteAddress()));
+                        request.remoteAddress(channel.getRemoteAddress());
                         // in case we throw an exception, i.e. when the limit is hit, we don't want to verify
                         final int nextByte = stream.read();
                         // calling read() is useful to make sure the message is fully read, even if there some kind of EOS marker
@@ -319,7 +318,7 @@ public class InboundHandler {
         final T response;
         try {
             response = handler.read(stream);
-            response.remoteAddress(new TransportAddress(remoteAddress));
+            response.remoteAddress(remoteAddress);
         } catch (Exception e) {
             final Exception serializationException = new TransportSerializationException(
                 "Failed to deserialize response from handler [" + handler + "]",

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -10,18 +10,22 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
+
+import java.net.InetSocketAddress;
 
 public abstract class TransportMessage implements Writeable, RefCounted {
 
-    private TransportAddress remoteAddress;
+    @Nullable // set by the transport service on inbound messages; unset on outbound messages
+    private InetSocketAddress remoteAddress;
 
-    public void remoteAddress(TransportAddress address) {
-        this.remoteAddress = address;
+    public void remoteAddress(InetSocketAddress remoteAddress) {
+        this.remoteAddress = remoteAddress;
     }
 
-    public TransportAddress remoteAddress() {
+    @Nullable // set by the transport service on inbound messages; unset on outbound messages
+    public InetSocketAddress remoteAddress() {
         return remoteAddress;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1792,8 +1792,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testHostOnMessages() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
-        final AtomicReference<TransportAddress> addressA = new AtomicReference<>();
-        final AtomicReference<TransportAddress> addressB = new AtomicReference<>();
+        final AtomicReference<InetSocketAddress> addressA = new AtomicReference<>();
+        final AtomicReference<InetSocketAddress> addressB = new AtomicReference<>();
         serviceB.registerRequestHandler("internal:action1", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
             addressA.set(request.remoteAddress());
             channel.sendResponse(new TestResponse((String) null));
@@ -1821,8 +1821,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             fail("message round trip did not complete within a sensible time frame");
         }
 
-        assertTrue(nodeA.getAddress().getAddress().equals(addressA.get().getAddress()));
-        assertTrue(nodeB.getAddress().getAddress().equals(addressB.get().getAddress()));
+        assertTrue(nodeA.getAddress().address().equals(addressA.get()));
+        assertTrue(nodeB.getAddress().address().equals(addressB.get()));
     }
 
     public void testRejectEarlyIncomingRequests() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1821,8 +1821,11 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             fail("message round trip did not complete within a sensible time frame");
         }
 
-        assertTrue(nodeA.getAddress().address().equals(addressA.get()));
-        assertTrue(nodeB.getAddress().address().equals(addressB.get()));
+        // nodeA opened the connection so the request originates from an ephemeral port, but from the right interface at least
+        assertEquals(nodeA.getAddress().address().getAddress(), addressA.get().getAddress());
+
+        // the response originates from the expected transport port
+        assertEquals(nodeB.getAddress().address(), addressB.get());
     }
 
     public void testRejectEarlyIncomingRequests() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.security.audit;
 
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
@@ -16,6 +15,7 @@ import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.Authoriza
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 public interface AuditTrail {
 
@@ -106,7 +106,7 @@ public interface AuditTrail {
         String action,
         String indices,
         String requestName,
-        TransportAddress remoteAddress,
+        InetSocketAddress remoteAddress,
         AuthorizationInfo authorizationInfo
     );
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.security.audit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.transport.TransportRequest;
@@ -20,6 +19,7 @@ import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -189,7 +189,7 @@ public class AuditTrailService {
             String action,
             String indices,
             String requestName,
-            TransportAddress remoteAddress,
+            InetSocketAddress remoteAddress,
             AuthorizationInfo authorizationInfo
         ) {}
 
@@ -416,7 +416,7 @@ public class AuditTrailService {
             String action,
             String indices,
             String requestName,
-            TransportAddress remoteAddress,
+            InetSocketAddress remoteAddress,
             AuthorizationInfo authorizationInfo
         ) {
             for (AuditTrail auditTrail : auditTrails) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
@@ -767,7 +766,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         String action,
         String index,
         String requestName,
-        TransportAddress remoteAddress,
+        InetSocketAddress remoteAddress,
         AuthorizationInfo authorizationInfo
     ) {
         assert eventType == ACCESS_DENIED || eventType == AuditLevel.ACCESS_GRANTED || eventType == SYSTEM_ACCESS_GRANTED;
@@ -804,7 +803,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(restAddress));
                 } else if (remoteAddress != null) {
                     logEntryBuilder.with(ORIGIN_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
-                        .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(remoteAddress.address()));
+                        .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(remoteAddress));
                 }
                 logEntryBuilder.build();
             }
@@ -1446,10 +1445,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 logEntry.with(ORIGIN_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(restAddress));
             } else {
-                final TransportAddress address = transportRequest.remoteAddress();
+                final InetSocketAddress address = transportRequest.remoteAddress();
                 if (address != null) {
                     logEntry.with(ORIGIN_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
-                        .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address.address()));
+                        .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address));
                 }
             }
             // fall through to local_node default

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -2872,7 +2872,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         MockIndicesRequest(ThreadContext threadContext, String... indices) throws IOException {
             super(IndicesOptions.strictExpandOpenAndForbidClosed(), indices);
             if (randomBoolean()) {
-                remoteAddress(buildNewFakeTransportAddress());
+                remoteAddress(buildNewFakeTransportAddress().address());
             }
             if (randomBoolean()) {
                 RemoteHostHeader.putRestRemoteAddress(threadContext, new InetSocketAddress(forge("localhost", "127.0.0.1"), 1234));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -2562,9 +2561,9 @@ public class LoggingAuditTrailTests extends ESTestCase {
         MockRequest(ThreadContext threadContext) throws IOException {
             if (randomBoolean()) {
                 if (randomBoolean()) {
-                    remoteAddress(buildNewFakeTransportAddress());
+                    remoteAddress(buildNewFakeTransportAddress().address());
                 } else {
-                    remoteAddress(new TransportAddress(InetAddress.getLoopbackAddress(), 1234));
+                    remoteAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 1234));
                 }
             }
             if (randomBoolean()) {
@@ -2584,7 +2583,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4))
             );
             if (randomBoolean()) {
-                remoteAddress(buildNewFakeTransportAddress());
+                remoteAddress(buildNewFakeTransportAddress().address());
             }
             if (randomBoolean()) {
                 RemoteHostHeader.putRestRemoteAddress(threadContext, new InetSocketAddress(forge("localhost", "127.0.0.1"), 1234));
@@ -2614,10 +2613,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
             checkedFields.put(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(restAddress));
         } else {
-            final TransportAddress address = request.remoteAddress();
+            final InetSocketAddress address = request.remoteAddress();
             if (address != null) {
                 checkedFields.put(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
-                    .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address.address()));
+                    .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address));
             }
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
@@ -204,7 +203,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(token.principal()).thenReturn(randomAlphaOfLength(5));
         transportRequest = new InternalRequest();
         remoteAddress = new InetSocketAddress(InetAddress.getLocalHost(), 100);
-        transportRequest.remoteAddress(new TransportAddress(remoteAddress));
+        transportRequest.remoteAddress(remoteAddress);
         restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress).build();
         threadContext = new ThreadContext(Settings.EMPTY);
 


### PR DESCRIPTION
We record the sender of each inbound `TransportMessage` so that it can
be recorded in the audit trail. Today we use a field of type
`TransportAddress` which is a wrapper around the underlying
`InetSocketAddress` that allows us to send the address over the wire. We
create a new wrapper for each inbound message which is a little
wasteful, and also completely unnecessary since we never actually send
it over the wire.

With this commit we skip the wrapping entirely and just use a bare
`InetSocketAddress` to identify the inbound connection on which the
message was received.

Closes #80690