### PR TITLE
Re-enable PluginCliTests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.packaging.test;
 
+import org.apache.http.client.fluent.Request;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
@@ -75,7 +76,7 @@ public class PluginCliTests extends PackagingTestCase {
         // Packaged installation don't get autoconfigured yet
         assertWithExamplePlugin(installResult -> {
             assertWhileRunning(() -> {
-                final String pluginsResponse = makeRequest("https://localhost:9200/_cat/plugins?h=component").strip();
+                final String pluginsResponse = makeRequest("http://localhost:9200/_cat/plugins?h=component").strip();
                 assertThat(pluginsResponse, equalTo(EXAMPLE_PLUGIN_NAME));
             });
         });

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.packaging.test;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
+import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.Before;
 
@@ -58,6 +59,7 @@ public class PluginCliTests extends PackagingTestCase {
 
     public void test10Install() throws Exception {
         install();
+        ServerUtils.disableSecurityFeatures(installation);
         setFileSuperuser("test_superuser", "test_superuser_password");
     }
 
@@ -147,10 +149,10 @@ public class PluginCliTests extends PackagingTestCase {
         try {
             Files.writeString(installation.config("elasticsearch-plugins.yml"), "content doesn't matter for this test");
             Shell.Result result = runElasticsearchStartCommand(null, false, true);
-            assertThat(result.isSuccess(), equalTo(false));
-            assertThat(
-                FileUtils.slurp(installation.logs.resolve("elasticsearch.log")),
-                containsString("Can only use [elasticsearch-plugins.yml] config file with distribution type [docker]")
+            assertElasticsearchFailure(
+                result,
+                "Can only use [elasticsearch-plugins.yml] config file with distribution type [docker]",
+                null
             );
         } finally {
             FileUtils.rm(installation.config("elasticsearch-plugins.yml"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
@@ -146,7 +146,7 @@ public class PluginCliTests extends PackagingTestCase {
     public void test32FailsToStartWhenPluginsConfigExists() throws Exception {
         try {
             Files.writeString(installation.config("elasticsearch-plugins.yml"), "content doesn't matter for this test");
-            Shell.Result result = runElasticsearchStartCommand(null, false,     true);
+            Shell.Result result = runElasticsearchStartCommand(null, false, true);
             assertThat(result.isSuccess(), equalTo(false));
             assertThat(
                 FileUtils.slurp(installation.logs.resolve("elasticsearch.log")),

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.packaging.test;
 
-import org.apache.http.client.fluent.Request;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PluginCliTests.java
@@ -148,7 +148,7 @@ public class PluginCliTests extends PackagingTestCase {
     public void test32FailsToStartWhenPluginsConfigExists() throws Exception {
         try {
             Files.writeString(installation.config("elasticsearch-plugins.yml"), "content doesn't matter for this test");
-            Shell.Result result = runElasticsearchStartCommand(null, false, true);
+            Shell.Result result = runElasticsearchStartCommand(null, false, false);
             assertElasticsearchFailure(
                 result,
                 "Can only use [elasticsearch-plugins.yml] config file with distribution type [docker]",


### PR DESCRIPTION
Fix `PluginCliTests` again. This removed the assertions specific to the `custom-settings` example plugin and fixed some of the assertions in the declarative plugin config tests.