### PR TITLE
[8.0] Fix ComposableIndexTemplate equals when composed_of is null (#80864)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -274,12 +274,25 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         ComposableIndexTemplate other = (ComposableIndexTemplate) obj;
         return Objects.equals(this.indexPatterns, other.indexPatterns)
             && Objects.equals(this.template, other.template)
-            && Objects.equals(this.componentTemplates, other.componentTemplates)
+            && componentTemplatesEquals(this.componentTemplates, other.componentTemplates)
             && Objects.equals(this.priority, other.priority)
             && Objects.equals(this.version, other.version)
             && Objects.equals(this.metadata, other.metadata)
             && Objects.equals(this.dataStreamTemplate, other.dataStreamTemplate)
             && Objects.equals(this.allowAutoCreate, other.allowAutoCreate);
+    }
+
+    static boolean componentTemplatesEquals(List<String> c1, List<String> c2) {
+        if (Objects.equals(c1, c2)) {
+            return true;
+        }
+        if (c1 == null && c2.isEmpty()) {
+            return true;
+        }
+        if (c2 == null && c1.isEmpty()) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class ComposableIndexTemplateTests extends AbstractDiffableSerializationTestCase<ComposableIndexTemplate> {
     @Override
     protected ComposableIndexTemplate makeTestChanges(ComposableIndexTemplate testInstance) {
@@ -79,11 +81,10 @@ public class ComposableIndexTemplateTests extends AbstractDiffableSerializationT
         }
 
         List<String> indexPatterns = randomList(1, 4, () -> randomAlphaOfLength(4));
-        List<String> componentTemplates = randomList(0, 10, () -> randomAlphaOfLength(5));
         return new ComposableIndexTemplate(
             indexPatterns,
             template,
-            componentTemplates,
+            randomBoolean() ? null : randomList(0, 10, () -> randomAlphaOfLength(5)),
             randomBoolean() ? null : randomNonNegativeLong(),
             randomBoolean() ? null : randomNonNegativeLong(),
             meta,
@@ -241,5 +242,14 @@ public class ComposableIndexTemplateTests extends AbstractDiffableSerializationT
             default:
                 throw new IllegalStateException("illegal randomization branch");
         }
+    }
+
+    public void testComponentTemplatesEquals() {
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(null, null), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(null, List.of()), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), null), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), List.of()), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(randomAlphaOfLength(5)), List.of()), equalTo(false));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), List.of(randomAlphaOfLength(5))), equalTo(false));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix ComposableIndexTemplate equals when composed_of is null (#80864)