### PR TITLE
[ML] Allow datafeed start with remote indices despite local index pat…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
@@ -168,6 +168,7 @@ public class DatafeedNodeSelector {
 
     @Nullable
     private AssignmentFailure verifyIndicesActive() {
+        boolean hasRemoteIndices = datafeedIndices.stream().filter(RemoteClusterLicenseChecker::isRemoteIndex).findAny().isPresent();
         String[] index = datafeedIndices.stream()
             // We cannot verify remote indices
             .filter(i -> RemoteClusterLicenseChecker.isRemoteIndex(i) == false)
@@ -177,7 +178,9 @@ public class DatafeedNodeSelector {
 
         try {
             concreteIndices = resolver.concreteIndexNames(clusterState, indicesOptions, true, index);
-            if (concreteIndices.length == 0) {
+
+            // If we have remote indices we cannot check those. We should not fail as they may contain data.
+            if (hasRemoteIndices == false && concreteIndices.length == 0) {
                 return new AssignmentFailure(
                     "cannot start datafeed ["
                         + datafeedId

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
@@ -168,7 +168,7 @@ public class DatafeedNodeSelector {
 
     @Nullable
     private AssignmentFailure verifyIndicesActive() {
-        boolean hasRemoteIndices = datafeedIndices.stream().filter(RemoteClusterLicenseChecker::isRemoteIndex).findAny().isPresent();
+        boolean hasRemoteIndices = datafeedIndices.stream().anyMatch(RemoteClusterLicenseChecker::isRemoteIndex);
         String[] index = datafeedIndices.stream()
             // We cannot verify remote indices
             .filter(i -> RemoteClusterLicenseChecker.isRemoteIndex(i) == false)


### PR DESCRIPTION
…tern not matching

When a datafeed is assigned we check that there are indices with fully assigned shards.
However, in the scenario where the datafeed has a mix of local and remote index patterns,
when the local index patterns do not match any index, results to failure to assign
the datafeed.

This should not be the behaviour. As the datafeed also has remote indices we should allow
starting the datafeed. This commit fixes this by skipping the check that local index patterns
produce matching indices when there are remote indices too.

Closes #81013
