### PR TITLE
Improve single-node watermark deprecation checks

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -649,14 +649,19 @@ class NodeDeprecationChecks {
         if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
             && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
+            String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 String.format(Locale.ROOT, "Setting [%s=false] is deprecated", key),
                 "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting",
                 String.format(
                     Locale.ROOT,
-                    "Remove the [%s] setting. Disk watermarks are always enabled for single node clusters in 8.0.",
-                    key
+                    "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, and [%s] may not be set to "
+                        + "[false] in these versions. Set [%s] to [true] to adopt the future behavior before upgrading. "
+                        + "If desired you may also set [%s] to [false] to completely disable disk-based allocation.",
+                    key,
+                    key,
+                    disableDiskDecider
                 ),
                 false,
                 null
@@ -669,18 +674,15 @@ class NodeDeprecationChecks {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
             String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
             return new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
-                String.format(
-                    Locale.ROOT,
-                    "Disabling disk watermarks for single node clusters is deprecated and no longer the default",
-                    key
-                ),
+                DeprecationIssue.Level.WARNING,
+                "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later.",
                 "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting",
                 String.format(
                     Locale.ROOT,
-                    "Disk watermarks are always enabled in 8.0, which will affect the behavior of this single node"
-                        + " cluster when you upgrade. You can set \"%s\" to false to disable"
-                        + " disk based allocation.",
+                    "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the "
+                        + "behavior of this cluster. Set [%s] to [true] to adopt the future behaviour before upgrading. "
+                        + "If desired you may also set [%s] to [false] to completely disable disk-based allocation.",
+                    key,
                     disableDiskDecider
                 ),
                 false,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -649,7 +649,6 @@ class NodeDeprecationChecks {
         if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
             && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
-            String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 String.format(Locale.ROOT, "Setting [%s=false] is deprecated", key),
@@ -657,11 +656,9 @@ class NodeDeprecationChecks {
                 String.format(
                     Locale.ROOT,
                     "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, and [%s] may not be set to "
-                        + "[false] in these versions. Set [%s] to [true] to adopt the future behavior before upgrading. "
-                        + "If desired you may also set [%s] to [false] to completely disable disk-based allocation.",
+                        + "[false] in these versions. Set [%s] to [true] to adopt the future behavior before upgrading.",
                     key,
-                    key,
-                    disableDiskDecider
+                    key
                 ),
                 false,
                 null
@@ -672,7 +669,6 @@ class NodeDeprecationChecks {
             && clusterState.getNodes().getDataNodes().size() == 1
             && clusterState.getNodes().getLocalNode().isMasterNode()) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
-            String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later.",
@@ -680,10 +676,8 @@ class NodeDeprecationChecks {
                 String.format(
                     Locale.ROOT,
                     "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the "
-                        + "behavior of this cluster. Set [%s] to [true] to adopt the future behavior before upgrading. "
-                        + "If desired you may also set [%s] to [false] to completely disable disk-based allocation.",
-                    key,
-                    disableDiskDecider
+                        + "behavior of this cluster. Set [%s] to [true] to adopt the future behavior before upgrading.",
+                    key
                 ),
                 false,
                 null

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.coordination.DiscoveryUpgradeService;
 import org.elasticsearch.cluster.coordination.JoinHelper;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
-import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -680,7 +680,7 @@ class NodeDeprecationChecks {
                 String.format(
                     Locale.ROOT,
                     "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the "
-                        + "behavior of this cluster. Set [%s] to [true] to adopt the future behaviour before upgrading. "
+                        + "behavior of this cluster. Set [%s] to [true] to adopt the future behavior before upgrading. "
                         + "If desired you may also set [%s] to [false] to completely disable disk-based allocation.",
                     key,
                     disableDiskDecider

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -816,7 +816,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             expectedUrl,
             "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the behavior of "
                 + "this cluster. Set [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] to [true] to adopt the future "
-                + "behaviour before upgrading. If desired you may also set [cluster.routing.allocation.disk.threshold_enabled] to [false] "
+                + "behavior before upgrading. If desired you may also set [cluster.routing.allocation.disk.threshold_enabled] to [false] "
                 + "to completely disable disk-based allocation.",
             false,
             null

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -778,8 +778,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                     "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, and "
                         + "[cluster.routing.allocation.disk.watermark.enable_for_single_data_node] may not be set to [false] in these "
                         + "versions. Set [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] to [true] to adopt the "
-                        + "future behavior before upgrading. If desired you may also set "
-                        + "[cluster.routing.allocation.disk.threshold_enabled] to [false] to completely disable disk-based allocation.",
+                        + "future behavior before upgrading.",
                     false,
                     null
                 )
@@ -816,8 +815,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             expectedUrl,
             "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the behavior of "
                 + "this cluster. Set [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] to [true] to adopt the future "
-                + "behavior before upgrading. If desired you may also set [cluster.routing.allocation.disk.threshold_enabled] to [false] "
-                + "to completely disable disk-based allocation.",
+                + "behavior before upgrading.",
             false,
             null
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -775,8 +775,11 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                     DeprecationIssue.Level.CRITICAL,
                     "Setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated",
                     expectedUrl,
-                    "Remove the [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] setting. Disk watermarks"
-                        + " are always enabled for single node clusters in 8.0.",
+                    "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, and "
+                        + "[cluster.routing.allocation.disk.watermark.enable_for_single_data_node] may not be set to [false] in these "
+                        + "versions. Set [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] to [true] to adopt the "
+                        + "future behavior before upgrading. If desired you may also set "
+                        + "[cluster.routing.allocation.disk.threshold_enabled] to [false] to completely disable disk-based allocation.",
                     false,
                     null
                 )
@@ -808,11 +811,13 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         final String expectedUrl = "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting";
         DeprecationIssue deprecationIssue = new DeprecationIssue(
-            DeprecationIssue.Level.CRITICAL,
-            "Disabling disk watermarks for single node clusters is deprecated and no longer the default",
+            DeprecationIssue.Level.WARNING,
+            "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later.",
             expectedUrl,
-            "Disk watermarks are always enabled in 8.0, which will affect the behavior of this single node cluster when you upgrade. You "
-                + "can set \"cluster.routing.allocation.disk.threshold_enabled\" to false to disable disk based allocation.",
+            "Disk watermarks do not treat single-node clusters differently in versions 8.0 and later, which will affect the behavior of "
+                + "this cluster. Set [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] to [true] to adopt the future "
+                + "behaviour before upgrading. If desired you may also set [cluster.routing.allocation.disk.threshold_enabled] to [false] "
+                + "to completely disable disk-based allocation.",
             false,
             null
         );


### PR DESCRIPTION
Adjusts the wording of the deprecation checks regarding the
`cluster.routing.allocation.disk.watermark.enable_for_single_data_node`
setting to clarify the action that is needed. Also reduces the level of
the check if the default behaviour is in use.

Closes #80817