### PR TITLE
[7.13] [DOCS] Fix syntax error in bulk `dynamic_templates` docs (#81264)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -645,7 +645,7 @@ end::require-alias[]
 tag::bulk-dynamic-templates[]
 `dynamic_templates`::
 (Optional, map)
-A map from the full name of fields to the name of <<dynamic-templates, dynamic templates>.
+A map from the full name of fields to the name of <<dynamic-templates, dynamic templates>>.
 Defaults to an empty map. If a name matches a dynamic template, then that template will be 
 applied regardless of other match predicates defined in the template. And if a field is 
 already defined in the mapping, then this parameter won't be used.


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Fix syntax error in bulk `dynamic_templates` docs (#81264)