### PR TITLE
Run test fixtures in containers with Java 17

### DIFF
--- a/test/fixtures/azure-fixture/Dockerfile
+++ b/test/fixtures/azure-fixture/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-17-jre
 ENTRYPOINT exec java -classpath "/fixture/shared/*" fixture.azure.AzureHttpFixture 0.0.0.0 8091 azure_integration_test_account container
 EXPOSE 8091

--- a/test/fixtures/azure-fixture/Dockerfile
+++ b/test/fixtures/azure-fixture/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre
+RUN apt-get install -qqy openjdk-17-jre-headless
 ENTRYPOINT exec java -classpath "/fixture/shared/*" fixture.azure.AzureHttpFixture 0.0.0.0 8091 azure_integration_test_account container
 EXPOSE 8091

--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-17-jre
 
 ARG port
 ARG bucket

--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre
+RUN apt-get install -qqy openjdk-17-jre-headless
 
 ARG port
 ARG bucket

--- a/test/fixtures/geoip-fixture/Dockerfile
+++ b/test/fixtures/geoip-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-17-jre
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/geoip-fixture/Dockerfile
+++ b/test/fixtures/geoip-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre
+RUN apt-get install -qqy openjdk-17-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-17-jre
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre
+RUN apt-get install -qqy openjdk-17-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/url-fixture/Dockerfile
+++ b/test/fixtures/url-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-17-jre
 
 ARG port
 ARG workingDir

--- a/test/fixtures/url-fixture/Dockerfile
+++ b/test/fixtures/url-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre
+RUN apt-get install -qqy openjdk-17-jre-headless
 
 ARG port
 ARG workingDir


### PR DESCRIPTION
In preparation of compiling the ES source code with the Java 17, we need to make sure that the test fixtures can run Java17 compiled classes