### PR TITLE
[7.16] [ML] Fix acceptable model snapshot versions in ML deprecation checker

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningField.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.settings.Setting;
@@ -39,6 +40,13 @@ public final class MachineLearningField {
         "api",
         License.OperationMode.PLATINUM
     );
+
+    // Ideally this would be 7.0.0, but it has to be 6.4.0 because due to an oversight it's impossible
+    // for the Java code to distinguish the model states for versions 6.4.0 to 7.9.3 inclusive.
+    public static final Version MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION = Version.fromString("6.4.0");
+    // We tell the user we support model snapshots newer than 7.0.0 as that's the major version
+    // boundary, even though behind the scenes we have to support back to 6.4.0.
+    public static final Version MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
 
     private MachineLearningField() {}
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -112,7 +112,7 @@ public class MlDeprecationIT extends ESRestTestCase {
         assertThat(response.getMlSettingsIssues(), hasSize(1));
         assertThat(
             response.getMlSettingsIssues().get(0).getMessage(),
-            containsString("Snapshot [1] for job [deprecation_check_job] has an obsolete minimum version")
+            containsString("Model snapshot [1] for job [deprecation_check_job] has an obsolete minimum version")
         );
         assertThat(response.getMlSettingsIssues().get(0).getMeta(), equalTo(Map.of("job_id", jobId, "snapshot_id", "1")));
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.deprecation;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
@@ -26,6 +25,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 
 public class MlDeprecationChecker implements DeprecationChecker {
 
@@ -66,20 +68,20 @@ public class MlDeprecationChecker implements DeprecationChecker {
     }
 
     static Optional<DeprecationIssue> checkModelSnapshot(ModelSnapshot modelSnapshot) {
-        if (modelSnapshot.getMinVersion().before(Version.V_7_0_0)) {
+        if (modelSnapshot.getMinVersion().before(MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION)) {
             StringBuilder details = new StringBuilder(
                 String.format(
                     Locale.ROOT,
                     "Delete model snapshot [%s] or update it to %s or greater.",
                     modelSnapshot.getSnapshotId(),
-                    Version.V_7_0_0
+                    MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION
                 )
             );
             if (modelSnapshot.getLatestRecordTimeStamp() != null) {
                 details.append(
                     String.format(
                         Locale.ROOT,
-                        " The model snapshot's latest record timestamp is [%s]",
+                        " The model snapshot's latest record timestamp is [%s].",
                         XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(modelSnapshot.getLatestRecordTimeStamp().getTime())
                     )
                 );
@@ -89,7 +91,9 @@ public class MlDeprecationChecker implements DeprecationChecker {
                     DeprecationIssue.Level.CRITICAL,
                     String.format(
                         Locale.ROOT,
-                        "Snapshot [%s] for job [%s] has an obsolete minimum version [%s]",
+                        // Important: the Kibana upgrade assistant expects this to match the pattern /[Mm]odel snapshot/
+                        // and if it doesn't then the expected "Fix" button won't appear for this deprecation.
+                        "Model snapshot [%s] for job [%s] has an obsolete minimum version [%s].",
                         modelSnapshot.getSnapshotId(),
                         modelSnapshot.getJobId(),
                         modelSnapshot.getMinVersion()


### PR DESCRIPTION
This is a followup to #81039.

The same requirement to tolerate model snapshots back to 6.4.0
that applies to the job opening code also applies to the deprecation
checker. Again, we tell the user that 7.0.0 is the model snapshot
version we support, but we actually have to support versions going
back to 6.4.0 because we didn't update the constant in the C++ in
7.0.0.

Additionally, the wording of the ML deprecation messages is very
slightly updated. The messages are different in the 7.16 branch,
where they were updated by #79387. This wording is copied forward
to master, but with the tiny change that "Snapshot" is changed to
"Model snapshot" in one place. This should make it clearer for
users that we're talking about ML model snapshots and not cluster
snapshots (which are completely different things). Another reason
to change the wording is that the UI is looking for the pattern
/[Mm]odel snapshot/ to decide when to display the "Fix" button for
upgrading ML model snapshots - see elastic/kibana#119745.

Backport of #81060