### PR TITLE
[geo-ip] Use Optional instead of runtime exceptions for geo-ip misses

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -11,7 +11,6 @@ package org.elasticsearch.ingest.geoip;
 import com.maxmind.db.NoCache;
 import com.maxmind.db.Reader;
 import com.maxmind.geoip2.DatabaseReader;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
 import com.maxmind.geoip2.model.AbstractResponse;
 import com.maxmind.geoip2.model.AsnResponse;
 import com.maxmind.geoip2.model.CityResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -152,16 +153,19 @@ class DatabaseReaderLazyLoader implements Closeable {
         return Files.newInputStream(databasePath);
     }
 
+    @Nullable
     CityResponse getCity(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::city);
+        return getResponse(ipAddress, DatabaseReader::tryCity);
     }
 
+    @Nullable
     CountryResponse getCountry(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::country);
+        return getResponse(ipAddress, DatabaseReader::tryCountry);
     }
 
+    @Nullable
     AsnResponse getAsn(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::asn);
+        return getResponse(ipAddress, DatabaseReader::tryAsn);
     }
 
     boolean preLookup() {
@@ -178,16 +182,15 @@ class DatabaseReaderLazyLoader implements Closeable {
         return currentUsages.get();
     }
 
+    @Nullable
     private <T extends AbstractResponse> T getResponse(
         InetAddress ipAddress,
-        CheckedBiFunction<DatabaseReader, InetAddress, T, Exception> responseProvider
+        CheckedBiFunction<DatabaseReader, InetAddress, Optional<T>, Exception> responseProvider
     ) {
         SpecialPermission.check();
         return AccessController.doPrivileged((PrivilegedAction<T>) () -> cache.putIfAbsent(ipAddress, databasePath.toString(), ip -> {
             try {
-                return responseProvider.apply(get(), ipAddress);
-            } catch (AddressNotFoundException e) {
-                throw new GeoIpProcessor.AddressNotFoundRuntimeException(e);
+                return responseProvider.apply(get(), ipAddress).orElse(null);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -48,7 +48,9 @@ final class GeoIpCache {
         AbstractResponse response = cache.get(cacheKey);
         if (response == null) {
             response = retrieveFunction.apply(ip);
-            cache.put(cacheKey, response);
+            if (response != null) {
+                cache.put(cacheKey, response);
+            }
         }
         return (T) response;
     }


### PR DESCRIPTION
By default MaxMind throws an `AddressNotFoundException` if a lookup was unsuccessful.  
We can't propagate it because of the `SecurityManager`, so we have to wrap it in `AddressNotFoundRuntimeException`.

Catching and re-throwing an exception is quite wasteful. Because of that sometimes geo-ip processors show up from time to time in a list of hot threads on ES clusters.

E.g.:
```
Hot threads at 2021-11-15T15:51:12.452Z, interval=500ms, busiestThreads=10000, ignoreIdleThreads=true:

   19.7% (98.5ms out of 500ms) cpu usage by thread 'elasticsearch[instance-0000000000][write][T#3]'
     2/10 snapshots sharing following 277 elements
       java.base@17/java.lang.Throwable.fillInStackTrace(Native Method)
       java.base@17/java.lang.Throwable.fillInStackTrace(Throwable.java:798)
       java.base@17/java.lang.Throwable.<init>(Throwable.java:316)
       java.base@17/java.lang.Exception.<init>(Exception.java:103)
       java.base@17/java.lang.RuntimeException.<init>(RuntimeException.java:97)
       org.elasticsearch.ingest.geoip.GeoIpProcessor$AddressNotFoundRuntimeException.<init>(GeoIpProcessor.java:468)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.lambda$getResponse$2(DatabaseReaderLazyLoader.java:189)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader$$Lambda$7489/0x0000000801ea0ff0.apply(Unknown Source)
       org.elasticsearch.ingest.geoip.GeoIpCache.putIfAbsent(GeoIpCache.java:47)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.lambda$getResponse$3(DatabaseReaderLazyLoader.java:185)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader$$Lambda$7488/0x0000000801ea0dc8.run(Unknown Source)
       java.base@17/java.security.AccessController.executePrivileged(AccessController.java:776)
       java.base@17/java.security.AccessController.doPrivileged(AccessController.java:318)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.getResponse(DatabaseReaderLazyLoader.java:184)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.getCity(DatabaseReaderLazyLoader.java:156)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.retrieveCityGeoData(GeoIpProcessor.java:207)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.getGeoData(GeoIpProcessor.java:159)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.execute(GeoIpProcessor.java:130)
--
       app//org.elasticsearch.ingest.CompoundProcessor$$Lambda$7471/0x0000000801e93220.accept(Unknown Source)
       app//org.elasticsearch.ingest.Processor.execute(Processor.java:46)
       app//org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:131)
       app//org.elasticsearch.ingest.CompoundProcessor.execute(CompoundProcessor.java:117)
       app//org.elasticsearch.ingest.Pipeline.execute(Pipeline.java:94)
       app//org.elasticsearch.ingest.IngestDocument.executePipeline(IngestDocument.java:765)
       app//org.elasticsearch.ingest.IngestService.innerExecute(IngestService.java:644)
       app//org.elasticsearch.ingest.IngestService.executePipelines(IngestService.java:525)
       app//org.elasticsearch.ingest.IngestService.access$000(IngestService.java:72)
       app//org.elasticsearch.ingest.IngestService$3.doRun(IngestService.java:496)
       app//org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:737)
       app//org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
       java.base@17/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
       java.base@17/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
       java.base@17/java.lang.Thread.run(Thread.java:833)
     2/10 snapshots sharing following 280 elements
       java.base@17/java.lang.Throwable.fillInStackTrace(Native Method)
       java.base@17/java.lang.Throwable.fillInStackTrace(Throwable.java:798)
       java.base@17/java.lang.Throwable.<init>(Throwable.java:271)
       java.base@17/java.lang.Exception.<init>(Exception.java:67)
       com.maxmind.geoip2.exception.GeoIp2Exception.<init>(GeoIp2Exception.java:15)
       com.maxmind.geoip2.exception.AddressNotFoundException.<init>(AddressNotFoundException.java:15)
       com.maxmind.geoip2.DatabaseReader.getOrThrowException(DatabaseReader.java:243)
       com.maxmind.geoip2.DatabaseReader.city(DatabaseReader.java:328)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader$$Lambda$7487/0x0000000801ea0ba8.apply(Unknown Source)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.lambda$getResponse$2(DatabaseReaderLazyLoader.java:187)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader$$Lambda$7489/0x0000000801ea0ff0.apply(Unknown Source)
       org.elasticsearch.ingest.geoip.GeoIpCache.putIfAbsent(GeoIpCache.java:47)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.lambda$getResponse$3(DatabaseReaderLazyLoader.java:185)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader$$Lambda$7488/0x0000000801ea0dc8.run(Unknown Source)
       java.base@17/java.security.AccessController.executePrivileged(AccessController.java:776)
       java.base@17/java.security.AccessController.doPrivileged(AccessController.java:318)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.getResponse(DatabaseReaderLazyLoader.java:184)
       org.elasticsearch.ingest.geoip.DatabaseReaderLazyLoader.getCity(DatabaseReaderLazyLoader.java:156)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.retrieveCityGeoData(GeoIpProcessor.java:207)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.getGeoData(GeoIpProcessor.java:159)
       org.elasticsearch.ingest.geoip.GeoIpProcessor.execute(GeoIpProcessor.java:130)
```

In order to avoid expensive exceptions, MaxMind provides API versions of methods that don't throw them, but return `Optional<Result>`. We can leverage them for checking the control flow instead of relying on exceptions.

