### PR TITLE
Hide TransportChannel#logger

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.action.support;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequest;
@@ -16,6 +19,8 @@ import org.elasticsearch.transport.TransportResponse;
 public final class ChannelActionListener<Response extends TransportResponse, Request extends TransportRequest>
     implements
         ActionListener<Response> {
+
+    private static final Logger logger = LogManager.getLogger();
 
     private final TransportChannel channel;
     private final Request request;
@@ -38,7 +43,15 @@ public final class ChannelActionListener<Response extends TransportResponse, Req
 
     @Override
     public void onFailure(Exception e) {
-        TransportChannel.sendErrorResponse(channel, actionName, request, e);
+        try {
+            channel.sendResponse(e);
+        } catch (Exception sendException) {
+            sendException.addSuppressed(e);
+            logger.warn(
+                () -> new ParameterizedMessage("Failed to send error response for action [{}] and request [{}]", actionName, request),
+                sendException
+            );
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.transport;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 
 import java.io.IOException;
@@ -19,8 +16,6 @@ import java.io.IOException;
  * A transport channel allows to send a response to a request on the channel.
  */
 public interface TransportChannel {
-
-    Logger logger = LogManager.getLogger(TransportChannel.class);
 
     String getProfileName();
 
@@ -35,20 +30,5 @@ public interface TransportChannel {
      */
     default Version getVersion() {
         return Version.CURRENT;
-    }
-
-    /**
-     * A helper method to send an exception and handle and log a subsequent exception
-     */
-    static void sendErrorResponse(TransportChannel channel, String actionName, TransportRequest request, Exception e) {
-        try {
-            channel.sendResponse(e);
-        } catch (Exception sendException) {
-            sendException.addSuppressed(e);
-            logger.warn(
-                () -> new ParameterizedMessage("Failed to send error response for action [{}] and request [{}]", actionName, request),
-                sendException
-            );
-        }
     }
 }


### PR DESCRIPTION
In #57573 we introduced a `public static Logger logger` field in
`TransportChannel` which some IDEs tend to automatically import if you
mention an as-yet-undeclared `logger` field. This commit reverts that
small part of #57573 so that we go back to using a private logger
belonging to `ChannelActionListener` instead.