### PR TITLE
[DOCS] Update note with create-enrollment-token tool link

### DIFF
--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -45,9 +45,14 @@ and enrollment token.
 . Copy the generated password and enrollment token and save them in a secure
 location. These values are shown only when you start {es} for the first time.
 +
-NOTE: If you need to reset the password for the `elastic` user or other
+[NOTE]
+====
+If you need to reset the password for the `elastic` user or other
 built-in users, run the <<reset-password,`elasticsearch-reset-password`>> tool.
-This tool is available in the {es} `/bin` directory.
+To generate new enrollment tokens for {kib} or {es} nodes, run the
+<<create-enrollment-token,`elasticsearch-create-enrollment-token`>> tool.
+These tools are available in the {es} `bin` directory.
+====
 
 . (Optional) Open a new terminal and verify that you can connect to your {es} 
 cluster by making an authenticated call. Enter the password for the `elastic` 


### PR DESCRIPTION
Updates the note in _Starting the Elastic Stack with security enabled_  after the step for copying the generated password and enrollment token with a link to the `elasticsearch-create-enrollment-token` tool.