### PR TITLE
Fix docs for passing JVM args to ./gradlew run

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -92,12 +92,12 @@ password: `elastic-password`.
 ==== Other useful arguments
 
 - In order to start a node with a different max heap space add: `-Dtests.heap.size=4G`
-- In order to disable assertions add: `-Dtests.asserts=false`
 - In order to use a custom data directory: `--data-dir=/tmp/foo`
 - In order to preserve data in between executions: `--preserve-data`
 - In order to remotely attach a debugger to the process: `--debug-jvm`
 - In order to set a different keystore password: `--keystore-password`
 - In order to set an Elasticsearch setting, provide a setting with the following prefix: `-Dtests.es.`
+- In order to pass a JVM seting, e.g. to disable assertions: `-Dtests.jvm.argline="-da"`
 
 === Test case filtering.
 

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -64,6 +64,15 @@ NOTE: If you have imported the project into IntelliJ according to the instructio
 link:/CONTRIBUTING.md#importing-the-project-into-intellij-idea[CONTRIBUTING.md] then a debug run configuration
 named "Debug Elasticsearch" will be created for you and configured appropriately.
 
+==== Disabling assertions
+
+When running Elasticsearch with `./gradlew run`, assertions are enabled by
+default. To disable them, add the following command line option:
+
+-------------------------
+-Dtests.jvm.argline="-da"
+-------------------------
+
 ==== Distribution
 
 By default a node is started with the zip distribution.


### PR DESCRIPTION
The instructions in `TESTING.asciidoc` for how to disable assertions when running `./gradlew run` didn't work. Fix the docs by describing how to pass JVM args, using disabling assertions as an example.