### PR TITLE
Fix WatcherRestartIT

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -30,9 +30,6 @@ public class WatcherRestartIT extends AbstractUpgradeTestCase {
     }
 
     public void testEnsureWatcherDeletesLegacyTemplates() throws Exception {
-        client().performRequest(new Request("POST", "/_watcher/_start"));
-        ensureWatcherStarted();
-
         if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
             // legacy index template created in previous releases should not be present anymore
             assertBusy(() -> {


### PR DESCRIPTION
This removes the unnecessary watcher start call in the test to reduce
the possibility of flakiness. The call is not needed as the Watcher
plugin is active and it will install (and upgrade/remove) the templates
regardless if watcher is started.

Fixes #80977