### PR TITLE
[DOCS] Add query parameters to update datafeed API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -42,14 +42,14 @@ credentials are used instead.
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[ml-update-datafeed-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `allow_no_indices`::
 (Optional, Boolean) If `true`, wildcard indices expressions that resolve into no
 concrete indices are ignored. This includes the `_all` string or when no indices
 are specified. Defaults to `true`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ds-expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -41,6 +41,26 @@ credentials are used instead.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
+[[ml-update-datafeed-query-params]]
+==== {api-query-parms-title}
+
+`allow_no_indices`::
+(Optional, Boolean) If `true`, wildcard indices expressions that resolve into no
+concrete indices are ignored. This includes the `_all` string or when no indices
+are specified. Defaults to `true`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ds-expand-wildcards]
++
+Defaults to `open`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
++
+deprecated:[7.16.0]
+
+`ignore_unavailable`::
+(Optional, Boolean) If `true`, unavailable indices (missing or closed) are
+ignored. Defaults to `false`.
+
 [role="child_attributes"]
 [[ml-update-datafeed-request-body]]
 == {api-request-body-title}


### PR DESCRIPTION
This PR updates the documentation for the [update datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html), since it was missing query parameters. The parameters *do* appear in the [REST API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json).

Relates to https://github.com/elastic/elasticsearch-specification/pull/1026

### Preview

https://elasticsearch_80777.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html#ml-update-datafeed-query-params