### PR TITLE
Make Circuit Breaker Lookup in BigArrays Faster

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -391,7 +391,10 @@ public class BigArrays {
     }
 
     final PageCacheRecycler recycler;
+    @Nullable
     private final CircuitBreakerService breakerService;
+    @Nullable
+    private final CircuitBreaker breaker;
     private final boolean checkBreaker;
     private final BigArrays circuitBreakingInstance;
     private final String breakerName;
@@ -410,6 +413,11 @@ public class BigArrays {
         this.checkBreaker = checkBreaker;
         this.recycler = recycler;
         this.breakerService = breakerService;
+        if (breakerService != null) {
+            breaker = breakerService.getBreaker(breakerName);
+        } else {
+            breaker = null;
+        }
         this.breakerName = breakerName;
         if (checkBreaker) {
             this.circuitBreakingInstance = this;
@@ -427,8 +435,7 @@ public class BigArrays {
      * we do not add the delta to the breaker if it trips.
      */
     void adjustBreaker(final long delta, final boolean isDataAlreadyCreated) {
-        if (this.breakerService != null) {
-            CircuitBreaker breaker = this.breakerService.getBreaker(breakerName);
+        if (this.breaker != null) {
             if (this.checkBreaker) {
                 // checking breaker means potentially tripping, but it doesn't
                 // have to if the delta is negative

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -31,7 +31,6 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -204,7 +203,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             }
             childCircuitBreakers.put(breakerSettings.getName(), validateAndCreateBreaker(breakerSettings));
         }
-        this.breakers = Collections.unmodifiableMap(childCircuitBreakers);
+        this.breakers = Map.copyOf(childCircuitBreakers);
         this.parentSettings = new BreakerSettings(
             CircuitBreaker.PARENT,
             TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes(),

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -243,7 +243,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
             assertThat(
                 exception.getMessage(),
-                containsString("usages [request=157286400/150mb, fielddata=54001664/51.5mb, inflight_requests=0/0b]")
+                containsString("usages [fielddata=54001664/51.5mb, request=157286400/150mb, inflight_requests=0/0b]")
             );
             assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         }
@@ -305,11 +305,11 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         assertThat(
             exception.getMessage(),
             containsString(
-                "usages [request="
+                "usages [fielddata=0/0b, request="
                     + requestCircuitBreakerUsed
                     + "/"
                     + new ByteSizeValue(requestCircuitBreakerUsed)
-                    + ", fielddata=0/0b, inflight_requests=0/0b]"
+                    + ", inflight_requests=0/0b]"
             )
         );
         assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));


### PR DESCRIPTION
I noticed that when benchmarking translog writes last week (which currently involve
copying a lot of bytes across 2 pooled buffers backed by `BigArrays`), a
non-trivial amount of time is spent on looking up the circuit breaker.
This PR makes that lookup faster in general by using a more efficient map,
but also just caches the breaker instance on `BigArrays` itself to not
have to do the lookup every 16k during a multi MB write in the first place.
