### PR TITLE
Remove unused ConnectTransportException#node

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -15,8 +16,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 public class ConnectTransportException extends ActionTransportException {
-
-    private final DiscoveryNode node;
 
     public ConnectTransportException(DiscoveryNode node, String msg) {
         this(node, msg, null, null);
@@ -32,21 +31,20 @@ public class ConnectTransportException extends ActionTransportException {
 
     public ConnectTransportException(DiscoveryNode node, String msg, String action, Throwable cause) {
         super(node == null ? null : node.getName(), node == null ? null : node.getAddress(), action, msg, cause);
-        this.node = node;
     }
 
     public ConnectTransportException(StreamInput in) throws IOException {
         super(in);
-        node = in.readOptionalWriteable(DiscoveryNode::new);
+        if (in.getVersion().before(Version.V_8_1_0)) {
+            in.readOptionalWriteable(DiscoveryNode::new);
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalWriteable(node);
-    }
-
-    public DiscoveryNode node() {
-        return node;
+        if (out.getVersion().before(Version.V_8_1_0)) {
+            out.writeBoolean(false); // optional & unused node field
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -410,12 +410,10 @@ public class ExceptionSerializationTests extends ESTestCase {
         DiscoveryNode node = new DiscoveryNode("thenode", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
         ConnectTransportException ex = serialize(new ConnectTransportException(node, "msg", "action", null));
         assertEquals("[][" + transportAddress + "][action] msg", ex.getMessage());
-        assertEquals(node, ex.node());
         assertNull(ex.getCause());
 
         ex = serialize(new ConnectTransportException(node, "msg", "action", new NullPointerException()));
         assertEquals("[][" + transportAddress + "][action] msg", ex.getMessage());
-        assertEquals(node, ex.node());
         assertTrue(ex.getCause() instanceof NullPointerException);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -87,6 +87,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.transport.TransportService.NOOP_TRANSPORT_INTERCEPTOR;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -1721,7 +1722,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 public void handleException(TransportException exp) {
                     Throwable cause = ExceptionsHelper.unwrapCause(exp);
                     assertThat(cause, instanceOf(ConnectTransportException.class));
-                    assertThat(((ConnectTransportException) cause).node(), equalTo(nodeA));
+                    assertThat(cause.getMessage(), allOf(containsString(nodeA.getName()), containsString(nodeA.getAddress().toString())));
                 }
             }
         );
@@ -1729,7 +1730,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final ExecutionException e = expectThrows(ExecutionException.class, res::get);
         Throwable cause = ExceptionsHelper.unwrapCause(e.getCause());
         assertThat(cause, instanceOf(ConnectTransportException.class));
-        assertThat(((ConnectTransportException) cause).node(), equalTo(nodeA));
+        assertThat(cause.getMessage(), allOf(containsString(nodeA.getName()), containsString(nodeA.getAddress().toString())));
 
         // wait for the transport to process the sending failure and disconnect from node
         assertBusy(() -> assertFalse(serviceB.nodeConnected(nodeA)));


### PR DESCRIPTION
`ConnectTransportException#node` is only used in a couple of assertions
in tests, but those assertions are either unnecessary or can be
rewritten without it so this field is effectively unused. This commit
removes it.