### PR TITLE
[ML] Track token positions and use source string to tag NER entities

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.results;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -161,6 +162,11 @@ public class NerResults extends NlpInferenceResults {
             }
             builder.endObject();
             return builder;
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
         }
 
         public Map<String, Object> toMap() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/BertRequestBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/BertRequestBuilder.java
@@ -34,7 +34,7 @@ public class BertRequestBuilder implements NlpTask.RequestBuilder {
 
     @Override
     public NlpTask.Request buildRequest(List<String> inputs, String requestId, Tokenization.Truncate truncate) throws IOException {
-        if (tokenizer.getPadToken().isEmpty()) {
+        if (tokenizer.getPadTokenId().isEmpty()) {
             throw new IllegalStateException("The input tokenizer does not have a " + BertTokenizer.PAD_TOKEN + " token in its vocabulary");
         }
 
@@ -46,10 +46,10 @@ public class BertRequestBuilder implements NlpTask.RequestBuilder {
 
     @Override
     public NlpTask.Request buildRequest(TokenizationResult tokenization, String requestId) throws IOException {
-        if (tokenizer.getPadToken().isEmpty()) {
+        if (tokenizer.getPadTokenId().isEmpty()) {
             throw new IllegalStateException("The input tokenizer does not have a " + BertTokenizer.PAD_TOKEN + " token in its vocabulary");
         }
-        return new NlpTask.Request(tokenization, jsonRequest(tokenization, tokenizer.getPadToken().getAsInt(), requestId));
+        return new NlpTask.Request(tokenization, jsonRequest(tokenization, tokenizer.getPadTokenId().getAsInt(), requestId));
     }
 
     static BytesReference jsonRequest(TokenizationResult tokenization, int padToken, String requestId) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessor.java
@@ -38,9 +38,9 @@ public class FillMaskProcessor implements NlpTask.Processor {
             throw new IllegalArgumentException("input request is empty");
         }
 
-        String mask = tokenizer.getMaskToken();
+        final String mask = tokenizer.getMaskToken();
         for (String input : inputs) {
-            int maskIndex = input.indexOf(tokenizer.getMaskToken());
+            int maskIndex = input.indexOf(mask);
             if (maskIndex < 0) {
                 throw new IllegalArgumentException("no " + mask + " token could be found");
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessor.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
-import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.NlpTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 
@@ -27,10 +26,10 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 
 public class FillMaskProcessor implements NlpTask.Processor {
 
-    private final NlpTask.RequestBuilder requestBuilder;
+    private final NlpTokenizer tokenizer;
 
     FillMaskProcessor(NlpTokenizer tokenizer, FillMaskConfig config) {
-        this.requestBuilder = tokenizer.requestBuilder();
+        this.tokenizer = tokenizer;
     }
 
     @Override
@@ -39,22 +38,23 @@ public class FillMaskProcessor implements NlpTask.Processor {
             throw new IllegalArgumentException("input request is empty");
         }
 
+        String mask = tokenizer.getMaskToken();
         for (String input : inputs) {
-            int maskIndex = input.indexOf(BertTokenizer.MASK_TOKEN);
+            int maskIndex = input.indexOf(tokenizer.getMaskToken());
             if (maskIndex < 0) {
-                throw new IllegalArgumentException("no " + BertTokenizer.MASK_TOKEN + " token could be found");
+                throw new IllegalArgumentException("no " + mask + " token could be found");
             }
 
-            maskIndex = input.indexOf(BertTokenizer.MASK_TOKEN, maskIndex + BertTokenizer.MASK_TOKEN.length());
+            maskIndex = input.indexOf(mask, maskIndex + mask.length());
             if (maskIndex > 0) {
-                throw new IllegalArgumentException("only one " + BertTokenizer.MASK_TOKEN + " token should exist in the input");
+                throw new IllegalArgumentException("only one " + mask + " token should exist in the input");
             }
         }
     }
 
     @Override
     public NlpTask.RequestBuilder getRequestBuilder(NlpConfig config) {
-        return requestBuilder;
+        return tokenizer.requestBuilder();
     }
 
     @Override
@@ -64,25 +64,55 @@ public class FillMaskProcessor implements NlpTask.Processor {
             return (tokenization, result) -> processResult(
                 tokenization,
                 result,
+                tokenizer,
                 fillMaskConfig.getNumTopClasses(),
                 fillMaskConfig.getResultsField()
             );
         } else {
-            return (tokenization, result) -> processResult(tokenization, result, FillMaskConfig.DEFAULT_NUM_RESULTS, DEFAULT_RESULTS_FIELD);
+            return (tokenization, result) -> processResult(
+                tokenization,
+                result,
+                tokenizer,
+                FillMaskConfig.DEFAULT_NUM_RESULTS,
+                DEFAULT_RESULTS_FIELD
+            );
         }
     }
 
     static InferenceResults processResult(
         TokenizationResult tokenization,
         PyTorchResult pyTorchResult,
+        NlpTokenizer tokenizer,
         int numResults,
         String resultsField
     ) {
-        if (tokenization.getTokenizations().isEmpty() || tokenization.getTokenizations().get(0).getTokens().length == 0) {
+        if (tokenization.getTokenizations().isEmpty() || tokenization.getTokenizations().get(0).getTokenIds().length == 0) {
             return new WarningInferenceResults("No valid tokens for inference");
         }
 
-        int maskTokenIndex = Arrays.asList(tokenization.getTokenizations().get(0).getTokens()).indexOf(BertTokenizer.MASK_TOKEN);
+        if (tokenizer.getMaskTokenId().isEmpty()) {
+            return new WarningInferenceResults(
+                "The token id for the mask token {} is not known in the tokenizer. Check the vocabulary contains the mask token",
+                tokenizer.getMaskToken()
+            );
+        }
+
+        int maskTokenIndex = -1;
+        int maskTokenId = tokenizer.getMaskTokenId().getAsInt();
+        for (int i = 0; i < tokenization.getTokenizations().get(0).getTokenIds().length; i++) {
+            if (tokenization.getTokenizations().get(0).getTokenIds()[i] == maskTokenId) {
+                maskTokenIndex = i;
+                break;
+            }
+        }
+        if (maskTokenIndex == -1) {
+            return new WarningInferenceResults(
+                "mask token id [{}] not found in the tokenization {}",
+                maskTokenId,
+                Arrays.asList(tokenization.getTokenizations().get(0).getTokenIds())
+            );
+        }
+
         // TODO - process all results in the batch
         double[] normalizedScores = NlpHelpers.convertToProbabilitiesBySoftMax(pyTorchResult.getInferenceResult()[0][maskTokenIndex]);
 
@@ -103,7 +133,7 @@ public class FillMaskProcessor implements NlpTask.Processor {
             tokenization.getTokenizations()
                 .get(0)
                 .getInput()
-                .replace(BertTokenizer.MASK_TOKEN, tokenization.getFromVocab(scoreAndIndices[0].index)),
+                .replace(tokenizer.getMaskToken(), tokenization.getFromVocab(scoreAndIndices[0].index)),
             results,
             Optional.ofNullable(resultsField).orElse(DEFAULT_RESULTS_FIELD),
             scoreAndIndices[0].score,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
@@ -296,8 +296,8 @@ public class NerProcessor implements NlpTask.Processor {
                     endTokenIndex++;
                 }
 
-                int startPos = token.token.startPos;
-                int endPos = tokens.get(endTokenIndex - 1).token.endPos;
+                int startPos = token.token.getStartPos();
+                int endPos = tokens.get(endTokenIndex - 1).token.getEndPos();
                 String entity = inputSeq.substring(startPos, endPos);
                 entities.add(
                     new NerResults.EntityGroup(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.DelimitedToken;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.NlpTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 
@@ -193,7 +194,7 @@ public class NerProcessor implements NlpTask.Processor {
 
         @Override
         public InferenceResults processResult(TokenizationResult tokenization, PyTorchResult pyTorchResult) {
-            if (tokenization.getTokenizations().isEmpty() || tokenization.getTokenizations().get(0).getTokens().length == 0) {
+            if (tokenization.getTokenizations().isEmpty() || tokenization.getTokenizations().get(0).getTokenIds().length == 0) {
                 return new WarningInferenceResults("no valid tokens to build result");
             }
             // TODO - process all results in the batch
@@ -213,6 +214,7 @@ public class NerProcessor implements NlpTask.Processor {
                     ? tokenization.getTokenizations().get(0).getInput().toLowerCase(Locale.ROOT)
                     : tokenization.getTokenizations().get(0).getInput()
             );
+
             return new NerResults(
                 resultsField,
                 buildAnnotatedText(tokenization.getTokenizations().get(0).getInput(), entities),
@@ -230,7 +232,7 @@ public class NerProcessor implements NlpTask.Processor {
         static List<TaggedToken> tagTokens(TokenizationResult.Tokenization tokenization, double[][] scores, IobTag[] iobMap) {
             List<TaggedToken> taggedTokens = new ArrayList<>();
             int startTokenIndex = 0;
-            while (startTokenIndex < tokenization.getTokens().length) {
+            while (startTokenIndex < tokenization.getTokenIds().length) {
                 int inputMapping = tokenization.getTokenMap()[startTokenIndex];
                 if (inputMapping < 0) {
                     // This token does not map to a token in the input (special tokens)
@@ -238,15 +240,9 @@ public class NerProcessor implements NlpTask.Processor {
                     continue;
                 }
                 int endTokenIndex = startTokenIndex;
-                StringBuilder word = new StringBuilder(tokenization.getTokens()[startTokenIndex]);
-                while (endTokenIndex < tokenization.getTokens().length - 1
+                while (endTokenIndex < tokenization.getTokenMap().length - 1
                     && tokenization.getTokenMap()[endTokenIndex + 1] == inputMapping) {
                     endTokenIndex++;
-                    // TODO Here we try to get rid of the continuation hashes at the beginning of sub-tokens.
-                    // It is probably more correct to implement detokenization on the tokenizer
-                    // that does reverse lookup based on token IDs.
-                    String endTokenWord = tokenization.getTokens()[endTokenIndex].substring(2);
-                    word.append(endTokenWord);
                 }
                 double[] avgScores = Arrays.copyOf(scores[startTokenIndex], iobMap.length);
                 for (int i = startTokenIndex + 1; i <= endTokenIndex; i++) {
@@ -262,7 +258,7 @@ public class NerProcessor implements NlpTask.Processor {
                 }
                 int maxScoreIndex = NlpHelpers.argmax(avgScores);
                 double score = avgScores[maxScoreIndex];
-                taggedTokens.add(new TaggedToken(word.toString(), iobMap[maxScoreIndex], score));
+                taggedTokens.add(new TaggedToken(tokenization.getTokens().get(inputMapping), iobMap[maxScoreIndex], score));
                 startTokenIndex = endTokenIndex + 1;
             }
             return taggedTokens;
@@ -283,14 +279,12 @@ public class NerProcessor implements NlpTask.Processor {
             }
             List<NerResults.EntityGroup> entities = new ArrayList<>();
             int startTokenIndex = 0;
-            int startFindInSeq = 0;
             while (startTokenIndex < tokens.size()) {
                 TaggedToken token = tokens.get(startTokenIndex);
                 if (token.tag.getEntity() == Entity.NONE) {
                     startTokenIndex++;
                     continue;
                 }
-                StringBuilder entityWord = new StringBuilder(token.word);
                 int endTokenIndex = startTokenIndex + 1;
                 double scoreSum = token.score;
                 while (endTokenIndex < tokens.size()) {
@@ -298,42 +292,49 @@ public class NerProcessor implements NlpTask.Processor {
                     if (endToken.tag.isBeginning() || endToken.tag.getEntity() != token.tag.getEntity()) {
                         break;
                     }
-                    // TODO Here we add a space between tokens.
-                    // It is probably more correct to implement detokenization on the tokenizer
-                    // that does reverse lookup based on token IDs.
-                    entityWord.append(" ").append(endToken.word);
                     scoreSum += endToken.score;
                     endTokenIndex++;
                 }
-                String entity = entityWord.toString();
-                int i = inputSeq.indexOf(entity, startFindInSeq);
+
+                int startPos = token.token.startPos;
+                int endPos = tokens.get(endTokenIndex - 1).token.endPos;
+                String entity = inputSeq.substring(startPos, endPos);
                 entities.add(
                     new NerResults.EntityGroup(
                         entity,
                         token.tag.getEntity().toString(),
                         scoreSum / (endTokenIndex - startTokenIndex),
-                        i,
-                        i == -1 ? -1 : i + entity.length()
+                        startPos,
+                        endPos
                     )
                 );
                 startTokenIndex = endTokenIndex;
-                if (i != -1) {
-                    startFindInSeq = i + entity.length();
-                }
             }
 
             return entities;
         }
 
         static class TaggedToken {
-            private final String word;
+            private final DelimitedToken token;
             private final IobTag tag;
             private final double score;
 
-            TaggedToken(String word, IobTag tag, double score) {
-                this.word = word;
+            TaggedToken(DelimitedToken token, IobTag tag, double score) {
+                this.token = token;
                 this.tag = tag;
                 this.score = score;
+            }
+
+            @Override
+            public String toString() {
+                return new StringBuilder("{").append("token:")
+                    .append(token)
+                    .append(", ")
+                    .append(tag)
+                    .append(", ")
+                    .append(score)
+                    .append("}")
+                    .toString();
             }
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.inference.nlp.BertRequestBuilder;
@@ -80,13 +79,28 @@ public class BertTokenizer implements NlpTokenizer {
     }
 
     @Override
-    public OptionalInt getPadToken() {
+    public OptionalInt getPadTokenId() {
         Integer pad = vocab.get(PAD_TOKEN);
         if (pad != null) {
             return OptionalInt.of(pad);
         } else {
             return OptionalInt.empty();
         }
+    }
+
+    @Override
+    public OptionalInt getMaskTokenId() {
+        Integer pad = vocab.get(MASK_TOKEN);
+        if (pad != null) {
+            return OptionalInt.of(pad);
+        } else {
+            return OptionalInt.empty();
+        }
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override
@@ -112,16 +126,17 @@ public class BertTokenizer implements NlpTokenizer {
     @Override
     public TokenizationResult.Tokenization tokenize(String seq, Tokenization.Truncate truncate) {
         var innerResult = innerTokenize(seq);
-        List<WordPieceTokenizer.TokenAndId> wordPieceTokens = innerResult.v1();
-        List<Integer> tokenPositionMap = innerResult.v2();
-        int numTokens = withSpecialTokens ? wordPieceTokens.size() + 2 : wordPieceTokens.size();
+        List<Integer> wordPieceTokenIds = innerResult.wordPieceTokenIds;
+        List<Integer> tokenPositionMap = innerResult.tokenPositionMap;
+        int numTokens = withSpecialTokens ? wordPieceTokenIds.size() + 2 : wordPieceTokenIds.size();
         boolean isTruncated = false;
+
         if (numTokens > maxSequenceLength) {
             switch (truncate) {
                 case FIRST:
                 case SECOND:
                     isTruncated = true;
-                    wordPieceTokens = wordPieceTokens.subList(0, withSpecialTokens ? maxSequenceLength - 2 : maxSequenceLength);
+                    wordPieceTokenIds = wordPieceTokenIds.subList(0, withSpecialTokens ? maxSequenceLength - 2 : maxSequenceLength);
                     break;
                 case NONE:
                     throw ExceptionsHelper.badRequestException(
@@ -132,78 +147,75 @@ public class BertTokenizer implements NlpTokenizer {
             }
             numTokens = maxSequenceLength;
         }
-        String[] tokens = new String[numTokens];
+
         int[] tokenIds = new int[numTokens];
         int[] tokenMap = new int[numTokens];
 
         if (withSpecialTokens) {
-            tokens[0] = CLASS_TOKEN;
             tokenIds[0] = vocab.get(CLASS_TOKEN);
             tokenMap[0] = SPECIAL_TOKEN_POSITION;
         }
 
         int i = withSpecialTokens ? 1 : 0;
         final int decrementHandler = withSpecialTokens ? 1 : 0;
-        for (WordPieceTokenizer.TokenAndId tokenAndId : wordPieceTokens) {
-            tokens[i] = tokenAndId.getToken();
-            tokenIds[i] = tokenAndId.getId();
+        for (var tokenId : wordPieceTokenIds) {
+            tokenIds[i] = tokenId;
             tokenMap[i] = tokenPositionMap.get(i - decrementHandler);
             i++;
         }
 
         if (withSpecialTokens) {
-            tokens[i] = SEPARATOR_TOKEN;
             tokenIds[i] = vocab.get(SEPARATOR_TOKEN);
             tokenMap[i] = SPECIAL_TOKEN_POSITION;
         }
 
-        return new TokenizationResult.Tokenization(seq, isTruncated, tokens, tokenIds, tokenMap);
+        return new TokenizationResult.Tokenization(seq, innerResult.tokens, isTruncated, tokenIds, tokenMap);
     }
 
     @Override
     public TokenizationResult.Tokenization tokenize(String seq1, String seq2, Tokenization.Truncate truncate) {
-        var innerResult = innerTokenize(seq1);
-        List<WordPieceTokenizer.TokenAndId> wordPieceTokenSeq1s = innerResult.v1();
-        List<Integer> tokenPositionMapSeq1 = innerResult.v2();
-        innerResult = innerTokenize(seq2);
-        List<WordPieceTokenizer.TokenAndId> wordPieceTokenSeq2s = innerResult.v1();
-        List<Integer> tokenPositionMapSeq2 = innerResult.v2();
+        var innerResultSeq1 = innerTokenize(seq1);
+        List<Integer> wordPieceTokenIdsSeq1 = innerResultSeq1.wordPieceTokenIds;
+        List<Integer> tokenPositionMapSeq1 = innerResultSeq1.tokenPositionMap;
+        var innerResultSeq2 = innerTokenize(seq2);
+        List<Integer> wordPieceTokenIdsSeq2 = innerResultSeq2.wordPieceTokenIds;
+        List<Integer> tokenPositionMapSeq2 = innerResultSeq2.tokenPositionMap;
         if (withSpecialTokens == false) {
             throw new IllegalArgumentException("Unable to do sequence pair tokenization without special tokens");
         }
         // [CLS] seq1 [SEP] seq2 [SEP]
-        int numTokens = wordPieceTokenSeq1s.size() + wordPieceTokenSeq2s.size() + 3;
+        int numTokens = wordPieceTokenIdsSeq1.size() + wordPieceTokenIdsSeq2.size() + 3;
 
         boolean isTruncated = false;
         if (numTokens > maxSequenceLength) {
             switch (truncate) {
                 case FIRST:
                     isTruncated = true;
-                    if (wordPieceTokenSeq2s.size() > maxSequenceLength - 3) {
+                    if (wordPieceTokenIdsSeq2.size() > maxSequenceLength - 3) {
                         throw ExceptionsHelper.badRequestException(
                             "Attempting truncation [{}] but input is too large for the second sequence. "
                                 + "The tokenized input length [{}] exceeds the maximum sequence length [{}], "
                                 + "when taking special tokens into account",
                             truncate.toString(),
-                            wordPieceTokenSeq2s.size(),
+                            wordPieceTokenIdsSeq2.size(),
                             maxSequenceLength - 3
                         );
                     }
-                    wordPieceTokenSeq1s = wordPieceTokenSeq1s.subList(0, maxSequenceLength - 3 - wordPieceTokenSeq2s.size());
+                    wordPieceTokenIdsSeq1 = wordPieceTokenIdsSeq1.subList(0, maxSequenceLength - 3 - wordPieceTokenIdsSeq2.size());
                     break;
                 case SECOND:
                     isTruncated = true;
-                    if (wordPieceTokenSeq1s.size() > maxSequenceLength - 3) {
+                    if (wordPieceTokenIdsSeq1.size() > maxSequenceLength - 3) {
                         throw ExceptionsHelper.badRequestException(
                             "Attempting truncation [{}] but input is too large for the first sequence. "
                                 + "The tokenized input length [{}] exceeds the maximum sequence length [{}], "
                                 + "when taking special tokens into account",
                             truncate.toString(),
-                            wordPieceTokenSeq2s.size(),
+                            wordPieceTokenIdsSeq1.size(),
                             maxSequenceLength - 3
                         );
                     }
-                    wordPieceTokenSeq2s = wordPieceTokenSeq2s.subList(0, maxSequenceLength - 3 - wordPieceTokenSeq1s.size());
+                    wordPieceTokenIdsSeq2 = wordPieceTokenIdsSeq2.subList(0, maxSequenceLength - 3 - wordPieceTokenIdsSeq1.size());
                     break;
                 case NONE:
                     throw ExceptionsHelper.badRequestException(
@@ -214,62 +226,71 @@ public class BertTokenizer implements NlpTokenizer {
             }
             numTokens = maxSequenceLength;
         }
-        String[] tokens = new String[numTokens];
         int[] tokenIds = new int[numTokens];
         int[] tokenMap = new int[numTokens];
 
-        tokens[0] = CLASS_TOKEN;
         tokenIds[0] = vocab.get(CLASS_TOKEN);
         tokenMap[0] = SPECIAL_TOKEN_POSITION;
 
         int i = 1;
-        for (WordPieceTokenizer.TokenAndId tokenAndId : wordPieceTokenSeq1s) {
-            tokens[i] = tokenAndId.getToken();
-            tokenIds[i] = tokenAndId.getId();
+        for (var tokenId : wordPieceTokenIdsSeq1) {
+            tokenIds[i] = tokenId;
             tokenMap[i] = tokenPositionMapSeq1.get(i - 1);
             i++;
         }
-        tokens[i] = SEPARATOR_TOKEN;
         tokenIds[i] = vocab.get(SEPARATOR_TOKEN);
         tokenMap[i] = SPECIAL_TOKEN_POSITION;
         ++i;
 
         int j = 0;
-        for (WordPieceTokenizer.TokenAndId tokenAndId : wordPieceTokenSeq2s) {
-            tokens[i] = tokenAndId.getToken();
-            tokenIds[i] = tokenAndId.getId();
+        for (var tokenId : wordPieceTokenIdsSeq2) {
+            tokenIds[i] = tokenId;
             tokenMap[i] = tokenPositionMapSeq2.get(j);
             i++;
             j++;
         }
 
-        tokens[i] = SEPARATOR_TOKEN;
         tokenIds[i] = vocab.get(SEPARATOR_TOKEN);
         tokenMap[i] = SPECIAL_TOKEN_POSITION;
 
-        return new TokenizationResult.Tokenization(seq1 + seq2, isTruncated, tokens, tokenIds, tokenMap);
+        List<DelimitedToken> tokens = new ArrayList<>(innerResultSeq1.tokens);
+        tokens.addAll(innerResultSeq2.tokens);
+        return new TokenizationResult.Tokenization(seq1 + seq2, tokens, isTruncated, tokenIds, tokenMap);
     }
 
-    private Tuple<List<WordPieceTokenizer.TokenAndId>, List<Integer>> innerTokenize(String seq) {
+    private InnerTokenization innerTokenize(String seq) {
         BasicTokenizer basicTokenizer = new BasicTokenizer(doLowerCase, doTokenizeCjKChars, doStripAccents, neverSplit);
-        List<String> delineatedTokens = basicTokenizer.tokenize(seq);
-        List<WordPieceTokenizer.TokenAndId> wordPieceTokens = new ArrayList<>();
+        var tokenSequences = basicTokenizer.tokenize(seq);
+        List<Integer> wordPieceTokens = new ArrayList<>();
         List<Integer> tokenPositionMap = new ArrayList<>();
 
-        for (int sourceIndex = 0; sourceIndex < delineatedTokens.size(); sourceIndex++) {
-            String token = delineatedTokens.get(sourceIndex);
+        for (int sourceIndex = 0; sourceIndex < tokenSequences.size(); sourceIndex++) {
+            String token = tokenSequences.get(sourceIndex).token;
             if (neverSplit.contains(token)) {
-                wordPieceTokens.add(new WordPieceTokenizer.TokenAndId(token, vocab.getOrDefault(token, vocab.get(UNKNOWN_TOKEN))));
+                wordPieceTokens.add(vocab.getOrDefault(token, vocab.get(UNKNOWN_TOKEN)));
                 tokenPositionMap.add(sourceIndex);
             } else {
-                List<WordPieceTokenizer.TokenAndId> tokens = wordPieceTokenizer.tokenize(token);
+                List<Integer> tokens = wordPieceTokenizer.tokenize(tokenSequences.get(sourceIndex));
                 for (int tokenCount = 0; tokenCount < tokens.size(); tokenCount++) {
                     tokenPositionMap.add(sourceIndex);
                 }
                 wordPieceTokens.addAll(tokens);
             }
         }
-        return Tuple.tuple(wordPieceTokens, tokenPositionMap);
+
+        return new InnerTokenization(tokenSequences, wordPieceTokens, tokenPositionMap);
+    }
+
+    private static class InnerTokenization {
+        List<DelimitedToken> tokens;
+        List<Integer> wordPieceTokenIds;
+        List<Integer> tokenPositionMap;
+
+        InnerTokenization(List<DelimitedToken> tokens, List<Integer> wordPieceTokenIds, List<Integer> tokenPositionMap) {
+            this.tokens = tokens;
+            this.wordPieceTokenIds = wordPieceTokenIds;
+            this.tokenPositionMap = tokenPositionMap;
+        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
@@ -265,7 +265,7 @@ public class BertTokenizer implements NlpTokenizer {
         List<Integer> tokenPositionMap = new ArrayList<>();
 
         for (int sourceIndex = 0; sourceIndex < tokenSequences.size(); sourceIndex++) {
-            String token = tokenSequences.get(sourceIndex).token;
+            String token = tokenSequences.get(sourceIndex).getToken();
             if (neverSplit.contains(token)) {
                 wordPieceTokens.add(vocab.getOrDefault(token, vocab.get(UNKNOWN_TOKEN)));
                 tokenPositionMap.add(sourceIndex);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
+
+import java.util.Objects;
+
+public class DelimitedToken {
+    public int startPos;
+    public int endPos;
+    public String token;
+
+    DelimitedToken(int startPos, int endPos, String token) {
+        this.startPos = startPos;
+        this.endPos = endPos;
+        this.token = token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DelimitedToken that = (DelimitedToken) o;
+        return startPos == that.startPos && endPos == that.endPos && Objects.equals(token, that.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startPos, endPos, token);
+    }
+
+    @Override
+    public String toString() {
+        return "{" + "startPos=" + startPos + ", endPos=" + endPos + ", token=" + token + '}';
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
@@ -10,14 +10,26 @@ package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 import java.util.Objects;
 
 public class DelimitedToken {
-    public int startPos;
-    public int endPos;
-    public String token;
+    private final int startPos;
+    private final int endPos;
+    private final String token;
 
     DelimitedToken(int startPos, int endPos, String token) {
         this.startPos = startPos;
         this.endPos = endPos;
         this.token = token;
+    }
+
+    public int getStartPos() {
+        return startPos;
+    }
+
+    public int getEndPos() {
+        return endPos;
+    }
+
+    public String getToken() {
+        return token;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/DelimitedToken.java
@@ -7,9 +7,29 @@
 
 package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class DelimitedToken {
+
+    /**
+     * Merges the list of tokens.
+     *
+     * Assumes that the tokens are in order.
+     *
+     * @param tokens
+     * @return The merged token
+     */
+    public static DelimitedToken mergeTokens(List<DelimitedToken> tokens) {
+        if (tokens.size() == 1) {
+            return tokens.get(0);
+        }
+
+        String merged = tokens.stream().map(DelimitedToken::getToken).collect(Collectors.joining());
+        return new DelimitedToken(tokens.get(0).getStartPos(), tokens.get(tokens.size() - 1).getEndPos(), merged);
+    }
+
     private final int startPos;
     private final int endPos;
     private final String token;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
@@ -30,7 +30,11 @@ public interface NlpTokenizer {
 
     NlpTask.RequestBuilder requestBuilder();
 
-    OptionalInt getPadToken();
+    OptionalInt getPadTokenId();
+
+    OptionalInt getMaskTokenId();
+
+    String getMaskToken();
 
     static NlpTokenizer build(Vocabulary vocabulary, Tokenization params) {
         ExceptionsHelper.requireNonNull(params, TOKENIZATION);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/TokenizationResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/TokenizationResult.java
@@ -33,9 +33,9 @@ public class TokenizationResult {
         return tokenizations;
     }
 
-    public void addTokenization(String input, boolean isTruncated, String[] tokens, int[] tokenIds, int[] tokenMap) {
+    public void addTokenization(String input, boolean isTruncated, List<DelimitedToken> tokens, int[] tokenIds, int[] tokenMap) {
         maxLength = Math.max(maxLength, tokenIds.length);
-        tokenizations.add(new Tokenization(input, isTruncated, tokens, tokenIds, tokenMap));
+        tokenizations.add(new Tokenization(input, tokens, isTruncated, tokenIds, tokenMap));
     }
 
     public void addTokenization(Tokenization tokenization) {
@@ -49,16 +49,15 @@ public class TokenizationResult {
 
     public static class Tokenization {
 
-        private final String inputSeqs;
-        private final String[] tokens;
+        private final String input;
+        private final List<DelimitedToken> tokens;
         private final int[] tokenIds;
         private final int[] tokenMap;
         private final boolean truncated;
 
-        public Tokenization(String input, boolean truncated, String[] tokens, int[] tokenIds, int[] tokenMap) {
-            assert tokens.length == tokenIds.length;
+        public Tokenization(String input, List<DelimitedToken> tokens, boolean truncated, int[] tokenIds, int[] tokenMap) {
             assert tokenIds.length == tokenMap.length;
-            this.inputSeqs = input;
+            this.input = input;
             this.tokens = tokens;
             this.tokenIds = tokenIds;
             this.tokenMap = tokenMap;
@@ -66,16 +65,7 @@ public class TokenizationResult {
         }
 
         /**
-         * The token strings from the tokenization process
-         *
-         * @return A list of tokens
-         */
-        public String[] getTokens() {
-            return tokens;
-        }
-
-        /**
-         * The integer values of the tokens in {@link #getTokens()}
+         * The integer values of the tokens}
          *
          * @return A list of token Ids
          */
@@ -95,7 +85,11 @@ public class TokenizationResult {
         }
 
         public String getInput() {
-            return inputSeqs;
+            return input;
+        }
+
+        public List<DelimitedToken> getTokens() {
+            return tokens;
         }
 
         public boolean isTruncated() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/WordPieceTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/WordPieceTokenizer.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -25,26 +26,7 @@ public class WordPieceTokenizer {
     private final String unknownToken;
     private final int maxInputCharsPerWord;
 
-    public static class TokenAndId {
-        private final String token;
-        private final int id;
-
-        TokenAndId(String token, int id) {
-            this.token = token;
-            this.id = id;
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public String getToken() {
-            return token;
-        }
-    }
-
     /**
-     *
      * @param vocab The token vocabulary
      * @param unknownToken If not found in the vocabulary
      * @param maxInputCharsPerWord Inputs tokens longer than this are 'unknown'
@@ -58,63 +40,55 @@ public class WordPieceTokenizer {
     /**
      * Wordpiece tokenize the input text.
      *
-     * @param text A single token or whitespace separated tokens.
-     *             Input should have been normalized by the {@link BasicTokenizer}.
-     * @return List of tokens
+     * @param token Word to tokenize
+     * @return List of token IDs
      */
-    public List<TokenAndId> tokenize(String text) {
-        String[] tokens = BasicTokenizer.whiteSpaceTokenize(text);
+    public List<Integer> tokenize(DelimitedToken token) {
 
-        List<TokenAndId> output = new ArrayList<>();
-        for (String token : tokens) {
-            if (token.length() > maxInputCharsPerWord) {
-                assert vocab.containsKey(unknownToken);
-                output.add(new TokenAndId(unknownToken, vocab.get(unknownToken)));
-                continue;
-            }
+        if (token.token.length() > maxInputCharsPerWord) {
+            assert vocab.containsKey(unknownToken);
+            return Collections.singletonList(vocab.get(unknownToken));
+        }
 
-            boolean isBad = false;
-            int start = 0;
-            List<TokenAndId> subTokens = new ArrayList<>();
-            int length = token.length();
-            while (start < length) {
-                int end = length;
+        List<Integer> output = new ArrayList<>();
+        boolean isBad = false;
+        int start = 0;
+        int length = token.token.length();
+        while (start < length) {
+            int end = length;
 
-                String currentValidSubStr = null;
+            String currentValidSubStr = null;
 
-                while (start < end) {
-                    String subStr;
-                    if (start > 0) {
-                        subStr = CONTINUATION + token.substring(start, end);
-                    } else {
-                        subStr = token.substring(start, end);
-                    }
-
-                    if (vocab.containsKey(subStr)) {
-                        currentValidSubStr = subStr;
-                        break;
-                    }
-
-                    end--;
+            while (start < end) {
+                String subStr;
+                if (start > 0) {
+                    subStr = CONTINUATION + token.token.substring(start, end);
+                } else {
+                    subStr = token.token.substring(start, end);
                 }
 
-                if (currentValidSubStr == null) {
-                    isBad = true;
+                if (vocab.containsKey(subStr)) {
+                    currentValidSubStr = subStr;
                     break;
                 }
 
-                subTokens.add(new TokenAndId(currentValidSubStr, vocab.get(currentValidSubStr)));
-
-                start = end;
+                end--;
             }
 
-            if (isBad) {
-                output.add(new TokenAndId(unknownToken, vocab.get(unknownToken)));
-            } else {
-                output.addAll(subTokens);
+            if (currentValidSubStr == null) {
+                isBad = true;
+                break;
             }
+
+            output.add(vocab.get(currentValidSubStr));
+
+            start = end;
         }
 
-        return output;
+        if (isBad) {
+            return Collections.singletonList(vocab.get(unknownToken));
+        } else {
+            return output;
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/WordPieceTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/WordPieceTokenizer.java
@@ -45,7 +45,7 @@ public class WordPieceTokenizer {
      */
     public List<Integer> tokenize(DelimitedToken token) {
 
-        if (token.token.length() > maxInputCharsPerWord) {
+        if (token.getToken().length() > maxInputCharsPerWord) {
             assert vocab.containsKey(unknownToken);
             return Collections.singletonList(vocab.get(unknownToken));
         }
@@ -53,7 +53,7 @@ public class WordPieceTokenizer {
         List<Integer> output = new ArrayList<>();
         boolean isBad = false;
         int start = 0;
-        int length = token.token.length();
+        int length = token.getToken().length();
         while (start < length) {
             int end = length;
 
@@ -62,9 +62,9 @@ public class WordPieceTokenizer {
             while (start < end) {
                 String subStr;
                 if (start > 0) {
-                    subStr = CONTINUATION + token.token.substring(start, end);
+                    subStr = CONTINUATION + token.getToken().substring(start, end);
                 } else {
-                    subStr = token.token.substring(start, end);
+                    subStr = token.getToken().substring(start, end);
                 }
 
                 if (vocab.containsKey(subStr)) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
@@ -14,18 +14,22 @@ import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BasicTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.DelimitedToken;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FillMaskProcessorTests extends ESTestCase {
 
@@ -45,17 +49,23 @@ public class FillMaskProcessorTests extends ESTestCase {
         String input = "The capital of " + BertTokenizer.MASK_TOKEN + " is Paris";
 
         List<String> vocab = Arrays.asList("The", "capital", "of", BertTokenizer.MASK_TOKEN, "is", "Paris", "France");
-        String[] tokens = input.split(" ");
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
+
         int[] tokenMap = new int[] { 0, 1, 2, 3, 4, 5 };
         int[] tokenIds = new int[] { 0, 1, 2, 3, 4, 5 };
 
         TokenizationResult tokenization = new TokenizationResult(vocab);
         tokenization.addTokenization(input, false, tokens, tokenIds, tokenMap);
 
+        BertTokenizer tokenizer = mock(BertTokenizer.class);
+        when(tokenizer.getMaskToken()).thenReturn(BertTokenizer.MASK_TOKEN);
+        when(tokenizer.getMaskTokenId()).thenReturn(OptionalInt.of(3));
+
         String resultsField = randomAlphaOfLength(10);
         FillMaskResults result = (FillMaskResults) FillMaskProcessor.processResult(
             tokenization,
             new PyTorchResult("1", scores, 0L, null),
+            tokenizer,
             4,
             resultsField
         );
@@ -72,12 +82,15 @@ public class FillMaskProcessorTests extends ESTestCase {
     }
 
     public void testProcessResults_GivenMissingTokens() {
+        BertTokenizer tokenizer = mock(BertTokenizer.class);
+        when(tokenizer.getMaskToken()).thenReturn("[MASK]");
+
         TokenizationResult tokenization = new TokenizationResult(Collections.emptyList());
-        tokenization.addTokenization("", false, new String[] {}, new int[] {}, new int[] {});
+        tokenization.addTokenization("", false, Collections.emptyList(), new int[] {}, new int[] {});
 
         PyTorchResult pyTorchResult = new PyTorchResult("1", new double[][][] { { {} } }, 0L, null);
         assertThat(
-            FillMaskProcessor.processResult(tokenization, pyTorchResult, 5, randomAlphaOfLength(10)),
+            FillMaskProcessor.processResult(tokenization, pyTorchResult, tokenizer, 5, randomAlphaOfLength(10)),
             instanceOf(WarningInferenceResults.class)
         );
     }
@@ -85,8 +98,10 @@ public class FillMaskProcessorTests extends ESTestCase {
     public void testValidate_GivenMissingMaskToken() {
         List<String> input = List.of("The capital of France is Paris");
 
+        BertTokenizer tokenizer = mock(BertTokenizer.class);
+        when(tokenizer.getMaskToken()).thenReturn("[MASK]");
         FillMaskConfig config = new FillMaskConfig(new VocabularyConfig("test-index"), null, null, null);
-        FillMaskProcessor processor = new FillMaskProcessor(mock(BertTokenizer.class), config);
+        FillMaskProcessor processor = new FillMaskProcessor(tokenizer, config);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.validateInputs(input));
         assertThat(e.getMessage(), containsString("no [MASK] token could be found"));
@@ -95,8 +110,11 @@ public class FillMaskProcessorTests extends ESTestCase {
     public void testProcessResults_GivenMultipleMaskTokens() {
         List<String> input = List.of("The capital of [MASK] is [MASK]");
 
+        BertTokenizer tokenizer = mock(BertTokenizer.class);
+        when(tokenizer.getMaskToken()).thenReturn("[MASK]");
+
         FillMaskConfig config = new FillMaskConfig(new VocabularyConfig("test-index"), null, null, null);
-        FillMaskProcessor processor = new FillMaskProcessor(mock(BertTokenizer.class), config);
+        FillMaskProcessor processor = new FillMaskProcessor(tokenizer, config);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.validateInputs(input));
         assertThat(e.getMessage(), containsString("only one [MASK] token should exist in the input"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -16,7 +16,9 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BasicTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.DelimitedToken;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 
 import java.util.ArrayList;
@@ -160,23 +162,26 @@ public class NerProcessorTests extends ESTestCase {
     }
 
     public void testGroupTaggedTokens() {
-        List<NerProcessor.NerResultProcessor.TaggedToken> tokens = new ArrayList<>();
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Hi", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Sarah", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Jessica", NerProcessor.IobTag.I_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("I", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("live", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("in", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Manchester", NerProcessor.IobTag.B_LOC, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("and", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("work", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("for", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Elastic", NerProcessor.IobTag.B_ORG, 1.0));
+        String input = "Hi Sarah Jessica, I live in Manchester and work for Elastic";
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
+        assertThat(tokens, hasSize(12));
 
-        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(
-            tokens,
-            "Hi Sarah Jessica, I live in Manchester and work for Elastic"
-        );
+        List<NerProcessor.NerResultProcessor.TaggedToken> taggedTokens = new ArrayList<>();
+        int i = 0;
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_LOC, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_ORG, 1.0));
+
+        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(taggedTokens, input);
         assertThat(entityGroups, hasSize(3));
         assertThat(entityGroups.get(0).getClassName(), equalTo("PER"));
         assertThat(entityGroups.get(0).getEntity(), equalTo("Sarah Jessica"));
@@ -187,23 +192,32 @@ public class NerProcessorTests extends ESTestCase {
     }
 
     public void testGroupTaggedTokens_GivenNoEntities() {
-        List<NerProcessor.NerResultProcessor.TaggedToken> tokens = new ArrayList<>();
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Hi", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("there", NerProcessor.IobTag.O, 1.0));
+        String input = "Hi there";
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
 
-        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(tokens, "Hi there");
+        List<NerProcessor.NerResultProcessor.TaggedToken> taggedTokens = new ArrayList<>();
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(0), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(1), NerProcessor.IobTag.O, 1.0));
+
+        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(taggedTokens, input);
         assertThat(entityGroups, is(empty()));
     }
 
     public void testGroupTaggedTokens_GivenConsecutiveEntities() {
-        List<NerProcessor.NerResultProcessor.TaggedToken> tokens = new ArrayList<>();
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Rita", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Sue", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("and", NerProcessor.IobTag.O, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("Bob", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("too", NerProcessor.IobTag.O, 1.0));
+        String input = "Rita, Sue, and Bob too";
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
 
-        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(tokens, "Rita, Sue, and Bob too");
+        List<NerProcessor.NerResultProcessor.TaggedToken> taggedTokens = new ArrayList<>();
+        int i = 0;
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+
+        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(taggedTokens, input);
         assertThat(entityGroups, hasSize(3));
         assertThat(entityGroups.get(0).getClassName(), equalTo("PER"));
         assertThat(entityGroups.get(0).getEntity(), equalTo("Rita"));
@@ -214,23 +228,58 @@ public class NerProcessorTests extends ESTestCase {
     }
 
     public void testGroupTaggedTokens_GivenConsecutiveContinuingEntities() {
-        List<NerProcessor.NerResultProcessor.TaggedToken> tokens = new ArrayList<>();
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("FirstName", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("SecondName", NerProcessor.IobTag.I_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("NextPerson", NerProcessor.IobTag.B_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("NextPersonSecondName", NerProcessor.IobTag.I_PER, 1.0));
-        tokens.add(new NerProcessor.NerResultProcessor.TaggedToken("something_else", NerProcessor.IobTag.B_ORG, 1.0));
+        String input = "FirstName SecondName, NextPerson NextPersonSecondName. something_else";
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
 
-        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(
-            tokens,
-            "FirstName SecondName, NextPerson NextPersonSecondName. something_else"
-        );
+        List<NerProcessor.NerResultProcessor.TaggedToken> taggedTokens = new ArrayList<>();
+        int i = 0;
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.B_ORG, 1.0));
+
+        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(taggedTokens, input);
         assertThat(entityGroups, hasSize(3));
         assertThat(entityGroups.get(0).getClassName(), equalTo("PER"));
         assertThat(entityGroups.get(0).getEntity(), equalTo("FirstName SecondName"));
         assertThat(entityGroups.get(1).getClassName(), equalTo("PER"));
         assertThat(entityGroups.get(1).getEntity(), equalTo("NextPerson NextPersonSecondName"));
         assertThat(entityGroups.get(2).getClassName(), equalTo("ORG"));
+    }
+
+    public void testEntityContainsPunctuation() {
+        String input = "Alexander, my name is Benjamin Trent, I work at Acme Inc..";
+        List<DelimitedToken> tokens = new BasicTokenizer(randomBoolean(), randomBoolean(), randomBoolean()).tokenize(input);
+
+        List<NerProcessor.NerResultProcessor.TaggedToken> taggedTokens = new ArrayList<>();
+        int i = 0;
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_PER, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_ORG, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_ORG, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.I_ORG, 1.0));
+        taggedTokens.add(new NerProcessor.NerResultProcessor.TaggedToken(tokens.get(i++), NerProcessor.IobTag.O, 1.0));
+        assertEquals(tokens.size(), taggedTokens.size());
+
+        List<NerResults.EntityGroup> entityGroups = NerProcessor.NerResultProcessor.groupTaggedTokens(taggedTokens, input);
+        assertThat(entityGroups, hasSize(3));
+        assertThat(entityGroups.get(0).getClassName(), equalTo("PER"));
+        assertThat(entityGroups.get(0).getEntity(), equalTo("Alexander"));
+        assertThat(entityGroups.get(1).getClassName(), equalTo("PER"));
+        assertThat(entityGroups.get(1).getEntity(), equalTo("Benjamin Trent"));
+        assertThat(entityGroups.get(2).getClassName(), equalTo("ORG"));
+        assertThat(entityGroups.get(2).getEntity(), equalTo("Acme Inc."));
     }
 
     public void testAnnotatedTextBuilder() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
@@ -198,18 +198,37 @@ public class BasicTokenizerTests extends ESTestCase {
     }
 
     public void testWhitespaceTokenize() {
-        List<DelimitedToken> delimitedTokens = BasicTokenizer.whiteSpaceTokenize("hello! how are you?");
-        assertThat(delimitedTokens, hasSize(4));
-        assertThat(tokenStrings(delimitedTokens), contains("hello!", "how", "are", "you?"));
+        {
+            List<DelimitedToken> delimitedTokens = BasicTokenizer.whiteSpaceTokenize("hello! how are you?");
+            assertThat(delimitedTokens, hasSize(4));
+            assertThat(tokenStrings(delimitedTokens), contains("hello!", "how", "are", "you?"));
 
-        assertThat(delimitedTokens.get(0), equalTo(new DelimitedToken(0, 7, "hello!")));
-        assertThat(delimitedTokens.get(1), equalTo(new DelimitedToken(7, 11, "how")));
-        assertThat(delimitedTokens.get(2), equalTo(new DelimitedToken(11, 15, "are")));
-        assertThat(delimitedTokens.get(3), equalTo(new DelimitedToken(15, 19, "you?")));
+            assertThat(delimitedTokens.get(0), equalTo(new DelimitedToken(0, 6, "hello!")));
+            assertThat(delimitedTokens.get(1), equalTo(new DelimitedToken(7, 10, "how")));
+            assertThat(delimitedTokens.get(2), equalTo(new DelimitedToken(11, 14, "are")));
+            assertThat(delimitedTokens.get(3), equalTo(new DelimitedToken(15, 19, "you?")));
+        }
+        {
+            List<DelimitedToken> delimitedTokens = BasicTokenizer.whiteSpaceTokenize("   leading whitespace");
+            assertThat(delimitedTokens, hasSize(2));
+            assertThat(tokenStrings(delimitedTokens), contains("leading", "whitespace"));
+
+            assertThat(delimitedTokens.get(0), equalTo(new DelimitedToken(3, 10, "leading")));
+            assertThat(delimitedTokens.get(1), equalTo(new DelimitedToken(11, 21, "whitespace")));
+        }
+        {
+            List<DelimitedToken> delimitedTokens = BasicTokenizer.whiteSpaceTokenize("double  spaced  text ");
+            assertThat(delimitedTokens, hasSize(3));
+            assertThat(tokenStrings(delimitedTokens), contains("double", "spaced", "text"));
+
+            assertThat(delimitedTokens.get(0), equalTo(new DelimitedToken(0, 6, "double")));
+            assertThat(delimitedTokens.get(1), equalTo(new DelimitedToken(8, 14, "spaced")));
+            assertThat(delimitedTokens.get(2), equalTo(new DelimitedToken(16, 20, "text")));
+        }
     }
 
     private List<String> tokenStrings(List<DelimitedToken> tokens) {
-        return tokens.stream().map(t -> t.token).collect(Collectors.toList());
+        return tokens.stream().map(DelimitedToken::getToken).collect(Collectors.toList());
     }
 
     private DelimitedToken makeToken(String str) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
@@ -11,9 +11,11 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 
 /**
@@ -24,91 +26,103 @@ public class BasicTokenizerTests extends ESTestCase {
 
     public void testLowerCase() {
         BasicTokenizer tokenizer = new BasicTokenizer();
-        List<String> tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU?  ");
-        assertThat(tokens, contains("hello", "!", "how", "are", "you", "?"));
+        var tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU?  ");
+        assertThat(tokenStrings(tokens), contains("hello", "!", "how", "are", "you", "?"));
 
         tokens = tokenizer.tokenize("H\u00E9llo");
-        assertThat(tokens, contains("hello"));
+        assertThat(tokenStrings(tokens), contains("hello"));
     }
 
     public void testLowerCaseWithoutStripAccents() {
         BasicTokenizer tokenizer = new BasicTokenizer(true, true, false);
-        List<String> tokens = tokenizer.tokenize(" \tHäLLo!how  \n Are yoU?  ");
-        assertThat(tokens, contains("hällo", "!", "how", "are", "you", "?"));
+        var tokens = tokenizer.tokenize(" \tHäLLo!how  \n Are yoU?  ");
+        assertThat(tokenStrings(tokens), contains("hällo", "!", "how", "are", "you", "?"));
 
         tokens = tokenizer.tokenize("H\u00E9llo");
-        assertThat(tokens, contains("h\u00E9llo"));
+        assertThat(tokenStrings(tokens), contains("h\u00E9llo"));
     }
 
     public void testLowerCaseStripAccentsDefault() {
         BasicTokenizer tokenizer = new BasicTokenizer(true, true);
-        List<String> tokens = tokenizer.tokenize(" \tHäLLo!how  \n Are yoU?  ");
-        assertThat(tokens, contains("hallo", "!", "how", "are", "you", "?"));
+        var tokens = tokenizer.tokenize(" \tHäLLo!how  \n Are yoU?  ");
+        assertThat(tokenStrings(tokens), contains("hallo", "!", "how", "are", "you", "?"));
 
         tokens = tokenizer.tokenize("H\u00E9llo");
-        assertThat(tokens, contains("hello"));
+        assertThat(tokenStrings(tokens), contains("hello"));
     }
 
     public void testNoLower() {
-        List<String> tokens = new BasicTokenizer(false, true, false).tokenize(" \tHäLLo!how  \n Are yoU?  ");
-        assertThat(tokens, contains("HäLLo", "!", "how", "Are", "yoU", "?"));
+        var tokens = new BasicTokenizer(false, true, false).tokenize(" \tHäLLo!how  \n Are yoU?  ");
+        assertThat(tokenStrings(tokens), contains("HäLLo", "!", "how", "Are", "yoU", "?"));
     }
 
     public void testNoLowerStripAccents() {
-        List<String> tokens = new BasicTokenizer(false, true, true).tokenize(" \tHäLLo!how  \n Are yoU?  ");
-        assertThat(tokens, contains("HaLLo", "!", "how", "Are", "yoU", "?"));
+        var tokens = new BasicTokenizer(false, true, true).tokenize(" \tHäLLo!how  \n Are yoU?  ");
+        assertThat(tokenStrings(tokens), contains("HaLLo", "!", "how", "Are", "yoU", "?"));
     }
 
     public void testNeverSplit() {
         BasicTokenizer tokenizer = new BasicTokenizer(false, false, false, Collections.singleton("[UNK]"));
-        List<String> tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]");
-        assertThat(tokens, contains("HeLLo", "!", "how", "Are", "yoU", "?", "[UNK]"));
+        var tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]");
+        assertThat(tokenStrings(tokens), contains("HeLLo", "!", "how", "Are", "yoU", "?", "[UNK]"));
 
         tokens = tokenizer.tokenize("Hello [UNK].");
-        assertThat(tokens, contains("Hello", "[UNK]", "."));
+        assertThat(tokenStrings(tokens), contains("Hello", "[UNK]", "."));
 
         tokens = tokenizer.tokenize("Hello [UNK]?");
-        assertThat(tokens, contains("Hello", "[UNK]", "?"));
+        assertThat(tokenStrings(tokens), contains("Hello", "[UNK]", "?"));
 
         tokens = tokenizer.tokenize("Hello [UNK]!!");
-        assertThat(tokens, contains("Hello", "[UNK]", "!", "!"));
+        assertThat(tokenStrings(tokens), contains("Hello", "[UNK]", "!", "!"));
 
         tokens = tokenizer.tokenize("Hello-[UNK]");
-        assertThat(tokens, contains("Hello", "-", "[UNK]"));
+        assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]"));
         tokens = tokenizer.tokenize("Hello-[UNK][UNK]");
-        assertThat(tokens, contains("Hello", "-", "[UNK]", "[UNK]"));
+        assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]", "[UNK]"));
+        assertThat(tokenStrings(tokens), contains("Hello", "[UNK]", "!", "!"));
     }
 
     public void testSplitOnPunctuation() {
-        List<String> tokens = BasicTokenizer.splitOnPunctuation("hi!");
-        assertThat(tokens, contains("hi", "!"));
+        var tokens = BasicTokenizer.splitOnPunctuation(new DelimitedToken(0, 3, "hi!"));
+        assertEquals(new DelimitedToken(0, 2, "hi"), tokens.get(0));
+        assertEquals(new DelimitedToken(2, 3, "!"), tokens.get(1));
 
-        tokens = BasicTokenizer.splitOnPunctuation("hi.");
-        assertThat(tokens, contains("hi", "."));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("hi."));
+        assertEquals(new DelimitedToken(0, 2, "hi"), tokens.get(0));
+        assertEquals(new DelimitedToken(2, 3, "."), tokens.get(1));
 
-        tokens = BasicTokenizer.splitOnPunctuation("!hi");
-        assertThat(tokens, contains("!", "hi"));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("!hi"));
+        assertEquals(new DelimitedToken(0, 1, "!"), tokens.get(0));
+        assertEquals(new DelimitedToken(1, 3, "hi"), tokens.get(1));
 
-        tokens = BasicTokenizer.splitOnPunctuation("don't");
-        assertThat(tokens, contains("don", "'", "t"));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("don't"));
+        assertEquals(new DelimitedToken(0, 3, "don"), tokens.get(0));
+        assertEquals(new DelimitedToken(3, 4, "'"), tokens.get(1));
+        assertEquals(new DelimitedToken(4, 5, "t"), tokens.get(2));
 
-        tokens = BasicTokenizer.splitOnPunctuation("!!hi");
-        assertThat(tokens, contains("!", "!", "hi"));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("!!hi"));
+        assertEquals(new DelimitedToken(0, 1, "!"), tokens.get(0));
+        assertEquals(new DelimitedToken(1, 2, "!"), tokens.get(1));
+        assertEquals(new DelimitedToken(2, 4, "hi"), tokens.get(2));
 
-        tokens = BasicTokenizer.splitOnPunctuation("[hi]");
-        assertThat(tokens, contains("[", "hi", "]"));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("[hi]"));
+        assertEquals(new DelimitedToken(0, 1, "["), tokens.get(0));
+        assertEquals(new DelimitedToken(1, 3, "hi"), tokens.get(1));
+        assertEquals(new DelimitedToken(3, 4, "]"), tokens.get(2));
 
-        tokens = BasicTokenizer.splitOnPunctuation("hi.");
-        assertThat(tokens, contains("hi", "."));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("!!"));
+        assertEquals(new DelimitedToken(0, 1, "!"), tokens.get(0));
+        assertEquals(new DelimitedToken(1, 2, "!"), tokens.get(1));
 
-        tokens = BasicTokenizer.splitOnPunctuation("!!");
-        assertThat(tokens, contains("!", "!"));
+        tokens = BasicTokenizer.splitOnPunctuation(makeToken("elastic’s"));
+        assertEquals(new DelimitedToken(0, 7, "elastic"), tokens.get(0));
+        assertEquals(new DelimitedToken(7, 8, "’"), tokens.get(1));
+        assertEquals(new DelimitedToken(8, 9, "s"), tokens.get(2));
 
-        tokens = BasicTokenizer.splitOnPunctuation("elastic’s");
-        assertThat(tokens, contains("elastic", "’", "s"));
-
-        tokens = BasicTokenizer.splitOnPunctuation("elastic‘s");
-        assertThat(tokens, contains("elastic", "‘", "s"));
+        tokens = BasicTokenizer.splitOnPunctuation(new DelimitedToken(4, 13, "elastic’s"));
+        assertEquals(new DelimitedToken(4, 11, "elastic"), tokens.get(0));
+        assertEquals(new DelimitedToken(11, 12, "’"), tokens.get(1));
+        assertEquals(new DelimitedToken(12, 13, "s"), tokens.get(2));
     }
 
     public void testStripAccents() {
@@ -123,18 +137,13 @@ public class BasicTokenizerTests extends ESTestCase {
     }
 
     public void testTokenizeChinese() {
-        List<String> tokens = new BasicTokenizer().tokenize("ah\u535A\u63A8zz");
-        assertThat(tokens, contains("ah", "\u535A", "\u63A8", "zz"));
+        var tokens = new BasicTokenizer().tokenize("ah\u535A\u63A8zz");
+        assertThat(tokenStrings(tokens), contains("ah", "\u535A", "\u63A8", "zz"));
     }
 
     public void testCleanText() {
         assertEquals("change these chars to spaces", BasicTokenizer.cleanText("change\tthese chars\rto\nspaces"));
         assertEquals("filter control chars", BasicTokenizer.cleanText("\u0000filter \uFFFDcontrol chars\u0005"));
-    }
-
-    public void testWhiteSpaceTokenize() {
-        assertThat(BasicTokenizer.whiteSpaceTokenize("nochange"), arrayContaining("nochange"));
-        assertThat(BasicTokenizer.whiteSpaceTokenize(" some  change "), arrayContaining("some", "", "change"));
     }
 
     public void testIsWhitespace() {
@@ -187,4 +196,24 @@ public class BasicTokenizerTests extends ESTestCase {
         assertTrue(BasicTokenizer.isCjkChar(0x2F800));
         assertFalse(BasicTokenizer.isCjkChar(0x2FA20));
     }
+
+    public void testWhitespaceTokenize() {
+        List<DelimitedToken> delimitedTokens = BasicTokenizer.whiteSpaceTokenize("hello! how are you?");
+        assertThat(delimitedTokens, hasSize(4));
+        assertThat(tokenStrings(delimitedTokens), contains("hello!", "how", "are", "you?"));
+
+        assertThat(delimitedTokens.get(0), equalTo(new DelimitedToken(0, 7, "hello!")));
+        assertThat(delimitedTokens.get(1), equalTo(new DelimitedToken(7, 11, "how")));
+        assertThat(delimitedTokens.get(2), equalTo(new DelimitedToken(11, 15, "are")));
+        assertThat(delimitedTokens.get(3), equalTo(new DelimitedToken(15, 19, "you?")));
+    }
+
+    private List<String> tokenStrings(List<DelimitedToken> tokens) {
+        return tokens.stream().map(t -> t.token).collect(Collectors.toList());
+    }
+
+    private DelimitedToken makeToken(String str) {
+        return new DelimitedToken(0, str.length(), str);
+    }
+
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
@@ -79,7 +79,6 @@ public class BasicTokenizerTests extends ESTestCase {
         assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]"));
         tokens = tokenizer.tokenize("Hello-[UNK][UNK]");
         assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]", "[UNK]"));
-        assertThat(tokenStrings(tokens), contains("Hello", "[UNK]", "!", "!"));
     }
 
     public void testSplitOnPunctuation() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -16,8 +16,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -45,6 +46,10 @@ public class BertTokenizerTests extends ESTestCase {
         "with"
     );
 
+    private List<String> tokenStrings(List<DelimitedToken> tokens) {
+        return tokens.stream().map(t -> t.token).collect(Collectors.toList());
+    }
+
     public void testTokenize() {
         BertTokenizer tokenizer = BertTokenizer.builder(
             TEST_CASED_VOCAB,
@@ -52,7 +57,7 @@ public class BertTokenizerTests extends ESTestCase {
         ).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", "fun"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("Elasticsearch", "fun"));
         assertArrayEquals(new int[] { 0, 1, 3 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1 }, tokenization.getTokenMap());
     }
@@ -90,18 +95,21 @@ public class BertTokenizerTests extends ESTestCase {
             "Elasticsearch fun with Pancake and Godzilla",
             Tokenization.Truncate.FIRST
         );
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", "fun", "with", "Pancake"));
+        assertArrayEquals(new int[] { 0, 1, 3, 18, 17 }, tokenization.getTokenIds());
 
-        tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 5, Tokenization.Truncate.FIRST)).build();
-        tokenization = tokenizer.tokenize("Elasticsearch fun with Pancake and Godzilla", Tokenization.Truncate.FIRST);
-        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "Elastic", "##search", "fun", "[SEP]"));
+        BertTokenizer tokenizerWithSpecialTokens = BertTokenizer.builder(
+            TEST_CASED_VOCAB,
+            new BertTokenization(null, true, 5, Tokenization.Truncate.FIRST)
+        ).build();
+        tokenization = tokenizerWithSpecialTokens.tokenize("Elasticsearch fun with Pancake and Godzilla", Tokenization.Truncate.FIRST);
+        assertArrayEquals(new int[] { 12, 0, 1, 3, 13 }, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { -1, 0, 0, 1, -1 }, tokenization.getTokenMap());
     }
 
     public void testTokenizeAppendSpecialTokens() {
         BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, Tokenization.createDefault()).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "Elastic", "##search", "fun", "[SEP]"));
         assertArrayEquals(new int[] { 12, 0, 1, 3, 13 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { -1, 0, 0, 1, -1 }, tokenization.getTokenMap());
     }
@@ -118,7 +126,7 @@ public class BertTokenizerTests extends ESTestCase {
             "Elasticsearch " + specialToken + " fun",
             Tokenization.Truncate.NONE
         );
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", specialToken, "fun"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("Elasticsearch", specialToken, "fun"));
         assertArrayEquals(new int[] { 0, 1, 15, 3 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1, 2 }, tokenization.getTokenMap());
     }
@@ -131,12 +139,12 @@ public class BertTokenizerTests extends ESTestCase {
             ).setDoLowerCase(false).setWithSpecialTokens(false).build();
 
             TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun", Tokenization.Truncate.NONE);
-            assertThat(tokenization.getTokens(), arrayContaining(BertTokenizer.UNKNOWN_TOKEN, "fun"));
             assertArrayEquals(new int[] { 3, 2 }, tokenization.getTokenIds());
             assertArrayEquals(new int[] { 0, 1 }, tokenization.getTokenMap());
 
             tokenization = tokenizer.tokenize("elasticsearch fun", Tokenization.Truncate.NONE);
-            assertThat(tokenization.getTokens(), arrayContaining("elastic", "##search", "fun"));
+            assertArrayEquals(new int[] { 0, 1, 2 }, tokenization.getTokenIds());
+            assertArrayEquals(new int[] { 0, 0, 1 }, tokenization.getTokenMap());
         }
 
         {
@@ -146,7 +154,7 @@ public class BertTokenizerTests extends ESTestCase {
                 .build();
 
             TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch fun", Tokenization.Truncate.NONE);
-            assertThat(tokenization.getTokens(), arrayContaining("elastic", "##search", "fun"));
+            assertArrayEquals(new int[] { 0, 1, 2 }, tokenization.getTokenIds());
         }
     }
 
@@ -154,12 +162,11 @@ public class BertTokenizerTests extends ESTestCase {
         BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, Tokenization.createDefault()).setWithSpecialTokens(false).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("Elasticsearch, fun.", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", ",", "fun", "."));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("Elasticsearch", ",", "fun", "."));
         assertArrayEquals(new int[] { 0, 1, 11, 3, 10 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1, 2, 3 }, tokenization.getTokenMap());
 
         tokenization = tokenizer.tokenize("Elasticsearch, fun [MASK].", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search", ",", "fun", "[MASK]", "."));
         assertArrayEquals(new int[] { 0, 1, 11, 3, 14, 10 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1, 2, 3, 4 }, tokenization.getTokenMap());
     }
@@ -171,15 +178,15 @@ public class BertTokenizerTests extends ESTestCase {
         ).setWithSpecialTokens(true).setNeverSplit(Set.of("[MASK]")).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("This is [MASK]-tastic!", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"));
 
         tokenization = tokenizer.tokenize("This is sub~[MASK]!", Tokenization.Truncate.NONE);
-        assertThat(tokenization.getTokens(), arrayContaining("[CLS]", "This", "is", "sub", "~", "[MASK]", "!", "[SEP]"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("[CLS]", "This", "is", "sub", "~", "[MASK]", "!", "[SEP]"));
 
         tokenization = tokenizer.tokenize("This is sub,[MASK].tastic!", Tokenization.Truncate.NONE);
         assertThat(
-            tokenization.getTokens(),
-            arrayContaining("[CLS]", "This", "is", "sub", ",", "[MASK]", ".", "ta", "##stic", "!", "[SEP]")
+            tokenStrings(tokenization.getTokens()),
+            contains("[CLS]", "This", "is", "sub", ",", "[MASK]", ".", "ta", "##stic", "!", "[SEP]")
         );
     }
 
@@ -200,22 +207,18 @@ public class BertTokenizerTests extends ESTestCase {
         assertThat(tr.getTokenizations(), hasSize(4));
 
         TokenizationResult.Tokenization tokenization = tr.getTokenizations().get(0);
-        assertThat(tokenization.getTokens(), arrayContaining("Elastic", "##search"));
         assertArrayEquals(new int[] { 0, 1 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0 }, tokenization.getTokenMap());
 
         tokenization = tr.getTokenizations().get(1);
-        assertThat(tokenization.getTokens(), arrayContaining("my", "little", "red", "car"));
         assertArrayEquals(new int[] { 4, 5, 6, 7 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 1, 2, 3 }, tokenization.getTokenMap());
 
         tokenization = tr.getTokenizations().get(2);
-        assertThat(tokenization.getTokens(), arrayContaining("God", "##zilla", "day"));
         assertArrayEquals(new int[] { 8, 9, 16 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1 }, tokenization.getTokenMap());
 
         tokenization = tr.getTokenizations().get(3);
-        assertThat(tokenization.getTokens(), arrayContaining("God", "##zilla", "Pancake", "red", "car", "day"));
         assertArrayEquals(new int[] { 8, 9, 17, 6, 7, 16 }, tokenization.getTokenIds());
         assertArrayEquals(new int[] { 0, 0, 1, 2, 3, 4 }, tokenization.getTokenMap());
     }
@@ -230,9 +233,11 @@ public class BertTokenizerTests extends ESTestCase {
             "Godzilla my little red car",
             Tokenization.Truncate.NONE
         );
+
+        var tokenStream = Arrays.stream(tokenization.getTokenIds()).mapToObj(TEST_CASED_VOCAB::get).collect(Collectors.toList());
         assertThat(
-            tokenization.getTokens(),
-            arrayContaining(
+            tokenStream,
+            contains(
                 BertTokenizer.CLASS_TOKEN,
                 "Elastic",
                 "##search",
@@ -260,9 +265,11 @@ public class BertTokenizerTests extends ESTestCase {
             "Godzilla my little red car",
             Tokenization.Truncate.FIRST
         );
+
+        var tokenStream = Arrays.stream(tokenization.getTokenIds()).mapToObj(TEST_CASED_VOCAB::get).collect(Collectors.toList());
         assertThat(
-            tokenization.getTokens(),
-            arrayContaining(
+            tokenStream,
+            contains(
                 BertTokenizer.CLASS_TOKEN,
                 "Elastic",
                 BertTokenizer.SEPARATOR_TOKEN,
@@ -286,9 +293,10 @@ public class BertTokenizerTests extends ESTestCase {
         tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, new BertTokenization(null, true, 10, Tokenization.Truncate.SECOND)).build();
 
         tokenization = tokenizer.tokenize("Elasticsearch is fun", "Godzilla my little red car", Tokenization.Truncate.SECOND);
+        tokenStream = Arrays.stream(tokenization.getTokenIds()).mapToObj(TEST_CASED_VOCAB::get).collect(Collectors.toList());
         assertThat(
-            tokenization.getTokens(),
-            arrayContaining(
+            tokenStream,
+            contains(
                 BertTokenizer.CLASS_TOKEN,
                 "Elastic",
                 "##search",

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -178,16 +178,19 @@ public class BertTokenizerTests extends ESTestCase {
         ).setWithSpecialTokens(true).setNeverSplit(Set.of("[MASK]")).build();
 
         TokenizationResult.Tokenization tokenization = tokenizer.tokenize("This is [MASK]-tastic!", Tokenization.Truncate.NONE);
-        assertThat(tokenStrings(tokenization.getTokens()), contains("[CLS]", "This", "is", "[MASK]", "-", "ta", "##stic", "!", "[SEP]"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("This", "is", "[MASK]", "-", "tastic", "!"));
+        assertArrayEquals(new int[] { 0, 1, 2, 3, 4, 6, 7, 8, 9 }, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { -1, 0, 1, 2, 3, 4, 4, 5, -1 }, tokenization.getTokenMap());
 
         tokenization = tokenizer.tokenize("This is sub~[MASK]!", Tokenization.Truncate.NONE);
-        assertThat(tokenStrings(tokenization.getTokens()), contains("[CLS]", "This", "is", "sub", "~", "[MASK]", "!", "[SEP]"));
+        assertThat(tokenStrings(tokenization.getTokens()), contains("This", "is", "sub", "~", "[MASK]", "!"));
+        assertArrayEquals(new int[] { 0, 1, 2, 10, 5, 3, 8, 9 }, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { -1, 0, 1, 2, 3, 4, 5, -1 }, tokenization.getTokenMap());
 
         tokenization = tokenizer.tokenize("This is sub,[MASK].tastic!", Tokenization.Truncate.NONE);
-        assertThat(
-            tokenStrings(tokenization.getTokens()),
-            contains("[CLS]", "This", "is", "sub", ",", "[MASK]", ".", "ta", "##stic", "!", "[SEP]")
-        );
+        assertThat(tokenStrings(tokenization.getTokens()), contains("This", "is", "sub", ",", "[MASK]", ".", "tastic", "!"));
+        assertArrayEquals(new int[] { 0, 1, 2, 10, 11, 3, 12, 6, 7, 8, 9 }, tokenization.getTokenIds());
+        assertArrayEquals(new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 6, 7, -1 }, tokenization.getTokenMap());
     }
 
     public void testBatchInput() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -47,7 +47,7 @@ public class BertTokenizerTests extends ESTestCase {
     );
 
     private List<String> tokenStrings(List<DelimitedToken> tokens) {
-        return tokens.stream().map(t -> t.token).collect(Collectors.toList());
+        return tokens.stream().map(DelimitedToken::getToken).collect(Collectors.toList());
     }
 
     public void testTokenize() {


### PR DESCRIPTION
By recording the position of the tokens in the original source string the entity labels can correctly constructed.

- Case is preserved
- Accents and other characters stripped during normalisation are preserved
- Fixes bugs with extra spaces or punctuation


The input `"My name is Benjamin Trent, I work at Acme Inc.."` now correctly groups `Acme Inc.` 

```
{
  "predicted_value" : "My name is [Benjamin Trent](PER&Benjamin+Trent), I work at [Acme Inc.](ORG&Acme+Inc.).",
  "entities" : [
    {
      "entity" : "Benjamin Trent",
      "class_name" : "PER",
      "class_probability" : 0.9994054708878661,
      "start_pos" : 11,
      "end_pos" : 25
    },
    {
      "entity" : "Acme Inc.",
      "class_name" : "ORG",
      "class_probability" : 0.818787531972483,
      "start_pos" : 37,
      "end_pos" : 46
    }
  ]
}
```

Monsieur Gillenormand is correctly grouped : `"M. Gillenormand, who had risen betimes like all old men in good health, had heard his entrance"`

```
{
  "predicted_value" : "[M. Gillenormand](PER&M.+Gillenormand), who had risen betimes like all old men in good health, had heard his entrance",
  "entities" : [
    {
      "entity" : "M. Gillenormand",
      "class_name" : "PER",
      "class_probability" : 0.9861165998812788,
      "start_pos" : 0,
      "end_pos" : 15
    }
  ]
}
```
