### PR TITLE
Replace createParser deprecated method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -134,8 +134,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         try (
             XContentParser parser = xContentType.xContent()
                 .createParser(
-                    XContentParserConfiguration.EMPTY
-                        .withRegistry(NamedXContentRegistry.EMPTY)
+                    XContentParserConfiguration.EMPTY.withRegistry(NamedXContentRegistry.EMPTY)
                         .withDeprecationHandler(DeprecationHandler.THROW_UNSUPPORTED_OPERATION),
                     response.getEntity().getContent()
                 )
@@ -153,8 +152,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         try (
             XContentParser parser = xContentType.xContent()
                 .createParser(
-                    XContentParserConfiguration.EMPTY
-                        .withRegistry(NamedXContentRegistry.EMPTY)
+                    XContentParserConfiguration.EMPTY.withRegistry(NamedXContentRegistry.EMPTY)
                         .withDeprecationHandler(DeprecationHandler.THROW_UNSUPPORTED_OPERATION),
                     response.getEntity().getContent()
                 )

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matchers;
@@ -133,8 +134,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         try (
             XContentParser parser = xContentType.xContent()
                 .createParser(
-                    NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    XContentParserConfiguration.EMPTY
+                        .withRegistry(NamedXContentRegistry.EMPTY)
+                        .withDeprecationHandler(DeprecationHandler.THROW_UNSUPPORTED_OPERATION),
                     response.getEntity().getContent()
                 )
         ) {
@@ -151,8 +153,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         try (
             XContentParser parser = xContentType.xContent()
                 .createParser(
-                    NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    XContentParserConfiguration.EMPTY
+                        .withRegistry(NamedXContentRegistry.EMPTY)
+                        .withDeprecationHandler(DeprecationHandler.THROW_UNSUPPORTED_OPERATION),
                     response.getEntity().getContent()
                 )
         ) {


### PR DESCRIPTION
The createParser method used by ESRestTestCase is deprecated in favor of a method taking a XContentParserConfiguration.