### PR TITLE
Checkstyle shadows vars pt8 (#81147)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/HiddenFieldCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/HiddenFieldCheck.java
@@ -30,6 +30,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
@@ -328,24 +329,33 @@ public class HiddenFieldCheck extends AbstractCheck {
         boolean isSetterMethod = false;
 
         // ES also allows setters with the same name as a property, and builder-style settings that start with "with".
-        if (("set" + capitalize(aName)).equals(methodName) || ("with" + capitalize(aName)).equals(methodName) || aName.equals(methodName)) {
+        final List<String> possibleSetterNames = List.of(
+            "set" + capitalize(aName, true),
+            "set" + capitalize(aName, false),
+            "with" + capitalize(aName, true),
+            "with" + capitalize(aName, false),
+            aName
+        );
+
+        if (possibleSetterNames.contains(methodName)) {
             // method name did match set${Name}(${anyType} ${aName})
             // where ${Name} is capitalized version of ${aName}
             // therefore this method is potentially a setter
             final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
             final String returnType = typeAST.getFirstChild().getText();
-            if (typeAST.findFirstToken(TokenTypes.LITERAL_VOID) != null || setterCanReturnItsClass && frame.isEmbeddedIn(returnType)) {
-                // this method has signature
-                //
-                // void set${Name}(${anyType} ${name})
-                //
-                // and therefore considered to be a setter
-                //
-                // or
-                //
-                // return type is not void, but it is the same as the class
-                // where method is declared and and mSetterCanReturnItsClass
-                // is set to true
+
+            // The method is named `setFoo`, `withFoo`, or just `foo` and returns void
+            final boolean returnsVoid = typeAST.findFirstToken(TokenTypes.LITERAL_VOID) != null;
+
+            // Or the method is named as above, and returns the class type or a builder type.
+            // It ought to be possible to see if we're in a `${returnType}.Builder`, but for some reason the parse
+            // tree has `returnType` as `.` when the current class is `Builder` so instead assume that a class called `Builder` is OK.
+            final boolean returnsSelf = setterCanReturnItsClass && frame.isEmbeddedIn(returnType);
+
+            final boolean returnsBuilder = setterCanReturnItsClass
+                && (frame.isEmbeddedIn(returnType + "Builder") || (frame.isEmbeddedIn("Builder")));
+
+            if (returnsVoid || returnsSelf || returnsBuilder) {
                 isSetterMethod = true;
             }
         }
@@ -360,13 +370,13 @@ public class HiddenFieldCheck extends AbstractCheck {
      * @param name a property name
      * @return capitalized property name
      */
-    private static String capitalize(final String name) {
+    private static String capitalize(final String name, boolean javaBeanCompliant) {
         String setterName = name;
         // we should not capitalize the first character if the second
         // one is a capital one, since according to JavaBeans spec
         // setXYzz() is a setter for XYzz property, not for xYzz one.
-        // @pugnascotia: unless the first char is 'x'.
-        if (name.length() == 1 || (Character.isUpperCase(name.charAt(1)) == false || name.charAt(0) == 'x')) {
+        // @pugnascotia: this is unhelpful in the Elasticsearch codebase. We have e.g. xContent -> setXContent, or nNeighbors -> nNeighbors.
+        if (name.length() == 1 || (javaBeanCompliant == false || Character.isUpperCase(name.charAt(1)) == false)) {
             setterName = name.substring(0, 1).toUpperCase(Locale.ENGLISH) + name.substring(1);
         }
         return setterName;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -282,31 +282,31 @@ public class IndicesRequestIT extends ESIntegTestCase {
         String[] bulkShardActions = new String[] { BulkAction.NAME + "[s][p]", BulkAction.NAME + "[s][r]" };
         interceptTransportActions(bulkShardActions);
 
-        List<String> indices = new ArrayList<>();
+        List<String> indicesOrAliases = new ArrayList<>();
         BulkRequest bulkRequest = new BulkRequest();
         int numIndexRequests = iterations(1, 10);
         for (int i = 0; i < numIndexRequests; i++) {
             String indexOrAlias = randomIndexOrAlias();
             bulkRequest.add(new IndexRequest(indexOrAlias, "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value"));
-            indices.add(indexOrAlias);
+            indicesOrAliases.add(indexOrAlias);
         }
         int numDeleteRequests = iterations(1, 10);
         for (int i = 0; i < numDeleteRequests; i++) {
             String indexOrAlias = randomIndexOrAlias();
             bulkRequest.add(new DeleteRequest(indexOrAlias, "type", "id"));
-            indices.add(indexOrAlias);
+            indicesOrAliases.add(indexOrAlias);
         }
         int numUpdateRequests = iterations(1, 10);
         for (int i = 0; i < numUpdateRequests; i++) {
             String indexOrAlias = randomIndexOrAlias();
             bulkRequest.add(new UpdateRequest(indexOrAlias, "type", "id").doc(Requests.INDEX_CONTENT_TYPE, "field1", "value1"));
-            indices.add(indexOrAlias);
+            indicesOrAliases.add(indexOrAlias);
         }
 
         internalCluster().coordOnlyNodeClient().bulk(bulkRequest).actionGet();
 
         clearInterceptedActions();
-        assertIndicesSubset(indices, bulkShardActions);
+        assertIndicesSubset(indicesOrAliases, bulkShardActions);
     }
 
     public void testGet() {
@@ -346,36 +346,36 @@ public class IndicesRequestIT extends ESIntegTestCase {
         String multiTermVectorsShardAction = MultiTermVectorsAction.NAME + "[shard][s]";
         interceptTransportActions(multiTermVectorsShardAction);
 
-        List<String> indices = new ArrayList<>();
+        List<String> indicesOrAliases = new ArrayList<>();
         MultiTermVectorsRequest multiTermVectorsRequest = new MultiTermVectorsRequest();
         int numDocs = iterations(1, 30);
         for (int i = 0; i < numDocs; i++) {
             String indexOrAlias = randomIndexOrAlias();
             multiTermVectorsRequest.add(indexOrAlias, "type", Integer.toString(i));
-            indices.add(indexOrAlias);
+            indicesOrAliases.add(indexOrAlias);
         }
         internalCluster().coordOnlyNodeClient().multiTermVectors(multiTermVectorsRequest).actionGet();
 
         clearInterceptedActions();
-        assertIndicesSubset(indices, multiTermVectorsShardAction);
+        assertIndicesSubset(indicesOrAliases, multiTermVectorsShardAction);
     }
 
     public void testMultiGet() {
         String multiGetShardAction = MultiGetAction.NAME + "[shard][s]";
         interceptTransportActions(multiGetShardAction);
 
-        List<String> indices = new ArrayList<>();
+        List<String> indicesOrAliases = new ArrayList<>();
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         int numDocs = iterations(1, 30);
         for (int i = 0; i < numDocs; i++) {
             String indexOrAlias = randomIndexOrAlias();
             multiGetRequest.add(indexOrAlias, "type", Integer.toString(i));
-            indices.add(indexOrAlias);
+            indicesOrAliases.add(indexOrAlias);
         }
         internalCluster().coordOnlyNodeClient().multiGet(multiGetRequest).actionGet();
 
         clearInterceptedActions();
-        assertIndicesSubset(indices, multiGetShardAction);
+        assertIndicesSubset(indicesOrAliases, multiGetShardAction);
     }
 
     public void testFlush() {
@@ -389,9 +389,9 @@ public class IndicesRequestIT extends ESIntegTestCase {
         internalCluster().coordOnlyNodeClient().admin().indices().flush(flushRequest).actionGet();
 
         clearInterceptedActions();
-        String[] indices = TestIndexNameExpressionResolver.newInstance()
+        String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
             .concreteIndexNames(client().admin().cluster().prepareState().get().getState(), flushRequest);
-        assertIndicesSubset(Arrays.asList(indices), indexShardActions);
+        assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 
     public void testForceMerge() {
@@ -416,9 +416,9 @@ public class IndicesRequestIT extends ESIntegTestCase {
         internalCluster().coordOnlyNodeClient().admin().indices().refresh(refreshRequest).actionGet();
 
         clearInterceptedActions();
-        String[] indices = TestIndexNameExpressionResolver.newInstance()
+        String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
             .concreteIndexNames(client().admin().cluster().prepareState().get().getState(), refreshRequest);
-        assertIndicesSubset(Arrays.asList(indices), indexShardActions);
+        assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 
     public void testClearCache() {
@@ -675,21 +675,21 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
     private String[] randomIndicesOrAliases() {
         int count = randomIntBetween(1, indices.size() * 2); // every index has an alias
-        String[] indices = new String[count];
+        String[] randomNames = new String[count];
         for (int i = 0; i < count; i++) {
-            indices[i] = randomIndexOrAlias();
+            randomNames[i] = randomIndexOrAlias();
         }
-        return indices;
+        return randomNames;
     }
 
     private String[] randomUniqueIndicesOrAliases() {
         String[] uniqueIndices = randomUniqueIndices();
-        String[] indices = new String[uniqueIndices.length];
+        String[] randomNames = new String[uniqueIndices.length];
         int i = 0;
         for (String index : uniqueIndices) {
-            indices[i++] = randomBoolean() ? index + "-alias" : index;
+            randomNames[i++] = randomBoolean() ? index + "-alias" : index;
         }
-        return indices;
+        return randomNames;
     }
 
     private String[] randomUniqueIndices() {
@@ -776,8 +776,8 @@ public class IndicesRequestIT extends ESIntegTestCase {
             return requests.remove(action);
         }
 
-        synchronized void interceptTransportActions(String... actions) {
-            Collections.addAll(this.actions, actions);
+        synchronized void interceptTransportActions(String... transportActions) {
+            Collections.addAll(this.actions, transportActions);
         }
 
         synchronized void clearInterceptedActions() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -337,7 +337,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     @Override
     protected InternalTopMetrics mutateInstance(InternalTopMetrics instance) throws IOException {
         String name = instance.getName();
-        SortOrder sortOrder = instance.getSortOrder();
+        SortOrder instanceSortOrder = instance.getSortOrder();
         List<String> metricNames = instance.getMetricNames();
         int size = instance.getSize();
         List<InternalTopMetrics.TopMetric> topMetrics = instance.getTopMetrics();
@@ -346,7 +346,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 name = randomAlphaOfLength(6);
                 break;
             case 1:
-                sortOrder = sortOrder == SortOrder.ASC ? SortOrder.DESC : SortOrder.ASC;
+                instanceSortOrder = instanceSortOrder == SortOrder.ASC ? SortOrder.DESC : SortOrder.ASC;
                 Collections.reverse(topMetrics);
                 break;
             case 2:
@@ -372,7 +372,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
             default:
                 throw new IllegalArgumentException("bad mutation");
         }
-        return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, instance.getMetadata());
+        return new InternalTopMetrics(name, instanceSortOrder, metricNames, size, topMetrics, instance.getMetadata());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/License.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/License.java
@@ -555,11 +555,11 @@ public class License implements ToXContentObject {
                 builder.humanReadable(true);
             }
         }
-        final int version;
+        final int licenseVersion;
         if (params.param(LICENSE_VERSION_MODE) != null && restViewMode) {
-            version = Integer.parseInt(params.param(LICENSE_VERSION_MODE));
+            licenseVersion = Integer.parseInt(params.param(LICENSE_VERSION_MODE));
         } else {
-            version = this.version;
+            licenseVersion = this.version;
         }
         if (restViewMode) {
             builder.field(Fields.STATUS, status().label());
@@ -569,11 +569,11 @@ public class License implements ToXContentObject {
         final String bwcType = hideEnterprise && "enterprise".equals(type) ? "platinum" : type;
         builder.field(Fields.TYPE, bwcType);
 
-        if (version == VERSION_START) {
+        if (licenseVersion == VERSION_START) {
             builder.field(Fields.SUBSCRIPTION_TYPE, subscriptionType);
         }
         builder.timeField(Fields.ISSUE_DATE_IN_MILLIS, Fields.ISSUE_DATE, issueDate);
-        if (version == VERSION_START) {
+        if (licenseVersion == VERSION_START) {
             builder.field(Fields.FEATURE, feature);
         }
 
@@ -581,7 +581,7 @@ public class License implements ToXContentObject {
             builder.timeField(Fields.EXPIRY_DATE_IN_MILLIS, Fields.EXPIRY_DATE, expiryDate);
         }
 
-        if (version >= VERSION_ENTERPRISE) {
+        if (licenseVersion >= VERSION_ENTERPRISE) {
             builder.field(Fields.MAX_NODES, maxNodes == -1 ? null : maxNodes);
             builder.field(Fields.MAX_RESOURCE_UNITS, maxResourceUnits == -1 ? null : maxResourceUnits);
         } else if (hideEnterprise && maxNodes == -1) {
@@ -598,7 +598,7 @@ public class License implements ToXContentObject {
         if (restViewMode) {
             builder.humanReadable(previouslyHumanReadable);
         }
-        if (version >= VERSION_START_DATE) {
+        if (licenseVersion >= VERSION_START_DATE) {
             builder.timeField(Fields.START_DATE_IN_MILLIS, Fields.START_DATE, startDate);
         }
         return builder;
@@ -921,7 +921,7 @@ public class License implements ToXContentObject {
             return this;
         }
 
-        public Builder fromLicenseSpec(License license, String signature) {
+        public Builder fromLicenseSpec(License license, String licenseSignature) {
             return uid(license.uid()).version(license.version())
                 .issuedTo(license.issuedTo())
                 .issueDate(license.issueDate())
@@ -933,7 +933,7 @@ public class License implements ToXContentObject {
                 .maxResourceUnits(license.maxResourceUnits())
                 .expiryDate(license.expiryDate())
                 .issuer(license.issuer())
-                .signature(signature);
+                .signature(licenseSignature);
         }
 
         /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -109,8 +109,8 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
     /**
      * Currently active license
      */
-    private final AtomicReference<License> currentLicense = new AtomicReference<>();
-    private SchedulerEngine scheduler;
+    private final AtomicReference<License> currentLicenseHolder = new AtomicReference<>();
+    private final SchedulerEngine scheduler;
     private final Clock clock;
 
     /**
@@ -447,7 +447,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         clusterService.removeListener(this);
         scheduler.stop();
         // clear current license
-        currentLicense.set(null);
+        currentLicenseHolder.set(null);
     }
 
     @Override
@@ -567,9 +567,9 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         // license can be null if the trial license is yet to be auto-generated
         // in this case, it is a no-op
         if (license != null) {
-            final License previousLicense = currentLicense.get();
+            final License previousLicense = currentLicenseHolder.get();
             if (license.equals(previousLicense) == false) {
-                currentLicense.set(license);
+                currentLicenseHolder.set(license);
                 license.setOperationModeFileWatcher(operationModeFileWatcher);
                 scheduler.add(new SchedulerEngine.Job(LICENSE_JOB, nextLicenseCheck(license)));
                 for (ExpirationCallback expirationCallback : expirationCallbacks) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/Licensing.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/Licensing.java
@@ -75,7 +75,7 @@ public class Licensing implements ActionPlugin {
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
@@ -73,9 +73,9 @@ public class StartBasicClusterTask extends ClusterStateUpdateTask {
         if (shouldGenerateNewBasicLicense(currentLicense)) {
             License selfGeneratedLicense = generateBasicLicense(currentState);
             if (request.isAcknowledged() == false && currentLicense != null) {
-                Map<String, String[]> ackMessages = LicenseService.getAckMessages(selfGeneratedLicense, currentLicense);
-                if (ackMessages.isEmpty() == false) {
-                    this.ackMessages.set(ackMessages);
+                Map<String, String[]> ackMessageMap = LicenseService.getAckMessages(selfGeneratedLicense, currentLicense);
+                if (ackMessageMap.isEmpty() == false) {
+                    this.ackMessages.set(ackMessageMap);
                     return currentState;
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -394,17 +394,19 @@ public class XPackLicenseState {
 
     /** Return the current license type. */
     public OperationMode getOperationMode() {
-        return executeAgainstStatus(status -> status.mode);
+        return executeAgainstStatus(statusToCheck -> statusToCheck.mode);
     }
 
     // Package private for tests
     /** Return true if the license is currently within its time boundaries, false otherwise. */
     public boolean isActive() {
-        return checkAgainstStatus(status -> status.active);
+        return checkAgainstStatus(statusToCheck -> statusToCheck.active);
     }
 
     public String statusDescription() {
-        return executeAgainstStatus(status -> (status.active ? "active" : "expired") + ' ' + status.mode.description() + " license");
+        return executeAgainstStatus(
+            statusToCheck -> (statusToCheck.active ? "active" : "expired") + ' ' + statusToCheck.mode.description() + " license"
+        );
     }
 
     void featureUsed(LicensedFeature feature) {
@@ -519,7 +521,14 @@ public class XPackLicenseState {
      */
     public XPackLicenseState copyCurrentLicenseState() {
         return executeAgainstStatus(
-            status -> new XPackLicenseState(listeners, isSecurityEnabled, isSecurityExplicitlyEnabled, status, usage, epochMillisProvider)
+            statusToCheck -> new XPackLicenseState(
+                listeners,
+                isSecurityEnabled,
+                isSecurityExplicitlyEnabled,
+                statusToCheck,
+                usage,
+                epochMillisProvider
+            )
         );
     }
 
@@ -533,11 +542,11 @@ public class XPackLicenseState {
      */
     @Deprecated
     public boolean isAllowedByLicense(OperationMode minimumMode, boolean needActive) {
-        return checkAgainstStatus(status -> {
-            if (needActive && false == status.active) {
+        return checkAgainstStatus(statusToCheck -> {
+            if (needActive && false == statusToCheck.active) {
                 return false;
             }
-            return isAllowedByOperationMode(status.mode, minimumMode);
+            return isAllowedByOperationMode(statusToCheck.mode, minimumMode);
         });
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/frozen/FreezeRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/frozen/FreezeRequest.java
@@ -97,6 +97,7 @@ public class FreezeRequest extends AcknowledgedRequest<FreezeRequest> implements
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public IndicesRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchRequest.java
@@ -95,6 +95,7 @@ public final class PutWatchRequest extends ActionRequest {
     /**
      * Set the source of the watch
      */
+    @SuppressWarnings("HiddenField")
     public void setSource(BytesReference source, XContentType xContentType) {
         this.source = source;
         this.xContentType = xContentType;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
@@ -58,8 +58,8 @@ public class DataTiersFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
         super.innerXContent(builder, params);
-        for (Map.Entry<String, TierSpecificStats> tierStats : tierStats.entrySet()) {
-            builder.field(tierStats.getKey(), tierStats.getValue());
+        for (Map.Entry<String, TierSpecificStats> entry : tierStats.entrySet()) {
+            builder.field(entry.getKey(), entry.getValue());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -104,6 +104,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings("HiddenField")
 public class XPackPlugin extends XPackClientPlugin
     implements
         ExtensiblePlugin,
@@ -157,7 +158,7 @@ public class XPackPlugin extends XPackClientPlugin
     private static final SetOnce<LicenseService> licenseService = new SetOnce<>();
     private static final SetOnce<LongSupplier> epochMillisSupplier = new SetOnce<>();
 
-    public XPackPlugin(final Settings settings, final Path configPath) {
+    public XPackPlugin(final Settings settings) {
         super(settings);
         // FIXME: The settings might be changed after this (e.g. from "additionalSettings" method in other plugins)
         // We should only depend on the settings from the Environment object passed to createComponents

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
@@ -113,8 +113,8 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
             return indicesOptions;
         }
 
-        public IndicesRequest indicesOptions(IndicesOptions indicesOptions) {
-            this.indicesOptions = indicesOptions;
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            this.indicesOptions = options;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncResponse.java
@@ -54,8 +54,8 @@ public class StoredAsyncResponse<R extends Writeable> extends ActionResponse
     }
 
     @Override
-    public StoredAsyncResponse<R> withExpirationTime(long expirationTimeMillis) {
-        return new StoredAsyncResponse<>(this.response, this.exception, expirationTimeMillis);
+    public StoredAsyncResponse<R> withExpirationTime(long expirationTime) {
+        return new StoredAsyncResponse<>(this.response, this.exception, expirationTime);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
@@ -57,8 +57,8 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis = expirationTimeMillis;
+    public void setExpirationTime(long expirationTime) {
+        this.expirationTimeMillis = expirationTime;
     }
 
     public long getExpirationTimeMillis() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
@@ -72,9 +72,9 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
             // sort by index name, then shard ID
             final Map<String, Map<Integer, StatsResponse>> taskResponsesByIndex = new TreeMap<>();
-            for (final StatsResponse statsResponse : statsResponse) {
-                taskResponsesByIndex.computeIfAbsent(statsResponse.status().followerIndex(), k -> new TreeMap<>())
-                    .put(statsResponse.status().getShardId(), statsResponse);
+            for (final StatsResponse response : statsResponse) {
+                taskResponsesByIndex.computeIfAbsent(response.status().followerIndex(), k -> new TreeMap<>())
+                    .put(response.status().getShardId(), response);
             }
             builder.startObject();
             {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -537,7 +537,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                     position.set(newPosition);
 
                     if (triggerSaveState()) {
-                        doSaveState(IndexerState.INDEXING, newPosition, () -> { nextSearch(); });
+                        doSaveState(IndexerState.INDEXING, newPosition, this::nextSearch);
                     } else {
                         nextSearch();
                     }
@@ -550,7 +550,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
         }
     }
 
-    private void onBulkResponse(BulkResponse response, JobPosition position) {
+    private void onBulkResponse(BulkResponse response, JobPosition jobPosition) {
         stats.markEndIndexing();
 
         // check if we should stop
@@ -560,7 +560,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
         try {
             if (triggerSaveState()) {
-                doSaveState(IndexerState.INDEXING, position, () -> { nextSearch(); });
+                doSaveState(IndexerState.INDEXING, jobPosition, this::nextSearch);
             } else {
                 nextSearch();
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -403,13 +403,13 @@ public class MlMetadata implements XPackPlugin.XPackMetadataCustom {
             return this;
         }
 
-        public Builder isUpgradeMode(boolean upgradeMode) {
-            this.upgradeMode = upgradeMode;
+        public Builder isUpgradeMode(boolean isUpgradeMode) {
+            this.upgradeMode = isUpgradeMode;
             return this;
         }
 
-        public Builder isResetMode(boolean resetMode) {
-            this.resetMode = resetMode;
+        public Builder isResetMode(boolean isResetMode) {
+            this.resetMode = isResetMode;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
@@ -122,8 +122,8 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             return timeout;
         }
 
-        public Request setCloseTimeout(TimeValue timeout) {
-            this.timeout = timeout;
+        public Request setCloseTimeout(TimeValue closeTimeout) {
+            this.timeout = closeTimeout;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
@@ -121,7 +121,7 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
 
         @Override
         public boolean match(Task task) {
-            return expandedJobsIds.stream().anyMatch(jobId -> OpenJobAction.JobTaskMatcher.match(task, jobId));
+            return expandedJobsIds.stream().anyMatch(id -> OpenJobAction.JobTaskMatcher.match(task, id));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
@@ -117,8 +117,8 @@ public class GetModelSnapshotsAction extends ActionType<GetModelSnapshotsAction.
             return desc;
         }
 
-        public void setDescOrder(boolean desc) {
-            this.desc = desc;
+        public void setDescOrder(boolean descOrder) {
+            this.desc = descOrder;
         }
 
         public PageParams getPageParams() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
@@ -142,8 +142,8 @@ public class GetRecordsAction extends ActionType<GetRecordsAction.Response> {
             return recordScoreFilter;
         }
 
-        public void setRecordScore(double recordScoreFilter) {
-            this.recordScoreFilter = recordScoreFilter;
+        public void setRecordScore(double recordScore) {
+            this.recordScoreFilter = recordScore;
         }
 
         public String getSort() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -252,8 +252,8 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
                 return this;
             }
 
-            public Builder setModels(List<TrainedModelConfig> configs) {
-                this.configs = configs;
+            public Builder setModels(List<TrainedModelConfig> models) {
+                this.configs = models;
                 return this;
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostDataAction.java
@@ -177,6 +177,7 @@ public class PostDataAction extends ActionType<PostDataAction.Response> {
             return xContentType;
         }
 
+        @SuppressWarnings("HiddenField")
         public void setContent(BytesReference content, XContentType xContentType) {
             this.content = content;
             this.xContentType = xContentType;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
@@ -101,18 +101,23 @@ public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalytic
         }
 
         private ActionRequestValidationException checkConfigIdIsValid(
-            DataFrameAnalyticsConfig config,
+            DataFrameAnalyticsConfig analyticsConfig,
             ActionRequestValidationException error
         ) {
-            if (MlStrings.isValidId(config.getId()) == false) {
+            if (MlStrings.isValidId(analyticsConfig.getId()) == false) {
                 error = ValidateActions.addValidationError(
-                    Messages.getMessage(Messages.INVALID_ID, DataFrameAnalyticsConfig.ID, config.getId()),
+                    Messages.getMessage(Messages.INVALID_ID, DataFrameAnalyticsConfig.ID, analyticsConfig.getId()),
                     error
                 );
             }
-            if (MlStrings.hasValidLengthForId(config.getId()) == false) {
+            if (MlStrings.hasValidLengthForId(analyticsConfig.getId()) == false) {
                 error = ValidateActions.addValidationError(
-                    Messages.getMessage(Messages.ID_TOO_LONG, DataFrameAnalyticsConfig.ID, config.getId(), MlStrings.ID_LENGTH_LIMIT),
+                    Messages.getMessage(
+                        Messages.ID_TOO_LONG,
+                        DataFrameAnalyticsConfig.ID,
+                        analyticsConfig.getId(),
+                        MlStrings.ID_LENGTH_LIMIT
+                    ),
                     error
                 );
             }
@@ -120,14 +125,14 @@ public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalytic
         }
 
         private ActionRequestValidationException checkNoIncludedAnalyzedFieldsAreExcludedBySourceFiltering(
-            DataFrameAnalyticsConfig config,
+            DataFrameAnalyticsConfig analyticsConfig,
             ActionRequestValidationException error
         ) {
-            if (config.getAnalyzedFields() == null) {
+            if (analyticsConfig.getAnalyzedFields() == null) {
                 return error;
             }
-            for (String analyzedInclude : config.getAnalyzedFields().includes()) {
-                if (config.getSource().isFieldExcluded(analyzedInclude)) {
+            for (String analyzedInclude : analyticsConfig.getAnalyzedFields().includes()) {
+                if (analyticsConfig.getSource().isFieldExcluded(analyzedInclude)) {
                     return ValidateActions.addValidationError(
                         "field ["
                             + analyzedInclude

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -119,8 +119,8 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            this.params.toXContent(builder, params);
+        public XContentBuilder toXContent(XContentBuilder builder, Params xContentParams) throws IOException {
+            this.params.toXContent(builder, xContentParams);
             return builder;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/Calendar.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/Calendar.java
@@ -152,8 +152,8 @@ public class Calendar implements ToXContentObject, Writeable {
             return calendarId;
         }
 
-        public void setId(String calendarId) {
-            this.calendarId = calendarId;
+        public void setId(String id) {
+            this.calendarId = id;
         }
 
         public Builder setJobIds(List<String> jobIds) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -991,11 +991,11 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return this;
         }
 
-        private Builder setAggregationsSafe(AggProvider aggProvider) {
+        private Builder setAggregationsSafe(AggProvider provider) {
             if (this.aggProvider != null) {
                 throw ExceptionsHelper.badRequestException("Found two aggregation definitions: [aggs] and [aggregations]");
             }
-            this.aggProvider = aggProvider;
+            this.aggProvider = provider;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -146,8 +146,8 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
         this.exponentialAvgCalculationContext.increment(searchTimeMs);
     }
 
-    public void incrementBucketCount(long bucketCount) {
-        this.bucketCount += bucketCount;
+    public void incrementBucketCount(long count) {
+        this.bucketCount += count;
     }
 
     public void setLatestRecordTimestamp(Instant latestRecordTimestamp) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -575,21 +575,21 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
-        public Builder setQuery(QueryProvider queryProvider) {
-            this.queryProvider = queryProvider;
+        public Builder setQuery(QueryProvider query) {
+            this.queryProvider = query;
             return this;
         }
 
-        private Builder setAggregationsSafe(AggProvider aggProvider) {
+        private Builder setAggregationsSafe(AggProvider provider) {
             if (this.aggProvider != null) {
                 throw ExceptionsHelper.badRequestException("Found two aggregation definitions: [aggs] and [aggregations]");
             }
-            setAggregations(aggProvider);
+            setAggregations(provider);
             return this;
         }
 
-        public Builder setAggregations(AggProvider aggProvider) {
-            this.aggProvider = aggProvider;
+        public Builder setAggregations(AggProvider provider) {
+            this.aggProvider = provider;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRoc.java
@@ -146,24 +146,26 @@ public class AucRoc extends AbstractAucRoc {
     @Override
     public Tuple<List<AggregationBuilder>, List<PipelineAggregationBuilder>> aggs(
         EvaluationParameters parameters,
-        EvaluationFields fields
+        EvaluationFields evaluationFields
     ) {
         if (result.get() != null) {
             return Tuple.tuple(Arrays.asList(), Arrays.asList());
         }
         // Store given {@code fields} for the purpose of generating error messages in {@code process}.
-        this.fields.trySet(fields);
+        this.fields.trySet(evaluationFields);
 
         double[] percentiles = IntStream.range(1, 100).mapToDouble(v -> (double) v).toArray();
         AggregationBuilder percentilesAgg = AggregationBuilders.percentiles(PERCENTILES_AGG_NAME)
-            .field(fields.getPredictedProbabilityField())
+            .field(evaluationFields.getPredictedProbabilityField())
             .percentiles(percentiles);
-        AggregationBuilder nestedAgg = AggregationBuilders.nested(NESTED_AGG_NAME, fields.getTopClassesField())
+        AggregationBuilder nestedAgg = AggregationBuilders.nested(NESTED_AGG_NAME, evaluationFields.getTopClassesField())
             .subAggregation(
-                AggregationBuilders.filter(NESTED_FILTER_AGG_NAME, QueryBuilders.termQuery(fields.getPredictedClassField(), className))
-                    .subAggregation(percentilesAgg)
+                AggregationBuilders.filter(
+                    NESTED_FILTER_AGG_NAME,
+                    QueryBuilders.termQuery(evaluationFields.getPredictedClassField(), className)
+                ).subAggregation(percentilesAgg)
             );
-        QueryBuilder actualIsTrueQuery = QueryBuilders.termQuery(fields.getActualField(), className);
+        QueryBuilder actualIsTrueQuery = QueryBuilders.termQuery(evaluationFields.getActualField(), className);
         AggregationBuilder percentilesForClassValueAgg = AggregationBuilders.filter(TRUE_AGG_NAME, actualIsTrueQuery)
             .subAggregation(nestedAgg);
         AggregationBuilder percentilesForRestAgg = AggregationBuilders.filter(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
@@ -102,15 +102,15 @@ public class Precision implements EvaluationMetric {
         EvaluationParameters parameters,
         EvaluationFields fields
     ) {
-        String actualField = fields.getActualField();
+        String actualFieldName = fields.getActualField();
         String predictedField = fields.getPredictedField();
         // Store given {@code actualField} for the purpose of generating error message in {@code process}.
-        this.actualField.trySet(actualField);
+        this.actualField.trySet(actualFieldName);
         if (topActualClassNames.get() == null) {  // This is step 1
             return Tuple.tuple(
                 Arrays.asList(
                     AggregationBuilders.terms(ACTUAL_CLASSES_NAMES_AGG_NAME)
-                        .field(actualField)
+                        .field(actualFieldName)
                         .order(Arrays.asList(BucketOrder.count(false), BucketOrder.key(true)))
                         .size(MAX_CLASSES_CARDINALITY)
                 ),
@@ -122,7 +122,7 @@ public class Precision implements EvaluationMetric {
                 .stream()
                 .map(className -> new KeyedFilter(className, QueryBuilders.matchQuery(predictedField, className).lenient(true)))
                 .toArray(KeyedFilter[]::new);
-            Script script = PainlessScripts.buildIsEqualScript(actualField, predictedField);
+            Script script = PainlessScripts.buildIsEqualScript(actualFieldName, predictedField);
             return Tuple.tuple(
                 Arrays.asList(
                     AggregationBuilders.filters(BY_PREDICTED_CLASS_AGG_NAME, keyedFiltersPredicted)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
@@ -96,18 +96,18 @@ public class Recall implements EvaluationMetric {
         EvaluationParameters parameters,
         EvaluationFields fields
     ) {
-        String actualField = fields.getActualField();
+        String actualFieldName = fields.getActualField();
         String predictedField = fields.getPredictedField();
         // Store given {@code actualField} for the purpose of generating error message in {@code process}.
-        this.actualField.trySet(actualField);
+        this.actualField.trySet(actualFieldName);
         if (result.get() != null) {
             return Tuple.tuple(Collections.emptyList(), Collections.emptyList());
         }
-        Script script = PainlessScripts.buildIsEqualScript(actualField, predictedField);
+        Script script = PainlessScripts.buildIsEqualScript(actualFieldName, predictedField);
         return Tuple.tuple(
             Arrays.asList(
                 AggregationBuilders.terms(BY_ACTUAL_CLASS_AGG_NAME)
-                    .field(actualField)
+                    .field(actualFieldName)
                     .order(Arrays.asList(BucketOrder.count(false), BucketOrder.key(true)))
                     .size(MAX_CLASSES_CARDINALITY)
                     .subAggregation(AggregationBuilders.avg(PER_ACTUAL_CLASS_RECALL_AGG_NAME).script(script))

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/AucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/AucRoc.java
@@ -132,16 +132,16 @@ public class AucRoc extends AbstractAucRoc {
     @Override
     public Tuple<List<AggregationBuilder>, List<PipelineAggregationBuilder>> aggs(
         EvaluationParameters parameters,
-        EvaluationFields fields
+        EvaluationFields evaluationFields
     ) {
         if (result.get() != null) {
             return Tuple.tuple(Collections.emptyList(), Collections.emptyList());
         }
         // Store given {@code fields} for the purpose of generating error messages in {@code process}.
-        this.fields.trySet(fields);
+        this.fields.trySet(evaluationFields);
 
-        String actualField = fields.getActualField();
-        String predictedProbabilityField = fields.getPredictedProbabilityField();
+        String actualField = evaluationFields.getActualField();
+        String predictedProbabilityField = evaluationFields.getPredictedProbabilityField();
         double[] percentiles = IntStream.range(1, 100).mapToDouble(v -> (double) v).toArray();
         AggregationBuilder percentilesAgg = AggregationBuilders.percentiles(PERCENTILES_AGG_NAME)
             .field(predictedProbabilityField)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ClassificationStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ClassificationStats.java
@@ -158,8 +158,8 @@ public class ClassificationStats implements AnalysisStats {
         return Objects.hash(jobId, timestamp, iteration, hyperparameters, timingStats, validationLoss);
     }
 
-    public String documentId(String jobId) {
-        return documentIdPrefix(jobId) + timestamp.toEpochMilli();
+    public String documentId(String _jobId) {
+        return documentIdPrefix(_jobId) + timestamp.toEpochMilli();
     }
 
     public static String documentIdPrefix(String jobId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
@@ -172,9 +172,9 @@ public class MemoryUsage implements Writeable, ToXContentObject {
         return Strings.toString(this);
     }
 
-    public String documentId(String jobId) {
+    public String documentId(String _jobId) {
         assert timestamp != null;
-        return documentIdPrefix(jobId) + timestamp.toEpochMilli();
+        return documentIdPrefix(_jobId) + timestamp.toEpochMilli();
     }
 
     public static String documentIdPrefix(String jobId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
@@ -124,8 +124,8 @@ public class OutlierDetectionStats implements AnalysisStats {
         return Objects.hash(jobId, timestamp, parameters, timingStats);
     }
 
-    public String documentId(String jobId) {
-        return documentIdPrefix(jobId) + timestamp.toEpochMilli();
+    public String documentId(String _jobId) {
+        return documentIdPrefix(_jobId) + timestamp.toEpochMilli();
     }
 
     public static String documentIdPrefix(String jobId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/RegressionStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/RegressionStats.java
@@ -158,8 +158,8 @@ public class RegressionStats implements AnalysisStats {
         return Objects.hash(jobId, timestamp, iteration, hyperparameters, timingStats, validationLoss);
     }
 
-    public String documentId(String jobId) {
-        return documentIdPrefix(jobId) + timestamp.toEpochMilli();
+    public String documentId(String _jobId) {
+        return documentIdPrefix(_jobId) + timestamp.toEpochMilli();
     }
 
     public static String documentIdPrefix(String jobId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -564,11 +564,11 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder setParsedDefinition(TrainedModelDefinition.Builder definition) {
-            if (definition == null) {
+        public Builder setParsedDefinition(TrainedModelDefinition.Builder definitionRef) {
+            if (definitionRef == null) {
                 return this;
             }
-            this.definition = LazyModelDefinition.fromParsedDefinition(definition.build());
+            this.definition = LazyModelDefinition.fromParsedDefinition(definitionRef.build());
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
@@ -598,9 +598,9 @@ public class Detector implements ToXContentObject, Writeable {
                 verifyFieldName(field);
             }
 
-            DetectorFunction function = this.function == null ? DetectorFunction.METRIC : this.function;
+            DetectorFunction detectorFunction = this.function == null ? DetectorFunction.METRIC : this.function;
             for (DetectionRule rule : rules) {
-                validateRule(rule, function);
+                validateRule(rule, detectorFunction);
             }
 
             // partition, by and over field names cannot be duplicates
@@ -675,7 +675,7 @@ public class Detector implements ToXContentObject, Writeable {
 
             return new Detector(
                 detectorDescription,
-                function,
+                detectorFunction,
                 fieldName,
                 byFieldName,
                 overFieldName,
@@ -719,14 +719,14 @@ public class Detector implements ToXContentObject, Writeable {
             return field.chars().anyMatch(Character::isISOControl);
         }
 
-        private void validateRule(DetectionRule rule, DetectorFunction function) {
-            checkFunctionHasRuleSupport(rule, function);
+        private void validateRule(DetectionRule rule, DetectorFunction detectorFunction) {
+            checkFunctionHasRuleSupport(rule, detectorFunction);
             checkScoping(rule);
         }
 
-        private void checkFunctionHasRuleSupport(DetectionRule rule, DetectorFunction function) {
-            if (ruleHasConditionOnResultValue(rule) && FUNCTIONS_WITHOUT_RULE_CONDITION_SUPPORT.contains(function)) {
-                String msg = Messages.getMessage(Messages.JOB_CONFIG_DETECTION_RULE_NOT_SUPPORTED_BY_FUNCTION, function);
+        private void checkFunctionHasRuleSupport(DetectionRule rule, DetectorFunction detectorFunction) {
+            if (ruleHasConditionOnResultValue(rule) && FUNCTIONS_WITHOUT_RULE_CONDITION_SUPPORT.contains(detectorFunction)) {
+                String msg = Messages.getMessage(Messages.JOB_CONFIG_DETECTION_RULE_NOT_SUPPORTED_BY_FUNCTION, detectorFunction);
                 throw ExceptionsHelper.badRequestException(msg);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -990,8 +990,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
-        public Builder setDataDescription(DataDescription.Builder description) {
-            dataDescription = ExceptionsHelper.requireNonNull(description, DATA_DESCRIPTION.getPreferredName()).build();
+        public Builder setDataDescription(DataDescription.Builder dataDescription) {
+            this.dataDescription = ExceptionsHelper.requireNonNull(dataDescription, DATA_DESCRIPTION.getPreferredName()).build();
             return this;
         }
 
@@ -1359,7 +1359,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
          * @param createTime The time this job was created
          * @return The job
          */
-        public Job build(Date createTime) {
+        public Job build(@SuppressWarnings("HiddenField") Date createTime) {
             setCreateTime(createTime);
             setJobVersion(Version.CURRENT);
             return build();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -938,8 +938,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
-        public Builder setClearFinishTime(boolean clearJobFinishTime) {
-            this.clearJobFinishTime = clearJobFinishTime;
+        public Builder setClearFinishTime(boolean clearFinishTime) {
+            this.clearJobFinishTime = clearFinishTime;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
@@ -487,10 +487,9 @@ public class DataCounts implements ToXContentObject, Writeable {
         this.latestEmptyBucketTimeStamp = latestEmptyBucketTimeStamp;
     }
 
-    public void updateLatestEmptyBucketTimeStamp(Date latestEmptyBucketTimeStamp) {
-        if (latestEmptyBucketTimeStamp != null
-            && (this.latestEmptyBucketTimeStamp == null || latestEmptyBucketTimeStamp.after(this.latestEmptyBucketTimeStamp))) {
-            this.latestEmptyBucketTimeStamp = latestEmptyBucketTimeStamp;
+    public void updateLatestEmptyBucketTimeStamp(Date timestamp) {
+        if (timestamp != null && (this.latestEmptyBucketTimeStamp == null || timestamp.after(this.latestEmptyBucketTimeStamp))) {
+            this.latestEmptyBucketTimeStamp = timestamp;
         }
     }
 
@@ -507,10 +506,9 @@ public class DataCounts implements ToXContentObject, Writeable {
         this.latestSparseBucketTimeStamp = latestSparseBucketTimeStamp;
     }
 
-    public void updateLatestSparseBucketTimeStamp(Date latestSparseBucketTimeStamp) {
-        if (latestSparseBucketTimeStamp != null
-            && (this.latestSparseBucketTimeStamp == null || latestSparseBucketTimeStamp.after(this.latestSparseBucketTimeStamp))) {
-            this.latestSparseBucketTimeStamp = latestSparseBucketTimeStamp;
+    public void updateLatestSparseBucketTimeStamp(Date timestamp) {
+        if (timestamp != null && (this.latestSparseBucketTimeStamp == null || timestamp.after(this.latestSparseBucketTimeStamp))) {
+            this.latestSparseBucketTimeStamp = timestamp;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
@@ -326,8 +326,8 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         }
 
         Map<String, LinkedHashSet<String>> inputFields = inputFieldMap();
-        for (String fieldName : inputFields.keySet()) {
-            builder.field(fieldName, inputFields.get(fieldName));
+        for (String inputFieldName : inputFields.keySet()) {
+            builder.field(inputFieldName, inputFields.get(inputFieldName));
         }
         builder.endObject();
         return builder;
@@ -343,19 +343,19 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
 
         if (influences != null) {
             for (Influence inf : influences) {
-                String fieldName = inf.getInfluencerFieldName();
+                String influencerFieldName = inf.getInfluencerFieldName();
                 for (String fieldValue : inf.getInfluencerFieldValues()) {
-                    addInputFieldsToMap(result, fieldName, fieldValue);
+                    addInputFieldsToMap(result, influencerFieldName, fieldValue);
                 }
             }
         }
         return result;
     }
 
-    private void addInputFieldsToMap(Map<String, LinkedHashSet<String>> inputFields, String fieldName, String fieldValue) {
-        if (Strings.isNullOrEmpty(fieldName) == false && fieldValue != null) {
-            if (ReservedFieldNames.isValidFieldName(fieldName)) {
-                inputFields.computeIfAbsent(fieldName, k -> new LinkedHashSet<>()).add(fieldValue);
+    private void addInputFieldsToMap(Map<String, LinkedHashSet<String>> inputFields, String inputFieldName, String fieldValue) {
+        if (Strings.isNullOrEmpty(inputFieldName) == false && fieldValue != null) {
+            if (ReservedFieldNames.isValidFieldName(inputFieldName)) {
+                inputFields.computeIfAbsent(inputFieldName, k -> new LinkedHashSet<>()).add(fieldValue);
             }
         }
     }
@@ -518,8 +518,8 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         return isInterim;
     }
 
-    public void setInterim(boolean isInterim) {
-        this.isInterim = isInterim;
+    public void setInterim(boolean interim) {
+        this.isInterim = interim;
     }
 
     public String getFieldName() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
@@ -287,8 +287,8 @@ public class Bucket implements ToXContentObject, Writeable {
         return isInterim;
     }
 
-    public void setInterim(boolean isInterim) {
-        this.isInterim = isInterim;
+    public void setInterim(boolean interim) {
+        this.isInterim = interim;
     }
 
     public long getProcessingTimeMs() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
@@ -279,8 +279,8 @@ public class ForecastRequestStats implements ToXContentObject, Writeable {
         this.messages = messages;
     }
 
-    public void setTimeStamp(Instant timestamp) {
-        this.timestamp = Instant.ofEpochMilli(timestamp.toEpochMilli());
+    public void setTimeStamp(Instant timeStamp) {
+        this.timestamp = Instant.ofEpochMilli(timeStamp.toEpochMilli());
     }
 
     public Instant getTimestamp() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -138,7 +138,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
     protected List<Plugin> plugins = new ArrayList<>();
 
     public LocalStateCompositeXPackPlugin(final Settings settings, final Path configPath) {
-        super(settings, configPath);
+        super(settings);
     }
 
     // Get around all the setOnce nonsense in the plugin

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackPluginTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackPluginTests.java
@@ -88,7 +88,7 @@ public class XPackPluginTests extends ESTestCase {
     }
 
     private XPackPlugin createXPackPlugin(Settings settings) throws Exception {
-        return new XPackPlugin(settings, null) {
+        return new XPackPlugin(settings) {
 
             @Override
             protected void setSslService(SSLService sslService) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
@@ -64,8 +64,8 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         try {
             // If a document does not have the enrich key, return the unchanged document
-            String field = ingestDocument.renderTemplate(this.field);
-            final Object value = ingestDocument.getFieldValue(field, Object.class, ignoreMissing);
+            String renderedField = ingestDocument.renderTemplate(this.field);
+            final Object value = ingestDocument.getFieldValue(renderedField, Object.class, ignoreMissing);
             if (value == null) {
                 handler.accept(ingestDocument, null);
                 return;
@@ -99,18 +99,18 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
                     return;
                 }
 
-                String targetField = ingestDocument.renderTemplate(this.targetField);
-                if (overrideEnabled || ingestDocument.hasField(targetField) == false) {
+                String renderedTargetField = ingestDocument.renderTemplate(this.targetField);
+                if (overrideEnabled || ingestDocument.hasField(renderedTargetField) == false) {
                     if (maxMatches == 1) {
                         Map<String, Object> firstDocument = searchHits[0].getSourceAsMap();
-                        ingestDocument.setFieldValue(targetField, firstDocument);
+                        ingestDocument.setFieldValue(renderedTargetField, firstDocument);
                     } else {
                         List<Map<String, Object>> enrichDocuments = new ArrayList<>(searchHits.length);
                         for (SearchHit searchHit : searchHits) {
                             Map<String, Object> enrichDocument = searchHit.getSourceAsMap();
                             enrichDocuments.add(enrichDocument);
                         }
-                        ingestDocument.setFieldValue(targetField, enrichDocuments);
+                        ingestDocument.setFieldValue(renderedTargetField, enrichDocuments);
                     }
                 }
                 handler.accept(ingestDocument, null);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -168,7 +168,7 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,
@@ -273,7 +273,7 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
     }
 
     @Override
-    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings unused) {
         return Collections.singletonList(
             new SystemIndexDescriptor(ENRICH_INDEX_PATTERN, "Contains data to support enrich ingest processors.")
         );

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -254,20 +254,20 @@ public class EnrichPolicyRunner implements Runnable {
         }
     }
 
-    private XContentBuilder resolveEnrichMapping(final EnrichPolicy policy, final List<Map<String, Object>> mappings) {
-        if (EnrichPolicy.MATCH_TYPE.equals(policy.getType())) {
+    private XContentBuilder resolveEnrichMapping(final EnrichPolicy enrichPolicy, final List<Map<String, Object>> mappings) {
+        if (EnrichPolicy.MATCH_TYPE.equals(enrichPolicy.getType())) {
             return createEnrichMappingBuilder((builder) -> builder.field("type", "keyword").field("doc_values", false));
-        } else if (EnrichPolicy.RANGE_TYPE.equals(policy.getType())) {
-            return createRangeEnrichMappingBuilder(policy, mappings);
-        } else if (EnrichPolicy.GEO_MATCH_TYPE.equals(policy.getType())) {
+        } else if (EnrichPolicy.RANGE_TYPE.equals(enrichPolicy.getType())) {
+            return createRangeEnrichMappingBuilder(enrichPolicy, mappings);
+        } else if (EnrichPolicy.GEO_MATCH_TYPE.equals(enrichPolicy.getType())) {
             return createEnrichMappingBuilder((builder) -> builder.field("type", "geo_shape"));
         } else {
-            throw new ElasticsearchException("Unrecognized enrich policy type [{}]", policy.getType());
+            throw new ElasticsearchException("Unrecognized enrich policy type [{}]", enrichPolicy.getType());
         }
     }
 
-    private XContentBuilder createRangeEnrichMappingBuilder(EnrichPolicy policy, List<Map<String, Object>> mappings) {
-        String matchFieldPath = "properties." + policy.getMatchField().replace(".", ".properties.");
+    private XContentBuilder createRangeEnrichMappingBuilder(EnrichPolicy enrichPolicy, List<Map<String, Object>> mappings) {
+        String matchFieldPath = "properties." + enrichPolicy.getMatchField().replace(".", ".properties.");
         List<Map<String, String>> matchFieldMappings = mappings.stream()
             .map(map -> ObjectPath.<Map<String, String>>eval(matchFieldPath, map))
             .filter(Objects::nonNull)
@@ -303,15 +303,15 @@ public class EnrichPolicyRunner implements Runnable {
                     }
                     throw new ElasticsearchException(
                         "Multiple distinct date format specified for match field '{}' - indices({})  format entries({})",
-                        policy.getMatchField(),
-                        Strings.collectionToCommaDelimitedString(policy.getIndices()),
+                        enrichPolicy.getMatchField(),
+                        Strings.collectionToCommaDelimitedString(enrichPolicy.getIndices()),
                         (formatEntries.contains(null) ? "(DEFAULT), " : "") + Strings.collectionToCommaDelimitedString(formatEntries)
                     );
 
                 default:
                     throw new ElasticsearchException(
                         "Field '{}' has type [{}] which doesn't appear to be a range type",
-                        policy.getMatchField(),
+                        enrichPolicy.getMatchField(),
                         type
                     );
             }
@@ -319,14 +319,14 @@ public class EnrichPolicyRunner implements Runnable {
         if (types.isEmpty()) {
             throw new ElasticsearchException(
                 "No mapping type found for match field '{}' - indices({})",
-                policy.getMatchField(),
-                Strings.collectionToCommaDelimitedString(policy.getIndices())
+                enrichPolicy.getMatchField(),
+                Strings.collectionToCommaDelimitedString(enrichPolicy.getIndices())
             );
         }
         throw new ElasticsearchException(
             "Multiple distinct mapping types for match field '{}' - indices({})  types({})",
-            policy.getMatchField(),
-            Strings.collectionToCommaDelimitedString(policy.getIndices()),
+            enrichPolicy.getMatchField(),
+            Strings.collectionToCommaDelimitedString(enrichPolicy.getIndices()),
             Strings.collectionToCommaDelimitedString(types)
         );
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
@@ -93,12 +93,15 @@ public class Criterion<Q extends QueryRequest> {
             tbreaker = (Comparable<Object>) tb;
         }
 
-        Object implicitTbreaker = implicitTiebreaker.extract(hit);
-        if (implicitTbreaker instanceof Number == false) {
-            throw new EqlIllegalArgumentException("Expected _shard_doc/implicit tiebreaker as long but got [{}]", implicitTbreaker);
+        Object extractedImplicitTiebreaker = implicitTiebreaker.extract(hit);
+        if (extractedImplicitTiebreaker instanceof Number == false) {
+            throw new EqlIllegalArgumentException(
+                "Expected _shard_doc/implicit tiebreaker as long but got [{}]",
+                extractedImplicitTiebreaker
+            );
         }
-        long implicitTiebreaker = ((Number) implicitTbreaker).longValue();
-        return new Ordinal((Timestamp) ts, tbreaker, implicitTiebreaker);
+        long implicitTiebreakerValue = ((Number) extractedImplicitTiebreaker).longValue();
+        return new Ordinal((Timestamp) ts, tbreaker, implicitTiebreakerValue);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
@@ -54,8 +54,8 @@ public class StringContainsFunctionPipe extends Pipe {
         return string.resolved() && substring.resolved();
     }
 
-    protected StringContainsFunctionPipe replaceChildren(Pipe string, Pipe substring) {
-        return new StringContainsFunctionPipe(source(), expression(), string, substring, caseInsensitive);
+    protected StringContainsFunctionPipe replaceChildren(Pipe pipeString, Pipe pipeSubstring) {
+        return new StringContainsFunctionPipe(source(), expression(), pipeString, pipeSubstring, caseInsensitive);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
@@ -125,8 +125,8 @@ public class Join extends LogicalPlan {
         return direction;
     }
 
-    public Join with(List<KeyedFilter> queries, KeyedFilter until, OrderDirection direction) {
-        return new Join(source(), queries, until, timestamp, tiebreaker, direction);
+    public Join with(List<KeyedFilter> keyedFilterQueries, KeyedFilter untilFilter, OrderDirection orderDirection) {
+        return new Join(source(), keyedFilterQueries, untilFilter, timestamp, tiebreaker, orderDirection);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
@@ -43,8 +43,8 @@ public class EsQueryExec extends LeafExec {
         return NodeInfo.create(this, EsQueryExec::new, output, queryContainer);
     }
 
-    public EsQueryExec with(QueryContainer queryContainer) {
-        return new EsQueryExec(source(), output, queryContainer);
+    public EsQueryExec with(QueryContainer container) {
+        return new EsQueryExec(source(), output, container);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
@@ -112,8 +112,8 @@ public class SequenceExec extends PhysicalPlan {
         return direction;
     }
 
-    public SequenceExec with(Limit limit) {
-        return new SequenceExec(source(), children(), keys(), timestamp(), tiebreaker(), limit, direction, maxSpan);
+    public SequenceExec with(Limit limitValue) {
+        return new SequenceExec(source(), children(), keys(), timestamp(), tiebreaker(), limitValue, direction, maxSpan);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
@@ -101,8 +101,8 @@ public class QueryContainer {
         return new QueryContainer(q, fields, attributes, sort, trackHits, includeFrozen, limit);
     }
 
-    public QueryContainer with(Limit limit) {
-        return new QueryContainer(query, fields, attributes, sort, trackHits, includeFrozen, limit);
+    public QueryContainer with(Limit limitValue) {
+        return new QueryContainer(query, fields, attributes, sort, trackHits, includeFrozen, limitValue);
     }
 
     public QueryContainer addColumn(Attribute attr) {

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -85,7 +85,6 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         final int count = randomIntBetween(3, 5);
         List<SamlServiceProviderDocument> documents = new ArrayList<>(count);
 
-        final ClusterService clusterService = super.getInstanceFromNode(ClusterService.class);
         // Install the template
         assertTrue("Template should have been installed", installTemplate());
         // No need to install it again


### PR DESCRIPTION
Part of #19752. Fix more instances where local variable names were
shadowing field names. Also expand the possible method names that are
skipped when checking for shadowed vars, and allow shadowed vars in
builder classes.