### PR TITLE
[7.15] [DOCS] Relocate `index.mapping.dimension_fields.limit` setting docs (#80964)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -326,19 +326,6 @@ Defaults to `*`, which matches all fields eligible for
     the default pipeline (if it exists). The special pipeline name `_none`
     indicates no ingest pipeline will run.
 
-[[index-mapping-dimension-fields-limit]]
-`index.mapping.dimension_fields.limit`::
-+
---
-.For internal use by Elastic only.
-[%collapsible]
-====
-Maximum number of time series dimensions for the index. Defaults to `16`.
-
-You can mark a field as a dimension using the `dimension` mapping parameter.
-====
---
-
 [[index-hidden]] `index.hidden`::
 
     Indicates whether the index should be hidden by default. Hidden indices are not

--- a/docs/reference/mapping/mapping-settings-limit.asciidoc
+++ b/docs/reference/mapping/mapping-settings-limit.asciidoc
@@ -47,3 +47,19 @@ If your field mappings contain a large, arbitrary set of keys, consider using th
     It usually shouldn't be necessary to set this setting. The default is okay
     unless a user starts to add a huge number of fields with really long names. Default is
     `Long.MAX_VALUE` (no limit).
+
+[[index-mapping-dimension-fields-limit]]
+`index.mapping.dimension_fields.limit`::
++
+--
+experimental:[] (<<dynamic-index-settings,Dynamic>>, integer)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+Maximum number of time series dimensions for the index. Defaults to `16`.
+
+You can mark a field as a dimension using the `time_series_dimension` mapping
+parameter.
+====
+--


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Relocate `index.mapping.dimension_fields.limit` setting docs (#80964)