### PR TITLE
[7.13] [DOCS] Change Docker quickstart to only bind to localhost (#80812)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -48,7 +48,7 @@ To start a single-node {es} cluster for development or testing, specify
 
 [source,sh,subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
+docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -21,7 +21,7 @@ Desktop].
 ----
 docker network create elastic
 docker pull {docker-repo}:{version}
-docker run --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
+docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 ----
 endif::[]
 
@@ -40,7 +40,7 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","txt",subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib01-test --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
+docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
 ----
 
 . To access {kib}, go to http://localhost:5601[http://localhost:5601]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Change Docker quickstart to only bind to localhost (#80812)