### PR TITLE
Spherical mercator transformation should handle properly out of bounds latitudes

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/SphericalMercatorUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/SphericalMercatorUtils.java
@@ -17,6 +17,8 @@ public class SphericalMercatorUtils {
 
     public static final double MERCATOR_BOUNDS = 20037508.34;
     private static final double MERCATOR_FACTOR = MERCATOR_BOUNDS / 180.0;
+    // latitude lower limit. Below this limit the transformation might result in -Infinity
+    private static final double LAT_LOWER_LIMIT = Math.nextUp(-90.0);
 
     /**
      * Transforms WGS84 longitude to a Spherical mercator longitude
@@ -29,7 +31,7 @@ public class SphericalMercatorUtils {
      * Transforms WGS84 latitude to a Spherical mercator latitude
      */
     public static double latToSphericalMercator(double lat) {
-        double y = Math.log(Math.tan((90 + lat) * Math.PI / 360)) / (Math.PI / 180);
+        double y = Math.log(Math.tan((90 + Math.max(lat, LAT_LOWER_LIMIT)) * Math.PI / 360)) / (Math.PI / 180);
         return y * MERCATOR_FACTOR;
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
@@ -42,13 +42,13 @@ public class SphericalMercatorUtilTests extends ESTestCase {
             assertThat(lat, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));
         }
         {
-            // out of bounds error
+            // out of bounds values
             final double lat = latToSphericalMercator(randomDoubleBetween(GeoTileUtils.LATITUDE_MASK, 90, false));
             assertThat(lat, Matchers.greaterThan(MERCATOR_BOUNDS));
             assertTrue(Double.isFinite(latToSphericalMercator(90)));
         }
         {
-            // out of bounds error
+            // out of bounds values
             final double lat = latToSphericalMercator(-randomDoubleBetween(GeoTileUtils.LATITUDE_MASK, 90, false));
             assertThat(lat, Matchers.lessThan(-MERCATOR_BOUNDS));
             assertTrue(Double.isFinite(latToSphericalMercator(-90)));

--- a/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
@@ -34,11 +34,25 @@ public class SphericalMercatorUtilTests extends ESTestCase {
         assertThat(latToSphericalMercator(GeoTileUtils.LATITUDE_MASK), Matchers.closeTo(MERCATOR_BOUNDS, 1e-7));
         assertThat(latToSphericalMercator(-GeoTileUtils.LATITUDE_MASK), Matchers.closeTo(-MERCATOR_BOUNDS, 1e-7));
         assertThat(latToSphericalMercator(0.0), Matchers.closeTo(0, 1e-7));
-        final double lat = latToSphericalMercator(
-            randomValueOtherThanMany(l -> l >= GeoTileUtils.LATITUDE_MASK || l <= -GeoTileUtils.LATITUDE_MASK, GeometryTestUtils::randomLat)
-        );
-        assertThat(lat, Matchers.greaterThanOrEqualTo(-MERCATOR_BOUNDS));
-        assertThat(lat, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));
+        {
+            final double lat = latToSphericalMercator(
+                randomValueOtherThanMany(l -> l >= GeoTileUtils.LATITUDE_MASK || l <= -GeoTileUtils.LATITUDE_MASK, GeometryTestUtils::randomLat)
+            );
+            assertThat(lat, Matchers.greaterThanOrEqualTo(-MERCATOR_BOUNDS));
+            assertThat(lat, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));
+        }
+        {
+            // out of bounds error
+            final double lat = latToSphericalMercator(randomDoubleBetween(GeoTileUtils.LATITUDE_MASK, 90, false));
+            assertThat(lat, Matchers.greaterThan(MERCATOR_BOUNDS));
+            assertTrue(Double.isFinite(latToSphericalMercator(90)));
+        }
+        {
+            // out of bounds error
+            final double lat = latToSphericalMercator(-randomDoubleBetween(GeoTileUtils.LATITUDE_MASK, 90, false));
+            assertThat(lat, Matchers.lessThan(-MERCATOR_BOUNDS));
+            assertTrue(Double.isFinite(latToSphericalMercator(-90)));
+        }
     }
 
     public void testRectangle() {

--- a/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
@@ -36,7 +36,10 @@ public class SphericalMercatorUtilTests extends ESTestCase {
         assertThat(latToSphericalMercator(0.0), Matchers.closeTo(0, 1e-7));
         {
             final double lat = latToSphericalMercator(
-                randomValueOtherThanMany(l -> l >= GeoTileUtils.LATITUDE_MASK || l <= -GeoTileUtils.LATITUDE_MASK, GeometryTestUtils::randomLat)
+                randomValueOtherThanMany(
+                    l -> l >= GeoTileUtils.LATITUDE_MASK || l <= -GeoTileUtils.LATITUDE_MASK,
+                    GeometryTestUtils::randomLat
+                )
             );
             assertThat(lat, Matchers.greaterThanOrEqualTo(-MERCATOR_BOUNDS));
             assertThat(lat, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));


### PR DESCRIPTION
Currently for latitudes close to -90, the transformation return -Infinity. This changes make sure we always return a correct number so we prevent issues downstream.

Fixes https://github.com/elastic/elasticsearch/issues/81128