### PR TITLE
TSDB: fix error without feature flag

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -132,6 +132,9 @@ if (BuildParams.isSnapshotBuild() == false) {
     tasks.named("test").configure {
         systemProperty 'es.index_mode_feature_flag_registered', 'true'
     }
+    tasks.named("internalClusterTest").configure {
+        systemProperty 'es.index_mode_feature_flag_registered', 'true'
+    }
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -813,7 +813,9 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_DEPTH_LIMIT_SETTING, this::setMappingDepthLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING, this::setMappingFieldNameLengthLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING, this::setMappingDimensionFieldsLimit);
-        scopedSettings.addSettingsUpdateConsumer(TIME_SERIES_END_TIME, this::updateTimeSeriesEndTime);
+        if (IndexSettings.isTimeSeriesModeEnabled()) {
+            scopedSettings.addSettingsUpdateConsumer(TIME_SERIES_END_TIME, this::updateTimeSeriesEndTime);
+        }
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {


### PR DESCRIPTION
When you haven't enable the tsdb feature flag we would refuse to start.
That's bad because we will likely release with the feature flag
disabled. This should get us starting again. It fixes:

* We tried to register a settings update consumer for the `end_time` for
  the tsdb index even when the `end_time` setting wasn't registered.
* Pass the feature flag to internal cluster tests.
