### PR TITLE
[7.16] Strip blocks from settings for reindex targets (#80887)

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -243,6 +243,30 @@ public class FeatureMigrationIT extends ESIntegTestCase {
         );
     }
 
+    public void testMigrateIndexWithWriteBlock() throws Exception {
+        createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
+
+        String indexName = Optional.ofNullable(INTERNAL_UNMANAGED.getPrimaryIndex())
+            .orElse(INTERNAL_UNMANAGED.getIndexPattern().replace("*", "old"));
+        client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder().put("index.blocks.write", true)).get();
+
+        TestPlugin.preMigrationHook.set((state) -> Collections.emptyMap());
+        TestPlugin.postMigrationHook.set((state, metadata) -> {});
+
+        ensureGreen();
+
+        client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest()).get();
+
+        assertBusy(() -> {
+            GetFeatureUpgradeStatusResponse statusResp = client().execute(
+                GetFeatureUpgradeStatusAction.INSTANCE,
+                new GetFeatureUpgradeStatusRequest()
+            ).get();
+            logger.info(Strings.toString(statusResp));
+            assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
+        });
+    }
+
     public void assertIndexHasCorrectProperties(
         Metadata metadata,
         String indexName,

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -459,9 +460,16 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             migrationInfo.getNextIndexName()
         );
 
+        Settings.Builder settingsBuilder = Settings.builder();
+        if (Objects.nonNull(migrationInfo.getSettings())) {
+            settingsBuilder.put(migrationInfo.getSettings());
+            settingsBuilder.remove("index.blocks.write");
+            settingsBuilder.remove("index.blocks.read");
+            settingsBuilder.remove("index.blocks.metadata");
+        }
         createRequest.waitForActiveShards(ActiveShardCount.ALL)
             .mappings(Collections.singletonMap("_doc", migrationInfo.getMappings()))
-            .settings(migrationInfo.getSettings() == null ? Settings.EMPTY : migrationInfo.getSettings());
+            .settings(migrationInfo.getSettings() == null ? Settings.EMPTY : settingsBuilder.build());
         metadataCreateIndexService.createIndex(createRequest, listener);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Strip blocks from settings for reindex targets (#80887)