### PR TITLE
[8.0] Add replicated field to get data stream api response. (#80988)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
@@ -35,6 +35,7 @@ public final class DataStream {
     @Nullable
     private final Map<String, Object> metadata;
     private final boolean allowCustomRouting;
+    private final boolean replicated;
 
     public DataStream(
         String name,
@@ -47,7 +48,8 @@ public final class DataStream {
         @Nullable Map<String, Object> metadata,
         boolean hidden,
         boolean system,
-        boolean allowCustomRouting
+        boolean allowCustomRouting,
+        boolean replicated
     ) {
         this.name = name;
         this.timeStampField = timeStampField;
@@ -60,6 +62,7 @@ public final class DataStream {
         this.hidden = hidden;
         this.system = system;
         this.allowCustomRouting = allowCustomRouting;
+        this.replicated = replicated;
     }
 
     public String getName() {
@@ -106,6 +109,10 @@ public final class DataStream {
         return allowCustomRouting;
     }
 
+    public boolean isReplicated() {
+        return replicated;
+    }
+
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField TIMESTAMP_FIELD_FIELD = new ParseField("timestamp_field");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
@@ -117,6 +124,7 @@ public final class DataStream {
     public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
     public static final ParseField SYSTEM_FIELD = new ParseField("system");
     public static final ParseField ALLOW_CUSTOM_ROUTING = new ParseField("allow_custom_routing");
+    public static final ParseField REPLICATED = new ParseField("replicated");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream", args -> {
@@ -132,6 +140,7 @@ public final class DataStream {
         boolean hidden = args[8] != null && (boolean) args[8];
         boolean system = args[9] != null && (boolean) args[9];
         boolean allowCustomRouting = args[10] != null && (boolean) args[10];
+        boolean replicated = args[11] != null && (boolean) args[11];
         return new DataStream(
             dataStreamName,
             timeStampField,
@@ -143,7 +152,8 @@ public final class DataStream {
             metadata,
             hidden,
             system,
-            allowCustomRouting
+            allowCustomRouting,
+            replicated
         );
     });
 
@@ -159,6 +169,7 @@ public final class DataStream {
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), HIDDEN_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SYSTEM_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), ALLOW_CUSTOM_ROUTING);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), REPLICATED);
     }
 
     public static DataStream fromXContent(XContentParser parser) throws IOException {
@@ -180,7 +191,8 @@ public final class DataStream {
             && Objects.equals(indexTemplate, that.indexTemplate)
             && Objects.equals(ilmPolicyName, that.ilmPolicyName)
             && Objects.equals(metadata, that.metadata)
-            && allowCustomRouting == that.allowCustomRouting;
+            && allowCustomRouting == that.allowCustomRouting
+            && replicated == that.replicated;
     }
 
     @Override
@@ -196,7 +208,8 @@ public final class DataStream {
             metadata,
             hidden,
             system,
-            allowCustomRouting
+            allowCustomRouting,
+            replicated
         );
     }
 }

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -578,7 +578,8 @@ stream's oldest backing index.
       "template": "my-data-stream-template",
       "hidden": false,
       "system": false,
-      "allow_custom_routing": false
+      "allow_custom_routing": false,
+      "replicated": false
     }
   ]
 }

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -207,6 +207,15 @@ use the <<indices-get-settings,get index settings API>>.
 (Boolean)
 If `true`, the data stream is created and managed by an Elastic stack component
 and cannot be modified through normal user interaction.
+
+`allow_custom_routing`::
+(Boolean)
+If `true`, the data stream this data stream allows custom routing on write request.
+
+`replicated`::
+(Boolean)
+If `true`, the data stream is created and managed by {ccr} and the local
+cluster can not write into this data stream or change its mappings.
 ====
 
 [[get-data-stream-api-example]]
@@ -247,7 +256,8 @@ The API returns the following response:
       "ilm_policy": "my-lifecycle-policy",
       "hidden": false,
       "system": false,
-      "allow_custom_routing": false
+      "allow_custom_routing": false,
+      "replicated": false
     },
     {
       "name": "my-data-stream-two",
@@ -269,7 +279,8 @@ The API returns the following response:
       "ilm_policy": "my-lifecycle-policy",
       "hidden": false,
       "system": false,
-      "allow_custom_routing": false
+      "allow_custom_routing": false,
+      "replicated": false
     }
   ]
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
@@ -120,6 +120,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
             public static final ParseField SYSTEM_FIELD = new ParseField("system");
             public static final ParseField ALLOW_CUSTOM_ROUTING = new ParseField("allow_custom_routing");
+            public static final ParseField REPLICATED = new ParseField("replicated");
 
             DataStream dataStream;
             ClusterHealthStatus dataStreamStatus;
@@ -190,6 +191,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 builder.field(HIDDEN_FIELD.getPreferredName(), dataStream.isHidden());
                 builder.field(SYSTEM_FIELD.getPreferredName(), dataStream.isSystem());
                 builder.field(ALLOW_CUSTOM_ROUTING.getPreferredName(), dataStream.isAllowCustomRouting());
+                builder.field(REPLICATED.getPreferredName(), dataStream.isReplicated());
                 builder.endObject();
                 return builder;
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -54,13 +54,15 @@ setup:
   - match: { data_streams.0.status: 'GREEN' }
   - match: { data_streams.0.template: 'my-template1' }
   - match: { data_streams.0.hidden: false }
+  - match: { data_streams.0.replicated: false }
   - match: { data_streams.1.name: simple-data-stream2 }
   - match: { data_streams.1.timestamp_field.name: '@timestamp' }
-  - match: { data_streams.0.generation: 1 }
+  - match: { data_streams.1.generation: 1 }
   - length: { data_streams.1.indices: 1 }
   - match: { data_streams.1.indices.0.index_name: '/\.ds-simple-data-stream2-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
   - match: { data_streams.1.template: 'my-template2' }
-  - match: { data_streams.0.hidden: false }
+  - match: { data_streams.1.hidden: false }
+  - match: { data_streams.1.replicated: false }
 
   # save the backing index names for later use
   - set: { data_streams.0.indices.0.index_name: idx0name }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add replicated field to get data stream api response. (#80988)