### PR TITLE
[7.16] [DOCS] Minor clarifications in LDAP SSL docs (#80897)

### DIFF
--- a/x-pack/docs/en/security/securing-communications/tls-ldap.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-ldap.asciidoc
@@ -2,20 +2,20 @@
 [[tls-ldap]]
 ==== Encrypting communications between {es} and LDAP
 
-To protect the user credentials that are sent for authentication in an LDAP 
-realm, it's highly recommended to encrypt communications between {es} and your 
-LDAP server. Connecting via SSL/TLS ensures that the identity of the LDAP server 
-is authenticated before {es} transmits the user credentials and the 
-contents of the connection are encrypted. Clients and nodes that connect via 
-TLS to the LDAP server need to have the LDAP server's certificate or the 
-server's root CA certificate installed in their keystore or truststore. 
+To protect the user credentials that are sent for authentication in an LDAP
+realm, it's highly recommended to encrypt communications between {es} and your
+LDAP server. Connecting via SSL/TLS ensures that the identity of the LDAP server
+is authenticated before {es} transmits the user credentials and the
+contents of the connection are encrypted. Clients and nodes that connect via
+TLS to the LDAP server need to have the LDAP server's certificate or the
+server's root CA certificate installed in their keystore or truststore.
 
-For more information, see <<ldap-realm>>. 
+For more information, see <<ldap-realm>>.
 
-. Configure the realm's TLS settings on each node to trust certificates signed 
-by the CA that signed your LDAP server certificates. The following example 
-demonstrates how to trust a CA certificate, `cacert.pem`, located within the 
-{es} configuration directory (ES_PATH_CONF):
+. Configure the realm's TLS settings on each node to trust certificates signed
+by the CA that signed your LDAP server certificates. The following example
+demonstrates how to trust a CA certificate, `cacert.pem`, located within the
+{es} <<config-files-location,configuration directory>>:
 +
 --
 [source,shell]
@@ -29,13 +29,16 @@ xpack:
             order: 0
             url: "ldaps://ldap.example.com:636"
             ssl:
-              certificate_authorities: [ "ES_PATH_CONF/cacert.pem" ]
+              certificate_authorities: [ "cacert.pem" ]
 --------------------------------------------------
 
-The CA certificate must be a PEM encoded.
+In the example above, the CA certificate must be PEM encoded.
+
+PKCS#12 and JKS files are also supported - see the description of
+`ssl.truststore.path` in <<ref-ldap-settings>>.
 
 NOTE: You can also specify the individual server certificates rather than the CA
-certificate, but this is only recommended if you have a single LDAP server or 
+certificate, but this is only recommended if you have a single LDAP server or
 the certificates are self-signed.
 
 --


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Minor clarifications in LDAP SSL docs (#80897)