### PR TITLE
Fix Failures in HierarchyCircuitBreakerServiceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -241,10 +241,10 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             );
             assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
             assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
-            assertThat(
-                exception.getMessage(),
-                containsString("usages [fielddata=54001664/51.5mb, request=157286400/150mb, inflight_requests=0/0b]")
-            );
+            assertThat(exception.getMessage(), containsString("usages ["));
+            assertThat(exception.getMessage(), containsString("fielddata=54001664/51.5mb"));
+            assertThat(exception.getMessage(), containsString("inflight_requests=0/0b"));
+            assertThat(exception.getMessage(), containsString("request=157286400/150mb"));
             assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         }
     }
@@ -302,16 +302,13 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             )
         );
         final long requestCircuitBreakerUsed = (requestBreaker.getUsed() + reservationInBytes) * 2;
+        assertThat(exception.getMessage(), containsString("usages ["));
+        assertThat(exception.getMessage(), containsString("fielddata=0/0b"));
         assertThat(
             exception.getMessage(),
-            containsString(
-                "usages [fielddata=0/0b, request="
-                    + requestCircuitBreakerUsed
-                    + "/"
-                    + new ByteSizeValue(requestCircuitBreakerUsed)
-                    + ", inflight_requests=0/0b]"
-            )
+            containsString("request=" + requestCircuitBreakerUsed + "/" + new ByteSizeValue(requestCircuitBreakerUsed))
         );
+        assertThat(exception.getMessage(), containsString("inflight_requests=0/0b"));
         assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         assertEquals(0, requestBreaker.getTrippedCount());
         assertEquals(1, service.stats().getStats(CircuitBreaker.PARENT).getTrippedCount());


### PR DESCRIPTION
In #81033 the type of map that is iterated over to compute the various
usage values was changed. This changed the order of the various breakers
in the exception string and made it less deterministic (although it was always
just deterministic by accident in these tests).
=> we shouldn't assume any order in the assertions
