### PR TITLE
Remove document types from path parameters

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -31,23 +31,6 @@
               "description":"Default index for items which don't provide one"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/_bulk",
-          "methods":[
-            "POST",
-            "PUT"
-          ],
-          "parts":{
-            "index":{
-              "type":"string",
-              "description":"Default index for items which don't provide one"
-            },
-            "type":{
-              "type":"string",
-              "description":"Default document type for items which don't provide one"
-            }
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -28,32 +28,6 @@
               "description":"The name of the index"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/{id}/_create",
-          "methods":[
-            "PUT",
-            "POST"
-          ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"Document ID"
-            },
-            "index":{
-              "type":"string",
-              "description":"The name of the index"
-            },
-            "type":{
-              "type":"string",
-              "description":"The type of the document",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -26,31 +26,6 @@
               "description":"The name of the index"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/{id}",
-          "methods":[
-            "DELETE"
-          ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"The document ID"
-            },
-            "index":{
-              "type":"string",
-              "description":"The name of the index"
-            },
-            "type":{
-              "type":"string",
-              "description":"The type of the document",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -26,31 +26,6 @@
               "description":"The name of the index"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/{id}/_source",
-          "methods":[
-            "HEAD"
-          ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"The document ID"
-            },
-            "index":{
-              "type":"string",
-              "description":"The name of the index"
-            },
-            "type":{
-              "type":"string",
-              "description":"The type of the document; deprecated and optional starting with 7.0",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -122,10 +122,6 @@
         ],
         "default":"indices"
       },
-      "types":{
-        "type":"list",
-        "description":"A comma-separated list of document types for the `indexing` index metric"
-      },
       "include_segment_file_sizes":{
         "type":"boolean",
         "description":"Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -31,28 +31,6 @@
               "description":"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/_validate/query",
-          "methods":[
-            "GET",
-            "POST"
-          ],
-          "parts":{
-            "index":{
-              "type":"list",
-              "description":"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"
-            },
-            "type":{
-              "type":"list",
-              "description":"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -24,29 +24,6 @@
               "description":"The indices or index-pattern(s) (containing rollup or regular data) that should be searched"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/_rollup_search",
-          "methods":[
-            "GET",
-            "POST"
-          ],
-          "parts":{
-            "index":{
-              "type":"list",
-              "description":"The indices or index-pattern(s) (containing rollup or regular data) that should be searched"
-            },
-            "type":{
-              "type":"string",
-              "required":false,
-              "description":"The doc type inside the index",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -27,31 +27,6 @@
               "description":"The name of the index"
             }
           }
-        },
-        {
-          "path":"/{index}/{type}/{id}/_update",
-          "methods":[
-            "POST"
-          ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"Document ID"
-            },
-            "index":{
-              "type":"string",
-              "description":"The name of the index"
-            },
-            "type":{
-              "type":"string",
-              "description":"The type of the document",
-              "deprecated":true
-            }
-          },
-          "deprecated":{
-            "version":"7.0.0",
-            "description":"Specifying types in urls has been deprecated"
-          }
         }
       ]
     },


### PR DESCRIPTION
Part of types removal, removes all the `type` path parameters (and `types` parameter from `indices.stats`). These types still exist within the compatibility REST API specs.