### PR TITLE
[8.0] Fleet: Add a new mapping for .fleet-agents default_api_key_history field (#80803)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -35,6 +35,10 @@
         "default_api_key_id": {
           "type": "keyword"
         },
+        "default_api_key_history": {
+          "type": "object",
+          "enabled": false
+        },
         "enrolled_at": {
           "type": "date"
         },


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fleet: Add a new mapping for .fleet-agents default_api_key_history field (#80803)