### PR TITLE
Fix stopping of old elasticsearch cluster

### DIFF
--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -132,5 +132,9 @@ public class OldElasticsearch {
         Path tmp = Files.createTempFile(baseDir, null, null);
         Files.write(tmp, Integer.toString(port).getBytes(StandardCharsets.UTF_8));
         Files.move(tmp, baseDir.resolve("ports"), StandardCopyOption.ATOMIC_MOVE);
+
+        tmp = Files.createTempFile(baseDir, null, null);
+        Files.write(tmp, Integer.toString(pid).getBytes(StandardCharsets.UTF_8));
+        Files.move(tmp, baseDir.resolve("pid"), StandardCopyOption.ATOMIC_MOVE);
     }
 }


### PR DESCRIPTION
due to not exposing the PID of the underlaying cluster the Fixture Stop task
was skipped, leaving running clusters behind after the build finished