### PR TITLE
[8.0] Allow specifying deprecation level for REST deprecation handler (#80629)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -107,10 +107,20 @@ public class DeprecationLogger {
      * so that it can be returned to the client.
      */
     public DeprecationLogger compatibleCritical(final String key, final String msg, final Object... params) {
-        String opaqueId = HeaderWarning.getXOpaqueId();
-        ESLogMessage deprecationMessage = DeprecatedMessage.compatibleDeprecationMessage(key, opaqueId, msg, params);
-        logger.log(CRITICAL, deprecationMessage);
-        return this;
+        return compatible(CRITICAL, key, msg, params);
     }
 
+    /**
+     * Used for handling previous version RestApiCompatible logic.
+     * Logs a message at the given level
+     * that has been broken in previous version.
+     * The message is also sent to the header warning logger,
+     * so that it can be returned to the client.
+     */
+    public DeprecationLogger compatible(final Level level, final String key, final String msg, final Object... params) {
+        String opaqueId = HeaderWarning.getXOpaqueId();
+        ESLogMessage deprecationMessage = DeprecatedMessage.compatibleDeprecationMessage(key, opaqueId, msg, params);
+        logger.log(level, deprecationMessage);
+        return this;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
@@ -38,8 +39,8 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            Route.builder(POST, "/_template/{name}").deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION).build(),
-            Route.builder(PUT, "/_template/{name}").deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION).build()
+            Route.builder(POST, "/_template/{name}").deprecated(DEPRECATION_WARNING, Level.WARN, DEPRECATION_VERSION).build(),
+            Route.builder(PUT, "/_template/{name}").deprecated(DEPRECATION_WARNING, Level.WARN, DEPRECATION_VERSION).build()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -234,7 +234,8 @@ public class RestControllerTests extends ESTestCase {
 
         // don't want to test everything -- just that it actually wraps the handler
         doCallRealMethod().when(controller).registerHandler(route, handler);
-        doCallRealMethod().when(controller).registerAsDeprecatedHandler(method, path, deprecatedInVersion, handler, deprecationMessage);
+        doCallRealMethod().when(controller)
+            .registerAsDeprecatedHandler(method, path, deprecatedInVersion, handler, deprecationMessage, null);
 
         controller.registerHandler(route, handler);
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Allow specifying deprecation level for REST deprecation handler (#80629)