### PR TITLE
[8.0] [ML] Fix datafeed preview with remote indices (#81099)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
 import org.junit.Before;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
@@ -51,21 +50,15 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         dataExtractor = mock(DataExtractor.class);
         actionListener = mock(ActionListener.class);
 
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                PreviewDatafeedAction.Response response = (PreviewDatafeedAction.Response) invocationOnMock.getArguments()[0];
-                capturedResponse = response.toString();
-                return null;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            PreviewDatafeedAction.Response response = (PreviewDatafeedAction.Response) invocationOnMock.getArguments()[0];
+            capturedResponse = response.toString();
+            return null;
         }).when(actionListener).onResponse(any());
 
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                capturedFailure = (Exception) invocationOnMock.getArguments()[0];
-                return null;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            capturedFailure = (Exception) invocationOnMock.getArguments()[0];
+            return null;
         }).when(actionListener).onFailure(any());
     }
 
@@ -95,7 +88,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         assertThat(previewDatafeed.getChunkingConfig(), equalTo(datafeed.build().getChunkingConfig()));
     }
 
-    public void testPreviewDatafed_GivenEmptyStream() throws IOException {
+    public void testPreviewDatafeed_GivenEmptyStream() throws IOException {
         when(dataExtractor.next()).thenReturn(Optional.empty());
 
         TransportPreviewDatafeedAction.previewDatafeed(dataExtractor, actionListener);
@@ -105,7 +98,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         verify(dataExtractor).cancel();
     }
 
-    public void testPreviewDatafed_GivenNonEmptyStream() throws IOException {
+    public void testPreviewDatafeed_GivenNonEmptyStream() throws IOException {
         String streamAsString = "{\"a\":1, \"b\":2} {\"c\":3, \"d\":4}\n{\"e\":5, \"f\":6}";
         InputStream stream = new ByteArrayInputStream(streamAsString.getBytes(StandardCharsets.UTF_8));
         when(dataExtractor.next()).thenReturn(Optional.of(stream));
@@ -117,7 +110,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         verify(dataExtractor).cancel();
     }
 
-    public void testPreviewDatafed_GivenFailure() throws IOException {
+    public void testPreviewDatafeed_GivenFailure() throws IOException {
         doThrow(new RuntimeException("failed")).when(dataExtractor).next();
 
         TransportPreviewDatafeedAction.previewDatafeed(dataExtractor, actionListener);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Fix datafeed preview with remote indices (#81099)