### PR TITLE
[ML] Improve error msg on starting scrolling datafeed with no matchin…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -79,6 +79,16 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
 
         // Step 2. Contruct the factory and notify listener
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(fieldCapabilitiesResponse -> {
+            if (fieldCapabilitiesResponse.getIndices().length == 0) {
+                listener.onFailure(
+                    ExceptionsHelper.badRequestException(
+                        "datafeed [{}] cannot retrieve data because no index matches datafeed's indices {}",
+                        datafeed.getId(),
+                        datafeed.getIndices()
+                    )
+                );
+                return;
+            }
             TimeBasedExtractedFields extractedFields = TimeBasedExtractedFields.build(job, datafeed, fieldCapabilitiesResponse);
             listener.onResponse(
                 new ScrollDataExtractorFactory(client, datafeed, job, extractedFields, xContentRegistry, timingStatsReporter)

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
@@ -177,7 +177,7 @@ setup:
         end: "2017-02-01T01:00:00Z"
 
 ---
-"Test start given datafeed index does not exist":
+"Test start datafeed given concrete index that does not exist":
   - do:
       ml.update_datafeed:
         datafeed_id: start-stop-datafeed-datafeed-1
@@ -192,6 +192,25 @@ setup:
 
   - do:
       catch: /datafeed \[start-stop-datafeed-datafeed-1] cannot retrieve data because index \[utopia\] does not exist/
+      ml.start_datafeed:
+        datafeed_id: "start-stop-datafeed-datafeed-1"
+
+---
+"Test start datafeed given index pattern with no matching indices":
+  - do:
+      ml.update_datafeed:
+        datafeed_id: start-stop-datafeed-datafeed-1
+        body:  >
+          {
+            "indexes":["utopia*"]
+          }
+
+  - do:
+      ml.open_job:
+        job_id: "start-stop-datafeed-job"
+
+  - do:
+      catch: /datafeed \[start-stop-datafeed-datafeed-1] cannot retrieve data because no index matches datafeed's indices \[utopia\*\]/
       ml.start_datafeed:
         datafeed_id: "start-stop-datafeed-datafeed-1"
 


### PR DESCRIPTION
…g indices

If a scrolling datafeed has an index pattern that matches no indices, starting
the datafeed fails with a message about the time field having no mappings.
This commit impvoves this by informing the user on the actual cause of the
error which is that no index matches the datafeed's indices.

Relates #81013
