### PR TITLE
 better exception message for MappingParser.parse

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -112,7 +112,7 @@ public final class MappingParser {
             if (typeParser != null) {
                 iterator.remove();
                 if (false == fieldNode instanceof Map) {
-                    throw new IllegalArgumentException("[_parent] must be an object containing [type]");
+                    throw new IllegalArgumentException("[" + fieldName + "] config must be an object");
                 }
                 @SuppressWarnings("unchecked")
                 Map<String, Object> fieldNodeMap = (Map<String, Object>) fieldNode;

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -133,4 +133,13 @@ public class MappingParserTests extends MapperServiceTestCase {
         );
         assertEquals("Type [alias] cannot be used in multi field", e.getMessage());
     }
+
+    public void testBadMetadataMapper() throws IOException {
+        XContentBuilder builder = topMapping(b -> { b.field(RoutingFieldMapper.NAME, "required"); });
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+        );
+        assertEquals("[_routing] config must be an object", e.getMessage());
+    }
 }


### PR DESCRIPTION
not only `_parent` cause the exception, every meta field that format error will case the exception.