### PR TITLE
[8.0] Fail fast remote cluster requests (#80589)

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/node/NodeClient.java
@@ -168,7 +168,7 @@ public class NodeClient extends AbstractClient {
 
     @Override
     public Client getRemoteClusterClient(String clusterAlias) {
-        return remoteClusterService.getRemoteClusterClient(threadPool(), clusterAlias);
+        return remoteClusterService.getRemoteClusterClient(threadPool(), clusterAlias, true);
     }
 
     public NamedWriteableRegistry getNamedWriteableRegistry() {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -23,12 +23,20 @@ final class RemoteClusterAwareClient extends AbstractClient {
     private final TransportService service;
     private final String clusterAlias;
     private final RemoteClusterService remoteClusterService;
+    private final boolean ensureConnected;
 
-    RemoteClusterAwareClient(Settings settings, ThreadPool threadPool, TransportService service, String clusterAlias) {
+    RemoteClusterAwareClient(
+        Settings settings,
+        ThreadPool threadPool,
+        TransportService service,
+        String clusterAlias,
+        boolean ensureConnected
+    ) {
         super(settings, threadPool);
         this.service = service;
         this.clusterAlias = clusterAlias;
         this.remoteClusterService = service.getRemoteClusterService();
+        this.ensureConnected = ensureConnected;
     }
 
     @Override
@@ -37,13 +45,21 @@ final class RemoteClusterAwareClient extends AbstractClient {
         Request request,
         ActionListener<Response> listener
     ) {
-        remoteClusterService.ensureConnected(clusterAlias, ActionListener.wrap(v -> {
-            Transport.Connection connection;
-            if (request instanceof RemoteClusterAwareRequest) {
-                DiscoveryNode preferredTargetNode = ((RemoteClusterAwareRequest) request).getPreferredTargetNode();
-                connection = remoteClusterService.getConnection(preferredTargetNode, clusterAlias);
-            } else {
-                connection = remoteClusterService.getConnection(clusterAlias);
+        maybeEnsureConnected(ActionListener.wrap(v -> {
+            final Transport.Connection connection;
+            try {
+                if (request instanceof RemoteClusterAwareRequest) {
+                    DiscoveryNode preferredTargetNode = ((RemoteClusterAwareRequest) request).getPreferredTargetNode();
+                    connection = remoteClusterService.getConnection(preferredTargetNode, clusterAlias);
+                } else {
+                    connection = remoteClusterService.getConnection(clusterAlias);
+                }
+            } catch (NoSuchRemoteClusterException e) {
+                if (ensureConnected == false) {
+                    // trigger another connection attempt, but don't wait for it to complete
+                    remoteClusterService.ensureConnected(clusterAlias, ActionListener.wrap(() -> {}));
+                }
+                throw e;
             }
             service.sendRequest(
                 connection,
@@ -53,6 +69,14 @@ final class RemoteClusterAwareClient extends AbstractClient {
                 new ActionListenerResponseHandler<>(listener, action.getResponseReader())
             );
         }, listener::onFailure));
+    }
+
+    private void maybeEnsureConnected(ActionListener<Void> ensureConnectedListener) {
+        if (ensureConnected) {
+            remoteClusterService.ensureConnected(clusterAlias, ensureConnectedListener);
+        } else {
+            ensureConnectedListener.onResponse(null);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -398,11 +398,12 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     /**
      * Returns a client to the remote cluster if the given cluster alias exists.
      *
-     * @param threadPool   the {@link ThreadPool} for the client
-     * @param clusterAlias the cluster alias the remote cluster is registered under
+     * @param threadPool      the {@link ThreadPool} for the client
+     * @param clusterAlias    the cluster alias the remote cluster is registered under
+     * @param ensureConnected whether requests should wait for a connection attempt when there isn't a connection available
      * @throws IllegalArgumentException if the given clusterAlias doesn't exist
      */
-    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias) {
+    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias, boolean ensureConnected) {
         if (transportService.getRemoteClusterService().isEnabled() == false) {
             throw new IllegalArgumentException(
                 "this node does not have the " + DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName() + " role"
@@ -411,7 +412,22 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         if (transportService.getRemoteClusterService().getRemoteClusterNames().contains(clusterAlias) == false) {
             throw new NoSuchRemoteClusterException(clusterAlias);
         }
-        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias);
+        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias, ensureConnected);
+    }
+
+    /**
+     * Returns a client to the remote cluster if the given cluster alias exists.
+     *
+     * @param threadPool   the {@link ThreadPool} for the client
+     * @param clusterAlias the cluster alias the remote cluster is registered under
+     * @throws IllegalArgumentException if the given clusterAlias doesn't exist
+     */
+    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias) {
+        return getRemoteClusterClient(
+            threadPool,
+            clusterAlias,
+            transportService.getRemoteClusterService().isSkipUnavailable(clusterAlias) == false
+        );
     }
 
     Collection<RemoteClusterConnection> getConnections() {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -717,7 +717,8 @@ public class TransportSearchActionTests extends ESTestCase {
 
                 }
             }
-            {
+            // put the following in assert busy as connections are lazily reestablished
+            assertBusy(() -> {
                 SearchRequest searchRequest = new SearchRequest();
                 final CountDownLatch latch = new CountDownLatch(1);
                 SetOnce<Tuple<SearchRequest, ActionListener<SearchResponse>>> setOnce = new SetOnce<>();
@@ -753,7 +754,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 assertEquals(totalClusters, searchResponse.getClusters().getTotal());
                 assertEquals(totalClusters, searchResponse.getClusters().getSuccessful());
                 assertEquals(totalClusters == 1 ? 1 : totalClusters + 1, searchResponse.getNumReducePhases());
-            }
+            });
             assertEquals(0, service.getConnectionManager().size());
         } finally {
             for (MockTransportService mockTransportService : mockTransportServices) {
@@ -913,7 +914,8 @@ public class TransportSearchActionTests extends ESTestCase {
 
                 }
             }
-            {
+            // run the following under assertBusy as connections are lazily reestablished
+            assertBusy(() -> {
                 final CountDownLatch latch = new CountDownLatch(1);
                 AtomicInteger skippedClusters = new AtomicInteger(0);
                 AtomicReference<Map<String, ClusterSearchShardsResponse>> response = new AtomicReference<>();
@@ -937,7 +939,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     assertTrue(map.containsKey(clusterAlias));
                     assertNotNull(map.get(clusterAlias));
                 }
-            }
+            });
             assertEquals(0, service.getConnectionManager().size());
         } finally {
             for (MockTransportService mockTransportService : mockTransportServices) {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
@@ -61,7 +61,15 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
 
-                try (RemoteClusterAwareClient client = new RemoteClusterAwareClient(Settings.EMPTY, threadPool, service, "cluster1")) {
+                try (
+                    RemoteClusterAwareClient client = new RemoteClusterAwareClient(
+                        Settings.EMPTY,
+                        threadPool,
+                        service,
+                        "cluster1",
+                        randomBoolean()
+                    )
+                ) {
                     SearchRequest request = new SearchRequest("test-index");
                     CountDownLatch responseLatch = new CountDownLatch(1);
                     AtomicReference<ClusterSearchShardsResponse> reference = new AtomicReference<>();
@@ -101,7 +109,15 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
 
-                try (RemoteClusterAwareClient client = new RemoteClusterAwareClient(Settings.EMPTY, threadPool, service, "cluster1")) {
+                try (
+                    RemoteClusterAwareClient client = new RemoteClusterAwareClient(
+                        Settings.EMPTY,
+                        threadPool,
+                        service,
+                        "cluster1",
+                        randomBoolean()
+                    )
+                ) {
                     SearchRequest request = new SearchRequest("test-index");
                     int numThreads = 10;
                     ExecutorService executorService = Executors.newFixedThreadPool(numThreads);

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -23,6 +24,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.NodeRoles.onlyRole;
@@ -64,7 +66,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                 logger.info("now accepting incoming requests on local transport");
                 RemoteClusterService remoteClusterService = service.getRemoteClusterService();
                 assertTrue(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
-                Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test");
+                Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test", randomBoolean());
                 ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().execute().get();
                 assertNotNull(clusterStateResponse);
                 assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
@@ -115,7 +117,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                     connectionManager.disconnectFromNode(remoteNode);
                     closeFuture.get();
 
-                    Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test");
+                    Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test", true);
                     ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().execute().get();
                     assertNotNull(clusterStateResponse);
                     assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
@@ -133,10 +135,69 @@ public class RemoteClusterClientTests extends ESTestCase {
             final RemoteClusterService remoteClusterService = service.getRemoteClusterService();
             final IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> remoteClusterService.getRemoteClusterClient(threadPool, "test")
+                () -> remoteClusterService.getRemoteClusterClient(threadPool, "test", randomBoolean())
             );
             assertThat(e.getMessage(), equalTo("this node does not have the remote_cluster_client role"));
         }
     }
 
+    public void testQuicklySkipUnavailableClusters() throws Exception {
+        Settings remoteSettings = Settings.builder().put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "foo_bar_cluster").build();
+        try (
+            MockTransportService remoteTransport = startTransport(
+                "remote_node",
+                Collections.emptyList(),
+                Version.CURRENT,
+                threadPool,
+                remoteSettings
+            )
+        ) {
+            DiscoveryNode remoteNode = remoteTransport.getLocalDiscoNode();
+
+            Settings localSettings = Settings.builder()
+                .put(onlyRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
+                .put("cluster.remote.test.seeds", remoteNode.getAddress().getAddress() + ":" + remoteNode.getAddress().getPort())
+                .put("cluster.remote.test.skip_unavailable", true)
+                .put("cluster.remote.initial_connect_timeout", "0s")
+                .build();
+            try (MockTransportService service = MockTransportService.createNewService(localSettings, Version.CURRENT, threadPool, null)) {
+                CountDownLatch latch = new CountDownLatch(1);
+                service.addConnectBehavior(remoteTransport, (transport, discoveryNode, profile, listener) -> {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                    listener.onFailure(new ConnectTransportException(discoveryNode, "simulated"));
+                });
+                service.start();
+                service.acceptIncomingRequests();
+                RemoteClusterService remoteClusterService = service.getRemoteClusterService();
+                Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test");
+
+                try {
+                    assertFalse(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
+
+                    // check that we quickly fail
+                    expectThrows(
+                        NoSuchRemoteClusterException.class,
+                        () -> client.admin().cluster().prepareState().get(TimeValue.timeValueSeconds(10))
+                    );
+                } finally {
+                    service.clearAllRules();
+                    latch.countDown();
+                }
+
+                assertBusy(() -> {
+                    try {
+                        client.admin().cluster().prepareState().get();
+                    } catch (NoSuchRemoteClusterException e) {
+                        // keep retrying on this exception, the goal is to check that we eventually reconnect
+                        throw new AssertionError(e);
+                    }
+                });
+                assertTrue(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fail fast remote cluster requests (#80589)