### PR TITLE
[8.0] Adjust snapshot index resolution behavior to be more intuitive (#79670)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -8,14 +8,11 @@
 
 package org.elasticsearch.snapshots;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.AssociatedIndexDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
@@ -23,7 +20,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -34,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.snapshots.SnapshotsService.NO_FEATURE_STATES_VALUE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -123,8 +118,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
             .collect(Collectors.toSet());
 
         assertThat("not-a-system-index", in(snapshottedIndices));
-        // TODO: without global state the system index shouldn't be snapshotted (8.0 & later only)
-        // assertThat(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, not(in(snapshottedIndices)));
+        assertThat(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, not(in(snapshottedIndices)));
     }
 
     /**
@@ -166,10 +160,10 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     /**
      * Take a snapshot with global state but don't restore system indexes. By
-     * default, snapshot restorations ignore global state. This means that,
-     * for now, the system index is treated as part of the snapshot and must be
-     * handled explicitly. Otherwise, as in this test, there will be an
-     * exception.
+     * default, snapshot restorations ignore global state and don't include system indices.
+     *
+     * This means that we should be able to take a snapshot with a system index in it and restore it without specifying indices, even if
+     * the cluster already has a system index with the same name (because the system index from the snapshot won't be restored).
      */
     public void testDefaultRestoreOnlyRegularIndices() {
         createRepository(REPO_NAME, "fs");
@@ -181,7 +175,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // snapshot including global state
         CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setWaitForCompletion(true)
             .setIncludeGlobalState(true)
             .get();
@@ -190,22 +183,18 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         // Delete the regular index so we can restore it
         assertAcked(cluster().client().admin().indices().prepareDelete(regularIndex));
 
-        // restore indices by feature, with only the regular index named explicitly
-        SnapshotRestoreException exception = expectThrows(
-            SnapshotRestoreException.class,
-            () -> clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap").setWaitForCompletion(true).get()
-        );
-
+        RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
+            .setWaitForCompletion(true)
+            .get();
+        assertThat(restoreResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertThat(
-            exception.getMessage(),
-            containsString(
-                "cannot restore index [" + SystemIndexTestPlugin.SYSTEM_INDEX_NAME + "] because an open index with same name already exists"
-            )
+            restoreResponse.getRestoreInfo().indices(),
+            allOf(hasItem(regularIndex), not(hasItem(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)))
         );
     }
 
     /**
-     * Take a snapshot with global state but restore features by state.
+     * Take a snapshot with global state but restore features by feature state.
      */
     public void testRestoreByFeature() {
         createRepository(REPO_NAME, "fs");
@@ -234,10 +223,9 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         // Delete the regular index so we can restore it
         assertAcked(cluster().client().admin().indices().prepareDelete(regularIndex));
 
-        // restore indices by feature, with only the regular index named explicitly
+        // restore indices by feature
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
             .setWaitForCompletion(true)
-            .setIndices(regularIndex)
             .setFeatureStates("SystemIndexTestPlugin")
             .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
@@ -265,7 +253,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // snapshot
         CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setFeatureStates(AssociatedIndicesTestPlugin.class.getSimpleName())
             .setWaitForCompletion(true)
             .get();
@@ -337,10 +324,9 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     /**
-     * Check that directly requesting a system index in a restore request logs a deprecation warning.
-     * @throws IllegalAccessException if something goes wrong with the mock log appender
+     * Check that directly requesting a system index in a restore request throws an Exception.
      */
-    public void testRestoringSystemIndexByNameIsDeprecated() throws IllegalAccessException {
+    public void testRestoringSystemIndexByNameIsRejected() throws IllegalAccessException {
         createRepository(REPO_NAME, "fs");
         // put a document in system index
         indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
@@ -353,36 +339,24 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
             .get();
         assertSnapshotSuccess(createSnapshotResponse);
 
-        // Delete the index so we can restore it without requesting the feature state
-        assertAcked(client().admin().indices().prepareDelete(SystemIndexTestPlugin.SYSTEM_INDEX_NAME).get());
+        // Now that we've taken the snapshot, add another doc
+        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "2", "purpose", "post-snapshot doc");
+        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
 
-        // Set up a mock log appender to watch for the log message we expect
-        MockLogAppender mockLogAppender = new MockLogAppender();
-        Loggers.addAppender(LogManager.getLogger("org.elasticsearch.deprecation.snapshots.RestoreService"), mockLogAppender);
-        mockLogAppender.start();
-        mockLogAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "restore-system-index-from-snapshot",
-                "org.elasticsearch.deprecation.snapshots.RestoreService",
-                Level.WARN,
-                "Restoring system indices by name is deprecated. Use feature states instead. System indices: [.test-system-idx]"
-            )
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
+                .setWaitForCompletion(true)
+                .setIndices(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)
+                .get()
+        );
+        assertThat(
+            ex.getMessage(),
+            equalTo("requested system indices [.test-system-idx], but system indices can only be restored as part of a feature state")
         );
 
-        // restore system index by name, rather than feature state
-        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setWaitForCompletion(true)
-            .setIndices(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)
-            .get();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
-
-        // Check that the message was logged and remove log appender
-        mockLogAppender.assertAllExpectationsMatched();
-        mockLogAppender.stop();
-        Loggers.removeAppender(LogManager.getLogger("org.elasticsearch.deprecation.snapshots.RestoreService"), mockLogAppender);
-
-        // verify only the original document is restored
-        assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(1L));
+        // Make sure the original index exists unchanged
+        assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
     }
 
     /**
@@ -457,11 +431,8 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
     /**
      * If the list of feature states to restore contains only "none" and we are restoring global state,
      * no feature states should be restored.
-     *
-     * In this test, we explicitly request a regular index to avoid any confusion over the meaning of
-     * "all indices."
      */
-    public void testRestoreSystemIndicesAsGlobalStateWithEmptyListOfFeatureStates() {
+    public void testRestoreSystemIndicesAsGlobalStateWithNoFeatureStates() {
         createRepository(REPO_NAME, "fs");
         String regularIndex = "my-index";
         indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
@@ -482,9 +453,8 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().indices().prepareDelete(regularIndex).get());
         assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
 
-        // restore regular index, with global state and an empty list of feature states
+        // restore with global state and all indices but explicitly no feature states.
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
             .setFeatureStates(new String[] { randomFrom("none", "NONE") })
@@ -493,44 +463,8 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // verify that the system index still has the updated document, i.e. has not been restored
         assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
-    }
-
-    /**
-     * If the list of feature states to restore contains only "none" and we are restoring global state,
-     * no feature states should be restored. However, for backwards compatibility, if no index is
-     * specified, system indices are included in "all indices." In this edge case, we get an error
-     * saying that the system index must be closed, because here it is included in "all indices."
-     */
-    public void testRestoreSystemIndicesAsGlobalStateWithEmptyListOfFeatureStatesNoIndicesSpecified() {
-        createRepository(REPO_NAME, "fs");
-        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
-        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
-
-        // run a snapshot including global state
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setWaitForCompletion(true)
-            .setIncludeGlobalState(true)
-            .get();
-        assertSnapshotSuccess(createSnapshotResponse);
-
-        // restore indices as global state without closing the index
-        SnapshotRestoreException exception = expectThrows(
-            SnapshotRestoreException.class,
-            () -> clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-                .setWaitForCompletion(true)
-                .setRestoreGlobalState(true)
-                .setFeatureStates(new String[] { randomFrom("none", "NONE") })
-                .get()
-        );
-
-        assertThat(
-            exception.getMessage(),
-            containsString(
-                "cannot restore index ["
-                    + SystemIndexTestPlugin.SYSTEM_INDEX_NAME
-                    + "] because an open index with same name already exists in the cluster."
-            )
-        );
+        // And the regular index has been restored
+        assertThat(getDocCount(regularIndex), equalTo(1L));
     }
 
     /**
@@ -574,7 +508,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // restore the snapshot
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setFeatureStates("SystemIndexTestPlugin")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
@@ -624,7 +557,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // Now restore the snapshot with no aliases
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setFeatureStates("SystemIndexTestPlugin")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(false)
@@ -709,7 +641,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         refresh(regularIndex, SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
 
         CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
             .setWaitForCompletion(true)
             .setIncludeGlobalState(true)
             .setFeatureStates(randomFrom("none", "NONE"))
@@ -726,75 +657,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
             .collect(Collectors.toSet());
 
         assertThat(snapshottedIndices, allOf(hasItem(regularIndex), not(hasItem(SystemIndexTestPlugin.SYSTEM_INDEX_NAME))));
-    }
-
-    public void testNoneFeatureStateOnRestore() {
-        createRepository(REPO_NAME, "fs");
-        final String regularIndex = "test-idx";
-
-        indexDoc(regularIndex, "1", "purpose", "create an index that can be restored");
-        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
-        refresh(regularIndex, SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
-
-        // Create a snapshot
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
-            .setWaitForCompletion(true)
-            .setIncludeGlobalState(true)
-            .get();
-        assertSnapshotSuccess(createSnapshotResponse);
-
-        // Index another doc into the system index
-        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "2", "purpose", "post-snapshot doc");
-        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
-        assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
-        // And delete the regular index so we can restore it
-        assertAcked(cluster().client().admin().indices().prepareDelete(regularIndex));
-
-        // Restore the snapshot specifying the regular index and "none" for feature states
-        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setIndices(regularIndex)
-            .setWaitForCompletion(true)
-            .setRestoreGlobalState(randomBoolean())
-            .setFeatureStates(randomFrom("none", "NONE"))
-            .get();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
-
-        // The regular index should only have one doc
-        assertThat(getDocCount(regularIndex), equalTo(1L));
-        // But the system index shouldn't have been touched
-        assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
-    }
-
-    /**
-     * This test checks a piece of BWC logic, and so should be removed when we block restoring system indices by name.
-     *
-     * This test checks whether it's possible to change the name of a system index when it's restored by name (rather than by feature state)
-     */
-    public void testCanRenameSystemIndicesIfRestoredByIndexName() {
-        createRepository(REPO_NAME, "fs");
-        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
-        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
-
-        // snapshot including our system index
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setWaitForCompletion(true)
-            .setIncludeGlobalState(false)
-            .get();
-        assertSnapshotSuccess(createSnapshotResponse);
-
-        // Now restore it with a rename
-        clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
-            .setIndices(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)
-            .setWaitForCompletion(true)
-            .setRestoreGlobalState(false)
-            .setFeatureStates(NO_FEATURE_STATES_VALUE)
-            .setRenamePattern(".test-(.+)")
-            .setRenameReplacement("restored-$1")
-            .get();
-
-        assertTrue("The renamed system index should be present", indexExists("restored-system-idx"));
-        assertTrue("The original index should still be present", indexExists(SystemIndexTestPlugin.SYSTEM_INDEX_NAME));
     }
 
     /**
@@ -890,7 +752,6 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> Blocked repo, starting snapshot...");
         final String partialSnapName = "test-partial-snap";
         ActionFuture<CreateSnapshotResponse> createSnapshotFuture = clusterAdmin().prepareCreateSnapshot(REPO_NAME, partialSnapName)
-            .setIndices(nonsystemIndex)
             .setIncludeGlobalState(true)
             .setWaitForCompletion(true)
             .setPartial(true)

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -762,7 +762,7 @@ public class Node implements Closeable {
                 repositoryService,
                 transportService,
                 actionModule.getActionFilters(),
-                systemIndices.getFeatures()
+                systemIndices
             );
             SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
                 settings,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -54,7 +54,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.regex.Regex;
@@ -356,8 +355,8 @@ public class RestoreService implements ClusterStateApplier {
             snapshotId,
             snapshotInfo,
             globalMetadata,
-            // include system data stream names in argument to this method
-            Stream.concat(requestIndices.stream(), featureStateDataStreams.stream()).collect(Collectors.toList()),
+            requestIndices,
+            featureStateDataStreams,
             request.includeAliases()
         );
         Map<String, DataStream> dataStreamsToRestore = result.v1();
@@ -367,47 +366,75 @@ public class RestoreService implements ClusterStateApplier {
         requestIndices.removeAll(dataStreamsToRestore.keySet());
 
         // And add the backing indices
-        Set<String> dataStreamIndices = dataStreamsToRestore.values()
-            .stream()
-            .flatMap(ds -> ds.getIndices().stream())
-            .map(Index::getName)
+        final Set<String> nonSystemDataStreamIndices;
+        final Set<String> systemDataStreamIndices;
+        {
+            Map<Boolean, Set<String>> dataStreamIndices = dataStreamsToRestore.values()
+                .stream()
+                .flatMap(ds -> ds.getIndices().stream().map(idx -> new Tuple<>(ds.isSystem(), idx.getName())))
+                .collect(Collectors.partitioningBy(Tuple::v1, Collectors.mapping(Tuple::v2, Collectors.toSet())));
+            systemDataStreamIndices = dataStreamIndices.get(true);
+            nonSystemDataStreamIndices = dataStreamIndices.get(false);
+        }
+        requestIndices.addAll(nonSystemDataStreamIndices);
+        final Set<String> allSystemIndicesToRestore = Stream.of(systemDataStreamIndices, featureStateIndices)
+            .flatMap(Collection::stream)
             .collect(Collectors.toSet());
-        requestIndices.addAll(dataStreamIndices);
+
+        // Strip system indices out of the list of "available" indices - these should only come from feature states.
+        List<String> availableNonSystemIndices;
+        {
+            Set<String> systemIndicesInSnapshot = new HashSet<>();
+            snapshotInfo.featureStates().stream().flatMap(state -> state.getIndices().stream()).forEach(systemIndicesInSnapshot::add);
+            // And the system data stream backing indices too
+            snapshotInfo.indices().stream().filter(systemIndices::isSystemIndexBackingDataStream).forEach(systemIndicesInSnapshot::add);
+
+            Set<String> explicitlyRequestedSystemIndices = new HashSet<>(requestIndices);
+            explicitlyRequestedSystemIndices.retainAll(systemIndicesInSnapshot);
+
+            if (explicitlyRequestedSystemIndices.size() > 0) {
+                throw new IllegalArgumentException(
+                    new ParameterizedMessage(
+                        "requested system indices {}, but system indices can only be restored as part of a feature state",
+                        explicitlyRequestedSystemIndices
+                    ).getFormattedMessage()
+                );
+            }
+
+            availableNonSystemIndices = snapshotInfo.indices()
+                .stream()
+                .filter(idxName -> systemIndicesInSnapshot.contains(idxName) == false)
+                .collect(Collectors.toList());
+        }
 
         // Resolve the indices that were directly requested
         final List<String> requestedIndicesInSnapshot = filterIndices(
-            snapshotInfo.indices(),
+            availableNonSystemIndices,
             requestIndices.toArray(String[]::new),
             request.indicesOptions()
         );
 
         // Combine into the final list of indices to be restored
-        final List<String> requestedIndicesIncludingSystem = Stream.concat(
-            requestedIndicesInSnapshot.stream(),
-            featureStateIndices.stream()
-        ).distinct().collect(Collectors.toList());
+        final List<String> requestedIndicesIncludingSystem = Stream.of(
+            requestedIndicesInSnapshot,
+            featureStateIndices,
+            systemDataStreamIndices
+        ).flatMap(Collection::stream).distinct().collect(Collectors.toList());
 
         final Set<String> explicitlyRequestedSystemIndices = new HashSet<>();
         for (IndexId indexId : repositoryData.resolveIndices(requestedIndicesIncludingSystem).values()) {
             IndexMetadata snapshotIndexMetaData = repository.getSnapshotIndexMetaData(repositoryData, snapshotId, indexId);
             if (snapshotIndexMetaData.isSystem()) {
-                if (requestedIndicesInSnapshot.contains(indexId.getName())) {
+                if (requestIndices.contains(indexId.getName())) {
                     explicitlyRequestedSystemIndices.add(indexId.getName());
                 }
             }
             metadataBuilder.put(snapshotIndexMetaData, false);
         }
 
-        // log a deprecation warning if the any of the indexes to delete were included in the request and the snapshot
-        // is from a version that should have feature states
-        if (snapshotInfo.version().onOrAfter(Version.V_7_12_0) && explicitlyRequestedSystemIndices.isEmpty() == false) {
-            deprecationLogger.warn(
-                DeprecationCategory.API,
-                "restore-system-index-from-snapshot",
-                "Restoring system indices by name is deprecated. Use feature states instead. System indices: "
-                    + explicitlyRequestedSystemIndices
-            );
-        }
+        assert explicitlyRequestedSystemIndices.size() == 0
+            : "it should be impossible to reach this point with explicitly requested system indices, but got: "
+                + explicitlyRequestedSystemIndices;
 
         // Now we can start the actual restore process by adding shards to be recovered in the cluster state
         // and updating cluster metadata (global and index) as needed
@@ -419,7 +446,13 @@ public class RestoreService implements ClusterStateApplier {
                 featureStatesToRestore.keySet(),
                 // Apply renaming on index names, returning a map of names where
                 // the key is the renamed index and the value is the original name
-                renamedIndices(request, requestedIndicesIncludingSystem, dataStreamIndices, featureStateIndices, repositoryData),
+                renamedIndices(
+                    request,
+                    requestedIndicesIncludingSystem,
+                    nonSystemDataStreamIndices,
+                    allSystemIndicesToRestore,
+                    repositoryData
+                ),
                 snapshotInfo,
                 metadataBuilder.dataStreams(dataStreamsToRestore, dataStreamAliasesToRestore).build(),
                 dataStreamsToRestore.values(),
@@ -501,13 +534,14 @@ public class RestoreService implements ClusterStateApplier {
         SnapshotInfo snapshotInfo,
         Metadata globalMetadata,
         List<String> requestIndices,
+        Collection<String> featureStateDataStreams,
         boolean includeAliases
     ) {
         Map<String, DataStream> dataStreams;
         Map<String, DataStreamAlias> dataStreamAliases;
         List<String> requestedDataStreams = filterIndices(
             snapshotInfo.dataStreams(),
-            requestIndices.toArray(String[]::new),
+            Stream.of(requestIndices, featureStateDataStreams).flatMap(Collection::stream).toArray(String[]::new),
             IndicesOptions.fromOptions(true, true, true, true)
         );
         if (requestedDataStreams.isEmpty()) {
@@ -522,13 +556,30 @@ public class RestoreService implements ClusterStateApplier {
             for (String requestedDataStream : requestedDataStreams) {
                 final DataStream dataStreamInSnapshot = dataStreamsInSnapshot.get(requestedDataStream);
                 assert dataStreamInSnapshot != null : "DataStream [" + requestedDataStream + "] not found in snapshot";
-                dataStreams.put(requestedDataStream, dataStreamInSnapshot);
+
+                if (dataStreamInSnapshot.isSystem() == false) {
+                    dataStreams.put(requestedDataStream, dataStreamInSnapshot);
+                } else if (requestIndices.contains(requestedDataStream)) {
+                    throw new IllegalArgumentException(
+                        new ParameterizedMessage(
+                            "requested system data stream [{}], but system data streams can only be restored as part of a feature state",
+                            requestedDataStream
+                        ).getFormattedMessage()
+                    );
+                } else if (featureStateDataStreams.contains(requestedDataStream)) {
+                    dataStreams.put(requestedDataStream, dataStreamInSnapshot);
+                } else {
+                    logger.debug(
+                        "omitting system data stream [{}] from snapshot restoration because its feature state was not requested",
+                        requestedDataStream
+                    );
+                }
             }
             if (includeAliases) {
                 dataStreamAliases = new HashMap<>();
                 final Map<String, DataStreamAlias> dataStreamAliasesInSnapshot = globalMetadata.dataStreamAliases();
                 for (DataStreamAlias alias : dataStreamAliasesInSnapshot.values()) {
-                    DataStreamAlias copy = alias.intersect(requestedDataStreams::contains);
+                    DataStreamAlias copy = alias.intersect(dataStreams.keySet()::contains);
                     if (copy.getDataStreams().isEmpty() == false) {
                         dataStreamAliases.put(alias.getName(), copy);
                     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -171,7 +171,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private final OngoingRepositoryOperations repositoryOperations = new OngoingRepositoryOperations();
 
-    private final Map<String, SystemIndices.Feature> systemIndexDescriptorMap;
+    private final SystemIndices systemIndices;
 
     /**
      * Setting that specifies the maximum number of allowed concurrent snapshot create and delete operations in the
@@ -195,7 +195,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         RepositoriesService repositoriesService,
         TransportService transportService,
         ActionFilters actionFilters,
-        Map<String, SystemIndices.Feature> systemIndexDescriptorMap
+        SystemIndices systemIndices
     ) {
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
@@ -218,7 +218,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING, i -> maxConcurrentOperations = i);
         }
-        this.systemIndexDescriptorMap = systemIndexDescriptorMap;
+        this.systemIndices = systemIndices;
     }
 
     /**
@@ -263,7 +263,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         if (request.includeGlobalState() || requestedStates.isEmpty() == false) {
             if (request.includeGlobalState() && requestedStates.isEmpty()) {
                 // If we're including global state and feature states aren't specified, include all of them
-                featureStatesSet = systemIndexDescriptorMap.keySet();
+                featureStatesSet = systemIndices.getFeatures().keySet();
             } else if (requestedStates.size() == 1 && NO_FEATURE_STATES_VALUE.equalsIgnoreCase(requestedStates.get(0))) {
                 // If there's exactly one value and it's "none", include no states
                 featureStatesSet = Collections.emptySet();
@@ -282,7 +282,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     return;
                 }
                 featureStatesSet = new HashSet<>(requestedStates);
-                featureStatesSet.retainAll(systemIndexDescriptorMap.keySet());
+                featureStatesSet.retainAll(systemIndices.getFeatures().keySet());
             }
         } else {
             featureStatesSet = Collections.emptySet();
@@ -307,7 +307,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName, "create snapshot");
                 ensureBelowConcurrencyLimit(repositoryName, snapshotName, snapshots, deletionsInProgress);
                 // Store newSnapshot here to be processed in clusterStateProcessed
-                List<String> indices = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(currentState, request));
+                List<String> indices = Arrays.stream(indexNameExpressionResolver.concreteIndexNames(currentState, request))
+                    .filter(indexName -> systemIndices.isSystemIndex(indexName) == false) // Only resolve system indices via Features
+                    .collect(Collectors.toList());
 
                 final Set<SnapshotFeatureInfo> featureStates = new HashSet<>();
                 final Set<String> systemDataStreamNames = new HashSet<>();
@@ -315,7 +317,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 // been requested by the request directly
                 final Set<String> indexNames = new HashSet<>(indices);
                 for (String featureName : featureStatesSet) {
-                    SystemIndices.Feature feature = systemIndexDescriptorMap.get(featureName);
+                    SystemIndices.Feature feature = systemIndices.getFeatures().get(featureName);
 
                     Set<String> featureSystemIndices = feature.getIndexDescriptors()
                         .stream()

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1716,7 +1716,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     repositoriesService,
                     transportService,
                     actionFilters,
-                    Collections.emptyMap()
+                    EmptySystemIndices.INSTANCE
                 );
                 nodeEnv = new NodeEnvironment(settings, environment);
                 final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -437,14 +437,14 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         return snapshotInfo;
     }
 
-    protected SnapshotInfo createSnapshot(String repositoryName, String snapshot, List<String> indices) {
+    protected SnapshotInfo createSnapshot(String repositoryName, String snapshot, List<String> indices, List<String> featureStates) {
         logger.info("--> creating snapshot [{}] of {} in [{}]", snapshot, indices, repositoryName);
         final CreateSnapshotResponse response = client().admin()
             .cluster()
             .prepareCreateSnapshot(repositoryName, snapshot)
             .setIndices(indices.toArray(Strings.EMPTY_ARRAY))
             .setWaitForCompletion(true)
-            .setFeatureStates(NO_FEATURE_STATES_VALUE) // Exclude all feature states to ensure only specified indices are included
+            .setFeatureStates(featureStates.toArray(Strings.EMPTY_ARRAY))
             .get();
 
         final SnapshotInfo snapshotInfo = response.getSnapshotInfo();
@@ -452,6 +452,10 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
         assertThat(snapshotInfo.failedShards(), equalTo(0));
         return snapshotInfo;
+    }
+
+    protected SnapshotInfo createSnapshot(String repositoryName, String snapshot, List<String> indices) {
+        return createSnapshot(repositoryName, snapshot, indices, Collections.singletonList(NO_FEATURE_STATES_VALUE));
     }
 
     protected void createIndexWithRandomDocs(String indexName, int docCount) throws InterruptedException {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSystemIndicesIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSystemIndicesIntegTests.java
@@ -39,14 +39,18 @@ public class SearchableSnapshotsSystemIndicesIntegTests extends BaseFrozenSearch
     }
 
     public void testCannotMountSystemIndex() throws Exception {
-        executeTest(TestSystemIndexPlugin.INDEX_NAME, new OriginSettingClient(client(), ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN));
+        executeTest(
+            TestSystemIndexPlugin.INDEX_NAME,
+            SearchableSnapshotsSystemIndicesIntegTests.class.getSimpleName(),
+            new OriginSettingClient(client(), ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN)
+        );
     }
 
     public void testCannotMountSnapshotBlobCacheIndex() throws Exception {
-        executeTest(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_INDEX, client());
+        executeTest(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_INDEX, "searchable_snapshots", client());
     }
 
-    private void executeTest(final String indexName, final Client client) throws Exception {
+    private void executeTest(final String indexName, final String featureName, final Client client) throws Exception {
         final boolean isHidden = randomBoolean();
         createAndPopulateIndex(indexName, Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, isHidden));
 
@@ -55,7 +59,13 @@ public class SearchableSnapshotsSystemIndicesIntegTests extends BaseFrozenSearch
 
         final String snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         final int numPrimaries = getNumShards(indexName).numPrimaries;
-        final SnapshotInfo snapshotInfo = createSnapshot(repositoryName, snapshotName, Collections.singletonList(indexName));
+        final SnapshotInfo snapshotInfo = createSnapshot(
+            repositoryName,
+            snapshotName,
+            Collections.singletonList("-*"),
+            Collections.singletonList(featureName)
+        );
+        // NOTE: The below assertion assumes that the only index in the feature is the named one. If that's not the case, this will fail.
         assertThat(snapshotInfo.successfulShards(), equalTo(numPrimaries));
         assertThat(snapshotInfo.failedShards(), equalTo(0));
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Adjust snapshot index resolution behavior to be more intuitive (#79670)