### PR TITLE
Fix typo in gap_policy's default value for Serial differencing aggregation

### DIFF
--- a/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
@@ -57,7 +57,7 @@ A `serial_diff` aggregation looks like this in isolation:
 |`buckets_path` |Path to the metric of interest (see <<buckets-path-syntax, `buckets_path` Syntax>> for more details |Required |
 |`lag` |The historical bucket to subtract from the current value. E.g. a lag of 7 will subtract the current value from
  the value 7 buckets ago. Must be a positive, non-zero integer |Optional |`1`
-|`gap_policy` |Determines what should happen when a gap in the data is encountered. |Optional |`insert_zero`
+|`gap_policy` |Determines what should happen when a gap in the data is encountered. |Optional |`insert_zeros`
 |`format` |Format to apply to the output value of this aggregation |Optional | `null`
 |===
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/MlAggsHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/MlAggsHelper.java
@@ -32,7 +32,7 @@ public final class MlAggsHelper {
     /**
      * This extracts the bucket values as doubles from the passed aggregations.
      *
-     * The gap policy is always `INSERT_ZERO`
+     * The gap policy is always `INSERT_ZEROS`
      * @param bucketPath The bucket path from which to extract values
      * @param aggregations The aggregations
      * @return The double values and doc_counts extracted from the path if the bucket path exists and the value is a valid number


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/blob/bf57b7426ea57c28711cf21987af12aff29dced9/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java#L42