### PR TITLE
[ML] Fix acceptable model snapshot versions in ML deprecation checker

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.settings.Setting;
@@ -43,6 +44,13 @@ public final class MachineLearningField {
         "api",
         License.OperationMode.PLATINUM
     );
+
+    // Ideally this would be 7.0.0, but it has to be 6.4.0 because due to an oversight it's impossible
+    // for the Java code to distinguish the model states for versions 6.4.0 to 7.9.3 inclusive.
+    public static final Version MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION = Version.fromString("6.4.0");
+    // We tell the user we support model snapshots newer than 7.0.0 as that's the major version
+    // boundary, even though behind the scenes we have to support back to 6.4.0.
+    public static final Version MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
 
     private MachineLearningField() {}
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -105,7 +105,7 @@ public class MlDeprecationIT extends ESRestTestCase {
         assertThat(response.getMlSettingsIssues(), hasSize(1));
         assertThat(
             response.getMlSettingsIssues().get(0).getMessage(),
-            containsString("model snapshot [1] for job [deprecation_check_job] needs to be deleted or upgraded")
+            containsString("Delete model snapshot [1] or update it to 7.0.0 or greater")
         );
         assertThat(response.getMlSettingsIssues().get(0).getMeta(), equalTo(Map.of("job_id", jobId, "snapshot_id", "1")));
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.deprecation;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
@@ -26,6 +25,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 
 public class MlDeprecationChecker implements DeprecationChecker {
 
@@ -67,22 +69,23 @@ public class MlDeprecationChecker implements DeprecationChecker {
     }
 
     static Optional<DeprecationIssue> checkModelSnapshot(ModelSnapshot modelSnapshot) {
-        if (modelSnapshot.getMinVersion().before(Version.V_7_0_0)) {
+        if (modelSnapshot.getMinVersion().before(MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION)) {
             StringBuilder details = new StringBuilder(
                 String.format(
                     Locale.ROOT,
-                    "model snapshot [%s] for job [%s] supports minimum version [%s] and needs to be at least [%s].",
+                    // Important: the Kibana upgrade assistant expects this to match the pattern /[Mm]odel snapshot/
+                    // and if it doesn't then the expected "Fix" button won't appear for this deprecation.
+                    "Model snapshot [%s] for job [%s] has an obsolete minimum version [%s].",
                     modelSnapshot.getSnapshotId(),
                     modelSnapshot.getJobId(),
-                    modelSnapshot.getMinVersion(),
-                    Version.V_7_0_0
+                    modelSnapshot.getMinVersion()
                 )
             );
             if (modelSnapshot.getLatestRecordTimeStamp() != null) {
                 details.append(
                     String.format(
                         Locale.ROOT,
-                        " The model snapshot's latest record timestamp is [%s]",
+                        " The model snapshot's latest record timestamp is [%s].",
                         XContentElasticsearchExtension.DEFAULT_FORMATTER.format(modelSnapshot.getLatestRecordTimeStamp().toInstant())
                     )
                 );
@@ -92,9 +95,9 @@ public class MlDeprecationChecker implements DeprecationChecker {
                     DeprecationIssue.Level.CRITICAL,
                     String.format(
                         Locale.ROOT,
-                        "model snapshot [%s] for job [%s] needs to be deleted or upgraded",
+                        "Delete model snapshot [%s] or update it to %s or greater.",
                         modelSnapshot.getSnapshotId(),
-                        modelSnapshot.getJobId()
+                        MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION
                     ),
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html",
                     details.toString(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -54,8 +54,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
-import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
-import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.checkAssignmentState;
 
 /*

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -67,6 +67,8 @@ import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
 import static org.elasticsearch.xpack.core.ml.MlTasks.PERSISTENT_TASK_MASTER_NODE_TIMEOUT;
 import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
@@ -74,12 +76,6 @@ import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIG
 public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksExecutor<OpenJobAction.JobParams> {
 
     private static final Logger logger = LogManager.getLogger(OpenJobPersistentTasksExecutor.class);
-    // Ideally this would be 7.0.0, but it has to be 6.4.0 because due to an oversight it's impossible
-    // for the Java code to distinguish the model states for versions 6.4.0 to 7.9.3 inclusive.
-    public static final Version MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION = Version.fromString("6.4.0");
-    // We tell the user we support model snapshots newer than 7.0.0 as that's the major version
-    // boundary, even though behind the scenes we have to support back to 6.4.0.
-    public static final Version MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
 
     // Resuming a job with a running datafeed from its current snapshot was added in 7.11 and
     // can only be done if the master node is on or after that version.


### PR DESCRIPTION
This is a followup to #81039.

The same requirement to tolerate model snapshots back to 6.4.0
that applies to the job opening code also applies to the deprecation
checker. Again, we tell the user that 7.0.0 is the model snapshot
version we support, but we actually have to support versions going
back to 6.4.0 because we didn't update the constant in the C++ in
7.0.0.

Additionally, the wording of the ML deprecation messages is very
slightly updated. The messages are different in the 7.16 branch,
where they were updated by #79387. This wording is copied forward
to master, but with the tiny change that "Snapshot" is changed to
"Model snapshot" in one place. This should make it clearer for
users that we're talking about ML model snapshots and not cluster
snapshots (which are completely different things). Another reason
to change the wording is that the UI is looking for the pattern
/[Mm]odel snapshot/ to decide when to display the "Fix" button for
upgrading ML model snapshots - see elastic/kibana#119745.