### PR TITLE
Unmute 'Create data stream' yaml rest test and

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -30,10 +30,8 @@ setup:
 ---
 "Create data stream":
   - skip:
-      version: all
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/81164"
-      #version: " - 7.8.99"
-      #reason: "data streams only supported in 7.9+"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -56,7 +54,6 @@ setup:
   - match: { data_streams.0.status: 'GREEN' }
   - match: { data_streams.0.template: 'my-template1' }
   - match: { data_streams.0.hidden: false }
-  - match: { data_streams.0.replicated: false }
   - match: { data_streams.1.name: simple-data-stream2 }
   - match: { data_streams.1.timestamp_field.name: '@timestamp' }
   - match: { data_streams.1.generation: 1 }
@@ -64,7 +61,6 @@ setup:
   - match: { data_streams.1.indices.0.index_name: '/\.ds-simple-data-stream2-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
   - match: { data_streams.1.template: 'my-template2' }
   - match: { data_streams.1.hidden: false }
-  - match: { data_streams.1.replicated: false }
 
   # save the backing index names for later use
   - set: { data_streams.0.indices.0.index_name: idx0name }
@@ -624,3 +620,53 @@ setup:
       catch: /cannot create index with name \[logs-foobar\], because it matches with template \[generic_logs_template\] that creates data streams only, use create data stream api instead/
       indices.create:
         index: logs-foobar
+
+---
+"Get data stream api check existence of replicated and allow_custom_routing fields":
+  - skip:
+      version: " - 7.16.0"
+      reason: "replicated and allow_custom_routing fields only supported in 7.16+"
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream2
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - match: { data_streams.0.timestamp_field.name: '@timestamp' }
+  - match: { data_streams.0.generation: 1 }
+  - length: { data_streams.0.indices: 1 }
+  - match: { data_streams.0.indices.0.index_name: '/\.ds-simple-data-stream1-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.0.status: 'GREEN' }
+  - match: { data_streams.0.template: 'my-template1' }
+  - match: { data_streams.0.hidden: false }
+  - match: { data_streams.0.replicated: false }
+  - match: { data_streams.0.allow_custom_routing: false }
+  - match: { data_streams.1.name: simple-data-stream2 }
+  - match: { data_streams.1.timestamp_field.name: '@timestamp' }
+  - match: { data_streams.1.generation: 1 }
+  - length: { data_streams.1.indices: 1 }
+  - match: { data_streams.1.indices.0.index_name: '/\.ds-simple-data-stream2-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.1.template: 'my-template2' }
+  - match: { data_streams.1.hidden: false }
+  - match: { data_streams.1.replicated: false }
+  - match: { data_streams.1.allow_custom_routing: false }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream2
+  - is_true: acknowledged
+


### PR DESCRIPTION
move the assertions of replicated field to a new test with different skip versions.

(The replicated was recently added and when the 'Create data stream' yaml rest test
is ran against older clusters this caused failured)

Closes #81164