### PR TITLE
[7.16] [ML] Parent datafeed actions to the datafeed's persistent task (#81143)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -258,7 +257,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                 remoteAliases,
                                 (cn) -> remoteClusterService.getConnection(cn).getVersion()
                             );
-                            createDataExtractor(task, job, datafeedConfigHolder.get(), params, waitForTaskListener);
+                            createDataExtractor(job, datafeedConfigHolder.get(), params, waitForTaskListener);
                         }
                     },
                         e -> listener.onFailure(
@@ -271,7 +270,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                     )
                 );
             } else {
-                createDataExtractor(task, job, datafeedConfigHolder.get(), params, waitForTaskListener);
+                createDataExtractor(job, datafeedConfigHolder.get(), params, waitForTaskListener);
             }
         };
 
@@ -350,14 +349,13 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
     /** Creates {@link DataExtractorFactory} solely for the purpose of validation i.e. verifying that it can be created. */
     private void createDataExtractor(
-        Task task,
         Job job,
         DatafeedConfig datafeed,
         StartDatafeedAction.DatafeedParams params,
         ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams>> listener
     ) {
         DataExtractorFactory.create(
-            new ParentTaskAssigningClient(client, clusterService.localNode(), task),
+            client,
             datafeed,
             job,
             xContentRegistry,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -257,7 +258,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                 remoteAliases,
                                 (cn) -> remoteClusterService.getConnection(cn).getVersion()
                             );
-                            createDataExtractor(job, datafeedConfigHolder.get(), params, waitForTaskListener);
+                            createDataExtractor(task, job, datafeedConfigHolder.get(), params, waitForTaskListener);
                         }
                     },
                         e -> listener.onFailure(
@@ -270,7 +271,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                     )
                 );
             } else {
-                createDataExtractor(job, datafeedConfigHolder.get(), params, waitForTaskListener);
+                createDataExtractor(task, job, datafeedConfigHolder.get(), params, waitForTaskListener);
             }
         };
 
@@ -349,13 +350,14 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
     /** Creates {@link DataExtractorFactory} solely for the purpose of validation i.e. verifying that it can be created. */
     private void createDataExtractor(
+        Task task,
         Job job,
         DatafeedConfig datafeed,
         StartDatafeedAction.DatafeedParams params,
         ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams>> listener
     ) {
         DataExtractorFactory.create(
-            client,
+            new ParentTaskAssigningClient(client, clusterService.localNode(), task),
             datafeed,
             job,
             xContentRegistry,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -6,8 +6,14 @@
  */
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterApplierService;
@@ -39,6 +45,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static org.elasticsearch.test.NodeRoles.nonRemoteClusterClientNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -80,11 +88,25 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 )
             )
         );
+        final DiscoveryNode localNode = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
         clusterService = new ClusterService(
             Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test_node").build(),
             clusterSettings,
             threadPool
         );
+        clusterService.getClusterApplierService()
+            .setInitialState(
+                ClusterState.builder(new ClusterName("DatafeedJobBuilderTests"))
+                    .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
+                    .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
+                    .build()
+            );
 
         datafeedJobBuilder = new DatafeedJobBuilder(
             client,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [ML] Parent datafeed actions to the datafeed's persistent task (#81143)