### PR TITLE
[7.16] [DOCS] Remove source query params from update/delete by query APIs (#81131)

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -235,12 +235,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sort]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
-
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
-
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -232,12 +232,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sort]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
-
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
-
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -138,18 +138,6 @@
         "type" : "list",
         "description" : "A comma-separated list of <field>:<direction> pairs"
       },
-      "_source": {
-        "type" : "list",
-        "description" : "True or false to return the _source field or not, or a list of fields to return"
-      },
-      "_source_excludes": {
-        "type" : "list",
-        "description" : "A list of fields to exclude from the returned _source field"
-      },
-      "_source_includes": {
-        "type" : "list",
-        "description" : "A list of fields to extract and return from the _source field"
-      },
       "terminate_after": {
         "type" : "number",
         "description" : "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -148,18 +148,6 @@
         "type":"list",
         "description":"A comma-separated list of <field>:<direction> pairs"
       },
-      "_source":{
-        "type":"list",
-        "description":"True or false to return the _source field or not, or a list of fields to return"
-      },
-      "_source_excludes":{
-        "type":"list",
-        "description":"A list of fields to exclude from the returned _source field"
-      },
-      "_source_includes":{
-        "type":"list",
-        "description":"A list of fields to extract and return from the _source field"
-      },
       "terminate_after":{
         "type":"number",
         "description":"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Remove source query params from update/delete by query APIs (#81131)