### PR TITLE
Remove unused fields in ActionTransportException

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.transport.NetworkExceptionHelper;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -143,8 +142,7 @@ final class OutboundHandler {
         final Exception error
     ) throws IOException {
         Version version = Version.min(this.version, nodeVersion);
-        TransportAddress address = new TransportAddress(channel.getLocalAddress());
-        RemoteTransportException tx = new RemoteTransportException(nodeName, address, action, error);
+        RemoteTransportException tx = new RemoteTransportException(nodeName, channel.getLocalAddress(), action, error);
         OutboundMessage.Response message = new OutboundMessage.Response(threadPool.getThreadContext(), tx, version, requestId, false, null);
         ActionListener<Void> listener = ActionListener.wrap(() -> messageListener.onResponseSent(requestId, action, error));
         sendMessage(channel, message, listener);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -13,12 +13,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 /**
  * A remote exception for an action. A wrapper exception around the actual remote cause and does not fill the
  * stack trace.
- *
- *
  */
 public class RemoteTransportException extends ActionTransportException implements ElasticsearchWrapperException {
 
@@ -28,6 +27,10 @@ public class RemoteTransportException extends ActionTransportException implement
 
     public RemoteTransportException(String name, TransportAddress address, String action, Throwable cause) {
         super(name, address, action, cause);
+    }
+
+    public RemoteTransportException(String name, InetSocketAddress address, String action, Throwable cause) {
+        super(name, address, action, null, cause);
     }
 
     public RemoteTransportException(StreamInput in) throws IOException {

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -340,9 +340,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     public void testActionTransportException() throws IOException {
         TransportAddress transportAddress = buildNewFakeTransportAddress();
         ActionTransportException ex = serialize(new ActionTransportException("name?", transportAddress, "ACTION BABY!", "message?", null));
-        assertEquals("ACTION BABY!", ex.action());
-        assertEquals(transportAddress, ex.address());
-        assertEquals("[name?][" + transportAddress.toString() + "][ACTION BABY!] message?", ex.getMessage());
+        assertEquals("[name?][" + transportAddress + "][ACTION BABY!] message?", ex.getMessage());
     }
 
     public void testSearchContextMissingException() throws IOException {
@@ -411,15 +409,13 @@ public class ExceptionSerializationTests extends ESTestCase {
         TransportAddress transportAddress = buildNewFakeTransportAddress();
         DiscoveryNode node = new DiscoveryNode("thenode", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
         ConnectTransportException ex = serialize(new ConnectTransportException(node, "msg", "action", null));
-        assertEquals("[][" + transportAddress.toString() + "][action] msg", ex.getMessage());
+        assertEquals("[][" + transportAddress + "][action] msg", ex.getMessage());
         assertEquals(node, ex.node());
-        assertEquals("action", ex.action());
         assertNull(ex.getCause());
 
         ex = serialize(new ConnectTransportException(node, "msg", "action", new NullPointerException()));
         assertEquals("[][" + transportAddress + "][action] msg", ex.getMessage());
         assertEquals(node, ex.node());
-        assertEquals("action", ex.action());
         assertTrue(ex.getCause() instanceof NullPointerException);
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -46,6 +47,8 @@ import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class OutboundHandlerTests extends ESTestCase {
@@ -300,8 +303,10 @@ public class OutboundHandlerTests extends ESTestCase {
         RemoteTransportException remoteException = tuple.v2().streamInput().readException();
         assertThat(remoteException.getCause(), instanceOf(ElasticsearchException.class));
         assertEquals(remoteException.getCause().getMessage(), "boom");
-        assertEquals(action, remoteException.action());
-        assertEquals(channel.getLocalAddress(), remoteException.address().address());
+        assertThat(
+            remoteException.getMessage(),
+            allOf(containsString('[' + NetworkAddress.format(channel.getLocalAddress()) + ']'), containsString('[' + action + ']'))
+        );
 
         assertEquals("header_value", header.getHeaders().v1().get("header"));
     }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2753,9 +2753,10 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             TransportException exception = receivedException.get();
             assertNotNull(exception);
             BytesStreamOutput streamOutput = new BytesStreamOutput();
+            streamOutput.setVersion(version0);
             exception.writeTo(streamOutput);
             String failedMessage = "Unexpected read bytes size. The transport exception that was received=" + exception;
-            // 49 bytes are the non-exception message bytes that have been received. It should include the initial
+            // 53 bytes are the non-exception message bytes that have been received. It should include the initial
             // handshake message and the header, version, etc bytes in the exception message.
             assertEquals(failedMessage, 53 + streamOutput.bytes().length(), stats.getRxSize().getBytes());
             assertEquals(111, stats.getTxSize().getBytes());


### PR DESCRIPTION
The fields in `ActionTransportException` are reflected in the message
generated at construction time, and apart from that they are only used
in tests. This commit removes them, and hence another spot where we were
creating a per-message `TransportAddress` object.

Relates #80690