### PR TITLE
Run Wildfly tests only on Java 11

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -76,6 +76,6 @@ tasks.named("check").configure {
 
 static def isDockerImageAvailable() {
   // The wildfly docker image is only available for x86 architectures so disable these tests on arm
-  // The wildfly docker image is only available for Java 11
+  // The wildfly docker image is only available for Java 11 (https://github.com/jboss-dockerfiles/wildfly/issues/148)
   return Architecture.current() == Architecture.X64 && BuildParams.getMinimumRuntimeVersion() == JavaVersion.VERSION_11
 }

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -8,6 +8,8 @@
 
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 import static org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes.DOCKER;
 
 apply plugin: 'war'
@@ -42,7 +44,8 @@ tasks.named("war").configure {
 }
 
 // The wildfly docker image is only available for x86 architectures so disable these tests on arm
-if (Architecture.current() == Architecture.X64) {
+// The wildfly docker image is only available for Java 11
+if (isDockerImageAvailable()) {
   testFixtures.useFixture()
 }
 
@@ -61,7 +64,7 @@ tasks.named("preProcessFixture").configure {
 
 tasks.register("integTest", Test) {
   outputs.doNotCacheIf('Build cache is disabled for Docker tests') { true }
-  onlyIf { Architecture.current() == Architecture.X64 }
+  onlyIf { isDockerImageAvailable() }
   maxParallelForks = '1'
   include '**/*IT.class'
   systemProperty 'tests.security.manager', 'false'
@@ -69,4 +72,10 @@ tasks.register("integTest", Test) {
 
 tasks.named("check").configure {
   dependsOn "integTest"
+}
+
+static def isDockerImageAvailable() {
+  // The wildfly docker image is only available for x86 architectures so disable these tests on arm
+  // The wildfly docker image is only available for Java 11
+  return Architecture.current() == Architecture.X64 && BuildParams.getMinimumRuntimeVersion() == JavaVersion.VERSION_11
 }


### PR DESCRIPTION
The Wildfly docker image supports only Java 11, so we can't use it if the code compiled against a later java version https://github.com/jboss-dockerfiles/wildfly#image-internals-updated-dec-13-2018

Wildfly 25.0.1 does support Java 17, but there's no Java17 docker image for it yet: https://github.com/jboss-dockerfiles/wildfly/issues/148