### PR TITLE
[8.0] Fix stopping of old elasticsearch cluster (#81059)

### DIFF
--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -132,5 +132,9 @@ public class OldElasticsearch {
         Path tmp = Files.createTempFile(baseDir, null, null);
         Files.write(tmp, Integer.toString(port).getBytes(StandardCharsets.UTF_8));
         Files.move(tmp, baseDir.resolve("ports"), StandardCopyOption.ATOMIC_MOVE);
+
+        tmp = Files.createTempFile(baseDir, null, null);
+        Files.write(tmp, Integer.toString(pid).getBytes(StandardCharsets.UTF_8));
+        Files.move(tmp, baseDir.resolve("pid"), StandardCopyOption.ATOMIC_MOVE);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix stopping of old elasticsearch cluster (#81059)