### PR TITLE
Use WARNING (rather than CRITICAL) for the empty _tier_preference deprecation issue

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -562,11 +562,7 @@ public class IndexDeprecationChecks {
                 String indexName = indexMetadata.getIndex().getName();
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "No ["
-                        + DataTier.TIER_PREFERENCE
-                        + "] is set for index ["
-                        + indexName
-                        + "].",
+                    "No [" + DataTier.TIER_PREFERENCE + "] is set for index [" + indexName + "].",
                     "https://ela.st/es-deprecation-7-empty-tier-preference",
                     "Specify a data tier preference for this index.",
                     false,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -561,7 +561,7 @@ public class IndexDeprecationChecks {
             if (tierPreference.isEmpty()) {
                 String indexName = indexMetadata.getIndex().getName();
                 return new DeprecationIssue(
-                    DeprecationIssue.Level.CRITICAL,
+                    DeprecationIssue.Level.WARNING,
                     "Index ["
                         + indexName
                         + "] does not have a ["

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -562,14 +562,13 @@ public class IndexDeprecationChecks {
                 String indexName = indexMetadata.getIndex().getName();
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "Index ["
-                        + indexName
-                        + "] does not have a ["
+                    "No ["
                         + DataTier.TIER_PREFERENCE
-                        + "] setting, "
-                        + "in 8.0 this setting will be required for all indices and may not be empty or null.",
+                        + "] is set for index ["
+                        + indexName
+                        + "].",
                     "https://ela.st/es-deprecation-7-empty-tier-preference",
-                    "Update the settings for this index to specify an appropriate tier preference.",
+                    "Specify a data tier preference for this index.",
                     false,
                     null
                 );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -844,10 +844,9 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 contains(
                     new DeprecationIssue(
                         DeprecationIssue.Level.WARNING,
-                        "Index [test] does not have a [index.routing.allocation.include._tier_preference] setting, "
-                            + "in 8.0 this setting will be required for all indices and may not be empty or null.",
+                        "No [index.routing.allocation.include._tier_preference] is set for index [test].",
                         "https://ela.st/es-deprecation-7-empty-tier-preference",
-                        "Update the settings for this index to specify an appropriate tier preference.",
+                        "Specify a data tier preference for this index.",
                         false,
                         null
                     )

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -843,7 +843,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 issues,
                 contains(
                     new DeprecationIssue(
-                        DeprecationIssue.Level.CRITICAL,
+                        DeprecationIssue.Level.WARNING,
                         "Index [test] does not have a [index.routing.allocation.include._tier_preference] setting, "
                             + "in 8.0 this setting will be required for all indices and may not be empty or null.",
                         "https://ela.st/es-deprecation-7-empty-tier-preference",


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/80645 -- @cjcenizal, @jakelandis, and I decided that dropping this deprecation issue from 'critical' to 'warning' is sufficient to unblock 7.16.0.

@debadair also would you like me to make any changes to the warning and details here?

Here's an example `message` and the associated `details`:

```Index [some-index-4] does not have a [index.routing.allocation.include._tier_preference] setting, in 8.0 this setting will be required for all indices and may not be empty or null.```

```Update the settings for this index to specify an appropriate tier preference.```

The same in screenshot form (note: after this PR it won't be 'Critical' anymore):
![Screen Shot 2021-11-23 at 3 28 40 PM](https://user-images.githubusercontent.com/187034/143099225-6a3a90f7-82e7-44b8-8828-8d75ce61a725.png)


