### PR TITLE
Unmute DataStreamsSnapshotsIT#testRestoreDataStreamAliasWithConflictingIndicesAlias() test

### DIFF
--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteComposableIndexTemplateAction;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -1083,17 +1084,23 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createFullSnapshot(REPO, snapshotName);
         client.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request("*")).actionGet();
         DataStreamIT.putComposableIndexTemplate("my-template", List.of("my-*"));
-        var request = new CreateDataStreamAction.Request("my-alias");
-        assertAcked(client.execute(CreateDataStreamAction.INSTANCE, request).actionGet());
-
-        var e = expectThrows(
-            IllegalStateException.class,
-            () -> client.admin().cluster().prepareRestoreSnapshot(REPO, snapshotName).setWaitForCompletion(true).get()
-        );
-        assertThat(e.getMessage(), containsString("data stream alias and data stream have the same name (my-alias)"));
+        try {
+            var request = new CreateDataStreamAction.Request("my-alias");
+            assertAcked(client.execute(CreateDataStreamAction.INSTANCE, request).actionGet());
+            var e = expectThrows(
+                IllegalStateException.class,
+                () -> client.admin().cluster().prepareRestoreSnapshot(REPO, snapshotName).setWaitForCompletion(true).get()
+            );
+            assertThat(e.getMessage(), containsString("data stream alias and data stream have the same name (my-alias)"));
+        } finally {
+            // Need to remove data streams in order to remove template
+            client.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request("*")).actionGet();
+            // Need to remove template, because base class doesn't remove composable index templates after each test (only legacy templates)
+            client.execute(DeleteComposableIndexTemplateAction.INSTANCE, new DeleteComposableIndexTemplateAction.Request("my-template"))
+                .actionGet();
+        }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/81040")
     public void testRestoreDataStreamAliasWithConflictingIndicesAlias() throws Exception {
         var snapshotName = "test-snapshot";
         createFullSnapshot(REPO, snapshotName);


### PR DESCRIPTION
and fix the test problem, which is that testRestoreDataStreamAliasWithConflictingDataStream()
test needs to remove the composable index template that it adds. The base test class
doesn't remove any composable index templates and this template interferes with the
testRestoreDataStreamAliasWithConflictingIndicesAlias() test.

Relates to #81040