### PR TITLE
Extending the timeout waiting for snapshot to be ready

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -437,7 +437,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
             } catch (ResponseException e) {
                 fail("expected snapshot to exist but it does not: " + EntityUtils.toString(e.getResponse().getEntity()));
             }
-        });
+        }, 60, TimeUnit.SECONDS);
 
         // Run retention every second
         ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();


### PR DESCRIPTION
This commit extends the timeout in SnapshotLifecycleRestIT::testBasicTimeBasedRetention for waiting for a snapshot
to be ready from 10 seconds to 60 seconds to avoid occasional failures.
Closes #79549