### PR TITLE
[Transform] Report transforms without config as erroneous.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.xcontent.ParseField;
@@ -28,6 +29,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -82,22 +84,60 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
 
     public static class Response extends AbstractGetResourcesResponse<TransformConfig> implements ToXContentObject {
 
+        public static class Error implements Writeable, ToXContentObject {
+            private static final ParseField TYPE = new ParseField("type");
+            private static final ParseField REASON = new ParseField("reason");
+
+            private final String type;
+            private final String reason;
+
+            public Error(String type, String reason) {
+                this.type = Objects.requireNonNull(type);
+                this.reason = Objects.requireNonNull(reason);
+            }
+
+            public Error(StreamInput in) throws IOException {
+                this.type = in.readString();
+                this.reason = in.readString();
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                builder.startObject();
+                builder.field(TYPE.getPreferredName(), type);
+                builder.field(REASON.getPreferredName(), reason);
+                builder.endObject();
+                return builder;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                out.writeString(type);
+                out.writeString(reason);
+            }
+        }
+
         public static final String INVALID_TRANSFORMS_DEPRECATION_WARNING = "Found [{}] invalid transforms";
         private static final ParseField INVALID_TRANSFORMS = new ParseField("invalid_transforms");
+        private static final ParseField ERRORS = new ParseField("errors");
 
-        private final List<String> transformsWithoutConfig;
+        private final List<Error> errors;
 
-        public Response(List<TransformConfig> transformConfigs, long count, List<String> transformsWithoutConfig) {
+        public Response(List<TransformConfig> transformConfigs, long count, List<Error> errors) {
             super(new QueryPage<>(transformConfigs, count, TransformField.TRANSFORMS));
-            this.transformsWithoutConfig = transformsWithoutConfig;
+            this.errors = errors;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
             if (in.getVersion().onOrAfter(Version.V_8_1_0)) {
-                this.transformsWithoutConfig = in.readOptionalStringList();
+                if (in.readBoolean()) {
+                    this.errors = in.readList(Error::new);
+                } else {
+                    this.errors = null;
+                }
             } else {
-                this.transformsWithoutConfig = null;
+                this.errors = null;
             }
         }
 
@@ -109,8 +149,8 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
             return getResources().count();
         }
 
-        public List<String> getTransformsWithoutConfig() {
-            return transformsWithoutConfig;
+        public List<Error> getErrors() {
+            return errors;
         }
 
         @Override
@@ -128,9 +168,6 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
                     invalidTransforms.add(configResponse.getId());
                 }
             }
-            if (transformsWithoutConfig != null) {
-                invalidTransforms.addAll(transformsWithoutConfig);
-            }
             builder.endArray();
             if (invalidTransforms.isEmpty() == false) {
                 builder.startObject(INVALID_TRANSFORMS.getPreferredName());
@@ -144,6 +181,9 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
                     invalidTransforms.size()
                 );
             }
+            if (errors != null) {
+                builder.field(ERRORS.getPreferredName(), errors);
+            }
             builder.endObject();
             return builder;
         }
@@ -152,7 +192,12 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
-                out.writeOptionalStringCollection(transformsWithoutConfig);
+                if (errors != null) {
+                    out.writeBoolean(true);
+                    out.writeList(errors);
+                } else {
+                    out.writeBoolean(false);
+                }
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.xpack.core.transform.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.xcontent.ParseField;
@@ -80,7 +80,7 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
         }
     }
 
-    public static class Response extends AbstractGetResourcesResponse<TransformConfig> implements Writeable, ToXContentObject {
+    public static class Response extends AbstractGetResourcesResponse<TransformConfig> implements ToXContentObject {
 
         public static final String INVALID_TRANSFORMS_DEPRECATION_WARNING = "Found [{}] invalid transforms";
         private static final ParseField INVALID_TRANSFORMS = new ParseField("invalid_transforms");
@@ -94,7 +94,11 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.transformsWithoutConfig = in.readOptionalStringList();
+            if (in.getVersion().onOrAfter(Version.V_8_1_0)) {
+                this.transformsWithoutConfig = in.readOptionalStringList();
+            } else {
+                this.transformsWithoutConfig = null;
+            }
         }
 
         public List<TransformConfig> getTransformConfigurations() {
@@ -147,7 +151,9 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeOptionalStringCollection(transformsWithoutConfig);
+            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+                out.writeOptionalStringCollection(transformsWithoutConfig);
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformActionResponseTests.java
@@ -19,52 +19,74 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
 import org.elasticsearch.xpack.core.watcher.watch.Payload.XContent;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class GetTransformActionResponseTests extends AbstractWireSerializingTransformTestCase<Response> {
 
     public static Response randomTransformResponse() {
-        List<TransformConfig> configs = new ArrayList<>();
-        int totalConfigs = randomInt(10);
-        for (int i = 0; i < totalConfigs; ++i) {
-            configs.add(TransformConfigTests.randomTransformConfig());
-        }
-
-        return new Response(configs, randomNonNegativeLong());
+        List<TransformConfig> configs = randomList(0, 10, () -> TransformConfigTests.randomTransformConfig());
+        List<String> transformsWithoutConfig = randomBoolean() ? randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)) : null;
+        return new Response(configs, randomNonNegativeLong(), transformsWithoutConfig);
     }
 
     public void testInvalidTransforms() throws IOException {
-        List<TransformConfig> transforms = new ArrayList<>();
+        List<TransformConfig> transforms = List.of(
+            TransformConfigTests.randomTransformConfig("valid-transform-1"),
+            TransformConfigTests.randomInvalidTransformConfig("invalid-transform-1"),
+            TransformConfigTests.randomTransformConfig("valid-transform-2"),
+            TransformConfigTests.randomInvalidTransformConfig("invalid-transform-2")
+        );
 
-        transforms.add(TransformConfigTests.randomTransformConfig());
-        transforms.add(TransformConfigTests.randomInvalidTransformConfig());
-        transforms.add(TransformConfigTests.randomTransformConfig());
-        transforms.add(TransformConfigTests.randomInvalidTransformConfig());
-
-        Response r = new Response(transforms, transforms.size());
+        Response r = new Response(transforms, transforms.size(), null);
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         r.toXContent(builder, XContent.EMPTY_PARAMS);
         Map<String, Object> responseAsMap = createParser(builder).map();
         assertEquals(2, XContentMapValues.extractValue("invalid_transforms.count", responseAsMap));
-        List<String> expectedInvalidTransforms = new ArrayList<>();
-        expectedInvalidTransforms.add(transforms.get(1).getId());
-        expectedInvalidTransforms.add(transforms.get(3).getId());
+        List<String> expectedInvalidTransforms = List.of("invalid-transform-1", "invalid-transform-2");
         assertEquals(expectedInvalidTransforms, XContentMapValues.extractValue("invalid_transforms.transforms", responseAsMap));
         assertWarnings(LoggerMessageFormat.format(Response.INVALID_TRANSFORMS_DEPRECATION_WARNING, 2));
     }
 
+    public void testTransformsWithoutConfig() throws IOException {
+        List<String> transformsWithoutConfig = List.of("transform-1", "transform-2", "transform-3");
+
+        Response r = new Response(List.of(), 0, transformsWithoutConfig);
+        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        r.toXContent(builder, XContent.EMPTY_PARAMS);
+        Map<String, Object> responseAsMap = createParser(builder).map();
+        assertThat(XContentMapValues.extractValue("invalid_transforms.count", responseAsMap), is(equalTo(3)));
+        assertThat(
+            XContentMapValues.extractValue("invalid_transforms.transforms", responseAsMap),
+            is(equalTo(List.of("transform-1", "transform-2", "transform-3")))
+        );
+        assertWarnings(LoggerMessageFormat.format(Response.INVALID_TRANSFORMS_DEPRECATION_WARNING, 3));
+    }
+
+    public void testBothInvalidConfigsAndTransformsWithoutConfig() throws IOException {
+        List<TransformConfig> transforms = List.of(TransformConfigTests.randomInvalidTransformConfig("invalid-transform-7"));
+        List<String> transformsWithoutConfig = List.of("transform-1", "transform-2", "transform-3");
+
+        Response r = new Response(transforms, transforms.size(), transformsWithoutConfig);
+        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        r.toXContent(builder, XContent.EMPTY_PARAMS);
+        Map<String, Object> responseAsMap = createParser(builder).map();
+        assertThat(XContentMapValues.extractValue("invalid_transforms.count", responseAsMap), is(equalTo(4)));
+        assertThat(
+            XContentMapValues.extractValue("invalid_transforms.transforms", responseAsMap),
+            is(equalTo(List.of("invalid-transform-7", "transform-1", "transform-2", "transform-3")))
+        );
+        assertWarnings(LoggerMessageFormat.format(Response.INVALID_TRANSFORMS_DEPRECATION_WARNING, 4));
+    }
+
     @SuppressWarnings("unchecked")
     public void testNoHeaderInResponse() throws IOException {
-        List<TransformConfig> transforms = new ArrayList<>();
-        int totalConfigs = randomInt(10);
+        List<TransformConfig> transforms = randomList(0, 10, () -> TransformConfigTests.randomTransformConfig());
 
-        for (int i = 0; i < totalConfigs; ++i) {
-            transforms.add(TransformConfigTests.randomTransformConfig());
-        }
-
-        Response r = new Response(transforms, transforms.size());
+        Response r = new Response(transforms, transforms.size(), null);
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         r.toXContent(builder, XContent.EMPTY_PARAMS);
         Map<String, Object> responseAsMap = createParser(builder).map();
@@ -79,7 +101,7 @@ public class GetTransformActionResponseTests extends AbstractWireSerializingTran
         for (int i = 0; i < transforms.size(); ++i) {
             assertArrayEquals(
                 transforms.get(i).getSource().getIndex(),
-                ((ArrayList<String>) XContentMapValues.extractValue("source.index", transformsResponse.get(i))).toArray(new String[0])
+                ((List<String>) XContentMapValues.extractValue("source.index", transformsResponse.get(i))).toArray(new String[0])
             );
             assertEquals(null, XContentMapValues.extractValue("headers", transformsResponse.get(i)));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -141,7 +141,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         );
     }
 
-    public static TransformConfig randomInvalidTransformConfig() {
+    public static TransformConfig randomInvalidTransformConfig(String id) {
         if (randomBoolean()) {
             PivotConfig pivotConfig;
             LatestConfig latestConfig;
@@ -154,7 +154,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             }
 
             return new TransformConfig(
-                randomAlphaOfLengthBetween(1, 10),
+                id,
                 randomInvalidSourceConfig(),
                 randomDestConfig(),
                 null,
@@ -171,7 +171,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             );
         } // else
         return new TransformConfig(
-            randomAlphaOfLengthBetween(1, 10),
+            id,
             randomSourceConfig(),
             randomDestConfig(),
             null,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -63,7 +63,7 @@ public class TransformDeprecationChecker implements DeprecationChecker {
             for (TransformConfig config : getTransformResponse.getTransformConfigurations()) {
                 issues.addAll(config.checkForDeprecations(components.xContentRegistry()));
             }
-            if (getTransformResponse.getCount() >= (page.getFrom() + page.getSize())) {
+            if (getTransformResponse.getTransformConfigurationCount() >= (page.getFrom() + page.getSize())) {
                 PageParams nextPage = new PageParams(page.getFrom() + page.getSize(), PageParams.DEFAULT_SIZE);
                 recursiveGetTransformsAndCollectDeprecations(components, issues, nextPage, listener);
             } else {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -14,7 +14,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -422,14 +421,13 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    protected static List<Map<String, Object>> getTransforms(List<String> expectedWarnings) throws IOException {
+    protected static List<Map<String, Object>> getTransforms(List<Map<String, String>> expectedErrors) throws IOException {
         Request request = new Request("GET", getTransformEndpoint() + "_all");
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
         Response response = adminClient().performRequest(request);
-        assertThat(response.getWarnings(), is(equalTo(expectedWarnings)));
         Map<String, Object> transforms = entityAsMap(response);
         List<Map<String, Object>> transformConfigs = (List<Map<String, Object>>) XContentMapValues.extractValue("transforms", transforms);
-
+        List<Map<String, String>> errors = (List<Map<String, String>>) XContentMapValues.extractValue("errors", transforms);
+        assertThat(errors, is(equalTo(expectedErrors)));
         return transformConfigs == null ? Collections.emptyList() : transformConfigs;
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public abstract class TransformRestTestCase extends ESRestTestCase {
 
@@ -420,10 +422,11 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    protected static List<Map<String, Object>> getTransforms() throws IOException {
+    protected static List<Map<String, Object>> getTransforms(List<String> expectedWarnings) throws IOException {
         Request request = new Request("GET", getTransformEndpoint() + "_all");
         request.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
         Response response = adminClient().performRequest(request);
+        assertThat(response.getWarnings(), is(equalTo(expectedWarnings)));
         Map<String, Object> transforms = entityAsMap(response);
         List<Map<String, Object>> transformConfigs = (List<Map<String, Object>>) XContentMapValues.extractValue("transforms", transforms);
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -420,7 +421,9 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     protected static List<Map<String, Object>> getTransforms() throws IOException {
-        Response response = adminClient().performRequest(new Request("GET", getTransformEndpoint() + "_all"));
+        Request request = new Request("GET", getTransformEndpoint() + "_all");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+        Response response = adminClient().performRequest(request);
         Map<String, Object> transforms = entityAsMap(response);
         List<Map<String, Object>> transformConfigs = (List<Map<String, Object>>) XContentMapValues.extractValue("transforms", transforms);
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -51,7 +53,7 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         createTransformRequest.setJsonEntity(config);
         Map<String, Object> createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));
         assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
-        assertEquals(1, getTransforms().size());
+        assertEquals(1, getTransforms(emptyList()).size());
         // there shouldn't be a task yet
         assertEquals(0, getNumberOfTransformTasks());
         startAndWaitForContinuousTransform(transformId, transformIndex, null);
@@ -64,12 +66,12 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_5", 3.72);
         assertNotNull(getTransformState(transformId));
 
-        assertEquals(1, getTransforms().size());
+        assertEquals(1, getTransforms(emptyList()).size());
 
         // delete the transform index
         beEvilAndDeleteTheTransformIndex();
         // transform is gone
-        assertEquals(0, getTransforms().size());
+        assertEquals(0, getTransforms(singletonList("Found [1] invalid transforms")).size());
         // but the task is still there
         assertEquals(1, getNumberOfTransformTasks());
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -22,6 +22,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class TransformRobustnessIT extends TransformRestTestCase {
 
+    private static final String DANGLING_TASK_ERROR_MESSAGE =
+        "Found task for transform [simple_continuous_pivot], but no configuration for it. "
+            + "To delete this transform use DELETE with force=true.";
+
     public void testTaskRemovalAfterInternalIndexGotDeleted() throws Exception {
         String indexName = "continuous_reviews";
         createReviewsIndex(indexName);
@@ -70,19 +74,7 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         // delete the transform index
         beEvilAndDeleteTheTransformIndex();
         // transform is gone
-        assertEquals(
-            0,
-            getTransforms(
-                List.of(
-                    Map.of(
-                        "type",
-                        "dangling_task",
-                        "reason",
-                        "Found task for transform [simple_continuous_pivot], but no configuration for it. To delete this transform use DELETE with force=true."
-                    )
-                )
-            ).size()
-        );
+        assertEquals(0, getTransforms(List.of(Map.of("type", "dangling_task", "reason", DANGLING_TASK_ERROR_MESSAGE))).size());
         // but the task is still there
         assertEquals(1, getNumberOfTransformTasks());
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
@@ -39,9 +39,9 @@ import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
-import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.elasticsearch.xpack.transform.transforms.TransformTask;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -98,10 +98,7 @@ public class TransformUsageTransportAction extends XPackUsageFeatureTransportAct
         ClusterState clusterState,
         ActionListener<XPackUsageFeatureResponse> listener
     ) {
-        PersistentTasksCustomMetadata taskMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
-        Collection<PersistentTasksCustomMetadata.PersistentTask<?>> transformTasks = taskMetadata == null
-            ? Collections.emptyList()
-            : taskMetadata.findTasks(TransformTaskParams.NAME, t -> true);
+        Collection<PersistentTasksCustomMetadata.PersistentTask<?>> transformTasks = TransformTask.findAllTransformTasks(clusterState);
         final int taskCount = transformTasks.size();
         final Map<String, Long> transformsCountByState = new HashMap<>();
         for (PersistentTasksCustomMetadata.PersistentTask<?> transformTask : transformTasks) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
@@ -67,6 +67,7 @@ public class TransportGetTransformAction extends AbstractTransportGetResourcesAc
         final ClusterState state = clusterService.state();
         TransformNodes.warnIfNoTransformNodes(state);
 
+        // Step 2: Search for all the transform tasks (matching the request) that *do not* have corresponding transform config.
         ActionListener<QueryPage<TransformConfig>> searchTransformConfigsListener = ActionListener.wrap(r -> {
             Set<String> transformConfigIds = r.results().stream().map(TransformConfig::getId).collect(toSet());
             Collection<PersistentTasksCustomMetadata.PersistentTask<?>> transformTasks = TransformTask.findTransformTasks(
@@ -80,6 +81,7 @@ public class TransportGetTransformAction extends AbstractTransportGetResourcesAc
             listener.onResponse(new Response(r.results(), r.count(), transformWithoutConfigIds));
         }, listener::onFailure);
 
+        // Step 1: Search for all the transform configs matching the request.
         searchResources(request, searchTransformConfigsListener);
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -43,6 +42,7 @@ import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformIndex;
+import org.elasticsearch.xpack.transform.transforms.TransformTask;
 
 import java.util.Objects;
 
@@ -91,8 +91,7 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
-        final PersistentTasksCustomMetadata pTasksMeta = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
-        final boolean transformIsRunning = pTasksMeta != null && pTasksMeta.getTask(request.getId()) != null;
+        final boolean transformIsRunning = TransformTask.getTransformTask(request.getId(), state) != null;
         if (transformIsRunning && request.isForce() == false) {
             listener.onFailure(
                 new ElasticsearchStatusException(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -149,10 +149,10 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                     checkTransformConfigAndLogWarnings(updatedConfig);
 
                     if (update.changesSettings(configAndVersion.v1())) {
-                        PersistentTasksCustomMetadata tasksMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(
+                        PersistentTasksCustomMetadata.PersistentTask<?> transformTask = TransformTask.getTransformTask(
+                            request.getId(),
                             clusterState
                         );
-                        PersistentTasksCustomMetadata.PersistentTask<?> transformTask = tasksMetadata.getTask(request.getId());
 
                         // to send a request to apply new settings at runtime, several requirements must be met:
                         // - transform must be running, meaning a task exists

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -16,9 +16,13 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
@@ -43,7 +47,11 @@ import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_START_FAILED_TRANSFORM;
 import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_FAILED_TRANSFORM;
@@ -452,7 +460,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         markAsCompleted();
     }
 
-    void persistStateToClusterState(TransformState state, ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener) {
+    void persistStateToClusterState(TransformState state, ActionListener<PersistentTask<?>> listener) {
         updatePersistentTaskState(state, ActionListener.wrap(success -> {
             logger.debug("[{}] successfully updated state for transform to [{}].", transform.getId(), state.toString());
             listener.onResponse(success);
@@ -568,4 +576,46 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         return context.getTaskState();
     }
 
+    public static PersistentTask<?> getTransformTask(String transformId, ClusterState clusterState) {
+        Collection<PersistentTask<?>> transformTasks = findTransformTasks(t -> t.getId().equals(transformId), clusterState);
+        if (transformTasks.isEmpty()) {
+            return null;
+        }
+        // Task ids are unique
+        assert (transformTasks.size() == 1);
+        PersistentTask<?> pTask = transformTasks.iterator().next();
+        if (pTask.getParams() instanceof TransformTaskParams) {
+            return pTask;
+        }
+        throw new ElasticsearchStatusException(
+            "Found transform persistent task [" + transformId + "] with incorrect params",
+            RestStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    public static Collection<PersistentTask<?>> findAllTransformTasks(ClusterState clusterState) {
+        return findTransformTasks(task -> true, clusterState);
+    }
+
+    public static Collection<PersistentTask<?>> findTransformTasks(Set<String> transformIds, ClusterState clusterState) {
+        return findTransformTasks(task -> transformIds.contains(task.getId()), clusterState);
+
+    }
+
+    public static Collection<PersistentTask<?>> findTransformTasks(String transformIdPattern, ClusterState clusterState) {
+        Predicate<PersistentTasksCustomMetadata.PersistentTask<?>> taskMatcher = transformIdPattern == null
+            || Strings.isAllOrWildcard(transformIdPattern) ? t -> true : t -> {
+                TransformTaskParams transformParams = (TransformTaskParams) t.getParams();
+                return Regex.simpleMatch(transformIdPattern, transformParams.getId());
+            };
+        return findTransformTasks(taskMatcher, clusterState);
+    }
+
+    private static Collection<PersistentTask<?>> findTransformTasks(Predicate<PersistentTask<?>> predicate, ClusterState clusterState) {
+        PersistentTasksCustomMetadata pTasksMeta = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
+        if (pTasksMeta == null) {
+            return Collections.emptyList();
+        }
+        return pTasksMeta.findTasks(TransformTaskParams.NAME, predicate);
+    }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -599,7 +599,6 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
 
     public static Collection<PersistentTask<?>> findTransformTasks(Set<String> transformIds, ClusterState clusterState) {
         return findTransformTasks(task -> transformIds.contains(task.getId()), clusterState);
-
     }
 
     public static Collection<PersistentTask<?>> findTransformTasks(String transformIdPattern, ClusterState clusterState) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -590,7 +590,8 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         throw new ElasticsearchStatusException(
             "Found transform persistent task [{}] with incorrect params",
             RestStatus.INTERNAL_SERVER_ERROR,
-            transformId);
+            transformId
+        );
     }
 
     public static Collection<PersistentTask<?>> findAllTransformTasks(ClusterState clusterState) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -582,15 +582,15 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             return null;
         }
         // Task ids are unique
-        assert (transformTasks.size() == 1);
+        assert (transformTasks.size() == 1) : "There were 2 or more transform tasks with the same id";
         PersistentTask<?> pTask = transformTasks.iterator().next();
         if (pTask.getParams() instanceof TransformTaskParams) {
             return pTask;
         }
         throw new ElasticsearchStatusException(
-            "Found transform persistent task [" + transformId + "] with incorrect params",
-            RestStatus.INTERNAL_SERVER_ERROR
-        );
+            "Found transform persistent task [{}] with incorrect params",
+            RestStatus.INTERNAL_SERVER_ERROR,
+            transformId);
     }
 
     public static Collection<PersistentTask<?>> findAllTransformTasks(ClusterState clusterState) {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -120,7 +120,7 @@ public class TransformTaskTests extends ESTestCase {
             "some_action",
             TaskId.EMPTY_TASK_ID,
             client,
-            newTransformTaskParams(transformConfig.getId()),
+            createTransformTaskParams(transformConfig.getId()),
             transformState,
             mock(SchedulerEngine.class),
             auditor,
@@ -198,7 +198,7 @@ public class TransformTaskTests extends ESTestCase {
             "some_action",
             TaskId.EMPTY_TASK_ID,
             client,
-            newTransformTaskParams(transformConfig.getId()),
+            createTransformTaskParams(transformConfig.getId()),
             transformState,
             mock(SchedulerEngine.class),
             auditor,
@@ -278,7 +278,7 @@ public class TransformTaskTests extends ESTestCase {
             assertThat(TransformTask.getTransformTask("other-1", clusterState), is(nullValue()));
         }
         {
-            TransformTaskParams transformTaskParams = newTransformTaskParams("transform-1");
+            TransformTaskParams transformTaskParams = createTransformTaskParams("transform-1");
             PersistentTaskParams otherTaskParams = mock(PersistentTaskParams.class);
             when(otherTaskParams.getWriteableName()).thenReturn(TransformTaskParams.NAME);
             ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
@@ -363,11 +363,11 @@ public class TransformTaskTests extends ESTestCase {
                     .putCustom(
                         PersistentTasksCustomMetadata.TYPE,
                         PersistentTasksCustomMetadata.builder()
-                            .addTask("transform-1", TransformTaskParams.NAME, newTransformTaskParams("transform-1"), null)
+                            .addTask("transform-1", TransformTaskParams.NAME, createTransformTaskParams("transform-1"), null)
                             .addTask("other-1", "other", null, null)
-                            .addTask("transform-2", TransformTaskParams.NAME, newTransformTaskParams("transform-2"), null)
+                            .addTask("transform-2", TransformTaskParams.NAME, createTransformTaskParams("transform-2"), null)
                             .addTask("other-2", "other", null, null)
-                            .addTask("transform-3", TransformTaskParams.NAME, newTransformTaskParams("transform-3"), null)
+                            .addTask("transform-3", TransformTaskParams.NAME, createTransformTaskParams("transform-3"), null)
                             .addTask("other-3", "other", null, null)
                             .build()
                     )
@@ -399,7 +399,7 @@ public class TransformTaskTests extends ESTestCase {
         assertThat(TransformTask.findTransformTasks(Set.of("transform-4", "transform-5"), clusterState), is(empty()));
     }
 
-    private static TransformTaskParams newTransformTaskParams(String transformId) {
+    private static TransformTaskParams createTransformTaskParams(String transformId) {
         return new TransformTaskParams(transformId, Version.CURRENT, TimeValue.timeValueSeconds(10), false);
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -12,10 +12,16 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.PersistentTaskParams;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
@@ -41,10 +47,17 @@ import org.junit.Before;
 
 import java.time.Clock;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -107,7 +120,7 @@ public class TransformTaskTests extends ESTestCase {
             "some_action",
             TaskId.EMPTY_TASK_ID,
             client,
-            new TransformTaskParams(transformConfig.getId(), Version.CURRENT, TimeValue.timeValueSeconds(10), false),
+            newTransformTaskParams(transformConfig.getId()),
             transformState,
             mock(SchedulerEngine.class),
             auditor,
@@ -185,7 +198,7 @@ public class TransformTaskTests extends ESTestCase {
             "some_action",
             TaskId.EMPTY_TASK_ID,
             client,
-            new TransformTaskParams(transformConfig.getId(), Version.CURRENT, TimeValue.timeValueSeconds(10), false),
+            newTransformTaskParams(transformConfig.getId()),
             transformState,
             mock(SchedulerEngine.class),
             auditor,
@@ -241,4 +254,152 @@ public class TransformTaskTests extends ESTestCase {
         assertEquals(state.getReason(), null);
     }
 
+    public void testGetTransformTask() {
+        {
+            ClusterState clusterState = ClusterState.EMPTY_STATE;
+            assertThat(TransformTask.getTransformTask("transform-1", clusterState), is(nullValue()));
+            assertThat(TransformTask.getTransformTask("other-1", clusterState), is(nullValue()));
+        }
+        {
+            ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
+                .metadata(
+                    Metadata.builder()
+                        .putCustom(
+                            PersistentTasksCustomMetadata.TYPE,
+                            PersistentTasksCustomMetadata.builder()
+                                .addTask("other-1", "other", null, null)
+                                .addTask("other-2", "other", null, null)
+                                .addTask("other-3", "other", null, null)
+                                .build()
+                        )
+                )
+                .build();
+            assertThat(TransformTask.getTransformTask("transform-1", clusterState), is(nullValue()));
+            assertThat(TransformTask.getTransformTask("other-1", clusterState), is(nullValue()));
+        }
+        {
+            TransformTaskParams transformTaskParams = newTransformTaskParams("transform-1");
+            PersistentTaskParams otherTaskParams = mock(PersistentTaskParams.class);
+            when(otherTaskParams.getWriteableName()).thenReturn(TransformTaskParams.NAME);
+            ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
+                .metadata(
+                    Metadata.builder()
+                        .putCustom(
+                            PersistentTasksCustomMetadata.TYPE,
+                            PersistentTasksCustomMetadata.builder()
+                                .addTask("transform-1", TransformTaskParams.NAME, transformTaskParams, null)
+                                .addTask("other-1", "other", null, null)
+                                .addTask("transform-2", TransformTaskParams.NAME, otherTaskParams, null)
+                                .addTask("other-2", "other", null, null)
+                                .addTask("transform-3", TransformTaskParams.NAME, null, null)
+                                .addTask("other-3", "other", null, null)
+                                .build()
+                        )
+                )
+                .build();
+            assertThat(TransformTask.getTransformTask("transform-1", clusterState).getId(), is(equalTo("transform-1")));
+            ElasticsearchStatusException e = expectThrows(
+                ElasticsearchStatusException.class,
+                () -> TransformTask.getTransformTask("transform-2", clusterState).getId()
+            );
+            assertThat(e.getMessage(), is(equalTo("Found transform persistent task [transform-2] with incorrect params")));
+            e = expectThrows(ElasticsearchStatusException.class, () -> TransformTask.getTransformTask("transform-3", clusterState).getId());
+            assertThat(e.getMessage(), is(equalTo("Found transform persistent task [transform-3] with incorrect params")));
+            assertThat(TransformTask.getTransformTask("other-1", clusterState), is(nullValue()));
+            assertThat(TransformTask.getTransformTask("other-2", clusterState), is(nullValue()));
+            assertThat(TransformTask.getTransformTask("other-3", clusterState), is(nullValue()));
+        }
+    }
+
+    public void testFindAllTransformTasks() {
+        {
+            ClusterState clusterState = ClusterState.EMPTY_STATE;
+            assertThat(TransformTask.findAllTransformTasks(clusterState), is(empty()));
+        }
+        {
+            ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
+                .metadata(
+                    Metadata.builder()
+                        .putCustom(
+                            PersistentTasksCustomMetadata.TYPE,
+                            PersistentTasksCustomMetadata.builder()
+                                .addTask("other-1", "other", null, null)
+                                .addTask("other-2", "other", null, null)
+                                .addTask("other-3", "other", null, null)
+                                .build()
+                        )
+                )
+                .build();
+            assertThat(TransformTask.findAllTransformTasks(clusterState), is(empty()));
+        }
+        {
+            ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
+                .metadata(
+                    Metadata.builder()
+                        .putCustom(
+                            PersistentTasksCustomMetadata.TYPE,
+                            PersistentTasksCustomMetadata.builder()
+                                .addTask("transform-1", TransformTaskParams.NAME, null, null)
+                                .addTask("other-1", "other", null, null)
+                                .addTask("transform-2", TransformTaskParams.NAME, null, null)
+                                .addTask("other-2", "other", null, null)
+                                .addTask("transform-3", TransformTaskParams.NAME, null, null)
+                                .addTask("other-3", "other", null, null)
+                                .build()
+                        )
+                )
+                .build();
+            assertThat(
+                TransformTask.findAllTransformTasks(clusterState).stream().map(PersistentTask::getId).collect(toList()),
+                containsInAnyOrder("transform-1", "transform-2", "transform-3")
+            );
+        }
+    }
+
+    public void testFindTransformTasks() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
+            .metadata(
+                Metadata.builder()
+                    .putCustom(
+                        PersistentTasksCustomMetadata.TYPE,
+                        PersistentTasksCustomMetadata.builder()
+                            .addTask("transform-1", TransformTaskParams.NAME, newTransformTaskParams("transform-1"), null)
+                            .addTask("other-1", "other", null, null)
+                            .addTask("transform-2", TransformTaskParams.NAME, newTransformTaskParams("transform-2"), null)
+                            .addTask("other-2", "other", null, null)
+                            .addTask("transform-3", TransformTaskParams.NAME, newTransformTaskParams("transform-3"), null)
+                            .addTask("other-3", "other", null, null)
+                            .build()
+                    )
+            )
+            .build();
+        assertThat(
+            TransformTask.findTransformTasks("trans*-*", clusterState).stream().map(PersistentTask::getId).collect(toList()),
+            containsInAnyOrder("transform-1", "transform-2", "transform-3")
+        );
+        assertThat(
+            TransformTask.findTransformTasks("*-2", clusterState).stream().map(PersistentTask::getId).collect(toList()),
+            contains("transform-2")
+        );
+        assertThat(TransformTask.findTransformTasks("*-4", clusterState), is(empty()));
+        assertThat(
+            TransformTask.findTransformTasks(Set.of("transform-1", "transform-2", "transform-3", "transform-4"), clusterState)
+                .stream()
+                .map(PersistentTask::getId)
+                .collect(toList()),
+            containsInAnyOrder("transform-1", "transform-2", "transform-3")
+        );
+        assertThat(
+            TransformTask.findTransformTasks(Set.of("transform-1", "transform-2"), clusterState)
+                .stream()
+                .map(PersistentTask::getId)
+                .collect(toList()),
+            containsInAnyOrder("transform-1", "transform-2")
+        );
+        assertThat(TransformTask.findTransformTasks(Set.of("transform-4", "transform-5"), clusterState), is(empty()));
+    }
+
+    private static TransformTaskParams newTransformTaskParams(String transformId) {
+        return new TransformTaskParams(transformId, Version.CURRENT, TimeValue.timeValueSeconds(10), false);
+    }
 }


### PR DESCRIPTION
When the transform config document (or the whole transform internal index) is deleted accidentally while the transform is running, there is no easy way for the user to find out as the running transforms without config are not listed anywhere.
This PR fixes that.
Now, the `GET` request gathers all the transform tasks without config and reports them as `invalid_transforms` in the response.
The user can then force delete such transforms.
The `_stats` action is left unchanged, i.e. transforms with missing config are not reported there.

Relates https://github.com/elastic/elasticsearch/issues/80955