### PR TITLE
[7.16] [DOCS] Adds missing query parameters to ML APIs (#80863)

### DIFF
--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -44,7 +44,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-jobs]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -45,7 +45,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-datafeeds]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -30,10 +30,6 @@ A job can be opened and closed multiple times throughout its lifecycle.
 A closed job cannot receive data or perform analysis operations, but you can
 still explore and navigate results.
 
-You can close multiple {anomaly-jobs} in a single API request by using a group
-name, a comma-separated list of jobs, or a wildcard expression. You can close
-all jobs by using `_all` or by specifying `*` as the `<job_id>`.
-
 If you close an {anomaly-job} whose {dfeed} is running, the request first tries
 to stop the {dfeed}. This behavior is equivalent to calling
 <<ml-stop-datafeed,stop {dfeed}>> with the same `timeout` and `force` parameters
@@ -64,6 +60,9 @@ results the job might have recently produced or might produce in the future.
 `<job_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard]
++
+You can close all jobs by using `_all` or by specifying `*` as the job
+identifier.
 
 [[ml-close-job-query-parms]]
 == {api-query-parms-title}
@@ -73,7 +72,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildca
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-jobs]
 
 `force`::
 (Optional, Boolean) Use to close a failed job, or to forcefully close a job
@@ -82,6 +81,12 @@ which has not responded to its initial close request.
 `timeout`::
 (Optional, <<time-units, time units>>) Controls the time to wait until a job 
 has closed. The default value is 30 minutes.
+
+[[ml-close-job-request-body]]
+== {api-request-body-title}
+
+You can also specify the query parameters (such as `allow_no_match` and `force`)
+in the request body.
 
 [[ml-close-job-response-codes]]
 == {api-response-codes-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -23,11 +23,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-calendar-event-desc]]
 == {api-description-title}
 
-You can get scheduled event information for multiple calendars in a single
-API request by using a comma-separated list of ids or a wildcard expression.
-You can get scheduled event information for all calendars by using `_all` or `*`
-as the `<calendar_id>`.
-
 For more information, see
 {ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
@@ -37,6 +32,11 @@ For more information, see
 `<calendar_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
++
+You can get scheduled event information for multiple calendars in a single
+API request by using a comma-separated list of ids or a wildcard expression.
+You can get scheduled event information for all calendars by using `_all` or `*`
+as the calendar identifier.
 
 [[ml-get-calendar-event-query-parms]]
 == {api-query-parms-title}
@@ -63,15 +63,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 [[ml-get-calendar-event-request-body]]
 == {api-request-body-title}
 
-`end`::
-    (Optional, string) Specifies to get events with timestamps earlier than this
-    time. Defaults to unset, which means results are not
-    limited to specific timestamps.
-
-`job_id`::
-    (Optional, string) Specifies to get events for a specific {anomaly-job}
-    identifier or job group. It must be used with a calendar identifier of `_all`
-    or `*`.
+You can also specify some of the query parameters (such as `end` and
+`job_id`) in the request body.
 
 `page.from`::
     (Optional, integer) Skips the specified number of events. Defaults to `0`.
@@ -79,11 +72,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 `page.size`::
     (Optional, integer) Specifies the maximum number of events to obtain.
     Defaults to `100`.
-
-`start`::
-    (Optional, string) Specifies to get events with timestamps after this time.
-    Defaults to unset, which means results are not limited to specific
-    timestamps.
 
 [[ml-get-calendar-event-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -23,11 +23,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-calendar-desc]]
 == {api-description-title}
 
-You can get information for multiple calendars in a single API request by using a
-comma-separated list of ids or a wildcard expression. You can get
-information for all calendars by using `_all`, by specifying `*` as the
-`<calendar_id>`, or by omitting the `<calendar_id>`.
-
 For more information, see
 {ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
@@ -37,6 +32,11 @@ For more information, see
 `<calendar_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
++
+You can get information for multiple calendars in a single API request by using
+a comma-separated list of ids or a wildcard expression. You can get information
+for all calendars by using `_all`, by specifying `*` as the calendar identifier,
+or by omitting the identifier.
 
 [[ml-get-calendar-query-parms]]
 == {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -66,15 +66,15 @@ Defaults to `100`.
 [[ml-get-category-request-body]]
 == {api-request-body-title}
 
+You can also specify the `partition_field_value` query parameter in the
+request body.
+
 `page`.`from`::
 (Optional, integer) Skips the specified number of categories. Defaults to `0`.
 
 `page`.`size`::
 (Optional, integer) Specifies the maximum number of categories to obtain. 
 Defaults to `100`.
-
-`partition_field_value`::
-(Optional, string) Only return categories for the specified partition.
 
 [[ml-get-category-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -29,11 +29,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-datafeed-stats-desc]]
 == {api-description-title}
 
-You can get statistics for multiple {dfeeds} in a single API request by using a
-comma-separated list of {dfeeds} or a wildcard expression. You can get
-statistics for all {dfeeds} by using `_all`, by specifying `*` as the
-`<feed_id>`, or by omitting the `<feed_id>`.
-
 If the {dfeed} is stopped, the only information you receive is the
 `datafeed_id` and the `state`.
 
@@ -46,10 +41,10 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 +
---
-If you do not specify one of these options, the API returns information about
-all {dfeeds}.
---
+You can get statistics for multiple {dfeeds} in a single API request by using a
+comma-separated list of {dfeeds} or a wildcard expression. You can get
+statistics for all {dfeeds} by using `_all`, by specifying `*` as the {dfeed}
+identifier, or by omitting the identifier.
 
 [[ml-get-datafeed-stats-query-parms]]
 == {api-query-parms-title}
@@ -59,7 +54,7 @@ all {dfeeds}.
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-datafeeds]
 
 [role="child_attributes"]
 [[ml-get-datafeed-stats-results]]

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -29,11 +29,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-datafeed-desc]]
 == {api-description-title}
 
-You can get information for multiple {dfeeds} in a single API request by using a
-comma-separated list of {dfeeds} or a wildcard expression. You can get
-information for all {dfeeds} by using `_all`, by specifying `*` as the
-`<feed_id>`, or by omitting the `<feed_id>`.
-
 IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 
 [[ml-get-datafeed-path-parms]]
@@ -43,10 +38,10 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 +
---
-If you do not specify one of these options, the API returns information about
-all {dfeeds}.
---
+You can get information for multiple {dfeeds} in a single API request by using a
+comma-separated list of {dfeeds} or a wildcard expression. You can get
+information for all {dfeeds} by using `_all`, by specifying `*` as the
+{dfeed} identifier, or by omitting the identifier.
 
 [[ml-get-datafeed-query-parms]]
 == {api-query-parms-title}
@@ -56,7 +51,7 @@ all {dfeeds}.
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-datafeeds]
 
 `exclude_generated`::
 (Optional, Boolean)

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -74,7 +74,7 @@ timestamps.
 [[ml-get-influencer-request-body]]
 == {api-request-body-title}
 
-You can also specify the query parameters (such as `desc` and
+You can also specify some of the query parameters (such as `desc` and
 `end`) in the request body.
 
 `page`.`from`::

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -27,11 +27,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-job-stats-desc]]
 == {api-description-title}
 
-You can get statistics for multiple {anomaly-jobs} in a single API request by
-using a group name, a comma-separated list of jobs, or a wildcard expression.
-You can get statistics for all {anomaly-jobs} by using `_all`, by specifying `*`
-as the `<job_id>`, or by omitting the `<job_id>`.
-
 IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 [[ml-get-job-stats-path-parms]]
@@ -39,7 +34,12 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 `<job_id>`::
 (Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
+Identifier for the anomaly detection job. It can be a job identifier, a group
+name, or a wildcard expression. You can get statistics for multiple
+{anomaly-jobs} in a single API request by using a group name, a comma-separated
+list of jobs, or a wildcard expression. You can get statistics for all
+{anomaly-jobs} by using `_all`, by specifying `*` as the job identifier, or by
+omitting the identifier.
 
 [[ml-get-job-stats-query-parms]]
 == {api-query-parms-title}
@@ -49,7 +49,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-jobs]
 
 [role="child_attributes"]
 [[ml-get-job-stats-results]]

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -27,11 +27,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-job-desc]]
 == {api-description-title}
 
-You can get information for multiple {anomaly-jobs} in a single API request by
-using a group name, a comma-separated list of jobs, or a wildcard expression.
-You can get information for all {anomaly-jobs} by using `_all`, by specifying
-`*` as the `<job_id>`, or by omitting the `<job_id>`.
-
 IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 [[ml-get-job-path-parms]]
@@ -39,7 +34,12 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 `<job_id>`::
 (Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
+Identifier for the anomaly detection job. It can be a job identifier, a group
+name, or a wildcard expression. You can get information for multiple
+{anomaly-jobs} in a single API request by using a group name, a comma-separated
+list of jobs, or a wildcard expression. You can get information for all
+{anomaly-jobs} by using `_all`, by specifying `*` as the job identifier, or by
+omitting the identifier.
 
 [[ml-get-job-query-parms]]
 == {api-query-parms-title}
@@ -49,7 +49,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-jobs]
 
 `exclude_generated`::
 (Optional, Boolean)

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -26,9 +26,6 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-overall-buckets-desc]]
 == {api-description-title}
 
-You can summarize the bucket results for all {anomaly-jobs} by using `_all` or
-by specifying `*` as the `<job_id>`.
-
 By default, an overall bucket has a span equal to the largest bucket span of the
 specified {anomaly-jobs}. To override that behavior, use the optional
 `bucket_span` parameter. To learn more about the concept of buckets, see
@@ -53,16 +50,19 @@ a span equal to the jobs' largest bucket span.
 `<job_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard-list]
++
+You can summarize the bucket results for all {anomaly-jobs} by using `_all` or
+by specifying `*` as the job identifier.
 
-[[ml-get-overall-buckets-request-body]]
-== {api-request-body-title}
+[[ml-get-overall-buckets-query-parms]]
+== {api-query-parms-title}
 
 `allow_no_jobs`::
 (Optional, Boolean) deprecated:[7.10,Use `allow_no_match` instead.]
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-jobs]
 
 `bucket_span`::
 (Optional, string) The span of the overall buckets. Must be greater or equal to
@@ -92,6 +92,12 @@ specific timestamps.
 `top_n`::
 (Optional, integer) The number of top {anomaly-job} bucket scores to be used in
 the `overall_score` calculation. Defaults to `1`.
+
+[[ml-get-overall-buckets-request-body]]
+== {api-request-body-title}
+
+You can also specify the query parameters (such as `allow_no_match` and
+`bucket_span`) in the request body.
 
 [[ml-get-overall-buckets-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -41,8 +41,8 @@ of detectors.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-[[ml-get-record-request-body]]
-== {api-request-body-title}
+[[ml-get-record-query-parms]]
+== {api-query-parms-title}
 
 `desc`::
 (Optional, Boolean)
@@ -57,16 +57,16 @@ specific timestamps.
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
-`page`.`from`::
+`from`::
 (Optional, integer) Skips the specified number of records. Defaults to `0`.
-
-`page`.`size`::
-(Optional, integer) Specifies the maximum number of records to obtain. Defaults
-to `100`.
 
 `record_score`::
 (Optional, double) Returns records with anomaly scores greater or equal than
 this value. Defaults to `0.0`.
+
+`size`::
+(Optional, integer) Specifies the maximum number of records to obtain. Defaults
+to `100`.
 
 `sort`::
 (Optional, string) Specifies the sort field for the requested records. By
@@ -75,6 +75,19 @@ default, the records are sorted by the `record_score` value.
 `start`::
 (Optional, string) Returns records with timestamps after this time. Defaults to
 `-1`, which means it is unset and results are not limited to specific timestamps.
+
+[[ml-get-record-request-body]]
+== {api-request-body-title}
+
+You can also specify some of the query parameters (such as `desc` and
+`end`) in the request body.
+
+`page`.`from`::
+(Optional, integer) Skips the specified number of records. Defaults to `0`.
+
+`page`.`size`::
+(Optional, integer) Specifies the maximum number of records to obtain. Defaults
+to `100`.
 
 [[ml-get-record-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -67,7 +67,7 @@ specifying `*` as the snapshot ID, or by omitting the snapshot ID.
 [[ml-get-snapshot-request-body]]
 == {api-request-body-title}
 
-You can also specify the query parameters (such as `desc` and
+You can also specify some of the query parameters (such as `desc` and
 `end`) in the request body.
 
 `page`.`from`::

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -38,12 +38,17 @@ data is received.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+[[ml-open-job-query-parms]]
+== {api-query-parms-title}
+
+`timeout`::
+(Optional, time) Controls the time to wait until a job has opened. The default
+value is 30 minutes.
+
 [[ml-open-job-request-body]]
 == {api-request-body-title}
 
-`timeout`::
-  (Optional, time) Controls the time to wait until a job has opened. The default
-  value is 30 minutes.
+You can also specify the `timeout` query parameter in the request body.
 
 [[ml-open-job-response-body]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -53,6 +53,27 @@ credentials are used instead.
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
+[[ml-put-datafeed-query-params]]
+== {api-query-parms-title}
+
+`allow_no_indices`::
+(Optional, Boolean) If `true`, wildcard indices expressions that resolve into no
+concrete indices are ignored. This includes the `_all` string or when no indices
+are specified. Defaults to `true`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `open`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
++
+deprecated:[7.16.0]
+
+`ignore_unavailable`::
+(Optional, Boolean) If `true`, unavailable indices (missing or closed) are
+ignored. Defaults to `false`.
+
+
 [role="child_attributes"]
 [[ml-put-datafeed-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -51,26 +51,32 @@ means the {anomaly-job} starts learning a new model from scratch when it is
 started.
 --
 
+[[ml-revert-snapshot-query-parms]]
+== {api-query-parms-title}
+
+`delete_intervening_results`::
+(Optional, Boolean) If true, deletes the results in the time period between
+the latest results and the time of the reverted snapshot. It also resets the
+model to accept records for this time period. The default value is false.
++
+--
+NOTE: If you choose not to delete intervening results when reverting a snapshot,
+the job will not accept input data that is older than the current time.
+If you want to resend data, then delete the intervening results.
+--
 
 [[ml-revert-snapshot-request-body]]
 == {api-request-body-title}
 
-`delete_intervening_results`::
-  (Optional, Boolean) If true, deletes the results in the time period between
-  the latest results and the time of the reverted snapshot. It also resets the
-  model to accept records for this time period. The default value is false.
-
-NOTE: If you choose not to delete intervening results when reverting a snapshot,
-the job will not accept input data that is older than the current time.
-If you want to resend data, then delete the intervening results.
-
+You can also specify the `delete_intervening_results` query parameter in the
+request body.
 
 [[ml-revert-snapshot-example]]
 == {api-examples-title}
 
 [source,console]
 --------------------------------------------------
-POST _ml/anomaly_detectors/high_sum_total_sales/model_snapshots/1575402237/_revert
+POST _ml/anomaly_detectors/low_request_rate/model_snapshots/1637092688/_revert
 {
   "delete_intervening_results": true
 }
@@ -83,23 +89,25 @@ When the operation is complete, you receive the following results:
 ----
 {
   "model" : {
-    "job_id" : "high_sum_total_sales",
-    "min_version" : "6.4.0",
-    "timestamp" : 1575402237000,
-    "description" : "State persisted due to job close at 2019-12-03T19:43:57+0000",
-    "snapshot_id" : "1575402237",
+    "job_id" : "low_request_rate",
+    "min_version" : "7.11.0",
+    "timestamp" : 1637092688000,
+    "description" : "State persisted due to job close at 2021-11-16T19:58:08+0000",
+    "snapshot_id" : "1637092688",
     "snapshot_doc_count" : 1,
     "model_size_stats" : {
-      "job_id" : "high_sum_total_sales",
+      "job_id" : "low_request_rate",
       "result_type" : "model_size_stats",
-      "model_bytes" : 1638816,
+      "model_bytes" : 45200,
+      "peak_model_bytes" : 101552,
       "model_bytes_exceeded" : 0,
-      "model_bytes_memory_limit" : 10485760,
+      "model_bytes_memory_limit" : 11534336,
       "total_by_field_count" : 3,
-      "total_over_field_count" : 3320,
+      "total_over_field_count" : 0,
       "total_partition_field_count" : 2,
       "bucket_allocation_failures_count" : 0,
       "memory_status" : "ok",
+      "assignment_memory_basis" : "current_model_bytes",
       "categorized_doc_count" : 0,
       "total_category_count" : 0,
       "frequent_category_count" : 0,
@@ -107,11 +115,11 @@ When the operation is complete, you receive the following results:
       "dead_category_count" : 0,
       "failed_category_count" : 0,
       "categorization_status" : "ok",
-      "log_time" : 1575402237000,
-      "timestamp" : 1576965600000
+      "log_time" : 1637092688530,
+      "timestamp" : 1641495600000
     },
-    "latest_record_time_stamp" : 1576971072000,
-    "latest_result_time_stamp" : 1576965600000,
+    "latest_record_time_stamp" : 1641502169000,
+    "latest_result_time_stamp" : 1641495600000,
     "retain" : false
   }
 }

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -48,7 +48,7 @@ identifier.
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-datafeeds]
 
 `force`::
   (Optional, Boolean) If true, the {dfeed} is stopped forcefully.

--- a/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
@@ -43,13 +43,18 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 
+
+[[ml-upgrade-job-model-snapshot-query-parms]]
+== {api-query-parms-title}
+
 `timeout`::
-  (Optional, time) Controls the time to wait for the request to complete. The default
-  value is 30 minutes.
+(Optional, time) Controls the time to wait for the request to complete. The
+default value is 30 minutes.
 
 `wait_for_completion`::
-(Optional, boolean) When true, the API won't respond until the upgrade is complete. Otherwise,
-it responds as soon as the upgrade task is assigned to a node. Default is false.
+(Optional, boolean) When true, the API won't respond until the upgrade is
+complete. Otherwise, it responds as soon as the upgrade task is assigned to a
+node. Default is false.
 
 [[ml-upgrade-job-model-snapshot-response-body]]
 == {api-response-body-title}

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -17,7 +17,7 @@ return an error and the job waits in the `opening` state until sufficient {ml}
 node capacity is available.
 end::allow-lazy-open[]
 
-tag::allow-no-datafeeds[]
+tag::allow-no-match-datafeeds[]
 Specifies what to do when the request:
 +
 --
@@ -30,9 +30,9 @@ there are no matches and the subset of results when there are partial matches.
 If this parameter is `false`, the request returns a `404` status code when there
 are no matches or only partial matches.
 --
-end::allow-no-datafeeds[]
+end::allow-no-match-datafeeds[]
 
-tag::allow-no-jobs[]
+tag::allow-no-match-jobs[]
 Specifies what to do when the request:
 +
 --
@@ -45,7 +45,7 @@ when there are no matches and the subset of results when there are partial
 matches. If this parameter is `false`, the request returns a `404` status code
 when there are no matches or only partial matches.
 --
-end::allow-no-jobs[]
+end::allow-no-match-jobs[]
 
 tag::allow-no-match[]
  Specifies what to do when the request:


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Adds missing query parameters to ML APIs (#80863)