### PR TITLE
[7.16] Support additional version schemes in relaxed mode (#81010)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
@@ -39,7 +39,9 @@ public final class Version implements Comparable<Version> {
 
     private static final Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha\\d+|beta\\d+|rc\\d+|SNAPSHOT))?");
 
-    private static final Pattern relaxedPattern = Pattern.compile("v?(\\d+)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9_]+(?:-[a-zA-Z0-9]+)*))?");
+    private static final Pattern relaxedPattern = Pattern.compile(
+        "v?(\\d+)\\.(\\d+)\\.(\\d+)(?:[\\-+]+([a-zA-Z0-9_]+(?:-[a-zA-Z0-9]+)*))?"
+    );
 
     public Version(int major, int minor, int revision) {
         this(major, minor, revision, null);

--- a/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
+++ b/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
@@ -41,6 +41,7 @@ public class VersionTests extends GradleUnitTestCase {
         assertVersionEquals("6.1.2-foo", 6, 1, 2, Version.Mode.RELAXED);
         assertVersionEquals("6.1.2-foo-bar", 6, 1, 2, Version.Mode.RELAXED);
         assertVersionEquals("16.01.22", 16, 1, 22, Version.Mode.RELAXED);
+        assertVersionEquals("20.10.10+dfsg1", 20, 10, 10, Version.Mode.RELAXED);
     }
 
     public void testCompareWithStringVersions() {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Support additional version schemes in relaxed mode (#81010)