### PR TITLE
Revert "Allow deprecation warning for the return_200_for_cluster_health_timeout parameter (#80178)"

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.health/20_request_timeout.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.health/20_request_timeout.yml
@@ -45,10 +45,7 @@
   - skip:
       version: " - 7.15.99"
       reason: "return_200_for_cluster_health_timeout was added in 7.16"
-      features: [ "allowed_warnings" ]
   - do:
-      allowed_warnings:
-        - 'the [return_200_for_cluster_health_timeout] parameter is deprecated and will be removed in a future release.'
       cluster.health:
         timeout: 1ms
         wait_for_active_shards: 5


### PR DESCRIPTION

This reverts commit 1c711e35fcb957f9a2fa1f1dbeebb8d3afb144a0.

