### PR TITLE
Fix after restore Lucene.pruneUnreferencedFiles() conditional

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -175,7 +175,7 @@ public abstract class FileRestoreContext {
 
     private void afterRestore(SnapshotFiles snapshotFiles, Store store, StoreFileMetadata restoredSegmentsFile) {
         try {
-            if (isSearchableSnapshotStore(store.indexSettings().getSettings())) {
+            if (isSearchableSnapshotStore(store.indexSettings().getSettings()) == false) {
                 Lucene.pruneUnreferencedFiles(restoredSegmentsFile.name(), store.directory());
             }
         } catch (IOException e) {


### PR DESCRIPTION
In  #68821 we introduced a condition to skip the pruning of unreferenced files after the restore of a snapshot for searchable snapshot shards. Sadly I managed to mess this up in a refactoring (#75308) few months after.

This commit reintroduces the right conditional which is to NOT prune Lucene files for searchable snapshot shards.