### PR TITLE
Changing deprecation info api message for templates with mappings with a single custom type to warning level

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -236,7 +236,7 @@ public class ClusterDeprecationChecks {
             deprecationIssue = null;
         } else if (templatesWithMultipleTypes.isEmpty()) {
             deprecationIssue = new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
+                DeprecationIssue.Level.WARNING,
                 "Custom mapping types in index templates are deprecated",
                 "https://ela.st/es-deprecation-7-custom-types",
                 "Update or remove the following index templates before upgrading to 8.0: "


### PR DESCRIPTION
Custom types in templates do not cause a server to fail to come up. So this commit takes the level of the
deprecation info API message down from critical to warning.
Relates #80676