### PR TITLE
Reduce verbosity-increase timeout to 3m

### DIFF
--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -89,7 +89,7 @@ the request to have failed. Defaults to `3s`.
 (<<static-cluster-setting,Static>>)
 Sets how long a node will attempt to discover its peers before it starts to log
 verbose messages describing why the connection attempts are failing. Defaults
-to `5m`.
+to `3m`.
 
 `discovery.seed_resolver.max_concurrent_resolvers`::
 (<<static-cluster-setting,Static>>)

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -68,7 +68,7 @@ public abstract class PeerFinder {
     // the master before we start to emit more verbose logs.
     public static final Setting<TimeValue> VERBOSITY_INCREASE_TIMEOUT_SETTING = Setting.timeSetting(
         "discovery.find_peers_warning_timeout",
-        TimeValue.timeValueMinutes(5),
+        TimeValue.timeValueMinutes(3),
         TimeValue.timeValueMillis(1),
         Setting.Property.NodeScope
     );


### PR DESCRIPTION
Today we increase the verbosity of discovery failures after 5 minutes
without a master. Unfortunately 5 minutes is a common orchestration
timeout, so if discovery is broken then we see nodes being shut down
just before they start to emit useful logs. This commit reduces the
default timeout to 3 minutes to address that.