### PR TITLE
[8.0] Reuse MappingMetadata instances in Metadata class.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -560,6 +560,45 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
+    IndexMetadata withMappingMetadata(MappingMetadata mapping) {
+        ImmutableOpenMap.Builder<String, MappingMetadata> mappingBuilder = ImmutableOpenMap.builder();
+        mappingBuilder.put(MapperService.SINGLE_MAPPING_NAME, mapping);
+
+        return new IndexMetadata(
+            this.index,
+            this.version,
+            this.mappingVersion,
+            this.settingsVersion,
+            this.aliasesVersion,
+            this.primaryTerms,
+            this.state,
+            this.numberOfShards,
+            this.numberOfReplicas,
+            this.settings,
+            mappingBuilder.build(),
+            this.aliases,
+            this.customData,
+            this.inSyncAllocationIds,
+            this.requireFilters,
+            this.initialRecoveryFilters,
+            this.includeFilters,
+            this.excludeFilters,
+            this.indexCreatedVersion,
+            this.routingNumShards,
+            this.routingPartitionSize,
+            this.routingPaths,
+            this.waitForActiveShards,
+            this.rolloverInfos,
+            this.isSystem,
+            this.isHidden,
+            this.timestampRange,
+            this.priority,
+            this.creationDate,
+            this.ignoreDiskWatermarks,
+            this.tierPreference
+        );
+    }
+
     public Index getIndex() {
         return index;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -149,6 +149,10 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
         return this.routingRequired;
     }
 
+    public String getSha256() {
+        return source.getSha256();
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(type());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -208,6 +208,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     private final String[] visibleClosedIndices;
 
     private SortedMap<String, IndexAbstraction> indicesLookup;
+    private final Map<String, MappingMetadata> mappingsByHash;
 
     private Metadata(
         String clusterUUID,
@@ -229,7 +230,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         String[] visibleOpenIndices,
         String[] allClosedIndices,
         String[] visibleClosedIndices,
-        SortedMap<String, IndexAbstraction> indicesLookup
+        SortedMap<String, IndexAbstraction> indicesLookup,
+        Map<String, MappingMetadata> mappingsByHash
     ) {
         this.clusterUUID = clusterUUID;
         this.clusterUUIDCommitted = clusterUUIDCommitted;
@@ -251,6 +253,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         this.allClosedIndices = allClosedIndices;
         this.visibleClosedIndices = visibleClosedIndices;
         this.indicesLookup = indicesLookup;
+        this.mappingsByHash = mappingsByHash;
     }
 
     public Metadata withIncrementedVersion() {
@@ -274,7 +277,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             visibleOpenIndices,
             allClosedIndices,
             visibleClosedIndices,
-            indicesLookup
+            indicesLookup,
+            mappingsByHash
         );
     }
 
@@ -942,6 +946,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return builder;
     }
 
+    Map<String, MappingMetadata> getMappingsByHash() {
+        return mappingsByHash;
+    }
+
     private static class MetadataDiff implements Diff<Metadata> {
 
         private final long version;
@@ -1096,6 +1104,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private final ImmutableOpenMap.Builder<String, Custom> customs;
 
         private SortedMap<String, IndexAbstraction> previousIndicesLookup;
+        private final Map<String, MappingMetadata> mappingsByHash;
 
         public Builder() {
             clusterUUID = UNKNOWN_CLUSTER_UUID;
@@ -1104,6 +1113,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             customs = ImmutableOpenMap.builder();
             indexGraveyard(IndexGraveyard.builder().build()); // create new empty index graveyard to initialize
             previousIndicesLookup = null;
+            mappingsByHash = new HashMap<>();
         }
 
         Builder(Metadata metadata) {
@@ -1118,11 +1128,13 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             this.templates = ImmutableOpenMap.builder(metadata.templates);
             this.customs = ImmutableOpenMap.builder(metadata.customs);
             previousIndicesLookup = metadata.getIndicesLookup();
+            this.mappingsByHash = new HashMap<>(metadata.mappingsByHash);
         }
 
         public Builder put(IndexMetadata.Builder indexMetadataBuilder) {
             // we know its a new one, increment the version and store
             indexMetadataBuilder.version(indexMetadataBuilder.version() + 1);
+            dedupeMapping(indexMetadataBuilder);
             IndexMetadata indexMetadata = indexMetadataBuilder.build();
             IndexMetadata previous = indices.put(indexMetadata.getIndex().getName(), indexMetadata);
             if (unsetPreviousIndicesLookup(previous, indexMetadata)) {
@@ -1135,6 +1147,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             if (indices.get(indexMetadata.getIndex().getName()) == indexMetadata) {
                 return this;
             }
+            indexMetadata = dedupeMapping(indexMetadata);
             // if we put a new index metadata, increment its version
             if (incrementVersion) {
                 indexMetadata = IndexMetadata.builder(indexMetadata).version(indexMetadata.getVersion() + 1).build();
@@ -1201,13 +1214,16 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             previousIndicesLookup = null;
 
             indices.clear();
+            mappingsByHash.clear();
             return this;
         }
 
         public Builder indices(ImmutableOpenMap<String, IndexMetadata> indices) {
             previousIndicesLookup = null;
 
-            this.indices.putAll(indices);
+            for (var cursor : indices) {
+                put(cursor.value, false);
+            }
             return this;
         }
 
@@ -1652,6 +1668,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 }
             }
 
+            purgeUnusedEntries(indices);
+
             // build all concrete indices arrays:
             // TODO: I think we can remove these arrays. it isn't worth the effort, for operations on all indices.
             // When doing an operation across all indices, most of the time is spent on actually going to all shards and
@@ -1692,7 +1710,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 visibleOpenIndicesArray,
                 allClosedIndicesArray,
                 visibleClosedIndicesArray,
-                indicesLookup
+                indicesLookup,
+                Collections.unmodifiableMap(mappingsByHash)
             );
         }
 
@@ -1911,6 +1930,63 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
             return builder.build();
         }
+
+        /**
+         * Dedupes {@link MappingMetadata} instance from the provided indexMetadata parameter using the sha256
+         * hash from the compressed source of the mapping. If there is a mapping with the same sha256 hash then
+         * a new {@link IndexMetadata} is returned with the found {@link MappingMetadata} instance, otherwise
+         * the {@link MappingMetadata} instance of the indexMetadata parameter is recorded and the indexMetadata
+         * parameter is then returned.
+         */
+        private IndexMetadata dedupeMapping(IndexMetadata indexMetadata) {
+            if (indexMetadata.mapping() == null) {
+                return indexMetadata;
+            }
+
+            String digest = indexMetadata.mapping().getSha256();
+            MappingMetadata entry = mappingsByHash.get(digest);
+            if (entry != null) {
+                return indexMetadata.withMappingMetadata(entry);
+            } else {
+                mappingsByHash.put(digest, indexMetadata.mapping());
+                return indexMetadata;
+            }
+        }
+
+        /**
+         * Similar to {@link #dedupeMapping(IndexMetadata)}.
+         */
+        private void dedupeMapping(IndexMetadata.Builder indexMetadataBuilder) {
+            if (indexMetadataBuilder.mapping() == null) {
+                return;
+            }
+
+            String digest = indexMetadataBuilder.mapping().getSha256();
+            MappingMetadata entry = mappingsByHash.get(digest);
+            if (entry != null) {
+                indexMetadataBuilder.putMapping(entry);
+            } else {
+                mappingsByHash.put(digest, indexMetadataBuilder.mapping());
+            }
+        }
+
+        private void purgeUnusedEntries(ImmutableOpenMap<String, IndexMetadata> indices) {
+            final Set<String> sha256HashesInUse = new HashSet<>(mappingsByHash.size());
+            for (var im : indices.values()) {
+                if (im.mapping() != null) {
+                    sha256HashesInUse.add(im.mapping().getSha256());
+                }
+            }
+
+            final var iterator = mappingsByHash.entrySet().iterator();
+            while (iterator.hasNext()) {
+                final var cacheKey = iterator.next().getKey();
+                if (sha256HashesInUse.contains(cacheKey) == false) {
+                    iterator.remove();
+                }
+            }
+        }
+
     }
 
     private static final ToXContent.Params FORMAT_PARAMS;

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -9,8 +9,10 @@
 package org.elasticsearch.common.compress;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -25,9 +27,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.zip.CRC32;
-import java.util.zip.CheckedOutputStream;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
@@ -39,46 +42,45 @@ import java.util.zip.Inflater;
  */
 public final class CompressedXContent {
 
-    private static final ThreadLocal<InflaterAndBuffer> inflater1 = ThreadLocal.withInitial(InflaterAndBuffer::new);
-    private static final ThreadLocal<InflaterAndBuffer> inflater2 = ThreadLocal.withInitial(InflaterAndBuffer::new);
+    private static final ThreadLocal<InflaterAndBuffer> inflater = ThreadLocal.withInitial(InflaterAndBuffer::new);
 
-    private static int crc32(BytesReference data) {
-        CRC32 crc32 = new CRC32();
+    private static String sha256(BytesReference data) {
+        MessageDigest messageDigest = MessageDigests.sha256();
         try {
-            data.writeTo(new CheckedOutputStream(Streams.NULL_OUTPUT_STREAM, crc32));
+            data.writeTo(new DigestOutputStream(Streams.NULL_OUTPUT_STREAM, messageDigest));
         } catch (IOException bogus) {
             // cannot happen
             throw new Error(bogus);
         }
-        return (int) crc32.getValue();
+        return Base64.getEncoder().encodeToString(messageDigest.digest());
     }
 
-    private static int crc32FromCompressed(byte[] compressed) {
-        CRC32 crc32 = new CRC32();
-        try (InflaterAndBuffer inflaterAndBuffer = inflater1.get()) {
+    private static String sha256FromCompressed(byte[] compressed) {
+        MessageDigest messageDigest = MessageDigests.sha256();
+        try (InflaterAndBuffer inflaterAndBuffer = inflater.get()) {
             final Inflater inflater = inflaterAndBuffer.inflater;
             final ByteBuffer buffer = inflaterAndBuffer.buffer;
             assert assertBufferIsCleared(buffer);
             setInflaterInput(compressed, inflater);
             do {
                 if (inflater.inflate(buffer) > 0) {
-                    crc32.update(buffer.flip());
+                    messageDigest.update(buffer.flip());
                 }
                 buffer.clear();
             } while (inflater.finished() == false);
-            return (int) crc32.getValue();
+            return Base64.getEncoder().encodeToString(messageDigest.digest());
         } catch (DataFormatException e) {
             throw new ElasticsearchException(e);
         }
     }
 
     private final byte[] bytes;
-    private final int crc32;
+    private final String sha256;
 
     // Used for serialization
-    private CompressedXContent(byte[] compressed, int crc32) {
+    private CompressedXContent(byte[] compressed, String sha256) {
         this.bytes = compressed;
-        this.crc32 = crc32;
+        this.sha256 = sha256;
         assertConsistent();
     }
 
@@ -87,8 +89,8 @@ public final class CompressedXContent {
      */
     public CompressedXContent(ToXContent xcontent, XContentType type, ToXContent.Params params) throws IOException {
         BytesStreamOutput bStream = new BytesStreamOutput();
-        CRC32 crc32 = new CRC32();
-        OutputStream checkedStream = new CheckedOutputStream(CompressorFactory.COMPRESSOR.threadLocalOutputStream(bStream), crc32);
+        MessageDigest messageDigest = MessageDigests.sha256();
+        OutputStream checkedStream = new DigestOutputStream(CompressorFactory.COMPRESSOR.threadLocalOutputStream(bStream), messageDigest);
         try (XContentBuilder builder = XContentFactory.contentBuilder(type, checkedStream)) {
             if (xcontent.isFragment()) {
                 builder.startObject();
@@ -99,7 +101,7 @@ public final class CompressedXContent {
             }
         }
         this.bytes = BytesReference.toBytes(bStream.bytes());
-        this.crc32 = (int) crc32.getValue();
+        this.sha256 = Base64.getEncoder().encodeToString(messageDigest.digest());
         assertConsistent();
     }
 
@@ -112,18 +114,18 @@ public final class CompressedXContent {
         if (compressor != null) {
             // already compressed...
             this.bytes = BytesReference.toBytes(data);
-            this.crc32 = crc32FromCompressed(this.bytes);
+            this.sha256 = sha256FromCompressed(this.bytes);
         } else {
             this.bytes = BytesReference.toBytes(CompressorFactory.COMPRESSOR.compress(data));
-            this.crc32 = crc32(data);
+            this.sha256 = sha256(data);
         }
         assertConsistent();
     }
 
     private void assertConsistent() {
         assert CompressorFactory.compressor(new BytesArray(bytes)) != null;
-        assert this.crc32 == crc32(uncompressed());
-        assert this.crc32 == crc32FromCompressed(bytes);
+        assert this.sha256.equals(sha256(uncompressed()));
+        assert this.sha256.equals(sha256FromCompressed(bytes));
     }
 
     public CompressedXContent(byte[] data) throws IOException {
@@ -157,13 +159,31 @@ public final class CompressedXContent {
         return uncompressed().utf8ToString();
     }
 
+    public String getSha256() {
+        return sha256;
+    }
+
     public static CompressedXContent readCompressedString(StreamInput in) throws IOException {
-        int crc32 = in.readInt();
-        return new CompressedXContent(in.readByteArray(), crc32);
+        final String sha256;
+        final byte[] compressedData;
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            sha256 = in.readString();
+            compressedData = in.readByteArray();
+        } else {
+            int crc32 = in.readInt();
+            compressedData = in.readByteArray();
+            sha256 = sha256FromCompressed(compressedData);
+        }
+        return new CompressedXContent(compressedData, sha256);
     }
 
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInt(crc32);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeString(sha256);
+        } else {
+            int crc32 = crc32FromCompressed(bytes);
+            out.writeInt(crc32);
+        }
         out.writeByteArray(bytes);
     }
 
@@ -173,59 +193,36 @@ public final class CompressedXContent {
         if (o == null || getClass() != o.getClass()) return false;
 
         CompressedXContent that = (CompressedXContent) o;
-
-        if (crc32 != that.crc32) {
-            return false;
-        }
-
-        if (Arrays.equals(bytes, that.bytes)) {
-            return true;
-        }
-        // compression is not entirely deterministic in all cases depending on hwo the compressed bytes were assembled, check uncompressed
-        // equality
-        return equalsWhenUncompressed(bytes, that.bytes);
-    }
-
-    // package private for testing
-    static boolean equalsWhenUncompressed(byte[] compressed1, byte[] compressed2) {
-        try (InflaterAndBuffer inflaterAndBuffer1 = inflater1.get(); InflaterAndBuffer inflaterAndBuffer2 = inflater2.get()) {
-            final Inflater inf1 = inflaterAndBuffer1.inflater;
-            final Inflater inf2 = inflaterAndBuffer2.inflater;
-            setInflaterInput(compressed1, inf1);
-            setInflaterInput(compressed2, inf2);
-            final ByteBuffer buf1 = inflaterAndBuffer1.buffer;
-            assert assertBufferIsCleared(buf1);
-            final ByteBuffer buf2 = inflaterAndBuffer2.buffer;
-            assert assertBufferIsCleared(buf2);
-            while (true) {
-                while (inf1.inflate(buf1) > 0 && buf1.hasRemaining())
-                    ;
-                while (inf2.inflate(buf2) > 0 && buf2.hasRemaining())
-                    ;
-                if (buf1.flip().equals(buf2.flip()) == false) {
-                    return false;
-                }
-                if (inf1.finished()) {
-                    // if the first inflater is done but the second one still has data we fail here, if it's the other way around we fail
-                    // on the next round because we will only read bytes into 2
-                    return inf2.finished();
-                }
-                buf1.clear();
-                buf2.clear();
-            }
-        } catch (DataFormatException e) {
-            throw new ElasticsearchException(e);
-        }
+        return sha256.equals(that.sha256);
     }
 
     @Override
     public int hashCode() {
-        return crc32;
+        return sha256.hashCode();
     }
 
     @Override
     public String toString() {
         return string();
+    }
+
+    private static int crc32FromCompressed(byte[] compressed) {
+        CRC32 crc32 = new CRC32();
+        try (InflaterAndBuffer inflaterAndBuffer = inflater.get()) {
+            final Inflater inflater = inflaterAndBuffer.inflater;
+            final ByteBuffer buffer = inflaterAndBuffer.buffer;
+            assert assertBufferIsCleared(buffer);
+            setInflaterInput(compressed, inflater);
+            do {
+                if (inflater.inflate(buffer) > 0) {
+                    crc32.update(buffer.flip());
+                }
+                buffer.clear();
+            } while (inflater.finished() == false);
+            return (int) crc32.getValue();
+        } catch (DataFormatException e) {
+            throw new ElasticsearchException(e);
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -142,13 +141,6 @@ public class DeflateCompressedXContentTests extends ESTestCase {
             XContentType.JSON,
             ToXContent.EMPTY_PARAMS
         );
-        assertFalse(CompressedXContent.equalsWhenUncompressed(one.compressed(), two.compressed()));
-    }
-
-    public void testEqualsCrcCollision() throws IOException {
-        final CompressedXContent content1 = new CompressedXContent("{\"d\":\"68&A<\"}".getBytes(StandardCharsets.UTF_8));
-        final CompressedXContent content2 = new CompressedXContent("{\"d\":\"gZG- \"}".getBytes(StandardCharsets.UTF_8));
-        assertEquals(content1.hashCode(), content2.hashCode()); // the inputs are a known CRC32 collision
-        assertNotEquals(content1, content2);
+        assertNotEquals(one.uncompressed(), two.uncompressed());
     }
 }


### PR DESCRIPTION
Backporting #80348 to 8.0 branch.

Hash the mapping source of a MappingMetadata instance and then
cache it in Metadata class. A mapping with the same hash
will use a cached MappingMetadata instance. This can
significantly reduce the number of MappingMetadata instances
for data streams and index patterns.

Idea originated from #69772, but just focusses on the jvm heap memory savings.
And hashes the mapping instead of assigning it an uuid.

Relates to #77466