### PR TITLE
[DOCS] Clarify that pipeline metadata IS required

### DIFF
--- a/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
@@ -52,7 +52,7 @@ documentation].
 
 `pipeline_metadata`::
 (Required, object)
-Optional metadata about the pipeline. May have any contents. This metadata is
+Arbitrary metadata about the pipeline. May have any contents. This metadata is
 not generated or used by {es} or {ls}.
 
 `pipeline_settings`::


### PR DESCRIPTION
The description for the pipeline_metadata parameter implied that it's optional, but it is required.