### PR TITLE
[DOCS] Un-deprecate transient cluster settings

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -48,9 +48,15 @@ PUT /_cluster/settings
 
 An example of a transient update:
 
-// tag::transient-settings-deprecation[]
-deprecated::[7.16,Transient settings are deprecated and will be removed in a future release. Use persistent cluster settings instead. See the <<transient-settings-migration-guide>>.]
-// end::transient-settings-deprecation[]
+// tag::transient-settings-warning[]
+[WARNING]
+====
+We no longer recommend using transient cluster settings. Use persistent cluster
+settings instead. If a cluster becomes unstable, transient settings can clear
+unexpectedly, resulting in a potentially undesired cluster configuration. See
+the <<transient-settings-migration-guide>>.
+====
+// end::transient-settings-warning[]
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -298,22 +298,19 @@ Use `model_size_bytes` instead.
 ==== Settings deprecations
 
 [[deprecate-transient-cluster-settings]]
-.Transient cluster settings are now deprecated.
+.We no longer recommend using transient cluster settings.
 [%collapsible]
 ====
 *Details* +
-Transient cluster settings are now deprecated and will be removed in a future release. This is because transient
-cluster settings have an unpredictable lifecycle. Transient cluster settings do not survive full cluster restarts or
-cluster instability. In these cases, {es} recovers the cluster state
-from persistent storage, effectively erasing the transient settings. The loss of transient settings can happen
-unexpectedly, leading to a potentially undesired cluster configuration.
+We no longer recommend using transient cluster settings. Use persistent cluster
+settings instead. If a cluster becomes unstable, transient settings can clear
+unexpectedly, resulting in an undesired cluster configuration.
 
 *Impact* +
-To avoid deprecation warnings, discontinue use of transient settings when modifying
-your cluster settings through the `PUT _cluster/settings` REST API. Use persistent
-settings instead. See the
+Transient cluster settings are not yet deprecated, but we plan to deprecate them
+in a future release. For migration steps, see the
 {ref}/transient-settings-migration-guide.html[Transient settings migration
-guide]. 
+guide].
 ====
 
 [discrete]

--- a/docs/reference/migration/transient-settings-migration-guide.asciidoc
+++ b/docs/reference/migration/transient-settings-migration-guide.asciidoc
@@ -14,12 +14,12 @@ PUT _cluster/settings
 ----
 ////
 
-Transient cluster settings are deprecated. Previously, you could use transient
+We no longer recommend using transient cluster settings. You can use transient
 settings to make temporary configuration changes to a cluster. However, a
 cluster restart or cluster instability can unexpectedly clear these settings,
 leading to a potentially undesired cluster configuration.
 
-To avoid deprecation warnings, reset any transient settings you've configured on
+To avoid this risk, reset any transient settings you've configured on
 your cluster. Convert any transient setting you'd like to keep to a persistent
 setting, which persists across cluster restarts and cluster instability. You
 should also update any custom workflows and applications to use persistent
@@ -59,8 +59,6 @@ steps.
 . Copy any settings you'd like to convert into the `persistent` object of a
 <<cluster-update-settings,cluster update settings API>> request. In the same
 request, reset any transient settings by assigning them a `null` value.
-+
-NOTE: Resetting transient settings will emit a deprecation warning.
 +
 [source,console]
 ----

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -148,7 +148,7 @@ doesn't require a restart and ensures a setting's value is the same on all
 nodes.
 ====
 
-include::{es-repo-dir}/cluster/update-settings.asciidoc[tag=transient-settings-deprecation]
+include::{es-repo-dir}/cluster/update-settings.asciidoc[tag=transient-settings-warning]
 --
 
 [[static-cluster-setting]]


### PR DESCRIPTION
#80556 reverted the deprecation of transient cluster settings. This replaces deprecation language in the docs with a warning/recommendation to avoid transient settings.

Closes #80557

### Previews
* Cluster update settings API: https://elasticsearch_80766.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/cluster-update-settings.html#cluster-update-settings-api-example
* Cluster and node setting types: https://elasticsearch_80766.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/settings.html#cluster-setting-types
* 7.16 deprecations: https://elasticsearch_80766.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/migrating-7.16.html#breaking_716_settings_deprecations
* Transient settings migration guide: https://elasticsearch_80766.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/transient-settings-migration-guide.html