### PR TITLE
[8.0] Remove obsolete typed legacy index templates (#80937)

### DIFF
--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/Logstash.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/Logstash.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -41,7 +42,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
@@ -190,5 +193,14 @@ public class Logstash extends Plugin implements SystemIndexPlugin {
     @Override
     public String getFeatureDescription() {
         return "Enables Logstash Central Management pipeline storage";
+    }
+
+    @Override
+    public UnaryOperator<Map<String, IndexTemplateMetadata>> getIndexTemplateMetadataUpgrader() {
+        return templates -> {
+            // .logstash is a system index now. deleting the legacy template
+            templates.remove("logstash-index-template");
+            return templates;
+        };
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1531,6 +1531,8 @@ public class Security extends Plugin
         return templates -> {
             // .security index is not managed by using templates anymore
             templates.remove("security_audit_log");
+            // .security is a system index now. deleting another legacy template that's not used anymore
+            templates.remove("security-index-template");
             return templates;
         };
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -716,6 +716,11 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     public UnaryOperator<Map<String, IndexTemplateMetadata>> getIndexTemplateMetadataUpgrader() {
         return map -> {
             map.keySet().removeIf(name -> name.startsWith("watch_history_"));
+            // watcher migrated to using system indices so these legacy templates are not needed anymore
+            map.remove(".watches");
+            map.remove(".triggered_watches");
+            // post 7.x we moved to typeless watch-history-10
+            map.remove(".watch-history-9");
             return map;
         };
     }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -9,10 +9,14 @@ package org.elasticsearch.upgrades;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class WatcherRestartIT extends AbstractUpgradeTestCase {
@@ -23,6 +27,34 @@ public class WatcherRestartIT extends AbstractUpgradeTestCase {
 
         client().performRequest(new Request("POST", "/_watcher/_start"));
         ensureWatcherStarted();
+    }
+
+    public void testEnsureWatcherDeletesLegacyTemplates() throws Exception {
+        client().performRequest(new Request("POST", "/_watcher/_start"));
+        ensureWatcherStarted();
+
+        if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+            // legacy index template created in previous releases should not be present anymore
+            assertBusy(() -> {
+                Request request = new Request("GET", "/_template/*watch*");
+                try {
+                    Response response = client().performRequest(request);
+                    Map<String, Object> responseLevel = entityAsMap(response);
+                    assertNotNull(responseLevel);
+
+                    assertThat(responseLevel.containsKey(".watches"), is(false));
+                    assertThat(responseLevel.containsKey(".triggered_watches"), is(false));
+                    assertThat(responseLevel.containsKey(".watch-history-9"), is(false));
+                } catch (ResponseException e) {
+                    // Not found is fine
+                    assertThat(
+                        "Unexpected failure getting templates: " + e.getResponse().getStatusLine(),
+                        e.getResponse().getStatusLine().getStatusCode(),
+                        is(404)
+                    );
+                }
+            }, 30, TimeUnit.SECONDS);
+        }
     }
 
     private void ensureWatcherStopped() throws Exception {


### PR DESCRIPTION
This removes a few legacy index templates that were superseded by
equivalent component templates or updated index templates.

(cherry picked from commit 0ed5eabcee86ee3f94fc7e6b22205099e7406b59)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #80949 80937