### PR TITLE
[8.0] [DOCS] Relocate 8.0 `repositories.fs.compress` breaking change (#81216)

### DIFF
--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -855,6 +855,22 @@ was explicitly configured. Starting in 8.0,
 This configuration means that transport compression will produce somewhat lower
 compression ratios in exchange for lower CPU load.
 ====
+
+.The `repositories.fs.compress` node-level setting has been removed.
+[%collapsible]
+====
+*Details* +
+For shared file system repositories (`"type": "fs"`), the node level setting `repositories.fs.compress` could
+previously be used to enable compression for all shared file system repositories where `compress` was not specified.
+The `repositories.fs.compress` setting has been removed.
+
+*Impact* +
+Use the repository specific `compress` setting to enable compression. See
+{ref}/snapshots-register-repository.html[Register a snapshot repository] for
+information on the `compress` setting.
+
+Discontinue use of the `repositories.fs.compress` node-level setting.
+====
 //end::notable-breaking-changes[]
 
 // This change is not notable because it should not have any impact on upgrades

--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -800,22 +800,6 @@ Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
 
-.The `repositories.fs.compress` node-level setting has been removed.
-[%collapsible]
-====
-*Details* +
-For shared file system repositories (`"type": "fs"`), the node level setting `repositories.fs.compress` could
-previously be used to enable compression for all shared file system repositories where `compress` was not specified.
-The `repositories.fs.compress` setting has been removed.
-
-*Impact* +
-Use the repository specific `compress` setting to enable compression. See
-{ref}/snapshots-register-repository.html[Register a snapshot repository] for
-information on the `compress` setting.
-
-Discontinue use of the `repositories.fs.compress` node-level setting.
-====
-
 .Snapshots compress metadata files by default.
 [%collapsible]
 ====


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Relocate 8.0 `repositories.fs.compress` breaking change (#81216)