### PR TITLE
[ML] No need to use parent task client when internal infer delegates

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.core.TimeValue;
@@ -190,9 +189,9 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             Collections.singletonList(doc),
             TimeValue.MAX_VALUE
         );
-        request.setParentTaskId(taskId);
+        request.setParentTask(taskId);
         executeAsyncWithOrigin(
-            new ParentTaskAssigningClient(client, taskId),
+            client,
             ML_ORIGIN,
             InferTrainedModelDeploymentAction.INSTANCE,
             request,


### PR DESCRIPTION
In #80731 the infer trained model task was correctly set to have as
parent task the internal infer action task when called from there.
However, it was done by both setting `Request.setParentTaskId` and
using a `ParentTaskAssigningClient`. There is no need to use a
parent task client. Instead, to set the parent task on the request
we should use `setParentTask` instead of `setParentTaskId` which
effectively sets the target task for a `BaseTasksRequest`.

The confusion of `BaseTasksRequest` holding two fields both names
`parentTaskId` and having two methods both setting the parent task
id will be addressed in a separate PR.
