### PR TITLE
[DOCS] Edits reset transforms API

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1108,8 +1108,8 @@ end::timeoutparms[]
 
 tag::transform-id[]
 Identifier for the {transform}. This identifier can contain lowercase
-alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start
-and end with alphanumeric characters.
+alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64
+character limit and must start and end with alphanumeric characters.
 end::transform-id[]
 
 tag::transform-id-wildcard[]

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -8,7 +8,7 @@
 <titleabbrev>Reset {transform}</titleabbrev>
 ++++
 
-Resets an existing {transform}.
+Resets a {transform}.
 
 [[reset-transform-request]]
 == {api-request-title}
@@ -20,7 +20,14 @@ Resets an existing {transform}.
 
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
-* Before you can reset the {transform}, you must stop it; alternatively, use the `force` query parameter.
+
+[[put-transform-desc]]
+== {api-description-title}
+
+Before you can reset the {transform}, you must stop it; alternatively, use the
+`force` query parameter.
+
+If the destination index was created by the transform, it is deleted.
 
 [[reset-transform-path-parms]]
 == {api-path-parms-title}
@@ -33,9 +40,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 == {api-query-parms-title}
 
 `force`::
-(Optional, Boolean) When `true`, the {transform} is reset regardless of its
-current state. The default value is `false`, meaning that the {transform} must be
-`stopped` before it can be reset.
+(Optional, Boolean)
+If this value is `true`, the {transform} is reset regardless of its current
+state. If it's false, the {transform} must be `stopped` before it can be reset.
+The default value is `false`
 
 [[reset-transform-examples]]
 == {api-examples-title}

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -21,7 +21,7 @@ Resets a {transform}.
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
 
-[[put-transform-desc]]
+[reset-transform-desc]]
 == {api-description-title}
 
 Before you can reset the {transform}, you must stop it; alternatively, use the


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/79828

This PR updates the "reset transform API" documentation to include the impact on the destination index and the character limit for the transform identifier.  It also includes some minor edits to the text.

### Preview

https://elasticsearch_81027.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/reset-transform.html