### PR TITLE
[8.0] [DOCS] Remove `timeout` and `master_timeout` parameters from request body (#80708)

### DIFF
--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -79,18 +79,6 @@ You can manually perform this verification using the
 [[put-snapshot-repo-api-request-body]]
 ==== {api-request-body-title}
 
-`master_timeout`::
-(Optional, <<time-units, time units>>)
-Specifies the period of time to wait for
-a connection to the master node. If no response is received before the timeout
-expires, the request fails and returns an error. Defaults to `30s`.
-
-`timeout`::
-(Optional, <<time-units, time units>>)
-Specifies the period of time to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `30s`.
-
 [[put-snapshot-repo-api-request-type]]
 `type`::
 +


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove `timeout` and `master_timeout` parameters from request body (#80708)