### PR TITLE
[TEST] Wait for async LDAP search to finish

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
@@ -31,12 +31,14 @@ import org.junit.After;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class SearchGroupsResolverInMemoryTests extends LdapTestCase {
 
@@ -77,6 +79,10 @@ public class SearchGroupsResolverInMemoryTests extends LdapTestCase {
             assertThat(((LDAPException) cause).getResultCode(), is(ResultCode.TIMEOUT));
         } finally {
             ldapServers[0].setProcessingDelayMillis(0);
+
+            // Wait for the async search to complete or timeout.
+            // Without this, we might trigger an orphaned thread - see https://github.com/pingidentity/ldapsdk/issues/120
+            assertBusy(() -> assertThat(connection.getActiveOperationCount(), lessThanOrEqualTo(0)), 1000, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/SearchGroupsResolverInMemoryTests.java
@@ -82,7 +82,7 @@ public class SearchGroupsResolverInMemoryTests extends LdapTestCase {
 
             // Wait for the async search to complete or timeout.
             // Without this, we might trigger an orphaned thread - see https://github.com/pingidentity/ldapsdk/issues/120
-            assertBusy(() -> assertThat(connection.getActiveOperationCount(), lessThanOrEqualTo(0)), 1000, TimeUnit.MILLISECONDS);
+            assertBusy(() -> assertThat(connection.getActiveOperationCount(), lessThanOrEqualTo(0)), 2000, TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION
LDAP SDK has a race condition where closing a connection while an
async search is still executing could lead to a Timer thread being
orphaned.
See: https://github.com/pingidentity/ldapsdk/issues/120

This commit changes SearchGroupsResolverInMemoryTests so that it waits
for the pending async search to complete (or timeout) before
returning. This ensures that when the close the connection the Timer
thread is cancelled (and stays cancelled).

Resolves: #80305