### PR TITLE
Guard GeoShapeCentroidAggregatorTests#testSingleValue from invalid polygons

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.xpack.spatial.index.fielddata.DimensionalShapeType;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
-import org.locationtech.spatial4j.exception.InvalidShapeException;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -158,7 +158,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                 GeoTestUtils.binaryGeoShapeDocValuesField("field", geometry);
             } catch (IllegalArgumentException e) {
                 // do not include geometry.
-                continue;
+                assumeNoException("The geometry[" + geometry.toString() + "] is not supported", e);
             }
             geometries.add(geometry);
             // find dimensional-shape-type of geometry

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -154,10 +154,14 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
             );
             Geometry geometry = geometryGenerator.apply(false);
             try {
-                geometries.add(GeometryNormalizer.apply(Orientation.CCW, geometry));
-            } catch (InvalidShapeException e) {
-                // do not include geometry
+                geometry = GeometryNormalizer.apply(Orientation.CCW, geometry);
+                // make sure we can index the geometry
+                GeoTestUtils.binaryGeoShapeDocValuesField("field", geometry);
+            } catch (IllegalArgumentException e) {
+                // do not include geometry.
+                continue;
             }
+            geometries.add(geometry);
             // find dimensional-shape-type of geometry
             CentroidCalculator centroidCalculator = new CentroidCalculator();
             centroidCalculator.add(geometry);


### PR DESCRIPTION
Our creation of random polygons can generate geometries that cannot be tessellated. In the case of GeoShapeCentroidAggregatorTests#testSingleValue we are not protecting about it so it an eventually fail. This change just makes sure that those geometries are ignored.

fixes #80329