### PR TITLE
Fix shadowed vars pt6 (#80899)

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -484,8 +484,8 @@ public class InstallPluginAction implements Closeable {
     }
 
     // for testing only
-    void setEnvironment(Environment env) {
-        this.env = env;
+    void setEnvironment(Environment environment) {
+        this.env = environment;
     }
 
     // for testing only

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
@@ -115,7 +115,7 @@ public class SyncPluginsAction implements PluginsSynchronizer {
 
     // @VisibleForTesting
     PluginChanges getPluginChanges(PluginsConfig pluginsConfig, Optional<PluginsConfig> cachedPluginsConfig) throws PluginSyncException {
-        final List<PluginInfo> existingPlugins = getExistingPlugins(this.env);
+        final List<PluginInfo> existingPlugins = getExistingPlugins();
 
         final List<PluginDescriptor> pluginsThatShouldExist = pluginsConfig.getPlugins();
         final List<PluginDescriptor> pluginsThatActuallyExist = existingPlugins.stream()
@@ -230,7 +230,7 @@ public class SyncPluginsAction implements PluginsSynchronizer {
         }).collect(Collectors.toList());
     }
 
-    private List<PluginInfo> getExistingPlugins(Environment env) throws PluginSyncException {
+    private List<PluginInfo> getExistingPlugins() throws PluginSyncException {
         final List<PluginInfo> plugins = new ArrayList<>();
 
         try {

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -293,15 +293,15 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     void installPlugins(final List<PluginDescriptor> plugins, final Path home, final InstallPluginAction action) throws Exception {
-        final Environment env = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
-        action.setEnvironment(env);
+        final Environment environment = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
+        action.setEnvironment(environment);
         action.execute(plugins);
     }
 
-    void assertPlugin(String name, Path original, Environment env) throws IOException {
-        assertPluginInternal(name, env.pluginsFile(), original);
-        assertConfigAndBin(name, original, env);
-        assertInstallCleaned(env);
+    void assertPlugin(String name, Path original, Environment environment) throws IOException {
+        assertPluginInternal(name, environment.pluginsFile(), original);
+        assertConfigAndBin(name, original, environment);
+        assertInstallCleaned(environment);
     }
 
     void assertPluginInternal(String name, Path pluginsFile, Path originalPlugin) throws IOException {
@@ -333,9 +333,9 @@ public class InstallPluginActionTests extends ESTestCase {
         assertFalse("config was not copied", Files.exists(got.resolve("config")));
     }
 
-    void assertConfigAndBin(String name, Path original, Environment env) throws IOException {
+    void assertConfigAndBin(String name, Path original, Environment environment) throws IOException {
         if (Files.exists(original.resolve("bin"))) {
-            Path binDir = env.binFile().resolve(name);
+            Path binDir = environment.binFile().resolve(name);
             assertTrue("bin dir exists", Files.exists(binDir));
             assertTrue("bin is a dir", Files.isDirectory(binDir));
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(binDir)) {
@@ -349,7 +349,7 @@ public class InstallPluginActionTests extends ESTestCase {
             }
         }
         if (Files.exists(original.resolve("config"))) {
-            Path configDir = env.configFile().resolve(name);
+            Path configDir = environment.configFile().resolve(name);
             assertTrue("config dir exists", Files.exists(configDir));
             assertTrue("config is a dir", Files.isDirectory(configDir));
 
@@ -357,7 +357,7 @@ public class InstallPluginActionTests extends ESTestCase {
             GroupPrincipal group = null;
 
             if (isPosix) {
-                PosixFileAttributes configAttributes = Files.getFileAttributeView(env.configFile(), PosixFileAttributeView.class)
+                PosixFileAttributes configAttributes = Files.getFileAttributeView(environment.configFile(), PosixFileAttributeView.class)
                     .readAttributes();
                 user = configAttributes.owner();
                 group = configAttributes.group();
@@ -385,8 +385,8 @@ public class InstallPluginActionTests extends ESTestCase {
         }
     }
 
-    void assertInstallCleaned(Environment env) throws IOException {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(env.pluginsFile())) {
+    void assertInstallCleaned(Environment environment) throws IOException {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(environment.pluginsFile())) {
             for (Path file : stream) {
                 if (file.getFileName().toString().startsWith(".installing")) {
                     fail("Installation dir still exists, " + file);
@@ -600,22 +600,22 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testPluginPermissions() throws Exception {
         assumeTrue("posix filesystem", isPosix);
 
-        final Path pluginDir = createPluginDir(temp);
-        final Path resourcesDir = pluginDir.resolve("resources");
-        final Path platformDir = pluginDir.resolve("platform");
+        final Path tempPluginDir = createPluginDir(temp);
+        final Path resourcesDir = tempPluginDir.resolve("resources");
+        final Path platformDir = tempPluginDir.resolve("platform");
         final Path platformNameDir = platformDir.resolve("linux-x86_64");
         final Path platformBinDir = platformNameDir.resolve("bin");
         Files.createDirectories(platformBinDir);
 
-        Files.createFile(pluginDir.resolve("fake-" + Version.CURRENT.toString() + ".jar"));
+        Files.createFile(tempPluginDir.resolve("fake-" + Version.CURRENT.toString() + ".jar"));
         Files.createFile(platformBinDir.resolve("fake_executable"));
         Files.createDirectory(resourcesDir);
         Files.createFile(resourcesDir.resolve("resource"));
 
-        final PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        final PluginDescriptor pluginZip = createPluginZip("fake", tempPluginDir);
 
         installPlugin(pluginZip);
-        assertPlugin("fake", pluginDir, env.v2());
+        assertPlugin("fake", tempPluginDir, env.v2());
 
         final Path fake = env.v2().pluginsFile().resolve("fake");
         final Path resources = fake.resolve("resources");
@@ -731,9 +731,9 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testOfficialPluginsHelpSortedAndMissingObviouslyWrongPlugins() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        new MockInstallPluginCommand().main(new String[] { "--help" }, terminal);
-        try (BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()))) {
+        MockTerminal mockTerminal = new MockTerminal();
+        new MockInstallPluginCommand().main(new String[] { "--help" }, mockTerminal);
+        try (BufferedReader reader = new BufferedReader(new StringReader(mockTerminal.getOutput()))) {
             String line = reader.readLine();
 
             // first find the beginning of our list of official plugins
@@ -1362,7 +1362,8 @@ public class InstallPluginActionTests extends ESTestCase {
 
     // checks the plugin requires a policy confirmation, and does not install when that is rejected by the user
     // the plugin is installed after this method completes
-    private void assertPolicyConfirmation(Tuple<Path, Environment> env, PluginDescriptor pluginZip, String... warnings) throws Exception {
+    private void assertPolicyConfirmation(Tuple<Path, Environment> pathEnvironmentTuple, PluginDescriptor pluginZip, String... warnings)
+        throws Exception {
         for (int i = 0; i < warnings.length; ++i) {
             String warning = warnings[i];
             for (int j = 0; j < i; ++j) {
@@ -1374,7 +1375,7 @@ public class InstallPluginActionTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("installation aborted by user"));
 
             assertThat(terminal.getErrorOutput(), containsString("WARNING: " + warning));
-            try (Stream<Path> fileStream = Files.list(env.v2().pluginsFile())) {
+            try (Stream<Path> fileStream = Files.list(pathEnvironmentTuple.v2().pluginsFile())) {
                 assertThat(fileStream.collect(Collectors.toList()), empty());
             }
 
@@ -1387,7 +1388,7 @@ public class InstallPluginActionTests extends ESTestCase {
             e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
             assertThat(e.getMessage(), containsString("installation aborted by user"));
             assertThat(terminal.getErrorOutput(), containsString("WARNING: " + warning));
-            try (Stream<Path> fileStream = Files.list(env.v2().pluginsFile())) {
+            try (Stream<Path> fileStream = Files.list(pathEnvironmentTuple.v2().pluginsFile())) {
                 assertThat(fileStream.collect(Collectors.toList()), empty());
             }
         }

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -680,7 +680,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * Tests that a single empty shard index is correctly recovered. Empty shards are often an edge case.
      */
     public void testEmptyShard() throws IOException {
-        final String index = "test_empty_shard";
+        final String indexName = "test_empty_shard";
 
         if (isRunningAgainstOldCluster()) {
             Settings.Builder settings = Settings.builder()
@@ -698,9 +698,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             if (randomBoolean()) {
                 settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), "-1");
             }
-            createIndex(index, settings.build());
+            createIndex(indexName, settings.build());
         }
-        ensureGreen(index);
+        ensureGreen(indexName);
     }
 
     /**
@@ -1077,21 +1077,24 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * that the index has started shards.
      */
     @SuppressWarnings("unchecked")
-    private void assertClosedIndex(final String index, final boolean checkRoutingTable) throws IOException {
+    private void assertClosedIndex(final String indexName, final boolean checkRoutingTable) throws IOException {
         final Map<String, ?> state = entityAsMap(client().performRequest(new Request("GET", "/_cluster/state")));
 
-        final Map<String, ?> metadata = (Map<String, Object>) XContentMapValues.extractValue("metadata.indices." + index, state);
+        final Map<String, ?> metadata = (Map<String, Object>) XContentMapValues.extractValue("metadata.indices." + indexName, state);
         assertThat(metadata, notNullValue());
         assertThat(metadata.get("state"), equalTo("close"));
 
-        final Map<String, ?> blocks = (Map<String, Object>) XContentMapValues.extractValue("blocks.indices." + index, state);
+        final Map<String, ?> blocks = (Map<String, Object>) XContentMapValues.extractValue("blocks.indices." + indexName, state);
         assertThat(blocks, notNullValue());
         assertThat(blocks.containsKey(String.valueOf(MetadataIndexStateService.INDEX_CLOSED_BLOCK_ID)), is(true));
 
         final Map<String, ?> settings = (Map<String, Object>) XContentMapValues.extractValue("settings", metadata);
         assertThat(settings, notNullValue());
 
-        final Map<String, ?> routingTable = (Map<String, Object>) XContentMapValues.extractValue("routing_table.indices." + index, state);
+        final Map<String, ?> routingTable = (Map<String, Object>) XContentMapValues.extractValue(
+            "routing_table.indices." + indexName,
+            state
+        );
         if (checkRoutingTable) {
             assertThat(routingTable, notNullValue());
             assertThat(Booleans.parseBoolean((String) XContentMapValues.extractValue("index.verified_before_close", settings)), is(true));
@@ -1110,7 +1113,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 for (Map<String, ?> shard : shards) {
                     assertThat(XContentMapValues.extractValue("shard", shard), equalTo(i));
                     assertThat(XContentMapValues.extractValue("state", shard), equalTo("STARTED"));
-                    assertThat(XContentMapValues.extractValue("index", shard), equalTo(index));
+                    assertThat(XContentMapValues.extractValue("index", shard), equalTo(indexName));
                 }
             }
         } else {
@@ -1320,12 +1323,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         client().performRequest(new Request("POST", "/" + index + "/_refresh"));
     }
 
-    private List<String> dataNodes(String index, RestClient client) throws IOException {
-        Request request = new Request("GET", index + "/_stats");
+    private List<String> dataNodes(String indexName, RestClient client) throws IOException {
+        Request request = new Request("GET", indexName + "/_stats");
         request.addParameter("level", "shards");
         Response response = client.performRequest(request);
         List<String> nodes = new ArrayList<>();
-        List<Object> shardStats = ObjectPath.createFromResponse(response).evaluate("indices." + index + ".shards.0");
+        List<Object> shardStats = ObjectPath.createFromResponse(response).evaluate("indices." + indexName + ".shards.0");
         for (Object shard : shardStats) {
             final String nodeId = ObjectPath.evaluate(shard, "routing.node");
             nodes.add(nodeId);
@@ -1337,8 +1340,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * Wait for an index to have green health, waiting longer than
      * {@link ESRestTestCase#ensureGreen}.
      */
-    protected void ensureGreenLongWait(String index) throws IOException {
-        Request request = new Request("GET", "/_cluster/health/" + index);
+    protected void ensureGreenLongWait(String indexName) throws IOException {
+        Request request = new Request("GET", "/_cluster/health/" + indexName);
         request.addParameter("timeout", "2m");
         request.addParameter("wait_for_status", "green");
         request.addParameter("wait_for_no_relocating_shards", "true");

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -104,12 +104,12 @@ public abstract class PackagingTestCase extends Assert {
     // the java installation already installed on the system
     protected static final String systemJavaHome;
     static {
-        Shell sh = new Shell();
+        Shell initShell = new Shell();
         if (Platforms.WINDOWS) {
-            systemJavaHome = sh.run("$Env:SYSTEM_JAVA_HOME").stdout.trim();
+            systemJavaHome = initShell.run("$Env:SYSTEM_JAVA_HOME").stdout.trim();
         } else {
             assert Platforms.LINUX || Platforms.DARWIN;
-            systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
+            systemJavaHome = initShell.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
         }
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -43,17 +43,14 @@ public class Distribution {
 
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
         this.hasJdk = filename.contains("no-jdk") == false;
-        String version = filename.split("-", 3)[1];
+        String tmpVersion = filename.split("-", 3)[1];
         if (packaging == Packaging.DEB) {
-            version = version.replace(".deb", "");
+            tmpVersion = tmpVersion.replace(".deb", "");
         } else if (packaging == Packaging.RPM) {
-            version = version.replace(".rpm", "");
+            tmpVersion = tmpVersion.replace(".rpm", "");
         }
-        this.baseVersion = version;
-        if (filename.contains("-SNAPSHOT")) {
-            version += "-SNAPSHOT";
-        }
-        this.version = version;
+        this.baseVersion = tmpVersion;
+        this.version = filename.contains("-SNAPSHOT") ? this.baseVersion + "-SNAPSHOT" : this.baseVersion;
     }
 
     public boolean isArchive() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -71,18 +71,18 @@ public class DockerRun {
     /**
      * Sets the UID that the container is run with, and the GID too if specified.
      *
-     * @param uid the UID to use, or {@code null} to use the image default
-     * @param gid the GID to use, or {@code null} to use the image default
+     * @param uidToUse the UID to use, or {@code null} to use the image default
+     * @param gidToUse the GID to use, or {@code null} to use the image default
      * @return the current builder
      */
-    public DockerRun uid(Integer uid, Integer gid) {
-        if (uid == null) {
-            if (gid != null) {
+    public DockerRun uid(Integer uidToUse, Integer gidToUse) {
+        if (uidToUse == null) {
+            if (gidToUse != null) {
                 throw new IllegalArgumentException("Cannot override GID without also overriding UID");
             }
         }
-        this.uid = uid;
-        this.gid = gid;
+        this.uid = uidToUse;
+        this.gid = gidToUse;
         return this;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/replication/RetentionLeasesReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RetentionLeasesReplicationTests.java
@@ -76,8 +76,8 @@ public class RetentionLeasesReplicationTests extends ESIndexLevelReplicationTest
         IndexMetadata indexMetadata = buildIndexMetadata(numberOfReplicas, settings, indexMapping);
         try (ReplicationGroup group = new ReplicationGroup(indexMetadata) {
             @Override
-            protected void syncRetentionLeases(ShardId shardId, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
-                listener.onResponse(new SyncRetentionLeasesResponse(new RetentionLeaseSyncAction.Request(shardId, leases)));
+            protected void syncRetentionLeases(ShardId id, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
+                listener.onResponse(new SyncRetentionLeasesResponse(new RetentionLeaseSyncAction.Request(id, leases)));
             }
         }) {
             group.startAll();
@@ -103,8 +103,8 @@ public class RetentionLeasesReplicationTests extends ESIndexLevelReplicationTest
         IndexMetadata indexMetadata = buildIndexMetadata(numberOfReplicas, settings, indexMapping);
         try (ReplicationGroup group = new ReplicationGroup(indexMetadata) {
             @Override
-            protected void syncRetentionLeases(ShardId shardId, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
-                listener.onResponse(new SyncRetentionLeasesResponse(new RetentionLeaseSyncAction.Request(shardId, leases)));
+            protected void syncRetentionLeases(ShardId id, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
+                listener.onResponse(new SyncRetentionLeasesResponse(new RetentionLeaseSyncAction.Request(id, leases)));
             }
         }) {
             group.startAll();

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -113,11 +113,11 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
 
         @Override
         public long getTotalSpace() throws IOException {
-            final long totalSpace = this.totalSpace;
-            if (totalSpace == -1) {
+            final long totalSpaceCopy = this.totalSpace;
+            if (totalSpaceCopy == -1) {
                 return super.getTotalSpace();
             } else {
-                return totalSpace;
+                return totalSpaceCopy;
             }
         }
 
@@ -128,21 +128,21 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
 
         @Override
         public long getUsableSpace() throws IOException {
-            final long totalSpace = this.totalSpace;
-            if (totalSpace == -1) {
+            final long totalSpaceCopy = this.totalSpace;
+            if (totalSpaceCopy == -1) {
                 return super.getUsableSpace();
             } else {
-                return Math.max(0L, totalSpace - getTotalFileSize(path));
+                return Math.max(0L, totalSpaceCopy - getTotalFileSize(path));
             }
         }
 
         @Override
         public long getUnallocatedSpace() throws IOException {
-            final long totalSpace = this.totalSpace;
-            if (totalSpace == -1) {
+            final long totalSpaceCopy = this.totalSpace;
+            if (totalSpaceCopy == -1) {
                 return super.getUnallocatedSpace();
             } else {
-                return Math.max(0L, totalSpace - getTotalFileSize(path));
+                return Math.max(0L, totalSpaceCopy - getTotalFileSize(path));
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -40,13 +40,13 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
         super(settings, clusterService, threadPool, client);
     }
 
-    public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction) {
-        this.diskUsageFunction = diskUsageFunction;
+    public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFn) {
+        this.diskUsageFunction = diskUsageFn;
         ClusterInfoServiceUtils.refresh(this);
     }
 
-    public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFunction) {
-        this.shardSizeFunction = shardSizeFunction;
+    public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFn) {
+        this.shardSizeFunction = shardSizeFn;
         ClusterInfoServiceUtils.refresh(this);
     }
 
@@ -58,8 +58,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
 
     @Override
     List<NodeStats> adjustNodesStats(List<NodeStats> nodesStats) {
-        final BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction = this.diskUsageFunction;
-        if (diskUsageFunction == null) {
+        final BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunctionCopy = this.diskUsageFunction;
+        if (diskUsageFunctionCopy == null) {
             return nodesStats;
         }
 
@@ -78,7 +78,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                     oldFsInfo.getTimestamp(),
                     oldFsInfo.getIoStats(),
                     StreamSupport.stream(oldFsInfo.spliterator(), false)
-                        .map(fsInfoPath -> diskUsageFunction.apply(discoveryNode, fsInfoPath))
+                        .map(fsInfoPath -> diskUsageFunctionCopy.apply(discoveryNode, fsInfoPath))
                         .toArray(FsInfo.Path[]::new)
                 ),
                 nodeStats.getTransport(),
@@ -108,12 +108,12 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
 
         @Override
         public Long getShardSize(ShardRouting shardRouting) {
-            final Function<ShardRouting, Long> shardSizeFunction = MockInternalClusterInfoService.this.shardSizeFunction;
-            if (shardSizeFunction == null) {
+            final Function<ShardRouting, Long> shardSizeFunctionCopy = MockInternalClusterInfoService.this.shardSizeFunction;
+            if (shardSizeFunctionCopy == null) {
                 return super.getShardSize(shardRouting);
             }
 
-            return shardSizeFunction.apply(shardRouting);
+            return shardSizeFunctionCopy.apply(shardRouting);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -802,14 +802,14 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             return getAnyNodeExcept();
         }
 
-        ClusterNode getAnyNodeExcept(ClusterNode... clusterNodes) {
-            List<ClusterNode> filteredNodes = getAllNodesExcept(clusterNodes);
+        ClusterNode getAnyNodeExcept(ClusterNode... clusterNodesToExclude) {
+            List<ClusterNode> filteredNodes = getAllNodesExcept(clusterNodesToExclude);
             assert filteredNodes.isEmpty() == false;
             return randomFrom(filteredNodes);
         }
 
-        List<ClusterNode> getAllNodesExcept(ClusterNode... clusterNodes) {
-            Set<String> forbiddenIds = Arrays.stream(clusterNodes).map(ClusterNode::getId).collect(Collectors.toSet());
+        List<ClusterNode> getAllNodesExcept(ClusterNode... clusterNodesToExclude) {
+            Set<String> forbiddenIds = Arrays.stream(clusterNodesToExclude).map(ClusterNode::getId).collect(Collectors.toSet());
             return this.clusterNodes.stream().filter(n -> forbiddenIds.contains(n.getId()) == false).collect(Collectors.toList());
         }
 
@@ -1250,7 +1250,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             ClusterNode restartedNode(
                 Function<Metadata, Metadata> adaptGlobalMetadata,
                 Function<Long, Long> adaptCurrentTerm,
-                Settings nodeSettings
+                Settings settings
             ) {
                 final TransportAddress address = randomBoolean() ? buildNewFakeTransportAddress() : localNode.getAddress();
                 final DiscoveryNode newLocalNode = new DiscoveryNode(
@@ -1261,7 +1261,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     address.getAddress(),
                     address,
                     Collections.emptyMap(),
-                    localNode.isMasterNode() && DiscoveryNode.isMasterNode(nodeSettings) ? DiscoveryNodeRole.BUILT_IN_ROLES : emptySet(),
+                    localNode.isMasterNode() && DiscoveryNode.isMasterNode(settings) ? DiscoveryNodeRole.BUILT_IN_ROLES : emptySet(),
                     Version.CURRENT
                 );
                 try {
@@ -1269,7 +1269,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         nodeIndex,
                         newLocalNode,
                         node -> new MockPersistedState(newLocalNode, persistedState, adaptGlobalMetadata, adaptCurrentTerm),
-                        nodeSettings,
+                        settings,
                         nodeHealthService
                     );
                 } finally {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -143,6 +143,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings("HiddenField")
 public abstract class EngineTestCase extends ESTestCase {
 
     protected final ShardId shardId = new ShardId(new Index("index", "_na_"), 0);

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -190,13 +190,13 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         );
 
         private final RetentionLeaseSyncer retentionLeaseSyncer = new RetentionLeaseSyncer(
-            (shardId, primaryAllocationId, primaryTerm, retentionLeases, listener) -> syncRetentionLeases(
-                shardId,
+            (_shardId, primaryAllocationId, primaryTerm, retentionLeases, listener) -> syncRetentionLeases(
+                _shardId,
                 retentionLeases,
                 listener
             ),
-            (shardId, primaryAllocationId, primaryTerm, retentionLeases) -> syncRetentionLeases(
-                shardId,
+            (_shardId, primaryAllocationId, primaryTerm, retentionLeases) -> syncRetentionLeases(
+                _shardId,
                 retentionLeases,
                 ActionListener.wrap(r -> {}, e -> { throw new AssertionError("failed to background sync retention lease", e); })
             )
@@ -213,13 +213,13 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
         }
 
-        private ShardRouting createShardRouting(String nodeId, boolean primary) {
+        private ShardRouting createShardRouting(String nodeId, boolean isPrimary) {
             return TestShardRouting.newShardRouting(
                 shardId,
                 nodeId,
-                primary,
+                isPrimary,
                 ShardRoutingState.INITIALIZING,
-                primary ? RecoverySource.EmptyStoreRecoverySource.INSTANCE : RecoverySource.PeerRecoverySource.INSTANCE
+                isPrimary ? RecoverySource.EmptyStoreRecoverySource.INSTANCE : RecoverySource.PeerRecoverySource.INSTANCE
             );
         }
 
@@ -342,10 +342,10 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             updateAllocationIDsOnPrimary();
         }
 
-        protected synchronized void recoverPrimary(IndexShard primary) {
-            final DiscoveryNode pNode = getDiscoveryNode(primary.routingEntry().currentNodeId());
-            primary.markAsRecovering("store", new RecoveryState(primary.routingEntry(), pNode, null));
-            recoverFromStore(primary);
+        protected synchronized void recoverPrimary(IndexShard primaryShard) {
+            final DiscoveryNode pNode = getDiscoveryNode(primaryShard.routingEntry().currentNodeId());
+            primaryShard.markAsRecovering("store", new RecoveryState(primaryShard.routingEntry(), pNode, null));
+            recoverFromStore(primaryShard);
         }
 
         public synchronized IndexShard addReplicaWithExistingPath(final ShardPath shardPath, final String nodeId) throws IOException {
@@ -406,7 +406,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
 
         public synchronized void promoteReplicaToPrimary(
             IndexShard replica,
-            BiConsumer<IndexShard, ActionListener<PrimaryReplicaSyncer.ResyncTask>> primaryReplicaSyncer
+            BiConsumer<IndexShard, ActionListener<PrimaryReplicaSyncer.ResyncTask>> primaryReplicaSyncerArg
         ) throws IOException {
             final long newTerm = indexMetadata.primaryTerm(shardId.id()) + 1;
             IndexMetadata.Builder newMetadata = IndexMetadata.builder(indexMetadata).primaryTerm(shardId.id(), newTerm);
@@ -421,7 +421,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             primary.updateShardState(
                 primaryRouting,
                 newTerm,
-                primaryReplicaSyncer,
+                primaryReplicaSyncerArg,
                 currentClusterStateVersion.incrementAndGet(),
                 activeIds(),
                 routingTable
@@ -589,12 +589,9 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             return replicationTargets;
         }
 
-        protected void syncRetentionLeases(ShardId shardId, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
-            new SyncRetentionLeases(
-                new RetentionLeaseSyncAction.Request(shardId, leases),
-                this,
-                listener.map(r -> new ReplicationResponse())
-            ).execute();
+        protected void syncRetentionLeases(ShardId id, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
+            new SyncRetentionLeases(new RetentionLeaseSyncAction.Request(id, leases), this, listener.map(r -> new ReplicationResponse()))
+                .execute();
         }
 
         public synchronized RetentionLease addRetentionLease(
@@ -722,8 +719,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
 
             @Override
-            public void perform(Request request, ActionListener<PrimaryResult> listener) {
-                performOnPrimary(getPrimaryShard(), request, listener);
+            public void perform(Request replicationRequest, ActionListener<PrimaryResult> primaryResultListener) {
+                performOnPrimary(getPrimaryShard(), replicationRequest, primaryResultListener);
             }
 
             @Override
@@ -772,20 +769,20 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             @Override
             public void performOn(
                 final ShardRouting replicaRouting,
-                final ReplicaRequest request,
+                final ReplicaRequest replicaRequest,
                 final long primaryTerm,
                 final long globalCheckpoint,
                 final long maxSeqNoOfUpdatesOrDeletes,
-                final ActionListener<ReplicationOperation.ReplicaResponse> listener
+                final ActionListener<ReplicationOperation.ReplicaResponse> replicaResponseListener
             ) {
                 IndexShard replica = replicationTargets.findReplicaShard(replicaRouting);
                 replica.acquireReplicaOperationPermit(
                     getPrimaryShard().getPendingPrimaryTerm(),
                     globalCheckpoint,
                     maxSeqNoOfUpdatesOrDeletes,
-                    listener.delegateFailure((delegatedListener, releasable) -> {
+                    replicaResponseListener.delegateFailure((delegatedListener, releasable) -> {
                         try {
-                            performOnReplica(request, replica);
+                            performOnReplica(replicaRequest, replica);
                             releasable.close();
                             delegatedListener.onResponse(
                                 new ReplicaResponse(replica.getLocalCheckpoint(), replica.getLastKnownGlobalCheckpoint())
@@ -796,7 +793,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                         }
                     }),
                     ThreadPool.Names.WRITE,
-                    request
+                    replicaRequest
                 );
             }
 
@@ -806,19 +803,19 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 long primaryTerm,
                 String message,
                 Exception exception,
-                ActionListener<Void> listener
+                ActionListener<Void> actionListener
             ) {
                 throw new UnsupportedOperationException("failing shard " + replica + " isn't supported. failure: " + message, exception);
             }
 
             @Override
             public void markShardCopyAsStaleIfNeeded(
-                ShardId shardId,
+                ShardId id,
                 String allocationId,
                 long primaryTerm,
-                ActionListener<Void> listener
+                ActionListener<Void> actionListener
             ) {
-                throw new UnsupportedOperationException("can't mark " + shardId + ", aid [" + allocationId + "] as stale");
+                throw new UnsupportedOperationException("can't mark " + id + ", aid [" + allocationId + "] as stale");
             }
         }
 
@@ -842,8 +839,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
 
             @Override
-            public void runPostReplicationActions(ActionListener<Void> listener) {
-                listener.onResponse(null);
+            public void runPostReplicationActions(ActionListener<Void> actionListener) {
+                actionListener.onResponse(null);
             }
         }
 
@@ -889,7 +886,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         final PlainActionFuture<Releasable> permitAcquiredFuture = new PlainActionFuture<>();
         primary.acquirePrimaryOperationPermit(permitAcquiredFuture, ThreadPool.Names.SAME, request);
         try (Releasable ignored = permitAcquiredFuture.actionGet()) {
-            MappingUpdatePerformer noopMappingUpdater = (update, shardId, type, listener1) -> {};
+            MappingUpdatePerformer noopMappingUpdater = (_update, _shardId, _type, _listener1) -> {};
             TransportShardBulkAction.performOnPrimary(
                 request,
                 primary,

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -70,12 +70,12 @@ public class MockScriptEngine implements ScriptEngine {
         Map<ScriptContext<?>, ContextCompiler> contexts
     ) {
 
-        Map<String, MockDeterministicScript> scripts = new HashMap<>(deterministicScripts.size() + nonDeterministicScripts.size());
-        deterministicScripts.forEach((key, value) -> scripts.put(key, MockDeterministicScript.asDeterministic(value)));
-        nonDeterministicScripts.forEach((key, value) -> scripts.put(key, MockDeterministicScript.asNonDeterministic(value)));
+        Map<String, MockDeterministicScript> scriptMap = new HashMap<>(deterministicScripts.size() + nonDeterministicScripts.size());
+        deterministicScripts.forEach((key, value) -> scriptMap.put(key, MockDeterministicScript.asDeterministic(value)));
+        nonDeterministicScripts.forEach((key, value) -> scriptMap.put(key, MockDeterministicScript.asNonDeterministic(value)));
 
         this.type = type;
-        this.scripts = Collections.unmodifiableMap(scripts);
+        this.scripts = Collections.unmodifiableMap(scriptMap);
         this.contexts = Collections.unmodifiableMap(contexts);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
@@ -251,8 +251,8 @@ public class BackgroundIndexer implements AutoCloseable {
 
     private volatile TimeValue timeout = BulkShardRequest.DEFAULT_TIMEOUT;
 
-    public void setRequestTimeout(TimeValue timeout) {
-        this.timeout = timeout;
+    public void setRequestTimeout(TimeValue requestTimeout) {
+        this.timeout = requestTimeout;
     }
 
     private volatile boolean ignoreIndexingFailures;

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -88,10 +88,10 @@ public final class ExternalTestCluster extends TestCluster {
             }
         }
         Settings clientSettings = clientSettingsBuilder.build();
-        MockTransportClient client = new MockTransportClient(clientSettings, pluginClasses);
+        MockTransportClient mockClient = new MockTransportClient(clientSettings, pluginClasses);
         try {
-            client.addTransportAddresses(transportAddresses);
-            NodesInfoResponse nodeInfos = client.admin()
+            mockClient.addTransportAddresses(transportAddresses);
+            NodesInfoResponse nodeInfos = mockClient.admin()
                 .cluster()
                 .prepareNodesInfo()
                 .clear()
@@ -113,11 +113,11 @@ public final class ExternalTestCluster extends TestCluster {
             }
             this.numDataNodes = dataNodes;
             this.numMasterAndDataNodes = masterAndDataNodes;
-            this.client = client;
+            this.client = mockClient;
 
             logger.info("Setup ExternalTestCluster [{}] made of [{}] nodes", nodeInfos.getClusterName().value(), size());
         } catch (Exception e) {
-            client.close();
+            mockClient.close();
             throw e;
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -961,7 +961,7 @@ public final class InternalTestCluster extends TestCluster {
             this.name = name;
             this.originalNodeSettings = originalNodeSettings;
             this.nodeAndClientId = nodeAndClientId;
-            markNodeDataDirsAsNotEligibleForWipe(node);
+            markNodeDataDirsAsNotEligibleForWipe();
         }
 
         Node node() {
@@ -1138,7 +1138,7 @@ public final class InternalTestCluster extends TestCluster {
                 }
             });
             closed.set(false);
-            markNodeDataDirsAsNotEligibleForWipe(node);
+            markNodeDataDirsAsNotEligibleForWipe();
         }
 
         @Override
@@ -1148,7 +1148,7 @@ public final class InternalTestCluster extends TestCluster {
                 resetClient();
             } finally {
                 closed.set(true);
-                markNodeDataDirsAsPendingForWipe(node);
+                markNodeDataDirsAsPendingForWipe();
                 node.close();
                 try {
                     if (node.awaitClose(10, TimeUnit.SECONDS) == false) {
@@ -1160,17 +1160,17 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
 
-        private void markNodeDataDirsAsPendingForWipe(Node node) {
+        private void markNodeDataDirsAsPendingForWipe() {
             assert Thread.holdsLock(InternalTestCluster.this);
-            NodeEnvironment nodeEnv = node.getNodeEnvironment();
+            NodeEnvironment nodeEnv = this.node.getNodeEnvironment();
             if (nodeEnv.hasNodeFile()) {
                 dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataPaths()));
             }
         }
 
-        private void markNodeDataDirsAsNotEligibleForWipe(Node node) {
+        private void markNodeDataDirsAsNotEligibleForWipe() {
             assert Thread.holdsLock(InternalTestCluster.this);
-            NodeEnvironment nodeEnv = node.getNodeEnvironment();
+            NodeEnvironment nodeEnv = this.node.getNodeEnvironment();
             if (nodeEnv.hasNodeFile()) {
                 dataDirToClean.removeAll(Arrays.asList(nodeEnv.nodeDataPaths()));
             }
@@ -2219,14 +2219,14 @@ public final class InternalTestCluster extends TestCluster {
         if (clusterService().state().routingTable().hasIndex(index)) {
             List<ShardRouting> allShards = clusterService().state().routingTable().allShards(index);
             DiscoveryNodes discoveryNodes = clusterService().state().getNodes();
-            Set<String> nodes = new HashSet<>();
+            Set<String> nodeNames = new HashSet<>();
             for (ShardRouting shardRouting : allShards) {
                 if (shardRouting.assignedToNode()) {
                     DiscoveryNode discoveryNode = discoveryNodes.get(shardRouting.currentNodeId());
-                    nodes.add(discoveryNode.getName());
+                    nodeNames.add(discoveryNode.getName());
                 }
             }
-            return nodes;
+            return nodeNames;
         }
         return Collections.emptySet();
     }
@@ -2329,7 +2329,7 @@ public final class InternalTestCluster extends TestCluster {
         } else {
             defaultMinMasterNodes = -1;
         }
-        final List<NodeAndClient> nodes = new ArrayList<>();
+        final List<NodeAndClient> nodeList = new ArrayList<>();
         final int prevMasterCount = getMasterNodesCount();
         int autoBootstrapMasterNodeIndex = autoManageMasterNodes
             && prevMasterCount == 0
@@ -2368,15 +2368,15 @@ public final class InternalTestCluster extends TestCluster {
                 firstNodeId + i,
                 builder.put(nodeSettings).build(),
                 false,
-                () -> rebuildUnicastHostFiles(nodes)
+                () -> rebuildUnicastHostFiles(nodeList)
             );
-            nodes.add(nodeAndClient);
+            nodeList.add(nodeAndClient);
         }
-        startAndPublishNodesAndClients(nodes);
+        startAndPublishNodesAndClients(nodeList);
         if (autoManageMasterNodes) {
             validateClusterFormed();
         }
-        return nodes.stream().map(NodeAndClient::getName).collect(Collectors.toList());
+        return nodeList.stream().map(NodeAndClient::getName).collect(Collectors.toList());
     }
 
     public List<String> startMasterOnlyNodes(int numNodes) {

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -55,11 +55,11 @@ public abstract class TestCluster implements Closeable {
     /**
      * This method should be executed before each test to reset the cluster to its initial state.
      */
-    public void beforeTest(Random random, double transportClientRatio) throws IOException, InterruptedException {
+    public void beforeTest(Random randomGenerator, double transportClientRatioValue) throws IOException, InterruptedException {
         assert transportClientRatio >= 0.0 && transportClientRatio <= 1.0;
-        logger.debug("Reset test cluster with transport client ratio: [{}]", transportClientRatio);
-        this.transportClientRatio = transportClientRatio;
-        this.random = new Random(random.nextLong());
+        logger.debug("Reset test cluster with transport client ratio: [{}]", transportClientRatioValue);
+        this.transportClientRatio = transportClientRatioValue;
+        this.random = new Random(randomGenerator.nextLong());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -121,7 +121,7 @@ public class TestSearchContext extends SearchContext {
     public void preProcess() {}
 
     @Override
-    public Query buildFilteredQuery(Query query) {
+    public Query buildFilteredQuery(Query q) {
         return null;
     }
 
@@ -166,8 +166,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext aggregations(SearchContextAggregations aggregations) {
-        this.aggregations = aggregations;
+    public SearchContext aggregations(SearchContextAggregations searchContextAggregations) {
+        this.aggregations = searchContextAggregations;
         return this;
     }
 
@@ -302,8 +302,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext sort(SortAndFormats sort) {
-        this.sort = sort;
+    public SearchContext sort(SortAndFormats sortAndFormats) {
+        this.sort = sortAndFormats;
         return this;
     }
 
@@ -313,8 +313,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext trackScores(boolean trackScores) {
-        this.trackScores = trackScores;
+    public SearchContext trackScores(boolean shouldTrackScores) {
+        this.trackScores = shouldTrackScores;
         return this;
     }
 
@@ -324,8 +324,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext trackTotalHitsUpTo(int trackTotalHitsUpTo) {
-        this.trackTotalHitsUpTo = trackTotalHitsUpTo;
+    public SearchContext trackTotalHitsUpTo(int trackTotalHitsUpToValue) {
+        this.trackTotalHitsUpTo = trackTotalHitsUpToValue;
         return this;
     }
 
@@ -335,8 +335,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext searchAfter(FieldDoc searchAfter) {
-        this.searchAfter = searchAfter;
+    public SearchContext searchAfter(FieldDoc searchAfterDoc) {
+        this.searchAfter = searchAfterDoc;
         return this;
     }
 
@@ -356,8 +356,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext parsedPostFilter(ParsedQuery postFilter) {
-        this.postFilter = postFilter;
+    public SearchContext parsedPostFilter(ParsedQuery postFilterQuery) {
+        this.postFilter = postFilterQuery;
         return this;
     }
 
@@ -367,9 +367,9 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext parsedQuery(ParsedQuery query) {
-        this.originalQuery = query;
-        this.query = query.query();
+    public SearchContext parsedQuery(ParsedQuery parsedQuery) {
+        this.originalQuery = parsedQuery;
+        this.query = parsedQuery.query();
         return this;
     }
 
@@ -389,8 +389,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext from(int from) {
-        this.from = from;
+    public SearchContext from(int fromValue) {
+        this.from = fromValue;
         return this;
     }
 
@@ -404,7 +404,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext size(int size) {
+    public SearchContext size(int sizeValue) {
         return null;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
@@ -59,28 +59,28 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
     }
 
     @Override
-    public void applyToCluster(InternalTestCluster cluster) {
-        this.cluster = cluster;
+    public void applyToCluster(InternalTestCluster testCluster) {
+        this.cluster = testCluster;
     }
 
     @Override
-    public void removeFromCluster(InternalTestCluster cluster) {
+    public void removeFromCluster(InternalTestCluster testCluster) {
         stopDisrupting();
     }
 
     @Override
-    public void removeAndEnsureHealthy(InternalTestCluster cluster) {
-        removeFromCluster(cluster);
-        ensureHealthy(cluster);
+    public void removeAndEnsureHealthy(InternalTestCluster testCluster) {
+        removeFromCluster(testCluster);
+        ensureHealthy(testCluster);
     }
 
     /**
      * ensures the cluster is healthy after the disruption
      */
-    public void ensureHealthy(InternalTestCluster cluster) {
+    public void ensureHealthy(InternalTestCluster testCluster) {
         assert activeDisruption == false;
-        ensureNodeCount(cluster);
-        ensureFullyConnectedCluster(cluster);
+        ensureNodeCount(testCluster);
+        ensureFullyConnectedCluster(testCluster);
     }
 
     /**
@@ -105,20 +105,20 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
         }
     }
 
-    protected void ensureNodeCount(InternalTestCluster cluster) {
-        cluster.validateClusterFormed();
+    protected void ensureNodeCount(InternalTestCluster testCluster) {
+        testCluster.validateClusterFormed();
     }
 
     @Override
-    public synchronized void applyToNode(String node, InternalTestCluster cluster) {
+    public synchronized void applyToNode(String node, InternalTestCluster testCluster) {
 
     }
 
     @Override
-    public synchronized void removeFromNode(String node1, InternalTestCluster cluster) {
+    public synchronized void removeFromNode(String node1, InternalTestCluster testCluster) {
         logger.info("stop disrupting node (disruption type: {}, disrupted links: {})", networkLinkDisruptionType, disruptedLinks);
-        applyToNodes(new String[] { node1 }, cluster.getNodeNames(), networkLinkDisruptionType::removeDisruption);
-        applyToNodes(cluster.getNodeNames(), new String[] { node1 }, networkLinkDisruptionType::removeDisruption);
+        applyToNodes(new String[] { node1 }, testCluster.getNodeNames(), networkLinkDisruptionType::removeDisruption);
+        applyToNodes(testCluster.getNodeNames(), new String[] { node1 }, networkLinkDisruptionType::removeDisruption);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -28,28 +28,28 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
     }
 
     @Override
-    public void applyToCluster(InternalTestCluster cluster) {
-        this.cluster = cluster;
+    public void applyToCluster(InternalTestCluster testCluster) {
+        this.cluster = testCluster;
         if (disruptedNode == null) {
-            String[] nodes = cluster.getNodeNames();
+            String[] nodes = testCluster.getNodeNames();
             disruptedNode = nodes[random.nextInt(nodes.length)];
         }
     }
 
     @Override
-    public void removeFromCluster(InternalTestCluster cluster) {
+    public void removeFromCluster(InternalTestCluster testCluster) {
         if (disruptedNode != null) {
-            removeFromNode(disruptedNode, cluster);
+            removeFromNode(disruptedNode, testCluster);
         }
     }
 
     @Override
-    public synchronized void applyToNode(String node, InternalTestCluster cluster) {
+    public synchronized void applyToNode(String node, InternalTestCluster testCluster) {
 
     }
 
     @Override
-    public synchronized void removeFromNode(String node, InternalTestCluster cluster) {
+    public synchronized void removeFromNode(String node, InternalTestCluster testCluster) {
         if (disruptedNode == null) {
             return;
         }
@@ -65,14 +65,14 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
         disruptedNode = null;
     }
 
-    protected void ensureNodeCount(InternalTestCluster cluster) {
+    protected void ensureNodeCount(InternalTestCluster testCluster) {
         assertFalse(
             "cluster failed to form after disruption was healed",
-            cluster.client()
+            testCluster.client()
                 .admin()
                 .cluster()
                 .prepareHealth()
-                .setWaitForNodes(String.valueOf(cluster.size()))
+                .setWaitForNodes(String.valueOf(testCluster.size()))
                 .setWaitForNoRelocatingShards(true)
                 .get()
                 .isTimedOut()

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -268,10 +268,10 @@ public abstract class ESRestTestCase extends ESTestCase {
         /**
          * Adds to the set of warnings that are permissible (but not required) when running
          * in mixed-version clusters or those that differ in version from the test client.
-         * @param allowedWarnings optional warnings that will be ignored if received
+         * @param allowedWarningsToAdd optional warnings that will be ignored if received
          */
-        public void compatible(String... allowedWarnings) {
-            this.allowedWarnings.addAll(Arrays.asList(allowedWarnings));
+        public void compatible(String... allowedWarningsToAdd) {
+            this.allowedWarnings.addAll(Arrays.asList(allowedWarningsToAdd));
         }
 
         @Override
@@ -417,11 +417,11 @@ public abstract class ESRestTestCase extends ESTestCase {
      * Wait for outstanding tasks to complete. The specified admin client is used to check the outstanding tasks and this is done using
      * {@link ESTestCase#assertBusy(CheckedRunnable)} to give a chance to any outstanding tasks to complete.
      *
-     * @param adminClient the admin client
+     * @param restClient the admin client
      * @throws Exception if an exception is thrown while checking the outstanding tasks
      */
-    public static void waitForPendingTasks(final RestClient adminClient) throws Exception {
-        waitForPendingTasks(adminClient, taskName -> false);
+    public static void waitForPendingTasks(final RestClient restClient) throws Exception {
+        waitForPendingTasks(restClient, taskName -> false);
     }
 
     /**
@@ -429,16 +429,16 @@ public abstract class ESRestTestCase extends ESTestCase {
      * {@link ESTestCase#assertBusy(CheckedRunnable)} to give a chance to any outstanding tasks to complete. The specified filter is used
      * to filter out outstanding tasks that are expected to be there.
      *
-     * @param adminClient the admin client
+     * @param restClient the admin client
      * @param taskFilter  predicate used to filter tasks that are expected to be there
      * @throws Exception if an exception is thrown while checking the outstanding tasks
      */
-    public static void waitForPendingTasks(final RestClient adminClient, final Predicate<String> taskFilter) throws Exception {
+    public static void waitForPendingTasks(final RestClient restClient, final Predicate<String> taskFilter) throws Exception {
         assertBusy(() -> {
             try {
                 final Request request = new Request("GET", "/_cat/tasks");
                 request.addParameter("detailed", "true");
-                final Response response = adminClient.performRequest(request);
+                final Response response = restClient.performRequest(request);
                 /*
                  * Check to see if there are outstanding tasks; we exclude the list task itself, and any expected outstanding tasks using
                  * the specified task filter.
@@ -1436,15 +1436,15 @@ public abstract class ESRestTestCase extends ESTestCase {
         ensureHealth(client(), index, requestConsumer);
     }
 
-    protected static void ensureHealth(RestClient client, String index, Consumer<Request> requestConsumer) throws IOException {
+    protected static void ensureHealth(RestClient restClient, String index, Consumer<Request> requestConsumer) throws IOException {
         Request request = new Request("GET", "/_cluster/health" + (index.trim().isEmpty() ? "" : "/" + index));
         requestConsumer.accept(request);
         try {
-            client.performRequest(request);
+            restClient.performRequest(request);
         } catch (ResponseException e) {
             if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.SC_REQUEST_TIMEOUT) {
                 try {
-                    final Response clusterStateResponse = client.performRequest(new Request("GET", "/_cluster/state?pretty"));
+                    final Response clusterStateResponse = restClient.performRequest(new Request("GET", "/_cluster/state?pretty"));
                     fail(
                         "timed out waiting for green state for index ["
                             + index
@@ -1505,9 +1505,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         deleteIndex(client(), name);
     }
 
-    protected static void deleteIndex(RestClient client, String name) throws IOException {
+    protected static void deleteIndex(RestClient restClient, String name) throws IOException {
         Request request = new Request("DELETE", "/" + name);
-        client.performRequest(request);
+        restClient.performRequest(request);
     }
 
     protected static void updateIndexSettings(String index, Settings.Builder settings) throws IOException {
@@ -1636,13 +1636,13 @@ public abstract class ESRestTestCase extends ESTestCase {
         registerRepository(client(), repository, type, verify, settings);
     }
 
-    protected static void registerRepository(RestClient client, String repository, String type, boolean verify, Settings settings)
+    protected static void registerRepository(RestClient restClient, String repository, String type, boolean verify, Settings settings)
         throws IOException {
         final Request request = new Request(HttpPut.METHOD_NAME, "_snapshot/" + repository);
         request.addParameter("verify", Boolean.toString(verify));
         request.setJsonEntity(Strings.toString(new PutRepositoryRequest(repository).type(type).settings(settings)));
 
-        final Response response = client.performRequest(request);
+        final Response response = restClient.performRequest(request);
         assertAcked("Failed to create repository [" + repository + "] of type [" + type + "]: " + response, response);
     }
 
@@ -1650,12 +1650,12 @@ public abstract class ESRestTestCase extends ESTestCase {
         createSnapshot(client(), repository, snapshot, waitForCompletion);
     }
 
-    protected static void createSnapshot(RestClient client, String repository, String snapshot, boolean waitForCompletion)
+    protected static void createSnapshot(RestClient restClient, String repository, String snapshot, boolean waitForCompletion)
         throws IOException {
         final Request request = new Request(HttpPut.METHOD_NAME, "_snapshot/" + repository + '/' + snapshot);
         request.addParameter("wait_for_completion", Boolean.toString(waitForCompletion));
 
-        final Response response = client.performRequest(request);
+        final Response response = restClient.performRequest(request);
         assertThat(
             "Failed to create snapshot [" + snapshot + "] in repository [" + repository + "]: " + response,
             response.getStatusLine().getStatusCode(),
@@ -1679,12 +1679,13 @@ public abstract class ESRestTestCase extends ESTestCase {
         deleteSnapshot(client(), repository, snapshot, ignoreMissing);
     }
 
-    protected static void deleteSnapshot(RestClient client, String repository, String snapshot, boolean ignoreMissing) throws IOException {
+    protected static void deleteSnapshot(RestClient restClient, String repository, String snapshot, boolean ignoreMissing)
+        throws IOException {
         final Request request = new Request(HttpDelete.METHOD_NAME, "_snapshot/" + repository + '/' + snapshot);
         if (ignoreMissing) {
             request.addParameter("ignore", "404");
         }
-        final Response response = client.performRequest(request);
+        final Response response = restClient.performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), ignoreMissing ? anyOf(equalTo(200), equalTo(404)) : equalTo(200));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -109,17 +109,17 @@ public class FakeRestRequest extends RestRequest {
         }
 
         @Override
-        public HttpResponse createResponse(RestStatus status, BytesReference content) {
-            Map<String, String> headers = new HashMap<>();
+        public HttpResponse createResponse(RestStatus status, BytesReference unused) {
+            Map<String, String> responseHeaders = new HashMap<>();
             return new HttpResponse() {
                 @Override
                 public void addHeader(String name, String value) {
-                    headers.put(name, value);
+                    responseHeaders.put(name, value);
                 }
 
                 @Override
                 public boolean containsHeader(String name) {
-                    return headers.containsKey(name);
+                    return responseHeaders.containsKey(name);
                 }
             };
         }
@@ -209,8 +209,8 @@ public class FakeRestRequest extends RestRequest {
             return this;
         }
 
-        public Builder withContent(BytesReference content, XContentType xContentType) {
-            this.content = content;
+        public Builder withContent(BytesReference contentBytes, XContentType xContentType) {
+            this.content = contentBytes;
             if (xContentType != null) {
                 headers.put("Content-Type", Collections.singletonList(xContentType.mediaType()));
             }
@@ -227,8 +227,8 @@ public class FakeRestRequest extends RestRequest {
             return this;
         }
 
-        public Builder withRemoteAddress(InetSocketAddress address) {
-            this.address = address;
+        public Builder withRemoteAddress(InetSocketAddress remoteAddress) {
+            this.address = remoteAddress;
             return this;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Holds an object and allows to extract specific values from it given their path
+ * Holds an object and allows extraction of specific values from it, given their path
  */
 public class ObjectPath {
 
@@ -77,24 +77,24 @@ public class ObjectPath {
     @SuppressWarnings("unchecked")
     public <T> T evaluate(String path, Stash stash) throws IOException {
         String[] parts = parsePath(path);
-        Object object = this.object;
+        Object result = this.object;
         for (String part : parts) {
-            object = evaluate(part, object, stash);
-            if (object == null) {
+            result = evaluate(part, result, stash);
+            if (result == null) {
                 return null;
             }
         }
-        return (T) object;
+        return (T) result;
     }
 
     @SuppressWarnings("unchecked")
-    private Object evaluate(String key, Object object, Stash stash) throws IOException {
+    private Object evaluate(String key, Object objectToEvaluate, Stash stash) throws IOException {
         if (stash.containsStashedValue(key)) {
             key = stash.getValue(key).toString();
         }
 
-        if (object instanceof Map) {
-            final Map<String, Object> objectAsMap = (Map<String, Object>) object;
+        if (objectToEvaluate instanceof Map) {
+            final Map<String, Object> objectAsMap = (Map<String, Object>) objectToEvaluate;
             if ("_arbitrary_key_".equals(key)) {
                 if (objectAsMap.isEmpty()) {
                     throw new IllegalArgumentException("requested [" + key + "] but the map was empty");
@@ -106,10 +106,10 @@ public class ObjectPath {
             }
             return objectAsMap.get(key);
         }
-        if (object instanceof List) {
-            List<Object> list = (List<Object>) object;
+        if (objectToEvaluate instanceof List) {
+            List<Object> list = (List<Object>) objectToEvaluate;
             try {
-                return list.get(Integer.valueOf(key));
+                return list.get(Integer.parseInt(key));
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("element was a list, but [" + key + "] was not numeric", e);
             } catch (IndexOutOfBoundsException e) {
@@ -120,7 +120,9 @@ public class ObjectPath {
             }
         }
 
-        throw new IllegalArgumentException("no object found for [" + key + "] within object of class [" + object.getClass() + "]");
+        throw new IllegalArgumentException(
+            "no object found for [" + key + "] within object of class [" + objectToEvaluate.getClass() + "]"
+        );
     }
 
     private String[] parsePath(String path) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
@@ -166,11 +166,11 @@ public class ClientYamlSuiteRestApi {
      * - /{index}/_alias/{name}, /{index}/_aliases/{name}
      * - /{index}/{type}/_mapping, /{index}/{type}/_mappings, /{index}/_mappings/{type}, /{index}/_mapping/{type}
      */
-    public List<ClientYamlSuiteRestApi.Path> getBestMatchingPaths(Set<String> params) {
+    public List<ClientYamlSuiteRestApi.Path> getBestMatchingPaths(Set<String> pathParams) {
         PriorityQueue<Tuple<Integer, Path>> queue = new PriorityQueue<>(Comparator.comparing(Tuple::v1, (a, b) -> Integer.compare(b, a)));
         for (ClientYamlSuiteRestApi.Path path : paths) {
             int matches = 0;
-            for (String actualParameter : params) {
+            for (String actualParameter : pathParams) {
                 if (path.getParts().contains(actualParameter)) {
                     matches++;
                 }
@@ -180,17 +180,17 @@ public class ClientYamlSuiteRestApi {
             }
         }
         if (queue.isEmpty()) {
-            throw new IllegalStateException("Unable to find a matching path for api [" + name + "]" + params);
+            throw new IllegalStateException("Unable to find a matching path for api [" + name + "]" + pathParams);
         }
-        List<Path> paths = new ArrayList<>();
+        List<Path> pathsByRelevance = new ArrayList<>();
         Tuple<Integer, Path> poll = queue.poll();
         int maxMatches = poll.v1();
         do {
-            paths.add(poll.v2());
+            pathsByRelevance.add(poll.v2());
             poll = queue.poll();
         } while (poll != null && poll.v1() == maxMatches);
 
-        return paths;
+        return pathsByRelevance;
     }
 
     public static class Path {
@@ -224,8 +224,8 @@ public class ClientYamlSuiteRestApi {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            Path path = (Path) o;
-            return this.path.equals(path.path);
+            Path other = (Path) o;
+            return this.path.equals(other.path);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -253,8 +253,8 @@ public class DoSection implements ExecutableSection {
         return catchParam;
     }
 
-    public void setCatch(String catchParam) {
-        this.catchParam = catchParam;
+    public void setCatch(String param) {
+        this.catchParam = param;
     }
 
     public ApiCallSection getApiCallSection() {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/FakeTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/FakeTransport.java
@@ -35,11 +35,11 @@ public class FakeTransport extends AbstractLifecycleComponent implements Transpo
     private TransportMessageListener listener;
 
     @Override
-    public void setMessageListener(TransportMessageListener listener) {
+    public void setMessageListener(TransportMessageListener messageListener) {
         if (this.listener != null) {
             throw new IllegalStateException("listener already set");
         }
-        this.listener = listener;
+        this.listener = messageListener;
     }
 
     @Override
@@ -63,8 +63,8 @@ public class FakeTransport extends AbstractLifecycleComponent implements Transpo
     }
 
     @Override
-    public void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Connection> listener) {
-        listener.onResponse(new CloseableConnection() {
+    public void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Connection> actionListener) {
+        actionListener.onResponse(new CloseableConnection() {
             @Override
             public DiscoveryNode getNode() {
                 return node;

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -74,7 +74,9 @@ public class MockTransport extends StubbableTransport {
 
     public MockTransport() {
         super(new FakeTransport());
-        setDefaultConnectBehavior((transport, discoveryNode, profile, listener) -> listener.onResponse(createConnection(discoveryNode)));
+        setDefaultConnectBehavior(
+            (transport, discoveryNode, profile, actionListener) -> actionListener.onResponse(createConnection(discoveryNode))
+        );
     }
 
     /**
@@ -172,12 +174,12 @@ public class MockTransport extends StubbableTransport {
     protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {}
 
     @Override
-    public void setMessageListener(TransportMessageListener listener) {
+    public void setMessageListener(TransportMessageListener messageListener) {
         if (this.listener != null) {
             throw new IllegalStateException("listener already set");
         }
-        this.listener = listener;
-        super.setMessageListener(listener);
+        this.listener = messageListener;
+        super.setMessageListener(messageListener);
     }
 
     protected NamedWriteableRegistry writeableRegistry() {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -44,8 +44,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return state == null ? Double.NEGATIVE_INFINITY : state.getMin();
+            double value(TDigestState digestState) {
+                return digestState == null ? Double.NEGATIVE_INFINITY : digestState.getMin();
             }
         },
         MAX {
@@ -55,8 +55,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return state == null ? Double.POSITIVE_INFINITY : state.getMax();
+            double value(TDigestState digestState) {
+                return digestState == null ? Double.POSITIVE_INFINITY : digestState.getMax();
             }
         },
         Q1 {
@@ -66,8 +66,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return state == null ? Double.NaN : state.quantile(0.25);
+            double value(TDigestState digestState) {
+                return digestState == null ? Double.NaN : digestState.quantile(0.25);
             }
         },
         Q2 {
@@ -77,8 +77,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return state == null ? Double.NaN : state.quantile(0.5);
+            double value(TDigestState digestState) {
+                return digestState == null ? Double.NaN : digestState.quantile(0.5);
             }
         },
         Q3 {
@@ -88,8 +88,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return state == null ? Double.NaN : state.quantile(0.75);
+            double value(TDigestState digestState) {
+                return digestState == null ? Double.NaN : digestState.quantile(0.75);
             }
         },
         LOWER {
@@ -99,8 +99,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return whiskers(state)[0];
+            double value(TDigestState digestState) {
+                return whiskers(digestState)[0];
             }
         },
         UPPER {
@@ -110,8 +110,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
 
             @Override
-            double value(TDigestState state) {
-                return whiskers(state)[1];
+            double value(TDigestState digestState) {
+                return whiskers(digestState)[1];
             }
         };
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -350,6 +350,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     protected InternalMultiTerms create(
         String name,
         List<Bucket> buckets,
@@ -415,11 +416,13 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     protected Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, Bucket prototype) {
         return new Bucket(prototype.terms, docCount, aggs, prototype.showDocCountError, docCountError, formats, keyConverters);
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public InternalMultiTerms create(List<Bucket> buckets) {
         return new InternalMultiTerms(
             name,
@@ -493,9 +496,9 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
     private InternalAggregation promoteToDouble(InternalAggregation aggregation, boolean[] needsPromotion) {
         InternalMultiTerms multiTerms = (InternalMultiTerms) aggregation;
-        List<Bucket> buckets = multiTerms.getBuckets();
+        List<Bucket> multiTermsBuckets = multiTerms.getBuckets();
         List<List<Object>> newKeys = new ArrayList<>();
-        for (InternalMultiTerms.Bucket bucket : buckets) {
+        for (InternalMultiTerms.Bucket bucket : multiTermsBuckets) {
             newKeys.add(new ArrayList<>(bucket.terms.size()));
         }
 
@@ -505,20 +508,20 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
             DocValueFormat format = formats.get(i);
             if (needsPromotion[i]) {
                 newKeyConverters.add(KeyConverter.DOUBLE);
-                for (int j = 0; j < buckets.size(); j++) {
-                    newKeys.get(j).add(converter.toDouble(format, buckets.get(j).terms.get(i)));
+                for (int j = 0; j < multiTermsBuckets.size(); j++) {
+                    newKeys.get(j).add(converter.toDouble(format, multiTermsBuckets.get(j).terms.get(i)));
                 }
             } else {
                 newKeyConverters.add(converter);
-                for (int j = 0; j < buckets.size(); j++) {
-                    newKeys.get(j).add(buckets.get(j).terms.get(i));
+                for (int j = 0; j < multiTermsBuckets.size(); j++) {
+                    newKeys.get(j).add(multiTermsBuckets.get(j).terms.get(i));
                 }
             }
         }
 
-        List<Bucket> newBuckets = new ArrayList<>(buckets.size());
-        for (int i = 0; i < buckets.size(); i++) {
-            Bucket oldBucket = buckets.get(i);
+        List<Bucket> newBuckets = new ArrayList<>(multiTermsBuckets.size());
+        for (int i = 0; i < multiTermsBuckets.size(); i++) {
+            Bucket oldBucket = multiTermsBuckets.get(i);
             newBuckets.add(
                 new Bucket(
                     newKeys.get(i),

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationFactory.java
@@ -57,15 +57,15 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
     @Override
     protected Aggregator createInternal(Aggregator parent, CardinalityUpperBound cardinality, Map<String, Object> metadata)
         throws IOException {
-        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(this.bucketCountThresholds);
+        TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(this.bucketCountThresholds);
         if (InternalOrder.isKeyOrder(order) == false
-            && bucketCountThresholds.getShardSize() == MultiTermsAggregationBuilder.DEFAULT_BUCKET_COUNT_THRESHOLDS.getShardSize()) {
+            && thresholds.getShardSize() == MultiTermsAggregationBuilder.DEFAULT_BUCKET_COUNT_THRESHOLDS.getShardSize()) {
             // The user has not made a shardSize selection. Use default
             // heuristic to avoid any wrong-ranking caused by distributed
             // counting
-            bucketCountThresholds.setShardSize(BucketUtils.suggestShardSideQueueSize(bucketCountThresholds.getRequiredSize()));
+            thresholds.setShardSize(BucketUtils.suggestShardSideQueueSize(thresholds.getRequiredSize()));
         }
-        bucketCountThresholds.ensureValidity();
+        thresholds.ensureValidity();
         return new MultiTermsAggregator(
             name,
             factories,
@@ -76,7 +76,7 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
             showTermDocCountError,
             order,
             collectMode,
-            bucketCountThresholds,
+            thresholds,
             cardinality,
             metadata
         );

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
@@ -146,11 +146,11 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
     List<List<Object>> docTerms(List<TermValues> termValuesList, int doc) throws IOException {
         List<List<Object>> terms = new ArrayList<>();
         for (TermValues termValues : termValuesList) {
-            List<Object> values = termValues.collectValues(doc);
-            if (values == null) {
+            List<Object> collectValues = termValues.collectValues(doc);
+            if (collectValues == null) {
                 return null;
             }
-            terms.add(values);
+            terms.add(collectValues);
         }
         return terms;
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/normalize/NormalizePipelineMethods.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/normalize/NormalizePipelineMethods.java
@@ -94,14 +94,14 @@ class NormalizePipelineMethods {
         private double sumExp;
 
         Softmax(double[] values) {
-            double sumExp = 0.0;
+            double _sumExp = 0.0;
             for (Double value : values) {
                 if (value.isNaN() == false) {
-                    sumExp += Math.exp(value);
+                    _sumExp += Math.exp(value);
                 }
             }
 
-            this.sumExp = sumExp;
+            this.sumExp = _sumExp;
         }
 
         @Override
@@ -117,6 +117,7 @@ class NormalizePipelineMethods {
         protected final double mean;
         protected final int count;
 
+        @SuppressWarnings("HiddenField")
         SinglePassSimpleStatisticsMethod(double[] values) {
             int count = 0;
             double sum = 0.0;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
@@ -61,20 +61,20 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
     }
 
     private SizedBucketAggregator findSizedBucketAncestor() {
-        SizedBucketAggregator sizedBucketAggregator = null;
+        SizedBucketAggregator aggregator = null;
         for (Aggregator ancestor = parent; ancestor != null; ancestor = ancestor.parent()) {
             if (ancestor instanceof SizedBucketAggregator) {
-                sizedBucketAggregator = (SizedBucketAggregator) ancestor;
+                aggregator = (SizedBucketAggregator) ancestor;
                 break;
             }
         }
-        if (sizedBucketAggregator == null) {
+        if (aggregator == null) {
             throw new IllegalArgumentException(
                 "The rate aggregation can only be used inside a date histogram aggregation or "
                     + "composite aggregation with one date histogram value source"
             );
         }
-        return sizedBucketAggregator;
+        return aggregator;
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/InternalRate.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/InternalRate.java
@@ -72,15 +72,15 @@ public class InternalRate extends InternalNumericMetricsAggregation.SingleValue 
         // Compute the sum of double values with Kahan summation algorithm which is more
         // accurate than naive summation.
         CompensatedSum kahanSummation = new CompensatedSum(0, 0);
-        Double divisor = null;
+        Double firstDivisor = null;
         for (InternalAggregation aggregation : aggregations) {
             double value = ((InternalRate) aggregation).sum;
             kahanSummation.add(value);
-            if (divisor == null) {
-                divisor = ((InternalRate) aggregation).divisor;
+            if (firstDivisor == null) {
+                firstDivisor = ((InternalRate) aggregation).divisor;
             }
         }
-        return new InternalRate(name, kahanSummation.value(), divisor, format, getMetadata());
+        return new InternalRate(name, kahanSummation.value(), firstDivisor, format, getMetadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -199,6 +199,7 @@ public class InternalStringStats extends InternalAggregation {
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public InternalStringStats reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         long count = 0;
         long totalLength = 0;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -147,7 +147,7 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
      */
     public TopMetricsAggregationBuilder(StreamInput in) throws IOException {
         super(in);
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({ "unchecked", "HiddenField" })
         List<SortBuilder<?>> sortBuilders = (List<SortBuilder<?>>) (List<?>) in.readNamedWriteableList(SortBuilder.class);
         this.sortBuilders = sortBuilders;
         this.size = in.readVInt();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -132,8 +132,8 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis = expirationTimeMillis;
+    public void setExpirationTime(long expirationTime) {
+        this.expirationTimeMillis = expirationTime;
     }
 
     @Override

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -85,6 +85,7 @@ class MutableSearchResponse {
      * Updates the response with the result of a partial reduction.
      * @param reducedAggs is a strategy for producing the reduced aggs
      */
+    @SuppressWarnings("HiddenField")
     synchronized void updatePartialResponse(
         int successfulShards,
         TotalHits totalHits,
@@ -138,11 +139,11 @@ class MutableSearchResponse {
     /**
      * Adds a shard failure concurrently (non-blocking).
      */
-    void addQueryFailure(int shardIndex, ShardSearchFailure failure) {
+    void addQueryFailure(int shardIndex, ShardSearchFailure shardSearchFailure) {
         synchronized (this) {
             failIfFrozen();
         }
-        queryFailures.set(shardIndex, failure);
+        queryFailures.set(shardIndex, shardSearchFailure);
     }
 
     private SearchResponse buildResponse(long taskStartTimeNanos, InternalAggregations reducedAggs) {
@@ -290,9 +291,9 @@ class MutableSearchResponse {
         }
         List<ShardSearchFailure> failures = new ArrayList<>();
         for (int i = 0; i < queryFailures.length(); i++) {
-            ShardSearchFailure failure = queryFailures.get(i);
-            if (failure != null) {
-                failures.add(failure);
+            ShardSearchFailure shardSearchFailure = queryFailures.get(i);
+            if (shardSearchFailure != null) {
+                failures.add(shardSearchFailure);
             }
         }
         return failures.toArray(new ShardSearchFailure[0]);

--- a/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
+++ b/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
@@ -44,7 +44,7 @@ public class AsyncResultsIndexPlugin extends Plugin implements SystemIndexPlugin
     }
 
     @Override
-    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings unused) {
         return Collections.singletonList(new SystemIndexDescriptor(XPackPlugin.ASYNC_RESULTS_INDEX + "*", this.getClass().getSimpleName()));
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -88,7 +88,7 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
     );
 
     private final List<AutoscalingExtension> autoscalingExtensions;
-    private final SetOnce<ClusterService> clusterService = new SetOnce<>();
+    private final SetOnce<ClusterService> clusterServiceHolder = new SetOnce<>();
     private final SetOnce<AllocationDeciders> allocationDeciders = new SetOnce<>();
     private final AutoscalingLicenseChecker autoscalingLicenseChecker;
 
@@ -115,7 +115,7 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        this.clusterService.set(clusterService);
+        this.clusterServiceHolder.set(clusterService);
         return org.elasticsearch.core.List.of(
             new AutoscalingCalculateCapacityService.Holder(this),
             autoscalingLicenseChecker,
@@ -209,26 +209,19 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
     @Override
     public Collection<AutoscalingDeciderService> deciders() {
         assert allocationDeciders.get() != null;
+        final ClusterService clusterService = clusterServiceHolder.get();
         return org.elasticsearch.core.List.of(
             new FixedAutoscalingDeciderService(),
-            new ReactiveStorageDeciderService(
-                clusterService.get().getSettings(),
-                clusterService.get().getClusterSettings(),
-                allocationDeciders.get()
-            ),
-            new ProactiveStorageDeciderService(
-                clusterService.get().getSettings(),
-                clusterService.get().getClusterSettings(),
-                allocationDeciders.get()
-            ),
+            new ReactiveStorageDeciderService(clusterService.getSettings(), clusterService.getClusterSettings(), allocationDeciders.get()),
+            new ProactiveStorageDeciderService(clusterService.getSettings(), clusterService.getClusterSettings(), allocationDeciders.get()),
             new FrozenShardsDeciderService(),
             new FrozenStorageDeciderService(),
             new FrozenExistenceDeciderService()
         );
     }
 
-    public Set<AutoscalingDeciderService> createDeciderServices(AllocationDeciders allocationDeciders) {
-        this.allocationDeciders.set(allocationDeciders);
+    public Set<AutoscalingDeciderService> createDeciderServices(AllocationDeciders deciders) {
+        this.allocationDeciders.set(deciders);
         return autoscalingExtensions.stream().flatMap(p -> p.deciders().stream()).collect(Collectors.toSet());
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
@@ -75,12 +75,12 @@ public class AutoscalingMetadata implements XPackPlugin.XPackMetadataCustom, Met
 
     public AutoscalingMetadata(final StreamInput in) throws IOException {
         final int size = in.readVInt();
-        final SortedMap<String, AutoscalingPolicyMetadata> policies = new TreeMap<>();
+        final SortedMap<String, AutoscalingPolicyMetadata> policiesMap = new TreeMap<>();
         for (int i = 0; i < size; i++) {
             final AutoscalingPolicyMetadata policyMetadata = new AutoscalingPolicyMetadata(in);
-            policies.put(policyMetadata.policy().name(), policyMetadata);
+            policiesMap.put(policyMetadata.policy().name(), policyMetadata);
         }
-        this.policies = policies;
+        this.policies = policiesMap;
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
@@ -93,11 +93,11 @@ public class PutAutoscalingPolicyAction extends ActionType<AcknowledgedResponse>
             }
             if (in.readBoolean()) {
                 int deciderCount = in.readInt();
-                SortedMap<String, Settings> deciders = new TreeMap<>();
+                SortedMap<String, Settings> decidersMap = new TreeMap<>();
                 for (int i = 0; i < deciderCount; ++i) {
-                    deciders.put(in.readString(), Settings.readSettingsFromStream(in));
+                    decidersMap.put(in.readString(), Settings.readSettingsFromStream(in));
                 }
-                this.deciders = Collections.unmodifiableSortedMap(deciders);
+                this.deciders = Collections.unmodifiableSortedMap(decidersMap);
             } else {
                 this.deciders = null;
             }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 public class TransportDeleteAutoscalingPolicyAction extends AcknowledgedTransportMasterNodeAction<DeleteAutoscalingPolicyAction.Request> {
 
-    private static final Logger logger = LogManager.getLogger(TransportPutAutoscalingPolicyAction.class);
+    private static final Logger LOGGER = LogManager.getLogger(TransportPutAutoscalingPolicyAction.class);
 
     @Inject
     public TransportDeleteAutoscalingPolicyAction(
@@ -66,7 +66,7 @@ public class TransportDeleteAutoscalingPolicyAction extends AcknowledgedTranspor
         clusterService.submitStateUpdateTask("delete-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
-                return deleteAutoscalingPolicy(currentState, request.name(), logger);
+                return deleteAutoscalingPolicy(currentState, request.name(), LOGGER);
             }
         });
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 
 public class TransportPutAutoscalingPolicyAction extends AcknowledgedTransportMasterNodeAction<PutAutoscalingPolicyAction.Request> {
 
-    private static final Logger logger = LogManager.getLogger(TransportPutAutoscalingPolicyAction.class);
+    private static final Logger LOGGER = LogManager.getLogger(TransportPutAutoscalingPolicyAction.class);
 
     private final PolicyValidator policyValidator;
     private final AutoscalingLicenseChecker autoscalingLicenseChecker;
@@ -119,7 +119,7 @@ public class TransportPutAutoscalingPolicyAction extends AcknowledgedTransportMa
         clusterService.submitStateUpdateTask("put-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
-                return putAutoscalingPolicy(currentState, request, policyValidator, logger);
+                return putAutoscalingPolicy(currentState, request, policyValidator, LOGGER);
             }
         });
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -185,9 +185,9 @@ public class AutoscalingMemoryInfoService {
     }
 
     public AutoscalingMemoryInfo snapshot() {
-        final ImmutableOpenMap<String, Long> nodeToMemory = this.nodeToMemory;
+        final ImmutableOpenMap<String, Long> nodeToMemoryRef = this.nodeToMemory;
         return node -> {
-            Long result = nodeToMemory.get(node.getEphemeralId());
+            Long result = nodeToMemoryRef.get(node.getEphemeralId());
             // noinspection NumberEquality
             if (result == FETCHING_SENTINEL) {
                 return null;

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
@@ -90,11 +90,11 @@ public class AutoscalingPolicy extends AbstractDiffable<AutoscalingPolicy> imple
         this.name = in.readString();
         this.roles = Collections.unmodifiableSortedSet(new TreeSet<>(in.readSet(StreamInput::readString)));
         int deciderCount = in.readInt();
-        SortedMap<String, Settings> deciders = new TreeMap<>();
+        SortedMap<String, Settings> decidersMap = new TreeMap<>();
         for (int i = 0; i < deciderCount; ++i) {
-            deciders.put(in.readString(), Settings.readSettingsFromStream(in));
+            decidersMap.put(in.readString(), Settings.readSettingsFromStream(in));
         }
-        this.deciders = Collections.unmodifiableSortedMap(deciders);
+        this.deciders = Collections.unmodifiableSortedMap(decidersMap);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -400,7 +400,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return allocation.metadata().getIndexSafe(shard.index());
         }
 
-        private Optional<String> highestPreferenceTier(List<String> preferredTiers, DiscoveryNodes nodes) {
+        private Optional<String> highestPreferenceTier(List<String> preferredTiers, DiscoveryNodes unused) {
             assert preferredTiers.isEmpty() == false;
             return Optional.of(preferredTiers.get(0));
         }
@@ -430,8 +430,8 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         }
 
         long unmovableSize(String nodeId, Collection<ShardRouting> shards) {
-            ClusterInfo info = this.info;
-            DiskUsage diskUsage = info.getNodeMostAvailableDiskUsages().get(nodeId);
+            ClusterInfo clusterInfo = this.info;
+            DiskUsage diskUsage = clusterInfo.getNodeMostAvailableDiskUsages().get(nodeId);
             if (diskUsage == null) {
                 // do not want to scale up then, since this should only happen when node has just joined (clearly edge case).
                 return 0;

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
@@ -395,9 +395,9 @@ public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
             });
         }
 
-        public void respond(BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responder) {
-            assertThat(responder, notNullValue());
-            this.responder = responder;
+        public void respond(BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responderValue) {
+            assertThat(responderValue, notNullValue());
+            this.responder = responderValue;
         }
 
         @Override
@@ -410,11 +410,11 @@ public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
             NodesStatsRequest nodesStatsRequest = (NodesStatsRequest) request;
             assertThat(nodesStatsRequest.timeout(), equalTo(fetchTimeout));
             assertThat(responder, notNullValue());
-            BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responder = this.responder;
+            BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responderValue = this.responder;
             this.responder = null;
             @SuppressWarnings("unchecked")
             ActionListener<NodesStatsResponse> statsListener = (ActionListener<NodesStatsResponse>) listener;
-            responder.accept(nodesStatsRequest, statsListener);
+            responderValue.accept(nodesStatsRequest, statsListener);
         }
 
         public void assertNoResponder() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -131,13 +131,13 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
 
     @Before
     public void setup() {
-        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
-        state = addRandomIndices(hotNodes, hotNodes, state);
-        state = addDataNodes(DATA_HOT_NODE_ROLE, "hot", state, hotNodes);
-        state = addDataNodes(DATA_WARM_NODE_ROLE, "warm", state, warmNodes);
-        this.state = state;
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test")).build();
+        clusterState = addRandomIndices(hotNodes, hotNodes, clusterState);
+        clusterState = addDataNodes(DATA_HOT_NODE_ROLE, "hot", clusterState, hotNodes);
+        clusterState = addDataNodes(DATA_WARM_NODE_ROLE, "warm", clusterState, warmNodes);
+        this.state = clusterState;
 
-        Set<ShardId> shardIds = shardIds(state.getRoutingNodes().unassigned());
+        Set<ShardId> shardIds = shardIds(clusterState.getRoutingNodes().unassigned());
         this.subjectShards = new HashSet<>(randomSubsetOf(randomIntBetween(1, shardIds.size()), shardIds));
     }
 
@@ -371,8 +371,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
     }
 
     private void verify(VerificationSubject subject, long expected, DiscoveryNodeRole role, AllocationDecider... allocationDeciders) {
-        ClusterState state = this.state;
-        verify(state, subject, expected, role, allocationDeciders);
+        verify(this.state, subject, expected, role, allocationDeciders);
     }
 
     private static void verify(

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -168,6 +168,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public Collection<Object> createComponents(
         final Client client,
         final ClusterService clusterService,
@@ -208,6 +209,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public List<PersistentTasksExecutor<?>> getPersistentTasksExecutor(
         ClusterService clusterService,
         ThreadPool threadPool,
@@ -264,7 +266,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     }
 
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,
@@ -357,6 +359,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
         }
     }
 
+    @SuppressWarnings("HiddenField")
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         if (enabled == false) {
             return Collections.emptyList();
@@ -414,7 +417,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     }
 
     @Override
-    public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+    public Collection<AllocationDecider> createAllocationDeciders(Settings unused, ClusterSettings clusterSettings) {
         return Collections.singletonList(new CcrPrimaryFollowerAllocationDecider());
     }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -136,6 +136,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
         };
     }
 
+    @SuppressWarnings("HiddenField")
     void start(
         final String followerHistoryUUID,
         final long leaderGlobalCheckpoint,
@@ -439,12 +440,12 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
 
     private void sendBulkShardOperationsRequest(
         List<Translog.Operation> operations,
-        long leaderMaxSeqNoOfUpdatesOrDeletes,
+        long leaderMaxSequenceNoOfUpdatesOrDeletes,
         AtomicInteger retryCounter
     ) {
-        assert leaderMaxSeqNoOfUpdatesOrDeletes != SequenceNumbers.UNASSIGNED_SEQ_NO : "mus is not replicated";
+        assert leaderMaxSequenceNoOfUpdatesOrDeletes != SequenceNumbers.UNASSIGNED_SEQ_NO : "mus is not replicated";
         final long startTime = relativeTimeProvider.getAsLong();
-        innerSendBulkShardOperationsRequest(followerHistoryUUID, operations, leaderMaxSeqNoOfUpdatesOrDeletes, response -> {
+        innerSendBulkShardOperationsRequest(followerHistoryUUID, operations, leaderMaxSequenceNoOfUpdatesOrDeletes, response -> {
             synchronized (ShardFollowNodeTask.this) {
                 totalWriteTimeMillis += TimeUnit.NANOSECONDS.toMillis(relativeTimeProvider.getAsLong() - startTime);
                 successfulWriteRequests++;
@@ -459,7 +460,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
             handleFailure(
                 e,
                 retryCounter,
-                () -> sendBulkShardOperationsRequest(operations, leaderMaxSeqNoOfUpdatesOrDeletes, retryCounter)
+                () -> sendBulkShardOperationsRequest(operations, leaderMaxSequenceNoOfUpdatesOrDeletes, retryCounter)
             );
         });
     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -620,12 +620,12 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
     }
 
     private void fetchFollowerShardInfo(
-        final Client client,
+        final Client followerClient,
         final ShardId shardId,
         final FollowerStatsInfoHandler handler,
         final Consumer<Exception> errorHandler
     ) {
-        client.admin().indices().stats(new IndicesStatsRequest().indices(shardId.getIndexName()), ActionListener.wrap(r -> {
+        followerClient.admin().indices().stats(new IndicesStatsRequest().indices(shardId.getIndexName()), ActionListener.wrap(r -> {
             IndexStats indexStats = r.getIndex(shardId.getIndexName());
             if (indexStats == null) {
                 IndexMetadata indexMetadata = clusterService.state().metadata().index(shardId.getIndex());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -273,7 +273,7 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
     }
 
     private void initiateFollowing(
-        final Client client,
+        final Client clientWithHeaders,
         final PutFollowAction.Request request,
         final ActionListener<PutFollowAction.Response> listener
     ) {
@@ -282,7 +282,7 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
         ResumeFollowAction.Request resumeFollowRequest = new ResumeFollowAction.Request();
         resumeFollowRequest.setFollowerIndex(request.getFollowerIndex());
         resumeFollowRequest.setParameters(new FollowParameters(parameters));
-        client.execute(
+        clientWithHeaders.execute(
             ResumeFollowAction.INSTANCE,
             resumeFollowRequest,
             ActionListener.wrap(

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -197,8 +197,8 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             .setMetadata(true)
             .setNodes(true)
             .get(ccrSettings.getRecoveryActionTimeout());
-        Metadata metadata = response.getState().metadata();
-        ImmutableOpenMap<String, IndexMetadata> indicesMap = metadata.indices();
+        Metadata responseMetadata = response.getState().metadata();
+        ImmutableOpenMap<String, IndexMetadata> indicesMap = responseMetadata.indices();
         List<String> indices = new ArrayList<>(indicesMap.keySet());
 
         // fork to the snapshot meta pool because the context expects to run on it and asserts that it does
@@ -208,7 +208,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                     new SnapshotInfo(
                         new Snapshot(this.metadata.name(), SNAPSHOT_ID),
                         indices,
-                        new ArrayList<>(metadata.dataStreams().keySet()),
+                        new ArrayList<>(responseMetadata.dataStreams().keySet()),
                         Collections.emptyList(),
                         response.getState().getNodes().getMaxNodeVersion(),
                         SnapshotState.SUCCESS
@@ -250,12 +250,12 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
         IndexMetadata.Builder imdBuilder = IndexMetadata.builder(leaderIndex);
         // Adding the leader index uuid for each shard as custom metadata:
-        Map<String, String> metadata = new HashMap<>();
-        metadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_SHARD_HISTORY_UUIDS, String.join(",", leaderHistoryUUIDs));
-        metadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_UUID_KEY, leaderIndexMetadata.getIndexUUID());
-        metadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_NAME_KEY, leaderIndexMetadata.getIndex().getName());
-        metadata.put(CcrConstants.CCR_CUSTOM_METADATA_REMOTE_CLUSTER_NAME_KEY, remoteClusterAlias);
-        imdBuilder.putCustom(CcrConstants.CCR_CUSTOM_METADATA_KEY, metadata);
+        Map<String, String> customMetadata = new HashMap<>();
+        customMetadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_SHARD_HISTORY_UUIDS, String.join(",", leaderHistoryUUIDs));
+        customMetadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_UUID_KEY, leaderIndexMetadata.getIndexUUID());
+        customMetadata.put(CcrConstants.CCR_CUSTOM_METADATA_LEADER_INDEX_NAME_KEY, leaderIndexMetadata.getIndex().getName());
+        customMetadata.put(CcrConstants.CCR_CUSTOM_METADATA_REMOTE_CLUSTER_NAME_KEY, remoteClusterAlias);
+        imdBuilder.putCustom(CcrConstants.CCR_CUSTOM_METADATA_KEY, customMetadata);
 
         imdBuilder.settings(leaderIndexMetadata.getSettings());
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -509,11 +509,11 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
             }
 
             @Override
-            protected synchronized void recoverPrimary(IndexShard primary) {
+            protected synchronized void recoverPrimary(IndexShard primaryShard) {
                 DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
                 Snapshot snapshot = new Snapshot("foo", new SnapshotId("bar", UUIDs.randomBase64UUID()));
                 ShardRouting routing = ShardRoutingHelper.newWithRestoreSource(
-                    primary.routingEntry(),
+                    primaryShard.routingEntry(),
                     new RecoverySource.SnapshotRecoverySource(
                         UUIDs.randomBase64UUID(),
                         snapshot,
@@ -521,9 +521,9 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                         new IndexId("test", UUIDs.randomBase64UUID(random()))
                     )
                 );
-                primary.markAsRecovering("remote recovery from leader", new RecoveryState(routing, localNode, null));
+                primaryShard.markAsRecovering("remote recovery from leader", new RecoveryState(routing, localNode, null));
                 final PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
-                primary.restoreFromRepository(new RestoreOnlyRepository(index.getName()) {
+                primaryShard.restoreFromRepository(new RestoreOnlyRepository(index.getName()) {
                     @Override
                     public void restoreShard(
                         Store store,
@@ -535,11 +535,11 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     ) {
                         ActionListener.completeWith(listener, () -> {
                             IndexShard leader = leaderGroup.getPrimary();
-                            Lucene.cleanLuceneIndex(primary.store().directory());
+                            Lucene.cleanLuceneIndex(primaryShard.store().directory());
                             try (Engine.IndexCommitRef sourceCommit = leader.acquireSafeIndexCommit()) {
                                 Store.MetadataSnapshot sourceSnapshot = leader.store().getMetadata(sourceCommit.getIndexCommit());
                                 for (StoreFileMetadata md : sourceSnapshot) {
-                                    primary.store()
+                                    primaryShard.store()
                                         .directory()
                                         .copyFrom(leader.store().directory(), md.name(), md.name(), IOContext.DEFAULT);
                                 }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -315,16 +315,16 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
         String id2 = indexResponse.getId();
 
-        String id;
+        String idToGet;
         String dataStreamToSnapshot;
         String backingIndexName;
         if (randomBoolean()) {
             dataStreamToSnapshot = "ds";
-            id = this.id;
+            idToGet = this.id;
             backingIndexName = this.dsBackingIndexName;
         } else {
             dataStreamToSnapshot = "other-ds";
-            id = id2;
+            idToGet = id2;
             backingIndexName = this.otherDsBackingIndexName;
         }
         boolean filterDuringSnapshotting = randomBoolean();
@@ -359,7 +359,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         assertEquals(1, restoreSnapshotResponse.getRestoreInfo().successfulShards());
 
-        assertEquals(DOCUMENT_SOURCE, client.prepareGet(backingIndexName, "_doc", id).get().getSourceAsMap());
+        assertEquals(DOCUMENT_SOURCE, client.prepareGet(backingIndexName, "_doc", idToGet).get().getSourceAsMap());
         SearchHit[] hits = client.prepareSearch(backingIndexName).get().getHits().getHits();
         assertEquals(1, hits.length);
         assertEquals(DOCUMENT_SOURCE, hits[0].getSourceAsMap());
@@ -850,7 +850,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testDeleteDataStreamDuringSnapshot() throws Exception {
-        Client client = client();
+        Client client1 = client();
 
         // this test uses a MockRepository
         assertAcked(client().admin().cluster().prepareDeleteRepository(REPO));
@@ -871,7 +871,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client.prepareIndex(dataStream, "_doc")
+            client1.prepareIndex(dataStream, "_doc")
                 .setOpType(DocWriteRequest.OpType.CREATE)
                 .setId(Integer.toString(i))
                 .setSource(Collections.singletonMap("@timestamp", "2020-12-12"))
@@ -882,7 +882,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertDocCount(dataStream, 100L);
 
         logger.info("--> snapshot");
-        ActionFuture<CreateSnapshotResponse> future = client.admin()
+        ActionFuture<CreateSnapshotResponse> future = client1.admin()
             .cluster()
             .prepareCreateSnapshot(repositoryName, SNAPSHOT)
             .setIndices(dataStream)
@@ -895,7 +895,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         // non-partial snapshots do not allow delete operations on data streams where snapshot has not been completed
         try {
             logger.info("--> delete index while non-partial snapshot is running");
-            client.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { dataStream })).actionGet();
+            client1.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { dataStream })).actionGet();
             fail("Expected deleting index to fail during snapshot");
         } catch (SnapshotInProgressException e) {
             assertThat(e.getMessage(), containsString("Cannot delete data streams that are being snapshotted: [" + dataStream));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingAppender.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingAppender.java
@@ -71,10 +71,10 @@ public class DeprecationIndexingAppender extends AbstractAppender {
     /**
      * Sets whether this appender is enabled or disabled. When disabled, the appender will
      * not perform indexing operations.
-     * @param isEnabled the enabled status of the appender.
+     * @param enabled the enabled status of the appender.
      */
-    public void setEnabled(boolean isEnabled) {
-        this.isEnabled = isEnabled;
+    public void setEnabled(boolean enabled) {
+        this.isEnabled = enabled;
     }
 
     /**


### PR DESCRIPTION
Backport of #80899.

Part of #19752. Fix more instances where local variable names were shadowing field names.
