### PR TITLE
Explicit write methods for always-missing values

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1203,4 +1203,17 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
+    /**
+     * Similar to {@link #writeOptionalWriteable} but for use when the value is always missing.
+     */
+    public <T extends Writeable> void writeMissingWriteable(Class<T> ignored) throws IOException {
+        writeBoolean(false);
+    }
+
+    /**
+     * Similar to {@link #writeOptionalString} but for use when the value is always missing.
+     */
+    public void writeMissingString() throws IOException {
+        writeBoolean(false);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
@@ -46,8 +46,8 @@ public class ActionTransportException extends TransportException {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().before(Version.V_8_1_0)) {
-            out.writeBoolean(false); // optional transport address
-            out.writeBoolean(false); // optional action
+            out.writeMissingWriteable(TransportAddress.class);
+            out.writeMissingString(); // action
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
@@ -44,7 +44,7 @@ public class ConnectTransportException extends ActionTransportException {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().before(Version.V_8_1_0)) {
-            out.writeBoolean(false); // optional & unused node field
+            out.writeMissingWriteable(DiscoveryNode.class);
         }
     }
 }


### PR DESCRIPTION
Today we use `writeBoolean(false);` to write to a `StreamOutput` an
optional value that is always missing. It's something of an
implementation detail that a missing value is indicated by a `false`
(i.e. a zero byte) so this commit wraps these calls in methods that
better indicate the intent.

Relates #80944
Relates #80692