### PR TITLE
Granting kibana_system reserved role access to "all" privileges to .preview.alerts* index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -42,6 +42,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
     public static final String ALERTS_LEGACY_INDEX = ".siem-signals*";
     public static final String ALERTS_BACKING_INDEX = ".internal.alerts*";
     public static final String ALERTS_INDEX_ALIAS = ".alerts*";
+    public static final String PREVIEW_ALERTS_INDEX_ALIAS = ".preview.alerts*";
 
     public static final RoleDescriptor SUPERUSER_ROLE_DESCRIPTOR = new RoleDescriptor(
         "superuser",
@@ -674,6 +675,9 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // "Alerts as data" public index aliases used in Security Solution, Observability, etc.
                 // Kibana system user uses them to read / write alerts.
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_INDEX_ALIAS).privileges("all").build(),
+                // "Alerts as data" public index alias used in Security Solution
+                // Kibana system user uses them to read / write alerts.
+                RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.PREVIEW_ALERTS_INDEX_ALIAS).privileges("all").build(),
                 // Endpoint / Fleet policy responses. Kibana requires read access to send telemetry
                 RoleDescriptor.IndicesPrivileges.builder().indices("metrics-endpoint.policy-*").privileges("read").build(),
                 // Endpoint metrics. Kibana requires read access to send telemetry

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -464,7 +464,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".apm-custom-link",
             ReservedRolesStore.ALERTS_LEGACY_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.ALERTS_BACKING_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
-            ReservedRolesStore.ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13))
+            ReservedRolesStore.ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13)),
+            ReservedRolesStore.PREVIEW_ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
 
         // read-only index access, including cross cluster


### PR DESCRIPTION
Required for: https://github.com/elastic/kibana/pull/116374

## Summary
An extension of https://github.com/elastic/elasticsearch/pull/76624. Adding for the new rule preview feature that utilizes alerts as data and a reserved index to write alerts. We are writing to a separate index than normal alerts so they won't show up with standard `.alerts*` queries, but still need the same permissions as "normal" alert indices
