### PR TITLE
[DOCS] Add kibana-verification-code tool docs

### DIFF
--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -19,6 +19,7 @@ tasks from the command line:
 * <<shard-tool>>
 * <<syskeygen>>
 * <<users-command>>
+* <<kibana-verification-code>>
 
 --
 
@@ -35,3 +36,4 @@ include::setup-passwords.asciidoc[]
 include::shard-tool.asciidoc[]
 include::syskeygen.asciidoc[]
 include::users-command.asciidoc[]
+include::kibana-verification-code.asciidoc[]

--- a/docs/reference/commands/kibana-verification-code.asciidoc
+++ b/docs/reference/commands/kibana-verification-code.asciidoc
@@ -1,0 +1,46 @@
+[[kibana-verification-code]]
+
+== kibana-verification-code
+
+The `kibana-verification-code` tool generates a verification code for enrolling
+a {kib} instance with a secured {es} cluster. 
+
+[discrete]
+=== Synopsis
+
+[source,shell]
+----
+bin/kibana-verification-code <1>
+[-V, --version] [-h, --help]
+----
+<1> This tool is available in the {kib} configuration directory.
+
+[discrete]
+=== Description
+
+Use this command to generate a verification code for {kib}. You enter this code
+in {kib} when manually configuring a secure connection with an {es} cluster.
+This tool is useful if you don’t have access to the {kib} terminal output, such
+as on a hosted environment. You can connect to a machine where {kib} is
+running (such as using SSH) and generate a verification code that you enter in
+{kib}.
+
+You must run this tool on the same machine where {kib} is running.
+
+[discrete]
+[[kibana-verification-code-parameters]]
+=== Parameters
+
+`-h, --help`:: Returns all of the command parameters.
+
+`-V, --version`:: Displays the {kib} version number.
+
+[discrete]
+=== Examples
+
+The following command generates a verification code for {kib}.
+
+[source,shell]
+----
+bin/kibana-verification-code
+----


### PR DESCRIPTION
Adds documentation for the `kibana-verification-code` tool. While it's technically a Kibana CLI tool, it's used for enrolling a Kibana instance with an Elasticsearch cluster, and feels more at home amongst the Elasticsearch CLI tools.

Preview link: https://elasticsearch_81265.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/kibana-verification-code.html