### PR TITLE
Allow to set the security manager

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -97,6 +97,7 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 "-Xmx" + System.getProperty("tests.heap.size", "512m"),
                 "-Xms" + System.getProperty("tests.heap.size", "512m"),
                 "--illegal-access=deny",
+                "-Djava.security.manager=allow",
                 // TODO: only open these for mockito when it is modularized
                 "--add-opens=java.base/java.security.cert=ALL-UNNAMED",
                 "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
@@ -27,6 +27,8 @@ final class SystemJvmOptions {
              * networkaddress.cache.negative ttl; set to -1 to cache forever.
              */
             "-Des.networkaddress.cache.negative.ttl=10",
+            // Allow to set the security manager.
+            "-Djava.security.manager=allow",
             // pre-touch JVM emory pages during initialization
             "-XX:+AlwaysPreTouch",
             // explicitly set the stack size


### PR DESCRIPTION
Post JDK 17 the security manager is disabled by default - setSecurityManager throws UOE - see [JEP 411][jep411].

This PR adds a command line option to explicitly allow to set the security manager, which enables early testing with releases greater than JDK 17. 

[jep411]: https://openjdk.java.net/jeps/411