### PR TITLE
[APM] Add multi-shard search test case

### DIFF
--- a/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
+++ b/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
@@ -10,9 +10,17 @@ package org.elasticsearch.xpack.apm;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.data.SpanData;
 
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.TracingPlugin;
@@ -21,11 +29,14 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskTracer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -54,6 +65,8 @@ public class ApmIT extends ESIntegTestCase {
 
         final Task testTask = new Task(randomNonNegativeLong(), "test", "action", "", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
 
+        APMTracer.CAPTURING_SPAN_EXPORTER.clear();
+
         taskTracer.onTaskRegistered(testTask);
         taskTracer.onTaskUnregistered(testTask);
 
@@ -67,5 +80,83 @@ public class ApmIT extends ESIntegTestCase {
             }
         }
         assertTrue(found);
+    }
+
+    public void testSearch() throws Exception {
+
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        final int nodeCount = internalCluster().numDataNodes();
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("test-matching")
+                .setMapping("{\"properties\":{\"message\":{\"type\":\"text\"},\"@timestamp\":{\"type\":\"date\"}}}")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, nodeCount * 6)
+                )
+        );
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("test-notmatching")
+                .setMapping("{\"properties\":{\"message\":{\"type\":\"text\"},\"@timestamp\":{\"type\":\"date\"}}}")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, nodeCount * 6)
+                )
+        );
+
+        ensureGreen("test-matching", "test-notmatching");
+
+        final String matchingDate = "2021-11-17";
+        final String nonMatchingDate = "2021-01-01";
+
+        final BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 1000; i++) {
+            final boolean isMatching = randomBoolean();
+            final IndexRequestBuilder indexRequestBuilder = client().prepareIndex(isMatching ? "test-matching" : "test-notmatching");
+            indexRequestBuilder.setSource(
+                "{\"@timestamp\":\"" + (isMatching ? matchingDate : nonMatchingDate) + "\",\"message\":\"\"}",
+                XContentType.JSON
+            );
+            bulkRequestBuilder.add(indexRequestBuilder);
+        }
+
+        assertFalse(bulkRequestBuilder.execute().actionGet(10, TimeUnit.SECONDS).hasFailures());
+
+        APMTracer.CAPTURING_SPAN_EXPORTER.clear();
+
+        client().prepareSearch()
+            .setQuery(new RangeQueryBuilder("@timestamp").gt("2021-11-01"))
+            .setSearchType(SearchType.QUERY_THEN_FETCH)
+            .setPreFilterShardSize(1)
+            .execute()
+            .actionGet(10, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+
+            final List<SpanData> capturedSpans = APMTracer.CAPTURING_SPAN_EXPORTER.getCapturedSpans();
+            boolean gotSearchSpan = false;
+            boolean gotCanMatchSpan = false;
+            for (SpanData capturedSpan : capturedSpans) {
+                logger.info("--> captured span [{}]", capturedSpan);
+                final String spanName = capturedSpan.getName();
+                if (spanName.equals(SearchAction.NAME)) {
+                    gotSearchSpan = true;
+                }
+                if (spanName.equals(SearchTransportService.QUERY_CAN_MATCH_NODE_NAME)) {
+                    gotCanMatchSpan = true;
+                }
+            }
+
+            assertTrue(gotSearchSpan);
+            assertTrue(gotCanMatchSpan);
+        });
     }
 }

--- a/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
+++ b/x-pack/plugin/apm-integration/src/internalClusterTest/java/org/elasticsearch/xpack/apm/ApmIT.java
@@ -139,24 +139,21 @@ public class ApmIT extends ESIntegTestCase {
             .execute()
             .actionGet(10, TimeUnit.SECONDS);
 
-        assertBusy(() -> {
-
-            final List<SpanData> capturedSpans = APMTracer.CAPTURING_SPAN_EXPORTER.getCapturedSpans();
-            boolean gotSearchSpan = false;
-            boolean gotCanMatchSpan = false;
-            for (SpanData capturedSpan : capturedSpans) {
-                logger.info("--> captured span [{}]", capturedSpan);
-                final String spanName = capturedSpan.getName();
-                if (spanName.equals(SearchAction.NAME)) {
-                    gotSearchSpan = true;
-                }
-                if (spanName.equals(SearchTransportService.QUERY_CAN_MATCH_NODE_NAME)) {
-                    gotCanMatchSpan = true;
-                }
+        final List<SpanData> capturedSpans = APMTracer.CAPTURING_SPAN_EXPORTER.getCapturedSpans();
+        boolean gotSearchSpan = false;
+        boolean gotCanMatchSpan = false;
+        for (SpanData capturedSpan : capturedSpans) {
+            logger.info("--> captured span [{}]", capturedSpan);
+            final String spanName = capturedSpan.getName();
+            if (spanName.equals(SearchAction.NAME)) {
+                gotSearchSpan = true;
             }
+            if (spanName.equals(SearchTransportService.QUERY_CAN_MATCH_NODE_NAME)) {
+                gotCanMatchSpan = true;
+            }
+        }
 
-            assertTrue(gotSearchSpan);
-            assertTrue(gotCanMatchSpan);
-        });
+        assertTrue(gotSearchSpan);
+        assertTrue(gotCanMatchSpan);
     }
 }

--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
@@ -39,7 +39,6 @@ import org.elasticsearch.plugins.TracingPlugin;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
@@ -223,11 +223,11 @@ public class APMTracer extends AbstractLifecycleComponent implements TracingPlug
 
         private final Queue<SpanData> capturedSpans = ConcurrentCollections.newQueue();
 
-        public synchronized void clear() {
+        public void clear() {
             capturedSpans.clear();
         }
 
-        public synchronized List<SpanData> getCapturedSpans() {
+        public List<SpanData> getCapturedSpans() {
             return List.copyOf(capturedSpans);
         }
 
@@ -248,7 +248,7 @@ public class APMTracer extends AbstractLifecycleComponent implements TracingPlug
         }
 
         @Override
-        public synchronized CompletableResultCode export(Collection<SpanData> spans) {
+        public CompletableResultCode export(Collection<SpanData> spans) {
             capturedSpans.addAll(spans);
             return CompletableResultCode.ofSuccess();
         }


### PR DESCRIPTION
Adds a test case that creates and populates a couple of multi-shard
indices and executes a search against them.