### PR TITLE
Add `xpack.apm.tracing.names.include` setting for filtering

### DIFF
--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APM.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APM.java
@@ -68,7 +68,12 @@ public class APM extends Plugin implements NetworkPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(APMTracer.APM_ENABLED_SETTING, APMTracer.APM_ENDPOINT_SETTING, APMTracer.APM_TOKEN_SETTING);
+        return List.of(
+            APMTracer.APM_ENABLED_SETTING,
+            APMTracer.APM_ENDPOINT_SETTING,
+            APMTracer.APM_TOKEN_SETTING,
+            APMTracer.APM_TRACING_NAMES_INCLUDE_SETTING
+        );
     }
 
     public List<TransportInterceptor> getTransportInterceptors(NamedWriteableRegistry namedWriteableRegistry, ThreadContext threadContext) {


### PR DESCRIPTION
This commit adds a dynamic cluster setting called `xpack.apm.tracing.names.include`
which allows the user to filter on the names of the transactions for which
tracing is enabled.
