### PR TITLE
[DOCS] Adds missing timeout parameter to transform APIs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1107,9 +1107,7 @@ end::timeout[]
 end::timeoutparms[]
 
 tag::transform-id[]
-Identifier for the {transform}. This identifier can contain lowercase
-alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64
-character limit and must start and end with alphanumeric characters.
+Identifier for the {transform}.
 end::transform-id[]
 
 tag::transform-id-wildcard[]

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -36,6 +36,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 current state. The default value is `false`, meaning that the {transform} must be
 `stopped` before it can be deleted.
 
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
+
 [[delete-transform-examples]]
 == {api-examples-title}
 

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -36,7 +36,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 current state. The default value is `false`, meaning that the {transform} must be
 `stopped` before it can be deleted.
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -67,7 +67,7 @@ provide {transform} configuration details in the request body.
 [[preview-transform-query-parms]]
 == {api-query-parms-title}
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -64,6 +64,14 @@ Id of the {transform} to preview.
 NOTE: If you provide the `<transform_id>` as a path parameter, you cannot
 provide {transform} configuration details in the request body.
 
+[[preview-transform-query-parms]]
+== {api-query-parms-title}
+
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
+
 [[preview-transform-request-body]]
 == {api-request-body-title}
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -65,7 +65,9 @@ cannot use both in a single {transform}.
 
 `<transform_id>`::
 (Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
+Identifier for the {transform}. This identifier can contain lowercase
+alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64
+character limit and must start and end with alphanumeric characters.
 
 [[put-transform-query-parms]]
 == {api-query-parms-title}

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -77,7 +77,7 @@ character limit and must start and end with alphanumeric characters.
 behavior may be desired if the source index does not exist until after the
 {transform} is created.
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -73,9 +73,14 @@ character limit and must start and end with alphanumeric characters.
 == {api-query-parms-title}
 
 `defer_validation`::
-  (Optional, Boolean) When `true`, deferrable validations are not run. This
-  behavior may be desired if the source index does not exist until after the
-  {transform} is created.
+(Optional, Boolean) When `true`, deferrable validations are not run. This
+behavior may be desired if the source index does not exist until after the
+{transform} is created.
+
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
 
 [role="child_attributes"]
 [[put-transform-request-body]]

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -45,7 +45,7 @@ If this value is `true`, the {transform} is reset regardless of its current
 state. If it's false, the {transform} must be `stopped` before it can be reset.
 The default value is `false`
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -45,6 +45,11 @@ If this value is `true`, the {transform} is reset regardless of its current
 state. If it's false, the {transform} must be `stopped` before it can be reset.
 The default value is `false`
 
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
+
 [[reset-transform-examples]]
 == {api-examples-title}
 

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Start {transform}</titleabbrev>
 ++++
 
-Starts one or more {transforms}.
+Starts a {transform}.
 
 [[start-transform-request]]
 == {api-request-title}
@@ -57,8 +57,7 @@ required privileges on the source and destination indices, the
 
 `<transform_id>`::
 (Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
-
+Identifier for the {transform}.
 
 [[start-transform-query-parms]]
 == {api-query-parms-title}

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -65,7 +65,7 @@ Identifier for the {transform}.
 `timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
-expires, the request fails and returns an error.
+expires, the request fails and returns an error. Defaults to `30s`.
    
 
 [[start-transform-example]]

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -39,8 +39,9 @@ fields in the destination index are derived from scripts (as in the case of
 If it is a latest {transform}, it does not deduce mapping definitions; it uses
 dynamic mappings.
 
-TIP: To use explicit mappings, create the destination index before you start the {transform}. Alternatively, you can create an index template, though it does not affect the
-deduced mappings in a pivot {transform}.
+TIP: To use explicit mappings, create the destination index before you start the
+{transform}. Alternatively, you can create an index template, though it does not
+affect the deduced mappings in a pivot {transform}.
 
 When the {transform} starts, a series of validations occur to ensure
 its success. If you deferred validation when you created the
@@ -57,6 +58,16 @@ required privileges on the source and destination indices, the
 `<transform_id>`::
 (Required, string)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
+
+
+[[start-transform-query-parms]]
+== {api-query-parms-title}
+
+`timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error.
+   
 
 [[start-transform-example]]
 == {api-examples-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -27,21 +27,14 @@ Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
 
 
-[[stop-transform-desc]]
-== {api-description-title}
-
-You can stop multiple {transforms} in a single API request by using a
-comma-separated list of {transforms} or a wildcard expression.
-All {transforms} can be stopped by using `_all` or `*` as the
-`<transform_id>`.
-
-
 [[stop-transform-path-parms]]
 == {api-path-parms-title}
 
 `<transform_id>`::
 (Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
+Identifier for the transform. To stop multiple {transforms}, use a
+comma-separated list or a wildcard expression. To stop all {transforms}, use
+`_all` or `*` as the identifier.
 
 [[stop-transform-query-parms]]
 == {api-query-parms-title}
@@ -63,15 +56,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transfo
   eventually moves the {transform} to `STOPPED`. The timeout simply means the API
   call itself timed out while waiting for the status change. Defaults to `30s`
 
-`wait_for_completion`::
-  (Optional, Boolean) If set to `true`, causes the API to block until the indexer 
-  state completely stops. If set to `false`, the API returns immediately and the
-  indexer will be stopped asynchronously in the background. Defaults to `false`.
-
 `wait_for_checkpoint`::
   (Optional, Boolean) If set to `true`, the transform will not completely stop
   until the current checkpoint is completed. If set to `false`, the {transform}
   stops as soon as possible. Defaults to `false`.
+
+`wait_for_completion`::
+  (Optional, Boolean) If set to `true`, causes the API to block until the indexer 
+  state completely stops. If set to `false`, the API returns immediately and the
+  indexer will be stopped asynchronously in the background. Defaults to `false`.
 
 [[stop-transform-response-codes]]
 == {api-response-codes-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -54,7 +54,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transfo
   more than `timeout` time has passed, the API throws a timeout exception. Even
   if a timeout exception is thrown, the stop request is still processing and
   eventually moves the {transform} to `STOPPED`. The timeout simply means the API
-  call itself timed out while waiting for the status change. Defaults to `30s`
+  call itself timed out while waiting for the status change. Defaults to `30s`.
 
 `wait_for_checkpoint`::
   (Optional, Boolean) If set to `true`, the transform will not completely stop

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -63,9 +63,14 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 == {api-query-parms-title}
 
 `defer_validation`::
-  (Optional, Boolean) When `true`, deferrable validations are not run. This
-  behavior may be desired if the source index does not exist until after the
-  {transform} is updated.
+(Optional, Boolean) When `true`, deferrable validations are not run. This
+behavior may be desired if the source index does not exist until after the
+{transform} is updated.
+
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
 
 [role="child_attributes"]
 [[update-transform-request-body]]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -67,7 +67,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 behavior may be desired if the source index does not exist until after the
 {transform} is updated.
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -59,8 +59,13 @@ destination index remains unchanged.
 == {api-query-parms-title}
 
 `dry_run`::
-  (Optional, Boolean) When `true`, only checks for updates but does not execute 
-  them. Defaults to `false`.
+(Optional, Boolean) When `true`, only checks for updates but does not execute 
+them. Defaults to `false`.
+
+timeout`::
+(Optional, time)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
 
 
 [[upgrade-transforms-response-body]]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -62,7 +62,7 @@ destination index remains unchanged.
 (Optional, Boolean) When `true`, only checks for updates but does not execute 
 them. Defaults to `false`.
 
-timeout`::
+`timeout`::
 (Optional, time)
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
@@ -30,7 +30,14 @@
         "type":"boolean",
         "required":false,
         "description":"When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform deletion"
       }
     }
   }
 }
+
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
@@ -34,6 +34,13 @@
         }
       ]
     },
+    "params":{
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the preview"
+      }
+    },
     "body":{
       "description":"The definition for the transform to preview",
       "required":false

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
@@ -31,6 +31,11 @@
         "type":"boolean",
         "required":false,
         "description":"If validations should be deferred until transform starts, defaults to false."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform to start"
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
@@ -30,6 +30,11 @@
         "type":"boolean",
         "required":false,
         "description":"When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform to reset"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
@@ -32,6 +32,11 @@
         "type":"boolean",
         "required":false,
         "description":"If validations should be deferred until transform starts, defaults to false."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the update"
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
@@ -25,6 +25,11 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to only check for updates but don't execute"
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the upgrade"
       }
     }
   }


### PR DESCRIPTION
The spec for the [start transform API](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/transform.start_transform.json) includes a `timeout` parameter, which is missing from the documentation.  Per https://github.com/elastic/elasticsearch/pull/81129#discussion_r759018204, timeout applies to all APIs, except GET, so this is a common parameter.

This PR updates the API specifications and the documentation to include this parameter.

### Preview

The timeout parameter is added to all of these API docs:
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html#preview-transform-path-params
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/reset-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/start-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/stop-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html
* https://elasticsearch_81129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html