### PR TITLE
[ML] Remove distributed jobs test trace logging

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -44,8 +44,6 @@ import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -65,39 +63,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
-
-    @Before
-    // upping the logging due to potential failures in: https://github.com/elastic/elasticsearch/issues/63980
-    public void setLogging() {
-        client().admin()
-            .cluster()
-            .prepareUpdateSettings()
-            .setPersistentSettings(
-                Settings.builder()
-                    .put("logger.org.elasticsearch.xpack.ml.action.TransportCloseJobAction", "TRACE")
-                    .put("logger.org.elasticsearch.xpack.ml.action.TransportOpenJobAction", "TRACE")
-                    .put("logger.org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor", "TRACE")
-                    .put("logger.org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager", "TRACE")
-                    .build()
-            )
-            .get();
-    }
-
-    @After
-    public void unsetLogging() {
-        client().admin()
-            .cluster()
-            .prepareUpdateSettings()
-            .setPersistentSettings(
-                Settings.builder()
-                    .putNull("logger.org.elasticsearch.xpack.ml.action.TransportCloseJobAction")
-                    .putNull("logger.org.elasticsearch.xpack.ml.action.TransportOpenJobAction")
-                    .putNull("logger.org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor")
-                    .putNull("logger.org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager")
-                    .build()
-            )
-            .get();
-    }
 
     public void testFailOverBasics() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(4);


### PR DESCRIPTION
There has been trace logging in BasicDistributedJobsIT for #63980
since February. This was added in #69198, on the basis that #69136
had probably fixed a problem but if not then the trace logging
would be useful. Since the tests have not been failing since they
were reenabled this logging can now be removed.