### PR TITLE
[DOCS] Fixes start and stop trained model deployment APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -43,7 +43,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-def
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-dfa-jobs]
 
 `from`::
 (Optional, integer) 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -54,7 +54,7 @@ You can get information for all {dfanalytics-jobs} by using _all, by specifying
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-dfa-jobs]
 
 `from`::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Start trained model deployment</titleabbrev>
 ++++
 
+experimental::[]
+
 Starts a new trained model deployment.
 
 [[start-trained-model-deployment-request]]
@@ -34,6 +36,26 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 [[start-trained-model-deployment-query-params]]
 == {api-query-parms-title}
 
+`inference_threads`::
+(Optional, integer)
+Sets the number of threads used by the inference process. This generally increases
+the inference speed. The inference process is a compute-bound process; any number 
+greater than the number of available CPU cores on the machine does not increase the 
+inference speed.
+Defaults to 1.
+
+`model_threads`::
+(Optional, integer)
+Indicates how many threads are used when sending inference requests to
+the model. Increasing this value generally increases the throughput. Defaults to
+1.
+
+`queue_capacity`::
+(Optional, integer)
+Controls how many inference requests are allowed in the queue at a time. Once the
+number of requests exceeds this value, new requests are rejected with a 429 error.
+Defaults to 1024.
+
 `timeout`::
 (Optional, time)
 Controls the amount of time to wait for the model to deploy. Defaults
@@ -46,26 +68,6 @@ Specifies the allocation status to wait for before returning. Defaults to
 any node. The value `started` indicates the model has started on at least one
 node. The value `fully_allocated` indicates the deployment has started on all
 valid nodes.
-
-`model_threads`::
-(Optional, integer)
-Indicates how many threads are used when sending inference requests to
-the model. Increasing this value generally increases the throughput. Defaults to
-1.
-
-`inference_threads`::
-(Optional, integer)
-Sets the number of threads used by the inference process. This generally increases
-the inference speed. The inference process is a compute-bound process; any number 
-greater than the number of available CPU cores on the machine does not increase the 
-inference speed.
-Defaults to 1.
-
-`queue_capacity`::
-(Optional, integer)
-Controls how many inference requests are allowed in the queue at a time. Once the
-number of requests exceeds this value, new requests are rejected with a 429 error.
-Defaults to 1024.
 
 [[start-trained-model-deployment-example]]
 == {api-examples-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -49,7 +49,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-def
   
 `allow_no_match`::
 (Optional, Boolean) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-dfa-jobs]
 
 
 `force`::

--- a/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
@@ -8,6 +8,8 @@
 
 experimental::[]
 
+Stops a trained model deployment.
+
 [[stop-trained-model-deployment-request]]
 == {api-request-title}
 

--- a/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
@@ -13,10 +13,11 @@ experimental::[]
 
 `POST _ml/trained_models/<model_id>/deployment/_stop`
 
-////
 [[stop-trained-model-deployment-prereq]]
 == {api-prereq-title}
-////
+
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 ////
 [[stop-trained-model-deployment-desc]]
@@ -36,12 +37,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `allow_no_match`::
 (Optional, Boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
-
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-deployments]
 
 `force`::
-  (Optional, Boolean) If true, the deployment is stopped even if it is referenced by
-  ingest pipelines.
+(Optional, Boolean) If true, the deployment is stopped even if it is referenced
+by ingest pipelines.
 
 ////
 [role="child_attributes"]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -32,6 +32,36 @@ are no matches or only partial matches.
 --
 end::allow-no-match-datafeeds[]
 
+tag::allow-no-match-deployments[]
+Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no deployments that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty array when there are no
+matches and the subset of results when there are partial matches. If this
+parameter is `false`, the request returns a `404` status code when there are no
+matches or only partial matches.
+--
+end::allow-no-match-deployments[]
+
+tag::allow-no-match-dfa-jobs[]
+ Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {dfanalytics-jobs} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `data_frame_analytics` array
+when there are no matches and the subset of results when there are partial
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
+end::allow-no-match-dfa-jobs[]
+
 tag::allow-no-match-jobs[]
 Specifies what to do when the request:
 +
@@ -46,21 +76,6 @@ matches. If this parameter is `false`, the request returns a `404` status code
 when there are no matches or only partial matches.
 --
 end::allow-no-match-jobs[]
-
-tag::allow-no-match[]
- Specifies what to do when the request:
-+
---
-* Contains wildcard expressions and there are no {dfanalytics-jobs} that match.
-* Contains the `_all` string or no identifiers and there are no matches.
-* Contains wildcard expressions and there are only partial matches.
-
-The default value is `true`, which returns an empty `data_frame_analytics` array
-when there are no matches and the subset of results when there are partial
-matches. If this parameter is `false`, the request returns a `404` status code
-when there are no matches or only partial matches.
---
-end::allow-no-match[]
 
 tag::allow-no-match-models[]
 Specifies what to do when the request:


### PR DESCRIPTION
The stop trained model deployment API incorrectly referenced data frame analytics jobs in its description of the `allow_no_match` parameter.

This PR:

* renames the generic "allow-no-match" tagged section to make it clearer that its not generic
* adds the missing security prerequisites to the stop trained model deployment API
* adds the missing "experimental" admonition in the start trained model deployment API and sorts its query parameters

