### PR TITLE
[ML] Make inference timeout test more reliable

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -204,7 +204,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         // even with a zero timeout a valid inference response may
         // be returned.
         // The test asserts that if an error occurs it is a timeout error
-        try{
+        try {
             infer("my words", modelId, TimeValue.ZERO);
         } catch (ResponseException ex) {
             assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(408));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -297,7 +297,7 @@ public class DeploymentManager {
             if (notified.compareAndSet(false, true)) {
                 processContext.getResultProcessor().ignoreResposeWithoutNotifying(String.valueOf(requestId));
                 listener.onFailure(
-                    new ElasticsearchStatusException("timeout [{}] waiting for inference result", RestStatus.TOO_MANY_REQUESTS, timeout)
+                    new ElasticsearchStatusException("timeout [{}] waiting for inference result", RestStatus.REQUEST_TIMEOUT, timeout)
                 );
                 return;
             }


### PR DESCRIPTION
#81091 shows that `PyTorchModelIT::testEvaluateWithMinimalTimeout` is not reliable as the timeout does not always occur. 
The test can be made robust by relaxing the assertion to say that if an error occurs it must be a timeout error. 

This also changes the HTTP status code from too many requests (429) to request timeout (408) 

Closes #81091