### PR TITLE
Change Docker quickstart to only bind to localhost

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -46,7 +46,7 @@ To start a single-node {es} cluster for development or testing, specify
 
 [source,sh,subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
+docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -21,7 +21,7 @@ Desktop].
 ----
 docker network create elastic
 docker pull {docker-repo}:{version}
-docker run --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
+docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 ----
 endif::[]
 
@@ -40,7 +40,7 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","txt",subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib01-test --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
+docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
 ----
 
 . To access {kib}, go to http://localhost:5601[http://localhost:5601]


### PR DESCRIPTION
Under the [wrong circumstances](https://twitter.com/gnyman/status/1441073513457233928) our quickstart will expose Elasticsearch and Kibana to the internet, which is rather surprising and what we avoid with our other defaults / setups.
[Discussed](https://twitter.com/gnyman/status/1441119091645812742) [multiple](https://twitter.com/xeraa/status/1441164987049803787) [times](https://twitter.com/hmoffatt/status/1461067219647885315), we should explicitly bind to localhost to avoid such surprises. Those who know Docker reasonably well will be able to change it without problems and those who don't know Docker are probably better off like this.

Since this has changed in 8.0, but we'll have 7.16 around for a long time, I've only committed the change to the 7.16 branch.