### PR TITLE
Fleet: Add a new mapping for .fleet-agents default_api_key_history field

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -35,6 +35,10 @@
         "default_api_key_id": {
           "type": "keyword"
         },
+        "default_api_key_history": {
+          "type": "object",
+          "enabled": false
+        },
         "enrolled_at": {
           "type": "date"
         },


### PR DESCRIPTION
## What does this PR do?
Adds new ```default_api_key_history``` property in order to be able to store is the history of Elasticsearch API keys for the agent for invalidation upon policy acknowledgement from the agent later on.
This field doesn't need to be indexed.

This change is prerequisite to the fleet server feature:
https://github.com/elastic/fleet-server/pull/884

## Related issues
- Relates: https://github.com/elastic/fleet-server/pull/884

## Screenshots

Populated ```default_api_key_history``` property :
<img width="433" alt="Screen Shot 2021-11-17 at 10 20 16 AM" src="https://user-images.githubusercontent.com/872351/142266597-200ecaba-4d7d-41bf-bc45-939a0b2073a6.png">

