### PR TITLE
[7.15] [DOCS] Add experimental label to TSDB mapping params and settings (#79647)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -326,19 +326,6 @@ Defaults to `*`, which matches all fields eligible for
     the default pipeline (if it exists). The special pipeline name `_none`
     indicates no ingest pipeline will run.
 
-[[index-mapping-dimension-fields-limit]]
-`index.mapping.dimension_fields.limit`::
-+
---
-.For internal use by Elastic only.
-[%collapsible]
-====
-Maximum number of time series dimensions for the index. Defaults to `16`.
-
-You can mark a field as a dimension using the `dimension` mapping parameter.
-====
---
-
 [[index-hidden]] `index.hidden`::
 
     Indicates whether the index should be hidden by default. Hidden indices are not

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -60,28 +60,6 @@ The following parameters are accepted by `keyword` fields:
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
 
-`dimension`::
-+
---
-.For internal use by Elastic only.
-[%collapsible]
-====
-// tag::dimension[]
-Marks the field as a time series dimension. Accepts `true` or `false` (default).
-
-The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
-index setting limits the number of dimensions in an index.
-
-Dimension fields have the following constraints:
-
-* The `doc_values` and `index` mapping parameters must be `true`.
-* Field values cannot be an <<array,array or multi-value>>.
-// end::dimension[]
-* Field values cannot be larger than 1024 bytes.
-* The field cannot use a <<normalizer,`normalizer`>>.
-====
---
-
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it
@@ -174,6 +152,31 @@ Dimension fields have the following constraints:
 <<mapping-field-meta,`meta`>>::
 
     Metadata about the field.
+
+`dimension`::
++
+--
+experimental:[]
+(Optional, Boolean)
+
+.For internal use by Elastic only.
+[%collapsible]
+====
+// tag::dimension[]
+Marks the field as a time series dimension. Accepts `true` or `false` (default).
+
+The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
+index setting limits the number of dimensions in an index.
+
+Dimension fields have the following constraints:
+
+* The `doc_values` and `index` mapping parameters must be `true`.
+* Field values cannot be an <<array,array or multi-value>>.
+// end::dimension[]
+* Field values cannot be larger than 1024 bytes.
+* The field cannot use a <<normalizer,`normalizer`>>.
+====
+--
 
 include::constant-keyword.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add experimental label to TSDB mapping params and settings (#79647)