### PR TITLE
Delete watcher legacy templates

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -184,26 +184,31 @@ public class MetadataIndexTemplateService {
      *
      * The provided templates must exist in the cluster, otherwise an {@link IndexTemplateMissingException} is reported.
      */
-    public static void removeTemplates(ClusterService clusterService, Set<String> templateNames,
-                                      ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("remove-templates [" + String.join(",", templateNames) +
-            "]", new ClusterStateUpdateTask(Priority.URGENT, MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT) {
+    public static void removeTemplates(
+        ClusterService clusterService,
+        Set<String> templateNames,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
+        clusterService.submitStateUpdateTask(
+            "remove-templates [" + String.join(",", templateNames) + "]",
+            new ClusterStateUpdateTask(Priority.URGENT, MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT) {
 
-            @Override
-            public ClusterState execute(ClusterState currentState) throws Exception {
-                return innerRemoveTemplates(currentState, templateNames);
-            }
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    return innerRemoveTemplates(currentState, templateNames);
+                }
 
-            @Override
-            public void onFailure(String source, Exception e) {
-                listener.onFailure(e);
-            }
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
 
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                listener.onResponse(AcknowledgedResponse.TRUE);
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    listener.onResponse(AcknowledgedResponse.TRUE);
+                }
             }
-        });
+        );
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2233,9 +2233,10 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         }
 
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        IndexTemplateMissingException indexTemplateMissingException = expectThrows(IndexTemplateMissingException.class,
-            () -> MetadataIndexTemplateService.innerRemoveTemplates(clusterService.state(),
-                Set.of("foo", "bar", "missing", "other_mssing")));
+        IndexTemplateMissingException indexTemplateMissingException = expectThrows(
+            IndexTemplateMissingException.class,
+            () -> MetadataIndexTemplateService.innerRemoveTemplates(clusterService.state(), Set.of("foo", "bar", "missing", "other_mssing"))
+        );
         assertThat(indexTemplateMissingException.getMessage(), is("index_template [missing,other_mssing] missing"));
 
         // let's also test the templates that did exists were not removed

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
@@ -49,10 +49,7 @@ public class WatcherLifeCycleService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(WatcherLifeCycleService.class);
 
-    public static final Set<String> LEGACY_WATCHER_INDEX_TEMPLATES = Set.of(
-        ".watches",
-        ".triggered_watches"
-    );
+    public static final Set<String> LEGACY_WATCHER_INDEX_TEMPLATES = Set.of(".watches", ".triggered_watches");
 
     private final AtomicReference<WatcherState> state = new AtomicReference<>(WatcherState.STARTED);
     private final AtomicReference<List<ShardRouting>> previousShardRoutings = new AtomicReference<>(Collections.emptyList());
@@ -128,18 +125,21 @@ public class WatcherLifeCycleService implements ClusterStateListener {
                     return;
                 }
 
-                MetadataIndexTemplateService.removeTemplates(clusterService, LEGACY_WATCHER_INDEX_TEMPLATES,
-                    ActionListener.wrap(r -> {
-                        legacyTemplatesDeleteInProgress.set(false);
-                        // we've done it so we shouldn't check anymore
-                        checkForLegacyTemplates.set(false);
-                        logger.debug("deleted legacy Watcher index templates [{}]", String.join(",", LEGACY_WATCHER_INDEX_TEMPLATES));
-                    }, e -> {
-                        legacyTemplatesDeleteInProgress.set(false);
-                        logger.debug(new ParameterizedMessage("unable to delete legacy Watcher index templates [{}]",
-                            String.join(",", LEGACY_WATCHER_INDEX_TEMPLATES)), e);
-                    })
-                );
+                MetadataIndexTemplateService.removeTemplates(clusterService, LEGACY_WATCHER_INDEX_TEMPLATES, ActionListener.wrap(r -> {
+                    legacyTemplatesDeleteInProgress.set(false);
+                    // we've done it so we shouldn't check anymore
+                    checkForLegacyTemplates.set(false);
+                    logger.debug("deleted legacy Watcher index templates [{}]", String.join(",", LEGACY_WATCHER_INDEX_TEMPLATES));
+                }, e -> {
+                    legacyTemplatesDeleteInProgress.set(false);
+                    logger.debug(
+                        new ParameterizedMessage(
+                            "unable to delete legacy Watcher index templates [{}]",
+                            String.join(",", LEGACY_WATCHER_INDEX_TEMPLATES)
+                        ),
+                        e
+                    );
+                }));
             }
         }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -40,6 +40,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -560,6 +561,13 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         ClusterChangedEvent event = new ClusterChangedEvent("whatever", currentState, previousState);
         lifeCycleService.clusterChanged(event);
         verify(watcherService).reload(eq(event.state()), anyString());
+    }
+
+    public void testLegacyWatcherTemplatesToDelete() {
+        assertThat(WatcherLifeCycleService.LEGACY_WATCHER_INDEX_TEMPLATES.size(), is(2));
+        Iterator<String> legacyTemplatesIterator = WatcherLifeCycleService.LEGACY_WATCHER_INDEX_TEMPLATES.iterator();
+        assertThat(legacyTemplatesIterator.next(), is(".watches"));
+        assertThat(legacyTemplatesIterator.next(), is(".triggered_watches"));
     }
 
     private void startWatcher() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 


### PR DESCRIPTION
This adds a bit of infrastructure to be able to remove multiple legacy templates 
with one cluster state update and removes the legacy watcher index templates.

Relates to #80853