### PR TITLE
Ensure LIBFFI_TMPDIR is exported by init script

### DIFF
--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -76,6 +76,10 @@ export ES_JAVA_HOME
 export JAVA_HOME
 export ES_PATH_CONF
 
+if [ -n "$LIBFFI_TMPDIR" ]; then
+  export LIBFFI_TMPDIR
+fi
+
 if [ ! -x "$DAEMON" ]; then
 	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"
 	exit 1

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -61,6 +61,10 @@ export JAVA_HOME
 export ES_PATH_CONF
 export ES_STARTUP_SLEEP_TIME
 
+if [ -n "$LIBFFI_TMPDIR" ]; then
+  export LIBFFI_TMPDIR
+fi
+
 lockfile=/var/lock/subsys/$prog
 
 if [ ! -x "$exec" ]; then


### PR DESCRIPTION
Change the init.d script that our packages include to explicitly export
LIBFFI_TMPDIR if a value is defined. It turned out that if you
configured a value in `/etc/sysconfig/elasticsearch`, that value was
visible to the `elasticsearch` script but not the Elasticsearch Java
process. Explicitly exporting the variable fixes this problem.