### PR TITLE
[Experiment] Old object sampling when we near Out of Memory 

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -158,13 +158,19 @@ public class HotThreads {
         return this;
     }
 
+    List<Integer[]> damnedList = new ArrayList<>();
+
     public String detect() throws Exception {
-        synchronized (mutex) {
+        for (;;) {
+            damnedList.add(new Integer[500_000]);
+            Thread.sleep(500);
+        }
+        /*synchronized (mutex) {
             return innerDetect(ManagementFactory.getThreadMXBean(), SunThreadInfo.INSTANCE, Thread.currentThread().getId(), (interval) -> {
                 Thread.sleep(interval);
                 return null;
             });
-        }
+        }*/
     }
 
     static boolean isKnownJDKThread(ThreadInfo threadInfo) {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -162,7 +162,7 @@ public class HotThreads {
 
     public String detect() throws Exception {
         for (;;) {
-            damnedList.add(new Integer[500_000]);
+            damnedList.add(new Integer[250_000]);
             Thread.sleep(500);
         }
         /*synchronized (mutex) {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -66,7 +67,7 @@ public class OldObjectsSampler {
                 logger.warn("Sampling result {}/{}", counter+1, NUM_SAMPLES);
                 if (events.isEmpty() == false) {
                     Map<RecordedEvent, Long> coalesced = coalesce(events);
-                    coalesced.entrySet().forEach(e -> {
+                    coalesced.entrySet().stream().sorted(Collections.reverseOrder(Map.Entry.comparingByValue())).forEach(e -> {
                         logger.warn("{} instances of:", e.getValue());
                         logger.warn(e.getKey());
                     });

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.monitor.jvm;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class OldObjectsSampler {
+    private static final int NUM_SAMPLES = 3;
+    private static final int SAMPLER_DELAY = 3_000;
+    private static final Logger logger = LogManager.getLogger(OldObjectsSampler.class);
+    private static final AtomicBoolean samplingOn = new AtomicBoolean();
+
+    private static List<RecordedEvent> fromRecording(Recording recording) throws IOException {
+        return RecordingFile.readAllEvents(dump(recording));
+    }
+
+    private static Path dump(Recording recording) throws IOException {
+        Path p = recording.getDestination();
+        if (p == null) {
+            File directory = new File(".");
+            ProcessHandle h = ProcessHandle.current();
+            p = new File(directory.getAbsolutePath(), "recording-" + recording.getId() + "-pid" + h.pid() + ".jfr").toPath();
+            recording.dump(p);
+        }
+        return p;
+    }
+
+    public static void dumpMemoryHogSuspects() throws IOException {
+        if (samplingOn.compareAndSet(false, true) == false) {
+            // Already sampling from a previous OOM event
+            return;
+        }
+        try {
+            for (int counter = 0; counter < NUM_SAMPLES; counter++) {
+                try (Recording r = new Recording()) {
+                    r.enable("jdk.OldObjectSample").withStackTrace().with("cutoff", "infinity");
+                    r.start();
+                    try {
+                        Thread.sleep(SAMPLER_DELAY);
+                    } catch (Exception ignore) {}
+                    r.stop();
+                    List<RecordedEvent> events = fromRecording(r);
+                    if (events.isEmpty() == false) {
+                        logger.warn("Sampling result {}/{}", counter+1, NUM_SAMPLES);
+                        logger.warn(events);
+                    }
+                }
+            }
+        } finally {
+            samplingOn.set(false);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/OldObjectsSampler.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -22,6 +22,10 @@ grant codeBase "${codebase.elasticsearch-secure-sm}" {
 grant codeBase "${codebase.elasticsearch}" {
   // needed for loading plugins which may expect the context class loader to be set
   permission java.lang.RuntimePermission "setContextClassLoader";
+  permission java.lang.management.ManagementPermission "control";
+  permission jdk.jfr.FlightRecorderPermission "accessFlightRecorder";
+  permission java.lang.RuntimePermission "manageProcess";
+  permission java.io.FilePermission "<<ALL FILES>>", "read, write";
 };
 
 //// Very special jar permissions:

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -62,6 +62,8 @@ grant codeBase "${codebase.jna}" {
 grant {
   // needed by vendored Guice
   permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.annotation";
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.event";
+  permission java.lang.RuntimePermission "getClassLoader";
 
   // checked by scripting engines, and before hacks and other issues in
   // third party code, to safeguard these against unprivileged code like scripts.


### PR DESCRIPTION
**Do not merge**

This PR is a pure experimental code that uses the JFR old object sampling events to capture a list of suspect allocations, that might be leading to an Out of Memory error. In it's basic form the code does the following:

- It installs a GC tenured area event notification for a given threshold of available memory. When the tenured (old object) area in the heap reaches this threshold, the JVM will send us a notification saying we are there.
- Upon receiving a low memory event from the JVM, we trigger the JFR sampling looking for objects that are allocated and rooted into old objects. We sample periodically, for a prolonged period of time to be able to truly capture the culprits. The longer the sampling period is, the higher the chances are that we'll find the source of heap exhaustion.