### PR TITLE
Capture task span context in thread context to parent nested tasks

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -32,8 +32,14 @@ public class Task implements TracingPlugin.Traceable {
      * The request header which is contained in HTTP request. We parse trace.id from it and store it in thread context.
      * TRACE_PARENT once parsed in RestController.tryAllHandler is not preserved
      * has to be declared as a header copied over from http request.
+     * May also be used internally when apm plugin is enabled.
      */
     public static final String TRACE_PARENT = "traceparent";
+
+    /**
+     * Is used internally to pass the apm trace context between the nodes
+     */
+    public static final String TRACE_STATE = "tracestate";
 
     /**
      * Parsed part of traceparent. It is stored in thread context and emitted in logs.

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -177,6 +178,30 @@ public class ThreadContextTests extends ESTestCase {
         assertEquals("bar", threadContext.getHeader("foo"));
         assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
+    }
+
+    public void testRemoveHeaders() {
+        Settings build = Settings.builder().put("request.headers.default", "1").build();
+        ThreadContext threadContext = new ThreadContext(build);
+        threadContext.putHeader("h_1", "h_1_value");
+        threadContext.putHeader("h_2", "h_2_value");
+        threadContext.putHeader("h_3", "h_3_value");
+
+        threadContext.putTransient("ctx.transient_1", 1);
+        threadContext.addResponseHeader("resp.header", "baaaam");
+        try (ThreadContext.StoredContext ctx = threadContext.removeRequestHeaders(Set.of("h_1", "h_3"))) {
+            assertThat(threadContext.getHeaders(), equalTo(Map.of("default", "1", "h_2", "h_2_value")));
+            assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.transient_1"));
+            assertEquals("1", threadContext.getHeader("default"));
+            assertEquals(1, threadContext.getResponseHeaders().get("resp.header").size());
+            assertEquals("baaaam", threadContext.getResponseHeaders().get("resp.header").get(0));
+        }
+
+        assertThat(threadContext.getHeaders(), equalTo(Map.of("default", "1", "h_1", "h_1_value", "h_2", "h_2_value", "h_3", "h_3_value")));
+        assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.transient_1"));
+        assertEquals("1", threadContext.getHeader("default"));
+        assertEquals(1, threadContext.getResponseHeaders().get("resp.header").size());
+        assertEquals("baaaam", threadContext.getResponseHeaders().get("resp.header").get(0));
     }
 
     public void testStoreContext() {

--- a/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
+++ b/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
@@ -21,11 +21,14 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskTracer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.TransportService;
+import org.junit.After;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -42,6 +45,11 @@ public class ApmIT extends ESIntegTestCase {
         secureSettings.setString(APMTracer.APM_ENDPOINT_SETTING.getKey(), System.getProperty("tests.apm.endpoint", ""));
         secureSettings.setString(APMTracer.APM_TOKEN_SETTING.getKey(), System.getProperty("tests.apm.token", ""));
         return Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings)).setSecureSettings(secureSettings).build();
+    }
+
+    @After
+    public void clearRecordedSpans() {
+        APMTracer.CAPTURING_SPAN_EXPORTER.clear();
     }
 
     public void testModule() {
@@ -67,5 +75,24 @@ public class ApmIT extends ESIntegTestCase {
             }
         }
         assertTrue(found);
+    }
+
+    public void testRecordsNestedSpans() {
+
+        APMTracer.CAPTURING_SPAN_EXPORTER.clear();// removing start related events
+
+        client().admin().cluster().prepareListTasks().get();
+
+        var parentTasks = APMTracer.CAPTURING_SPAN_EXPORTER.findSpanByName("cluster:monitor/tasks/lists").collect(toList());
+        assertThat(parentTasks, hasSize(1));
+        var parentTask = parentTasks.get(0);
+        assertThat(parentTask.getParentSpanId(), equalTo("0000000000000000"));
+
+        var childrenTasks = APMTracer.CAPTURING_SPAN_EXPORTER.findSpanByName("cluster:monitor/tasks/lists[n]").collect(toList());
+        assertThat(childrenTasks, hasSize(internalCluster().size()));
+        for (SpanData childrenTask : childrenTasks) {
+            assertThat(childrenTask.getParentSpanId(), equalTo(parentTask.getSpanId()));
+            assertThat(childrenTask.getTraceId(), equalTo(parentTask.getTraceId()));
+        }
     }
 }

--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
@@ -232,7 +232,7 @@ public class APMTracer extends AbstractLifecycleComponent implements TracingPlug
         }
 
         public Stream<SpanData> findSpan(Predicate<SpanData> predicate) {
-            return capturedSpans.stream().filter(predicate);
+            return getCapturedSpans().stream().filter(predicate);
         }
 
         public Stream<SpanData> findSpanByName(String name) {


### PR DESCRIPTION
Pass a task's span context via the `ThreadContext` to parent nested tasks.