### PR TITLE
Update execute-enrich-policy.asciidoc

### DIFF
--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -87,8 +87,9 @@ Once created, you cannot update
 or index documents to an enrich index.
 Instead, update your source indices
 and <<execute-enrich-policy-api,execute>> the enrich policy again.
-This creates a new enrich index from your updated source indices
-and deletes the previous enrich index.
+This creates a new enrich index from your updated source indices. 
+The previous enrich index will deleted with a delayed maintenance job. 
+By default this is done every 15 minutes. 
 // end::update-enrich-index[]
 
 Because this API request performs several operations,


### PR DESCRIPTION
Changed the wording, as the execution of the policy does not trigger the delete. That delete is done periodical and can be configured with the `enrich.cleanup_period` 

https://www.elastic.co/guide/en/elasticsearch/reference/7.16/enrich-setup.html#ingest-enrich-settings

