### PR TITLE
[8.0][DOCS] Clarifies transform ID character limit

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1108,8 +1108,8 @@ end::timeoutparms[]
 
 tag::transform-id[]
 Identifier for the {transform}. This identifier can contain lowercase
-alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start
-and end with alphanumeric characters.
+alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64
+character limit and must start and end with alphanumeric characters.
 end::transform-id[]
 
 tag::transform-id-wildcard[]


### PR DESCRIPTION
Backports part of https://github.com/elastic/elasticsearch/pull/81027