### PR TITLE
[7.16] [geo-ip] Use Optional instead of runtime exceptions for geo-ip misses (#80737)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -11,7 +11,6 @@ package org.elasticsearch.ingest.geoip;
 import com.maxmind.db.NoCache;
 import com.maxmind.db.Reader;
 import com.maxmind.geoip2.DatabaseReader;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
 import com.maxmind.geoip2.model.AbstractResponse;
 import com.maxmind.geoip2.model.AsnResponse;
 import com.maxmind.geoip2.model.CityResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -152,16 +153,19 @@ class DatabaseReaderLazyLoader implements Closeable {
         return Files.newInputStream(databasePath);
     }
 
+    @Nullable
     CityResponse getCity(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::city);
+        return getResponse(ipAddress, DatabaseReader::tryCity);
     }
 
+    @Nullable
     CountryResponse getCountry(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::country);
+        return getResponse(ipAddress, DatabaseReader::tryCountry);
     }
 
+    @Nullable
     AsnResponse getAsn(InetAddress ipAddress) {
-        return getResponse(ipAddress, DatabaseReader::asn);
+        return getResponse(ipAddress, DatabaseReader::tryAsn);
     }
 
     boolean preLookup() {
@@ -178,16 +182,15 @@ class DatabaseReaderLazyLoader implements Closeable {
         return currentUsages.get();
     }
 
+    @Nullable
     private <T extends AbstractResponse> T getResponse(
         InetAddress ipAddress,
-        CheckedBiFunction<DatabaseReader, InetAddress, T, Exception> responseProvider
+        CheckedBiFunction<DatabaseReader, InetAddress, Optional<T>, Exception> responseProvider
     ) {
         SpecialPermission.check();
         return AccessController.doPrivileged((PrivilegedAction<T>) () -> cache.putIfAbsent(ipAddress, databasePath.toString(), ip -> {
             try {
-                return responseProvider.apply(get(), ipAddress);
-            } catch (AddressNotFoundException e) {
-                throw new GeoIpProcessor.AddressNotFoundRuntimeException(e);
+                return responseProvider.apply(get(), ipAddress).orElse(null);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -48,7 +48,9 @@ final class GeoIpCache {
         AbstractResponse response = cache.get(cacheKey);
         if (response == null) {
             response = retrieveFunction.apply(ip);
-            cache.put(cacheKey, response);
+            if (response != null) {
+                cache.put(cacheKey, response);
+            }
         }
         return (T) response;
     }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -156,23 +156,13 @@ public final class GeoIpProcessor extends AbstractProcessor {
             final InetAddress ipAddress = InetAddresses.forString(ip);
             Map<String, Object> geoData;
             if (databaseType.endsWith(CITY_DB_SUFFIX)) {
-                try {
-                    geoData = retrieveCityGeoData(lazyLoader, ipAddress);
-                } catch (AddressNotFoundRuntimeException e) {
-                    geoData = Collections.emptyMap();
-                }
+                geoData = retrieveCityGeoData(lazyLoader, ipAddress);
             } else if (databaseType.endsWith(COUNTRY_DB_SUFFIX)) {
-                try {
-                    geoData = retrieveCountryGeoData(lazyLoader, ipAddress);
-                } catch (AddressNotFoundRuntimeException e) {
-                    geoData = Collections.emptyMap();
-                }
+                geoData = retrieveCountryGeoData(lazyLoader, ipAddress);
+
             } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
-                try {
-                    geoData = retrieveAsnGeoData(lazyLoader, ipAddress);
-                } catch (AddressNotFoundRuntimeException e) {
-                    geoData = Collections.emptyMap();
-                }
+                geoData = retrieveAsnGeoData(lazyLoader, ipAddress);
+
             } else {
                 throw new ElasticsearchParseException(
                     "Unsupported database type [" + lazyLoader.getDatabaseType() + "]",
@@ -208,6 +198,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     private Map<String, Object> retrieveCityGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         CityResponse response = lazyLoader.getCity(ipAddress);
+        if (response == null) {
+            return Map.of();
+        }
         Country country = response.getCountry();
         City city = response.getCity();
         Location location = response.getLocation();
@@ -283,6 +276,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     private Map<String, Object> retrieveCountryGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         CountryResponse response = lazyLoader.getCountry(ipAddress);
+        if (response == null) {
+            return Map.of();
+        }
         Country country = response.getCountry();
         Continent continent = response.getContinent();
 
@@ -317,6 +313,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     private Map<String, Object> retrieveAsnGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         AsnResponse response = lazyLoader.getAsn(ipAddress);
+        if (response == null) {
+            return Map.of();
+        }
         Integer asn = response.getAutonomousSystemNumber();
         String organization_name = response.getAutonomousSystemOrganization();
         Network network = response.getNetwork();
@@ -482,17 +481,6 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 ignoreMissing,
                 firstOnly
             );
-        }
-    }
-
-    // Geoip2's AddressNotFoundException is checked and due to the fact that we need run their code
-    // inside a PrivilegedAction code block, we are forced to catch any checked exception and rethrow
-    // it with an unchecked exception.
-    // package private for testing
-    static final class AddressNotFoundRuntimeException extends RuntimeException {
-
-        AddressNotFoundRuntimeException(Throwable cause) {
-            super(cause);
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -199,7 +199,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private Map<String, Object> retrieveCityGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         CityResponse response = lazyLoader.getCity(ipAddress);
         if (response == null) {
-            return Map.of();
+            return Collections.emptyMap();
         }
         Country country = response.getCountry();
         City city = response.getCity();
@@ -277,7 +277,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private Map<String, Object> retrieveCountryGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         CountryResponse response = lazyLoader.getCountry(ipAddress);
         if (response == null) {
-            return Map.of();
+            return Collections.emptyMap();
         }
         Country country = response.getCountry();
         Continent continent = response.getContinent();
@@ -314,7 +314,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private Map<String, Object> retrieveAsnGeoData(DatabaseReaderLazyLoader lazyLoader, InetAddress ipAddress) {
         AsnResponse response = lazyLoader.getAsn(ipAddress);
         if (response == null) {
-            return Map.of();
+            return Collections.emptyMap();
         }
         Integer asn = response.getAutonomousSystemNumber();
         String organization_name = response.getAutonomousSystemOrganization();


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [geo-ip] Use Optional instead of runtime exceptions for geo-ip misses (#80737)