### PR TITLE
[8.0] Fix after restore Lucene.pruneUnreferencedFiles() conditional (#81047)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -175,7 +175,7 @@ public abstract class FileRestoreContext {
 
     private void afterRestore(SnapshotFiles snapshotFiles, Store store, StoreFileMetadata restoredSegmentsFile) {
         try {
-            if (isSearchableSnapshotStore(store.indexSettings().getSettings())) {
+            if (isSearchableSnapshotStore(store.indexSettings().getSettings()) == false) {
                 Lucene.pruneUnreferencedFiles(restoredSegmentsFile.name(), store.directory());
             }
         } catch (IOException e) {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix after restore Lucene.pruneUnreferencedFiles() conditional (#81047)