### PR TITLE
Fix resolution of RPM packages for pre-7.0 versions

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/RpmElasticsearchDistributionType.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/RpmElasticsearchDistributionType.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.gradle.internal.distribution;
 
+import org.elasticsearch.gradle.ElasticsearchDistribution;
 import org.elasticsearch.gradle.ElasticsearchDistributionType;
+import org.elasticsearch.gradle.Version;
 
 public class RpmElasticsearchDistributionType implements ElasticsearchDistributionType {
 
@@ -27,5 +29,10 @@ public class RpmElasticsearchDistributionType implements ElasticsearchDistributi
     @Override
     public boolean isDocker() {
         return false;
+    }
+
+    @Override
+    public String getClassifier(ElasticsearchDistribution.Platform platform, Version version) {
+        return version.onOrAfter("7.0.0") ? ElasticsearchDistributionType.super.getClassifier(platform, version) : "";
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -10,8 +10,10 @@ package org.elasticsearch.packaging.test;
 
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
+import org.elasticsearch.Version;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Packages;
+import org.junit.BeforeClass;
 
 import java.nio.file.Paths;
 
@@ -20,6 +22,7 @@ import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.elasticsearch.packaging.util.ServerUtils.makeRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assume.assumeTrue;
 
 public class PackageUpgradeTests extends PackagingTestCase {
 
@@ -27,6 +30,12 @@ public class PackageUpgradeTests extends PackagingTestCase {
     protected static final Distribution bwcDistribution;
     static {
         bwcDistribution = new Distribution(Paths.get(System.getProperty("tests.bwc-distribution")));
+    }
+
+    @BeforeClass
+    public static void filterVersions() {
+        // These older packages actually can no longer be installed with newer package managers
+        assumeTrue(Version.fromString(bwcDistribution.baseVersion).onOrAfter(Version.V_6_3_0));
     }
 
     public void test10InstallBwcVersion() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -44,6 +44,11 @@ public class Distribution {
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
         this.hasJdk = filename.contains("no-jdk") == false;
         String version = filename.split("-", 3)[1];
+        if (packaging == Packaging.DEB) {
+            version = version.replace(".deb", "");
+        } else if (packaging == Packaging.RPM) {
+            version = version.replace(".rpm", "");
+        }
         this.baseVersion = version;
         if (filename.contains("-SNAPSHOT")) {
             version += "-SNAPSHOT";


### PR DESCRIPTION
Prior to 7.0 we didn't include a classifier on package artifacts. Fix this so we can resolve these for our upgrade tests.