### PR TITLE
[DOCS] Remove soft limit for snapshot repositories

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -68,7 +68,3 @@ ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref-v:     {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
 endif::[]
-
-// Max recommended snapshots in a snapshot repo.
-// Used in the snapshot/restore docs.
-:max-snapshot-count: 200

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -86,7 +86,6 @@ Time period after which a snapshot is considered expired and eligible for
 deletion. {slm-init} deletes expired snapshots based on the
 <<slm-retention-schedule,`slm.retention_schedule`>>.
 
-// To update {max-snapshot-count}, see docs/Version.asciidoc
 `max_count`::
 (Optional, integer)
 Maximum number of snapshots to retain, even if the snapshots have not yet
@@ -94,9 +93,6 @@ expired. If the number of snapshots in the repository exceeds this limit, the
 policy retains the most recent snapshots and deletes older snapshots. This limit
 only includes snapshots with a <<get-snapshot-api-response-state,`state`>> of
 `SUCCESS`.
-+
-NOTE: This value should not exceed {max-snapshot-count}. See
-<<snapshot-retention-limits>>.
 
 `min_count`::
 (Optional, integer)

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -215,7 +215,7 @@ PUT _slm/policy/nightly-snapshots
     states, see <<back-up-specific-feature-state>>.
 <6> Optional retention rules. This configuration keeps snapshots for 30 days,
     retaining at least 5 and no more than 50 snapshots regardless of age. See
-    <<slm-retention-task>>.
+    <<slm-retention-task>> and <<snapshot-retention-limits>>.
 
 [discrete]
 [[manually-run-slm-policy]]
@@ -267,6 +267,18 @@ POST _slm/_execute_retention
 
 An {slm-init} policy's retention rules only apply to snapshots created using the
 policy. Other snapshots don't count toward the policy's retention limits.
+
+[discrete]
+[[snapshot-retention-limits]]
+==== Snapshot retention limits
+
+We recommend you include retention rules in your {slm-init} policy to delete
+snapshots you no longer need.
+
+A snapshot repository can safely scale to thousands of snapshots. However, to
+manage its metadata, a larger repository requires more memory and disk space on
+the master node. Retention rules ensure a repository's metadata doesn't grow to
+a size that may destabilize the master node.
 
 [discrete]
 [[manually-create-snapshot]]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -277,7 +277,7 @@ snapshots you no longer need.
 
 A snapshot repository can safely scale to thousands of snapshots. However, to
 manage its metadata, a large repository requires more memory on the master node.
-Retention rules ensure a repository's metadata doesn't grow to a size that may
+Retention rules ensure a repository's metadata doesn't grow to a size that could
 destabilize the master node.
 
 [discrete]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -276,7 +276,7 @@ We recommend you include retention rules in your {slm-init} policy to delete
 snapshots you no longer need.
 
 A snapshot repository can safely scale to thousands of snapshots. However, to
-manage its metadata, a larger repository requires more memory and disk space on
+manage its metadata, a large repository requires more memory and disk space on
 the master node. Retention rules ensure a repository's metadata doesn't grow to
 a size that may destabilize the master node.
 

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -276,9 +276,9 @@ We recommend you include retention rules in your {slm-init} policy to delete
 snapshots you no longer need.
 
 A snapshot repository can safely scale to thousands of snapshots. However, to
-manage its metadata, a large repository requires more memory and disk space on
-the master node. Retention rules ensure a repository's metadata doesn't grow to
-a size that may destabilize the master node.
+manage its metadata, a large repository requires more memory on the master node.
+Retention rules ensure a repository's metadata doesn't grow to a size that may
+destabilize the master node.
 
 [discrete]
 [[manually-create-snapshot]]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -215,7 +215,7 @@ PUT _slm/policy/nightly-snapshots
     states, see <<back-up-specific-feature-state>>.
 <6> Optional retention rules. This configuration keeps snapshots for 30 days,
     retaining at least 5 and no more than 50 snapshots regardless of age. See
-    <<slm-retention-task>> and <<snapshot-retention-limits>>.
+    <<slm-retention-task>>.
 
 [discrete]
 [[manually-run-slm-policy]]
@@ -267,15 +267,6 @@ POST _slm/_execute_retention
 
 An {slm-init} policy's retention rules only apply to snapshots created using the
 policy. Other snapshots don't count toward the policy's retention limits.
-
-[discrete]
-[[snapshot-retention-limits]]
-==== Snapshot retention limits
-
-While not a hard limit, a snapshot repository shouldn't contain more than
-{max-snapshot-count} snapshots at a time. This ensures the repository's metadata
-doesn't grow to a size that may destabilize the master node. We recommend you
-set up your {slm-init} policy's retention rules to enforce this limit.
 
 [discrete]
 [[manually-create-snapshot]]
@@ -536,9 +527,7 @@ from a previous week or month.
 To fix this, you can create multiple {slm-init} policies with the same snapshot
 repository that run on different schedules. Since a policy's retention rules
 only apply to its snapshots, a policy won't delete a snapshot created by another
-policy. However, you'll need to ensure the total number of snapshots in the
-repository doesn't exceed the <<snapshot-retention-limits,{max-snapshot-count}
-snapshot soft limit>>.
+policy.
 
 For example, the following {slm-init} policy takes hourly snapshots with a
 maximum of 24 snapshots. The policy keeps its snapshots for one day.


### PR DESCRIPTION
As part of #74350, snapshot repositories no longer have a 200 snapshot soft limit. This removes docs related to the limit from 7.14+ branches.

cc @Leaf-Lin 