### PR TITLE
[8.0] [ML] Add versioning to native inference indices (#80700)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
@@ -37,8 +37,11 @@ public final class InferenceIndexConstants {
     public static final String INDEX_NAME_PREFIX = ".ml-inference-";
     public static final String INDEX_PATTERN = INDEX_NAME_PREFIX + "*";
     public static final String LATEST_INDEX_NAME = INDEX_NAME_PREFIX + INDEX_VERSION;
-    public static final String NATIVE_DEFINITION_STORE_INDEX_NAME = INDEX_NAME_PREFIX + "native";
     public static final ParseField DOC_TYPE = new ParseField("doc_type");
+
+    private static final String NATIVE_INDEX_PREFIX = INDEX_NAME_PREFIX + "native-";
+    private static final String NATIVE_INDEX_VERSION = "000001";
+    private static final String NATIVE_LATEST_INDEX = NATIVE_INDEX_PREFIX + NATIVE_INDEX_VERSION;
 
     private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
 
@@ -51,7 +54,7 @@ public final class InferenceIndexConstants {
     }
 
     public static String nativeDefinitionStore() {
-        return NATIVE_DEFINITION_STORE_INDEX_NAME;
+        return NATIVE_LATEST_INDEX;
     }
 
     public static Settings settings() {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Add versioning to native inference indices (#80700)