### PR TITLE
[7.16] Allow specifying deprecation level for REST deprecation handler (#80629)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
@@ -7,10 +7,12 @@
  */
 package org.elasticsearch.rest;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.Nullable;
 
 import java.util.Objects;
 
@@ -25,6 +27,8 @@ public class DeprecationRestHandler implements RestHandler {
     private final String deprecationMessage;
     private final DeprecationLogger deprecationLogger;
     private final String deprecationKey;
+    @Nullable
+    private final Level deprecationLevel;
 
     /**
      * Create a {@link DeprecationRestHandler} that encapsulates the {@code handler} using the {@code deprecationLogger} to log
@@ -42,6 +46,7 @@ public class DeprecationRestHandler implements RestHandler {
         RestHandler handler,
         RestRequest.Method method,
         String path,
+        @Nullable Level deprecationLevel,
         String deprecationMessage,
         DeprecationLogger deprecationLogger
     ) {
@@ -49,6 +54,12 @@ public class DeprecationRestHandler implements RestHandler {
         this.deprecationMessage = requireValidHeader(deprecationMessage);
         this.deprecationLogger = Objects.requireNonNull(deprecationLogger);
         this.deprecationKey = DEPRECATED_ROUTE_KEY + "_" + method + "_" + path;
+        if (deprecationLevel != null && (deprecationLevel != Level.WARN && deprecationLevel != DeprecationLogger.CRITICAL)) {
+            throw new IllegalArgumentException(
+                "unexpected deprecation logger level: " + deprecationLevel + ", expected either 'CRITICAL' or 'WARN'"
+            );
+        }
+        this.deprecationLevel = deprecationLevel;
     }
 
     /**
@@ -58,7 +69,12 @@ public class DeprecationRestHandler implements RestHandler {
      */
     @Override
     public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
-        deprecationLogger.critical(DeprecationCategory.API, deprecationKey, deprecationMessage);
+        // The default value for deprecated requests without a version warning is CRITICAL
+        if (deprecationLevel == null || deprecationLevel == DeprecationLogger.CRITICAL) {
+            deprecationLogger.critical(DeprecationCategory.API, deprecationKey, deprecationMessage);
+        } else {
+            deprecationLogger.warn(DeprecationCategory.API, deprecationKey, deprecationMessage);
+        }
 
         handler.handleRequest(request, channel, client);
     }

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.rest;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest.Method;
 import org.elasticsearch.xcontent.XContent;
@@ -78,10 +80,19 @@ public interface RestHandler {
         private final RestApiVersion restApiVersion;
 
         private final String deprecationMessage;
+        @Nullable
+        private final Level deprecationLevel;
 
         private final Route replacedRoute;
 
-        private Route(Method method, String path, RestApiVersion restApiVersion, String deprecationMessage, Route replacedRoute) {
+        private Route(
+            Method method,
+            String path,
+            RestApiVersion restApiVersion,
+            String deprecationMessage,
+            Level deprecationLevel,
+            Route replacedRoute
+        ) {
             this.method = Objects.requireNonNull(method);
             this.path = Objects.requireNonNull(path);
             this.restApiVersion = Objects.requireNonNull(restApiVersion);
@@ -89,6 +100,7 @@ public interface RestHandler {
             // a deprecated route will have a deprecation message, and the restApiVersion
             // will represent the version when the route was deprecated
             this.deprecationMessage = deprecationMessage;
+            this.deprecationLevel = deprecationLevel;
 
             // a route that replaces another route will have a reference to the route that was replaced
             this.replacedRoute = replacedRoute;
@@ -103,7 +115,7 @@ public interface RestHandler {
          * @param path   the path, e.g. "/"
          */
         public Route(Method method, String path) {
-            this(method, path, RestApiVersion.current(), null, null);
+            this(method, path, RestApiVersion.current(), null, null, null);
         }
 
         public static class RouteBuilder {
@@ -113,6 +125,8 @@ public interface RestHandler {
             private RestApiVersion restApiVersion;
 
             private String deprecationMessage;
+            @Nullable
+            private Level deprecationLevel;
 
             private Route replacedRoute;
 
@@ -144,6 +158,29 @@ public interface RestHandler {
             }
 
             /**
+             * Marks that the route being built has been deprecated (for some reason -- the deprecationMessage), and notes the major
+             * version in which that deprecation occurred.
+             * <p>
+             * For example:
+             * <pre> {@code
+             * Route.builder(GET, "_upgrade")
+             *  .deprecated("The _upgrade API is no longer useful and will be removed.", RestApiVersion.V_7)
+             *  .build()}</pre>
+             *
+             * @param deprecationMessage the user-visible explanation of this deprecation
+             * @param deprecationLevel the level at which to log the deprecation
+             * @param deprecatedInVersion the major version in which the deprecation occurred
+             * @return a reference to this object.
+             */
+            public RouteBuilder deprecated(String deprecationMessage, Level deprecationLevel, RestApiVersion deprecatedInVersion) {
+                assert this.replacedRoute == null;
+                this.restApiVersion = Objects.requireNonNull(deprecatedInVersion);
+                this.deprecationMessage = Objects.requireNonNull(deprecationMessage);
+                this.deprecationLevel = deprecationLevel;
+                return this;
+            }
+
+            /**
              * Marks that the route being built replaces another route, and notes the major version in which that replacement occurred.
              * <p>
              * For example:
@@ -158,18 +195,18 @@ public interface RestHandler {
              */
             public RouteBuilder replaces(Method method, String path, RestApiVersion replacedInVersion) {
                 assert this.deprecationMessage == null;
-                this.replacedRoute = new Route(method, path, replacedInVersion, null, null);
+                this.replacedRoute = new Route(method, path, replacedInVersion, null, null, null);
                 return this;
             }
 
             public Route build() {
                 if (replacedRoute != null) {
-                    return new Route(method, path, restApiVersion, null, replacedRoute);
+                    return new Route(method, path, restApiVersion, null, null, replacedRoute);
                 } else if (deprecationMessage != null) {
-                    return new Route(method, path, restApiVersion, deprecationMessage, null);
+                    return new Route(method, path, restApiVersion, deprecationMessage, deprecationLevel, null);
                 } else {
                     // this is a little silly, but perfectly legal
-                    return new Route(method, path, restApiVersion, null, null);
+                    return new Route(method, path, restApiVersion, null, null, null);
                 }
             }
         }
@@ -192,6 +229,11 @@ public interface RestHandler {
 
         public String getDeprecationMessage() {
             return deprecationMessage;
+        }
+
+        @Nullable
+        public Level getDeprecationLevel() {
+            return deprecationLevel;
         }
 
         public boolean isDeprecated() {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
@@ -40,8 +41,8 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return org.elasticsearch.core.List.of(
-            Route.builder(POST, "/_template/{name}").deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION).build(),
-            Route.builder(PUT, "/_template/{name}").deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION).build()
+            Route.builder(POST, "/_template/{name}").deprecated(DEPRECATION_WARNING, Level.WARN, DEPRECATION_VERSION).build(),
+            Route.builder(PUT, "/_template/{name}").deprecated(DEPRECATION_WARNING, Level.WARN, DEPRECATION_VERSION).build()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -43,7 +43,7 @@ public class DeprecationRestHandlerTests extends ESTestCase {
     public void testNullHandler() {
         expectThrows(
             NullPointerException.class,
-            () -> new DeprecationRestHandler(null, METHOD, PATH, deprecationMessage, deprecationLogger)
+            () -> new DeprecationRestHandler(null, METHOD, PATH, null, deprecationMessage, deprecationLogger)
         );
     }
 
@@ -52,12 +52,12 @@ public class DeprecationRestHandlerTests extends ESTestCase {
 
         expectThrows(
             IllegalArgumentException.class,
-            () -> new DeprecationRestHandler(handler, METHOD, PATH, invalidDeprecationMessage, deprecationLogger)
+            () -> new DeprecationRestHandler(handler, METHOD, PATH, null, invalidDeprecationMessage, deprecationLogger)
         );
     }
 
     public void testNullDeprecationLogger() {
-        expectThrows(NullPointerException.class, () -> new DeprecationRestHandler(handler, METHOD, PATH, deprecationMessage, null));
+        expectThrows(NullPointerException.class, () -> new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, null));
     }
 
     public void testHandleRequestLogsWarningThenForwards() throws Exception {
@@ -65,7 +65,14 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         RestChannel channel = mock(RestChannel.class);
         NodeClient client = mock(NodeClient.class);
 
-        DeprecationRestHandler deprecatedHandler = new DeprecationRestHandler(handler, METHOD, PATH, deprecationMessage, deprecationLogger);
+        DeprecationRestHandler deprecatedHandler = new DeprecationRestHandler(
+            handler,
+            METHOD,
+            PATH,
+            null,
+            deprecationMessage,
+            deprecationLogger
+        );
 
         // test it
         deprecatedHandler.handleRequest(request, channel, client);
@@ -125,12 +132,12 @@ public class DeprecationRestHandlerTests extends ESTestCase {
 
     public void testSupportsContentStreamTrue() {
         when(handler.supportsContentStream()).thenReturn(true);
-        assertTrue(new DeprecationRestHandler(handler, METHOD, PATH, deprecationMessage, deprecationLogger).supportsContentStream());
+        assertTrue(new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger).supportsContentStream());
     }
 
     public void testSupportsContentStreamFalse() {
         when(handler.supportsContentStream()).thenReturn(false);
-        assertFalse(new DeprecationRestHandler(handler, METHOD, PATH, deprecationMessage, deprecationLogger).supportsContentStream());
+        assertFalse(new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger).supportsContentStream());
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -232,7 +232,7 @@ public class RestControllerTests extends ESTestCase {
 
         // don't want to test everything -- just that it actually wraps the handler
         doCallRealMethod().when(controller).registerHandler(route, handler);
-        doCallRealMethod().when(controller).registerAsDeprecatedHandler(method, path, handler, deprecationMessage);
+        doCallRealMethod().when(controller).registerAsDeprecatedHandler(method, path, handler, deprecationMessage, null);
 
         controller.registerHandler(route, handler);
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Allow specifying deprecation level for REST deprecation handler (#80629)