### PR TITLE
[ML] Improve logging when opening a model is cancelled

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
@@ -76,13 +76,18 @@ public class PyTorchStateStreamer {
         restorer.setSearchSize(1);
         restorer.restoreModelDefinition(doc -> writeChunk(doc, restoreStream), success -> {
             logger.debug("model [{}] state restored in [{}] documents from index [{}]", modelId, restorer.getNumDocsWritten(), index);
-            if (modelBytesWritten.get() != modelSize) {
-                logger.error(
-                    "model [{}] restored state size [{}] does not equal the expected model size [{}]",
-                    modelId,
-                    modelBytesWritten,
-                    modelSize
-                );
+
+            if (success) {
+                if (modelBytesWritten.get() != modelSize) {
+                    logger.error(
+                        "model [{}] restored state size [{}] does not equal the expected model size [{}]",
+                        modelId,
+                        modelBytesWritten,
+                        modelSize
+                    );
+                }
+            } else {
+                logger.info("[{}] loading model state cancelled", modelId);
             }
             listener.onResponse(success);
         }, listener::onFailure);


### PR DESCRIPTION
If a deployment is stopped while it is writing the model state to the native process an alarming error message is logged:

`model [foo] restored state size [X] does not equal the expected model size [Y]"`

 Better to log what actually happened