### PR TITLE
[ML] In 8.x ML will have to tolerate model snapshots for 6.4.0+

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
@@ -197,7 +197,7 @@ public class AnomalyJobCRUDIT extends MlSingleNodeTestCase {
         assertThat(
             ex.getMessage(),
             containsString(
-                "[open-job-with-old-model-snapshot] job snapshot [snap_1] has min version before [7.0.0], "
+                "[open-job-with-old-model-snapshot] job model snapshot [snap_1] has min version before [7.0.0], "
                     + "please revert to a newer model snapshot or reset the job"
             )
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -54,7 +54,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
-import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.checkAssignmentState;
 
 /*
@@ -191,17 +192,17 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                             return;
                         }
                         assert modelSnapshot.getPage().results().size() == 1;
-                        if (modelSnapshot.getPage().results().get(0).getMinVersion().onOrAfter(MIN_SUPPORTED_SNAPSHOT_VERSION)) {
+                        if (modelSnapshot.getPage().results().get(0).getMinVersion().onOrAfter(MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION)) {
                             modelSnapshotValidationListener.onResponse(true);
                             return;
                         }
                         listener.onFailure(
                             ExceptionsHelper.badRequestException(
-                                "[{}] job snapshot [{}] has min version before [{}], "
+                                "[{}] job model snapshot [{}] has min version before [{}], "
                                     + "please revert to a newer model snapshot or reset the job",
                                 jobParams.getJobId(),
                                 jobParams.getJob().getModelSnapshotId(),
-                                MIN_SUPPORTED_SNAPSHOT_VERSION.toString()
+                                MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION.toString()
                             )
                         );
                     }, failure -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -74,7 +74,12 @@ import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIG
 public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksExecutor<OpenJobAction.JobParams> {
 
     private static final Logger logger = LogManager.getLogger(OpenJobPersistentTasksExecutor.class);
-    public static final Version MIN_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
+    // Ideally this would be 7.0.0, but it has to be 6.4.0 because due to an oversight it's impossible
+    // for the Java code to distinguish the model states for versions 6.4.0 to 7.9.3 inclusive.
+    public static final Version MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION = Version.fromString("6.4.0");
+    // We tell the user we support model snapshots newer than 7.0.0 as that's the major version
+    // boundary, even though behind the scenes we have to support back to 6.4.0.
+    public static final Version MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
 
     // Resuming a job with a running datafeed from its current snapshot was added in 7.11 and
     // can only be done if the master node is on or after that version.
@@ -425,16 +430,17 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                     }
                     assert snapshot.getPage().results().size() == 1;
                     ModelSnapshot snapshotObj = snapshot.getPage().results().get(0);
-                    if (snapshotObj.getMinVersion().onOrAfter(MIN_SUPPORTED_SNAPSHOT_VERSION)) {
+                    if (snapshotObj.getMinVersion().onOrAfter(MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION)) {
                         listener.onResponse(true);
                         return;
                     }
                     listener.onFailure(
                         ExceptionsHelper.badRequestException(
-                            "[{}] job snapshot [{}] has min version before [{}], please revert to a newer model snapshot or reset the job",
+                            "[{}] job model snapshot [{}] has min version before [{}], "
+                                + "please revert to a newer model snapshot or reset the job",
                             jobId,
                             jobSnapshotId,
-                            MIN_SUPPORTED_SNAPSHOT_VERSION.toString()
+                            MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION.toString()
                         )
                     );
                 }, snapshotFailure -> {


### PR DESCRIPTION
Previously we intended that 8.x ML would only accept model snapshots
created in version 7.0.0 or above. However, due to a bug
(elastic/ml-cpp#1545) it's not possible to distinguish model
snapshots created in versions 6.4.0-7.9.3 inclusive. Therefore,
to be sure of meeting the stated policy of accepting model snapshots
created in 7.0.0 or above ML will have to really accept those
labelled as 6.4.0 or above.

Fixes #81011