### PR TITLE
[ML] Switch message and detail for model snapshot deprecations

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -105,7 +105,7 @@ public class MlDeprecationIT extends ESRestTestCase {
         assertThat(response.getMlSettingsIssues(), hasSize(1));
         assertThat(
             response.getMlSettingsIssues().get(0).getMessage(),
-            containsString("Delete model snapshot [1] or update it to 7.0.0 or greater")
+            containsString("Model snapshot [1] for job [deprecation_check_job] has an obsolete minimum version")
         );
         assertThat(response.getMlSettingsIssues().get(0).getMeta(), equalTo(Map.of("job_id", jobId, "snapshot_id", "1")));
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -73,12 +73,9 @@ public class MlDeprecationChecker implements DeprecationChecker {
             StringBuilder details = new StringBuilder(
                 String.format(
                     Locale.ROOT,
-                    // Important: the Kibana upgrade assistant expects this to match the pattern /[Mm]odel snapshot/
-                    // and if it doesn't then the expected "Fix" button won't appear for this deprecation.
-                    "Model snapshot [%s] for job [%s] has an obsolete minimum version [%s].",
+                    "Delete model snapshot [%s] or update it to %s or greater.",
                     modelSnapshot.getSnapshotId(),
-                    modelSnapshot.getJobId(),
-                    modelSnapshot.getMinVersion()
+                    MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION
                 )
             );
             if (modelSnapshot.getLatestRecordTimeStamp() != null) {
@@ -95,9 +92,12 @@ public class MlDeprecationChecker implements DeprecationChecker {
                     DeprecationIssue.Level.CRITICAL,
                     String.format(
                         Locale.ROOT,
-                        "Delete model snapshot [%s] or update it to %s or greater.",
+                        // Important: the Kibana upgrade assistant expects this to match the pattern /[Mm]odel snapshot/
+                        // and if it doesn't then the expected "Fix" button won't appear for this deprecation.
+                        "Model snapshot [%s] for job [%s] has an obsolete minimum version [%s].",
                         modelSnapshot.getSnapshotId(),
-                        MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION
+                        modelSnapshot.getJobId(),
+                        modelSnapshot.getMinVersion()
                     ),
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html",
                     details.toString(),


### PR DESCRIPTION
This is a fix to the fix of #81060.

In the original fix where I tried to port the changes
from #79387 to master I didn't notice that the text of
the message and detail of the deprecation had been
largely switched around. My tweaks to the wording
in #81060 did not make this major switch. This PR
switches the two strings we generate.

This is only for 8.0 and 8.1. For 7.16 the discrepancy
became obvious in the backport of #81060 to that
branch, so it's already correct there.