### PR TITLE
[8.0] [DOCS] Fixes query parameters for get buckets API (#80643)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -38,15 +38,17 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 (Optional, string) The timestamp of a single bucket result. If you do not
 specify this parameter, the API returns information about all buckets.
 
-[[ml-get-bucket-request-body]]
-== {api-request-body-title}
+
+[[ml-get-bucket-query-parms]]
+== {api-query-parms-title}
 
 `anomaly_score`::
 (Optional, double) Returns buckets with anomaly scores greater or equal than
 this value. Defaults to `0.0`.
 
 `desc`::
-(Optional, Boolean) If true, the buckets are sorted in descending order. Defaults to `false`.
+(Optional, Boolean) If true, the buckets are sorted in descending order.
+Defaults to `false`.
 
 `end`::
 (Optional, string) Returns buckets with timestamps earlier than this time.
@@ -60,11 +62,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 `expand`::
 (Optional, Boolean) If true, the output includes anomaly records. Defaults to `false`.
 
-`page`.`from`::
+`from`::
 (Optional, integer) Skips the specified number of buckets. Defaults to `0`.
 
-`page`.`size`::
-(Optional, integer) Specifies the maximum number of buckets to obtain. Defaults to `100`.
+`size`::
+(Optional, integer) Specifies the maximum number of buckets to obtain. Defaults
+to `100`.
 
 `sort`::
 (Optional, string) Specifies the sort field for the requested buckets. By
@@ -74,6 +77,26 @@ default, the buckets are sorted by the `timestamp` field.
 (Optional, string) Returns buckets with timestamps after this time. Defaults to 
 `-1`, which means it is unset and results are not limited to specific 
 timestamps.
+
+[[ml-get-bucket-request-body]]
+== {api-request-body-title}
+
+You can also specify the query parameters in the request body; the exception are
+`from` and `size`, use `page` instead:
+
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
+
+`from`:::
+(Optional, integer) Skips the specified number of buckets. Defaults to `0`.
+
+`size`:::
+(Optional, integer) Specifies the maximum number of buckets to obtain. Defaults
+to `100`.
+====
 
 [role="child_attributes"]
 [[ml-get-bucket-results]]
@@ -101,15 +124,16 @@ influencer. This score might be updated as newer data is analyzed.
 (number) The length of the bucket in seconds. This value matches the 
 `bucket_span` that is specified in the job.
 
+`influencer_field_name`:::
+(string) The field name of the influencer.
+////
+`influencer_field_value`:::
+(string) The field value of the influencer. 
+////
+
 `initial_anomaly_score`:::
 (number) The score between 0-100 for each bucket influencer. This score is the
 initial value that was calculated at the time the bucket was processed.
-
-`influencer_field_name`:::
-(string) The field name of the influencer.
-
-`influencer_field_value`:::
-(string) The field value of the influencer. 
 
 `is_interim`:::
 (Boolean)

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -63,15 +63,23 @@ as the calendar identifier.
 [[ml-get-calendar-event-request-body]]
 == {api-request-body-title}
 
-You can also specify some of the query parameters (such as `end` and
-`job_id`) in the request body.
+You can also specify the query parameters in the request body; the exception are
+`from` and `size`, use `page` instead:
 
-`page.from`::
-    (Optional, integer) Skips the specified number of events. Defaults to `0`.
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
 
-`page.size`::
-    (Optional, integer) Specifies the maximum number of events to obtain.
-    Defaults to `100`.
+`from`:::
+(Optional, integer) Skips the specified number of events. Defaults to `0`.
+
+`size`:::
+(Optional, integer) Specifies the maximum number of events to obtain. Defaults
+to `100`.
+====
+
 
 [[ml-get-calendar-event-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -53,14 +53,20 @@ or by omitting the identifier.
 [[ml-get-calendar-request-body]]
 == {api-request-body-title}
 
-`page`.`from`::
-    (Optional, integer) Skips the specified number of calendars. This object is 
-    supported only when you omit the `<calendar_id>`. Defaults to `0`.
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
 
-`page`.`size`::
-    (Optional, integer) Specifies the maximum number of calendars to obtain.
-    This object is  supported only when you omit the `<calendar_id>`. Defaults
-    to `100`.
+`from`:::
+(Optional, integer) Skips the specified number of calendars. This object is 
+supported only when you omit the `<calendar_id>`. Defaults to `0`.
+
+`size`:::
+(Optional, integer) Specifies the maximum number of calendars to obtain. This
+object is  supported only when you omit the `<calendar_id>`. Defaults to `100`.
+====
 
 [[ml-get-calendar-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -68,12 +68,19 @@ Defaults to `100`.
 You can also specify the `partition_field_value` query parameter in the
 request body.
 
-`page`.`from`::
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
+
+`from`:::
 (Optional, integer) Skips the specified number of categories. Defaults to `0`.
 
-`page`.`size`::
+`size`:::
 (Optional, integer) Specifies the maximum number of categories to obtain. 
 Defaults to `100`.
+====
 
 [[ml-get-category-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -74,15 +74,22 @@ timestamps.
 [[ml-get-influencer-request-body]]
 == {api-request-body-title}
 
-You can also specify some of the query parameters (such as `desc` and
-`end`) in the request body.
+You can also specify the query parameters in the request body; the exception are
+`from` and `size`, use `page` instead:
 
-`page`.`from`::
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
+
+`from`:::
 (Optional, integer) Skips the specified number of influencers. Defaults to `0`.
 
-`page`.`size`::
+`size`:::
 (Optional, integer) Specifies the maximum number of influencers to obtain. 
 Defaults to `100`.
+====
 
 [[ml-get-influencer-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -79,15 +79,22 @@ default, the records are sorted by the `record_score` value.
 [[ml-get-record-request-body]]
 == {api-request-body-title}
 
-You can also specify some of the query parameters (such as `desc` and
-`end`) in the request body.
+You can also specify the query parameters in the request body; the exception are
+`from` and `size`, use `page` instead:
 
-`page`.`from`::
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
+
+`from`:::
 (Optional, integer) Skips the specified number of records. Defaults to `0`.
 
-`page`.`size`::
+`size`:::
 (Optional, integer) Specifies the maximum number of records to obtain. Defaults
 to `100`.
+====
 
 [[ml-get-record-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -67,15 +67,22 @@ specifying `*` as the snapshot ID, or by omitting the snapshot ID.
 [[ml-get-snapshot-request-body]]
 == {api-request-body-title}
 
-You can also specify some of the query parameters (such as `desc` and
-`end`) in the request body.
+You can also specify the query parameters in the request body; the exception are
+`from` and `size`, use `page` instead:
 
-`page`.`from`::
+`page`::
++
+.Properties of `page`
+[%collapsible%open]
+====
+
+`from`:::
 (Optional, integer) Skips the specified number of snapshots. Defaults to `0`.
 
-`page`.`size`::
+`size`:::
 (Optional, integer) Specifies the maximum number of snapshots to obtain. 
 Defaults to `100`.
+====
 
 [role="child_attributes"]
 [[ml-get-snapshot-results]]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fixes query parameters for get buckets API (#80643)