### PR TITLE
[DOC] Move warning & explicate static setting

### DIFF
--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -1,8 +1,6 @@
 [[index-modules-history-retention]]
 == History retention
 
-NOTE: {ccr-cap} will not function if soft deletes are disabled.
-
 {es} sometimes needs to replay some of the operations that were performed on a
 shard. For instance, if a replica is briefly offline then it may be much more
 efficient to replay the few operations it missed while it was offline than to
@@ -57,6 +55,8 @@ setting. If soft deletes are disabled then peer recoveries can still sometimes
 take place by copying just the missing operations from the translog
 <<index-modules-translog-retention,as long as those operations are retained
 there>>.
+
+NOTE: {ccr-cap} will not function if soft deletes are disabled.
 
 [discrete]
 === History retention settings

--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -1,6 +1,8 @@
 [[index-modules-history-retention]]
 == History retention
 
+NOTE: {ccr-cap} will not function if soft deletes are disabled.
+
 {es} sometimes needs to replay some of the operations that were performed on a
 shard. For instance, if a replica is briefly offline then it may be much more
 efficient to replay the few operations it missed while it was offline than to
@@ -50,11 +52,11 @@ of a retention lease defaults to `12h` which should be long enough for most
 reasonable recovery scenarios.
 
 Soft deletes are enabled by default on indices created in recent versions, but
-they can be explicitly enabled or disabled at index creation time. If soft
-deletes are disabled then peer recoveries can still sometimes take place by
-copying just the missing operations from the translog
+they can be explicitly enabled or disabled at index creation time as a static 
+setting. If soft deletes are disabled then peer recoveries can still sometimes 
+take place by copying just the missing operations from the translog
 <<index-modules-translog-retention,as long as those operations are retained
-there>>. {ccr-cap} will not function if soft deletes are disabled.
+there>>.
 
 [discrete]
 === History retention settings


### PR DESCRIPTION
Howdy! 

Small edits for user `CMD+F` ability & emphasis: explicates static setting (to explain why get errors if attempt to edit on existing index) & pulls CCR warning to top.

In curiosity, AFAICT all other static/dynamic settings that fit under modules are left to the child pages [from here](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings) but [History retention](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-history-retention.html) seems to uniquely locate the info on the parent page and then reference it on a child page. Is this intended (asking because it breaks general flow & I'm trying to follow along 🙂)?

Thanks for all you do!


**Edit** re-reading, I'm seeing parent page even states for static section containing duplicative info. Does it make sense to only provide the info on the child page? If so, may I have help because I see references to, but am not sure how the tagging reference system words in the docs?

> Below is a list of all static index settings that are not associated with any specific index module: