### PR TITLE
[8.0] [ML] No need to use parent task client when internal infer delegates (#80905)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.core.TimeValue;
@@ -186,9 +185,9 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             Collections.singletonList(doc),
             TimeValue.MAX_VALUE
         );
-        request.setParentTaskId(taskId);
+        request.setParentTask(taskId);
         executeAsyncWithOrigin(
-            new ParentTaskAssigningClient(client, taskId),
+            client,
             ML_ORIGIN,
             InferTrainedModelDeploymentAction.INSTANCE,
             request,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] No need to use parent task client when internal infer delegates (#80905)