### PR TITLE
Disallow explicitly requesting system indices in snapshots

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -323,6 +323,29 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         );
     }
 
+    public void testSnapshottingSystemIndexByNameIsRejected() throws Exception {
+        createRepository(REPO_NAME, "fs");
+        // put a document in system index
+        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
+        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
+
+        IllegalArgumentException error = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
+                .setIndices(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)
+                .setWaitForCompletion(true)
+                .setIncludeGlobalState(randomBoolean())
+                .get()
+        );
+
+        // And create a successful snapshot so we don't upset the test framework
+        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
+            .setWaitForCompletion(true)
+            .setIncludeGlobalState(true)
+            .get();
+        assertSnapshotSuccess(createSnapshotResponse);
+    }
+
     /**
      * Check that directly requesting a system index in a restore request throws an Exception.
      */

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -337,6 +337,13 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setIncludeGlobalState(randomBoolean())
                 .get()
         );
+        assertThat(
+            error.getMessage(),
+            equalTo(
+                "the [indices] parameter includes system indices [.test-system-idx]; to include or exclude system indices from a snapshot, "
+                    + "use the [include_global_state] or [feature_states] parameters"
+            )
+        );
 
         // And create a successful snapshot so we don't upset the test framework
         CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -317,8 +317,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     if (explicitlyRequestedSystemIndices.isEmpty() == false) {
                         throw new IllegalArgumentException(
                             new ParameterizedMessage(
-                                "the [indices] parameter includes system indices {}; to include or exclude system indices from a " +
-                                    "snapshot, use the [include_global_state] or [feature_states] parameters",
+                                "the [indices] parameter includes system indices {}; to include or exclude system indices from a "
+                                    + "snapshot, use the [include_global_state] or [feature_states] parameters",
                                 explicitlyRequestedSystemIndices
                             ).getFormattedMessage()
                         );

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -317,8 +317,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     if (explicitlyRequestedSystemIndices.isEmpty() == false) {
                         throw new IllegalArgumentException(
                             new ParameterizedMessage(
-                                "system indices [{}] were explicitly requested, but snapshots should use the "
-                                    + "[include_global_state] or [feature_states] parameters to control inclusion of system indices",
+                                "the [indices] parameter includes system indices {}; to include or exclude system indices from a " +
+                                    "snapshot, use the [include_global_state] or [feature_states] parameters",
                                 explicitlyRequestedSystemIndices
                             ).getFormattedMessage()
                         );


### PR DESCRIPTION
This commit changes SnapshotsService to throw an error when a
system index is explicitly requested, rather than silently
dropping it, and adds a test to verify that behavior.

Note that *only* system indices requested by full name return
an error, requesting e.g. `"indices": ".geo*"` (which would normally resolve to
`.geoip_databases`) does not include its system index and does not
error, but requesting `"indices": ".geoip_databases"` *will* return
an error.

Follow-up to #79670

---

This should have been part of the original change - I thought we had already done this, but @jrodewig pointed out to me that it silently dropped system indices instead.