### PR TITLE
[8.0] [DOCS] Fix elasticsearch-reset-password typo (#80919)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -103,7 +103,7 @@ For example:
 
 [source,sh]
 ----
-docker exec -it es-node01 /usr/share/elasticsearch/bin/reset-elastic-password
+docker exec -it es-node01 /usr/share/elasticsearch/bin/elasticsearch-reset-password
 ----
 ====
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix elasticsearch-reset-password typo (#80919)