### PR TITLE
[7.16] [DOCS] Remove soft limit for snapshot repositories (#80745)

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -68,7 +68,3 @@ ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref-v:     {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
 endif::[]
-
-// Max recommended snapshots in a snapshot repo.
-// Used in the snapshot/restore docs.
-:max-snapshot-count: 200

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -86,7 +86,6 @@ Time period after which a snapshot is considered expired and eligible for
 deletion. {slm-init} deletes expired snapshots based on the
 <<slm-retention-schedule,`slm.retention_schedule`>>.
 
-// To update {max-snapshot-count}, see docs/Version.asciidoc
 `max_count`::
 (Optional, integer)
 Maximum number of snapshots to retain, even if the snapshots have not yet
@@ -94,9 +93,6 @@ expired. If the number of snapshots in the repository exceeds this limit, the
 policy retains the most recent snapshots and deletes older snapshots. This limit
 only includes snapshots with a <<get-snapshot-api-response-state,`state`>> of
 `SUCCESS`.
-+
-NOTE: This value should not exceed {max-snapshot-count}. See
-<<snapshot-retention-limits>>.
 
 `min_count`::
 (Optional, integer)

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -272,10 +272,13 @@ policy. Other snapshots don't count toward the policy's retention limits.
 [[snapshot-retention-limits]]
 ==== Snapshot retention limits
 
-While not a hard limit, a snapshot repository shouldn't contain more than
-{max-snapshot-count} snapshots at a time. This ensures the repository's metadata
-doesn't grow to a size that may destabilize the master node. We recommend you
-set up your {slm-init} policy's retention rules to enforce this limit.
+We recommend you include retention rules in your {slm-init} policy to delete
+snapshots you no longer need.
+
+A snapshot repository can safely scale to thousands of snapshots. However, to
+manage its metadata, a large repository requires more memory on the master node.
+Retention rules ensure a repository's metadata doesn't grow to a size that could
+destabilize the master node.
 
 [discrete]
 [[manually-create-snapshot]]
@@ -536,9 +539,7 @@ from a previous week or month.
 To fix this, you can create multiple {slm-init} policies with the same snapshot
 repository that run on different schedules. Since a policy's retention rules
 only apply to its snapshots, a policy won't delete a snapshot created by another
-policy. However, you'll need to ensure the total number of snapshots in the
-repository doesn't exceed the <<snapshot-retention-limits,{max-snapshot-count}
-snapshot soft limit>>.
+policy.
 
 For example, the following {slm-init} policy takes hourly snapshots with a
 maximum of 24 snapshots. The policy keeps its snapshots for one day.


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Remove soft limit for snapshot repositories (#80745)