### PR TITLE
Performance improvements

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -458,7 +458,7 @@ public class Augmentation {
             // CharSequqence's toString is *supposed* to always return the characters in the sequence as a String
             return receiver.toString();
         }
-        StringBuffer result = new StringBuffer(initialBufferForReplaceWith(receiver));
+        StringBuilder result = new StringBuilder(initialBufferForReplaceWith(receiver));
         do {
             m.appendReplacement(result, Matcher.quoteReplacement(replacementBuilder.apply(m)));
         } while (m.find());
@@ -476,7 +476,7 @@ public class Augmentation {
             // CharSequqence's toString is *supposed* to always return the characters in the sequence as a String
             return receiver.toString();
         }
-        StringBuffer result = new StringBuffer(initialBufferForReplaceWith(receiver));
+        StringBuilder result = new StringBuilder(initialBufferForReplaceWith(receiver));
         m.appendReplacement(result, Matcher.quoteReplacement(replacementBuilder.apply(m)));
         m.appendTail(result);
         return result.toString();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -183,8 +183,9 @@ public class FieldFetcher {
     private void collectUnmapped(Map<String, DocumentField> documentFields, Map<String, Object> source, String parentPath, int lastState) {
         // lookup field patterns containing wildcards
         if (this.unmappedFieldsFetchAutomaton != null) {
-            for (String key : source.keySet()) {
-                Object value = source.get(key);
+            for (Map.Entry<String, Object> sourceEntry : source.entrySet()) {
+                String key = sourceEntry.getKey();
+                Object value = sourceEntry.getValue();
                 String currentPath = parentPath + key;
                 if (this.fieldContexts.containsKey(currentPath)) {
                     continue;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
@@ -51,7 +51,7 @@ public class ActiveDirectorySIDUtil {
         }
 
         char[] hex = Hex.encodeHex(bytes);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         // start with 'S'
         sb.append('S');
@@ -76,7 +76,7 @@ public class ActiveDirectorySIDUtil {
 
         // sub-authorities, little-endian
         for (int i = 0; i < count; i++) {
-            StringBuffer rid = new StringBuffer();
+            StringBuilder rid = new StringBuilder();
 
             for (int k = 3; k >= 0; k--) {
                 rid.append(hex[16 + (i * 8) + (k * 2)]);


### PR DESCRIPTION
These are purely performance enhancements, no changes to any existing feature and no new features.

StringBuilder is faster than StringBuffer as there is no synchronization.

Obtaining an entrySet is faster than obtaining a keySet and then performing N lookups.
