### PR TITLE
[7.16] Fix references to moved classes in plugin examples (#80736)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -163,6 +163,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
         DependencyHandler dependencies = project.getDependencies();
         dependencies.add("compileOnly", "org.elasticsearch:elasticsearch:" + VersionProperties.getElasticsearch());
         dependencies.add("testImplementation", "org.elasticsearch.test:framework:" + VersionProperties.getElasticsearch());
+        dependencies.add("testImplementation", "org.apache.logging.log4j:log4j-core:" + VersionProperties.getVersions().get("log4j"));
 
         // we "upgrade" these optional deps to provided for plugins, since they will run
         // with a full elasticsearch server that includes optional deps

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -19,7 +19,7 @@ subprojects {
   targetCompatibility = 8
 
   repositories {
-    if (gradle.includedBuilds == false) {
+    if (!gradle.includedBuilds) {
       // Only necessary when building plugins against SNAPSHOT versions of Elasticsearch
       maven {
         url = 'https://snapshots.elastic.co/maven/'

--- a/plugins/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/examples/security-authorization-engine/src/javaRestTest/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
+++ b/plugins/examples/security-authorization-engine/src/javaRestTest/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
-import org.elasticsearch.cluster.metadata.IndexAbstraction.Index;
+import org.elasticsearch.cluster.metadata.IndexAbstraction.ConcreteIndex;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -120,11 +120,11 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
     public void testAuthorizeIndexAction() {
         CustomAuthorizationEngine engine = new CustomAuthorizationEngine();
         Map<String, IndexAbstraction> indicesMap = new HashMap<>();
-        indicesMap.put("index", new Index(IndexMetadata.builder("index")
+        indicesMap.put("index", new ConcreteIndex(IndexMetadata.builder("index")
             .settings(Settings.builder().put("index.version.created", Version.CURRENT))
             .numberOfShards(1)
             .numberOfReplicas(0)
-            .build()));
+            .build(), null));
         // authorized
         {
             RequestInfo requestInfo =

--- a/plugins/examples/settings.gradle
+++ b/plugins/examples/settings.gradle
@@ -14,7 +14,7 @@ rootDir.listFiles().findAll { it.directory && new File(it, 'build.gradle').exist
 gradle.rootProject {
   ext {
     // Fetch Elasticsearch version from outer build
-    if (gradle.includedBuilds) {
+    if (!gradle.includedBuilds) {
       new File(rootDir.parentFile.parentFile, 'build-tools-internal/version.properties').withInputStream { is ->
         def props = new Properties()
         props.load(is)


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Fix references to moved classes in plugin examples (#80736)