### PR TITLE
[7.16] SQL: Fix rearranging columns in PIVOT queries (#81032)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
@@ -76,6 +76,21 @@ null           |48396.28571428572|62140.666666666664
 // end::averageWithTwoValuesAndAlias
 ;
 
+averageWithTwoValuesAndAlias-DuplicateDropAndReorderColumns
+schema::c1:d|c2:d|languages:bt|c3:d
+SELECT XY as c1, XY as c2, languages, XY as c3 FROM (SELECT languages, gender, salary FROM test_emp) PIVOT (AVG(salary) FOR gender IN ('M' AS "XY", 'F' "XX"));
+
+       c1        |       c2        |   languages   |       c3
+-----------------+-----------------+---------------+-----------------
+48396.28571428572|48396.28571428572|null           |48396.28571428572
+49767.22222222222|49767.22222222222|1              |49767.22222222222
+44103.90909090909|44103.90909090909|2              |44103.90909090909
+51741.90909090909|51741.90909090909|3              |51741.90909090909
+47058.90909090909|47058.90909090909|4              |47058.90909090909
+39052.875        |39052.875        |5              |39052.875
+
+;
+
 averageWithThreeValuesIncludingNull
 schema::languages:bt|'M':d|'F':d
 SELECT * FROM (SELECT languages, gender, salary FROM test_emp) PIVOT (AVG(salary) FOR gender IN ('M', 'F'));

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -384,7 +384,7 @@ public class Querier {
         ) {
             super(listener, client, cfg, output, query, request);
 
-            isPivot = query.fields().stream().anyMatch(t -> t.v1() instanceof PivotColumnRef);
+            isPivot = query.fields().stream().anyMatch(t -> t.extraction() instanceof PivotColumnRef);
         }
 
         @Override
@@ -462,12 +462,12 @@ public class Querier {
 
         protected List<BucketExtractor> initBucketExtractors(SearchResponse response) {
             // create response extractors for the first time
-            List<Tuple<FieldExtraction, String>> refs = query.fields();
+            List<QueryContainer.FieldInfo> refs = query.fields();
 
             List<BucketExtractor> exts = new ArrayList<>(refs.size());
             ConstantExtractor totalCount = new ConstantExtractor(response.getHits().getTotalHits().value);
-            for (Tuple<FieldExtraction, String> ref : refs) {
-                exts.add(createExtractor(ref.v1(), totalCount));
+            for (QueryContainer.FieldInfo ref : refs) {
+                exts.add(createExtractor(ref.extraction(), totalCount));
             }
             return exts;
         }
@@ -537,11 +537,11 @@ public class Querier {
         @Override
         protected void handleResponse(SearchResponse response, ActionListener<Page> listener) {
             // create response extractors for the first time
-            List<Tuple<FieldExtraction, String>> refs = query.fields();
+            List<QueryContainer.FieldInfo> refs = query.fields();
 
             List<HitExtractor> exts = new ArrayList<>(refs.size());
-            for (Tuple<FieldExtraction, String> ref : refs) {
-                exts.add(createExtractor(ref.v1()));
+            for (QueryContainer.FieldInfo ref : refs) {
+                exts.add(createExtractor(ref.extraction()));
             }
 
             ScrollCursor.handle(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
@@ -56,7 +56,7 @@ public abstract class SourceGenerator {
         // need to be retrieved from the result documents
 
         // NB: the sortBuilder takes care of eliminating duplicates
-        container.fields().forEach(f -> f.v1().collectFields(sortBuilder));
+        container.fields().forEach(f -> f.extraction().collectFields(sortBuilder));
         sortBuilder.build(source);
 
         // add the aggs (if present)

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.sql.planner;
 
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.ql.execution.search.AggRef;
-import org.elasticsearch.xpack.ql.execution.search.FieldExtraction;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.AttributeMap;
@@ -17,6 +16,7 @@ import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Foldables;
 import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.NameId;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.expression.Order;
 import org.elasticsearch.xpack.ql.expression.ReferenceAttribute;
@@ -143,9 +143,17 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 AttributeMap.Builder<Expression> aliases = AttributeMap.<Expression>builder().putAll(queryC.aliases());
                 AttributeMap.Builder<Pipe> processors = AttributeMap.<Pipe>builder().putAll(queryC.scalarFunctions());
 
+                // recreate the query container's fields such that they appear in order of the projection and with hidden fields
+                // last. This is mostly needed for PIVOT queries where we have to fold projections on aggregations because they cannot be
+                // optimized away. Most (all) other queries usually prune nested projections in earlier steps.
+                List<QueryContainer.FieldInfo> fields = new ArrayList<>(queryC.fields().size());
+                List<QueryContainer.FieldInfo> hiddenFields = new ArrayList<>(queryC.fields());
+
                 for (NamedExpression pj : project.projections()) {
+                    Attribute attr = pj.toAttribute();
+                    NameId attributeId = attr.id();
+
                     if (pj instanceof Alias) {
-                        Attribute attr = pj.toAttribute();
                         Expression e = ((Alias) pj).child();
 
                         // track all aliases (to determine their reference later on)
@@ -155,13 +163,27 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                         if (e instanceof ScalarFunction) {
                             processors.put(attr, ((ScalarFunction) e).asPipe());
                         }
+
+                        if (e instanceof NamedExpression) {
+                            attributeId = ((NamedExpression) e).toAttribute().id();
+                        }
+                    }
+
+                    for (QueryContainer.FieldInfo field : queryC.fields()) {
+                        if (field.attribute().id().equals(attributeId)) {
+                            fields.add(field);
+                            hiddenFields.remove(field);
+                            break;
+                        }
                     }
                 }
+
+                fields.addAll(hiddenFields);
 
                 QueryContainer clone = new QueryContainer(
                     queryC.query(),
                     queryC.aggs(),
-                    queryC.fields(),
+                    fields,
                     aliases.build(),
                     queryC.pseudoFunctions(),
                     processors.build(),
@@ -574,7 +596,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                         }
 
                         // add the computed column
-                        queryC = qC.get().addColumn(new ComputedRef(proc), id);
+                        queryC = qC.get().addColumn(new ComputedRef(proc), id, ne.toAttribute());
                     }
 
                     // apply the same logic above (for function inputs) to non-scalar functions with small variations:
@@ -588,11 +610,19 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                         // attributes can only refer to declared groups
                         if (target instanceof Attribute) {
                             Check.notNull(matchingGroup, "Cannot find group [{}]", Expressions.name(target));
-                            queryC = queryC.addColumn(new GroupByRef(matchingGroup.id(), null, isDateBased(target.dataType())), id);
+                            queryC = queryC.addColumn(
+                                new GroupByRef(matchingGroup.id(), null, isDateBased(target.dataType())),
+                                id,
+                                ne.toAttribute()
+                            );
                         }
                         // handle histogram
                         else if (target instanceof GroupingFunction) {
-                            queryC = queryC.addColumn(new GroupByRef(matchingGroup.id(), null, isDateBased(target.dataType())), id);
+                            queryC = queryC.addColumn(
+                                new GroupByRef(matchingGroup.id(), null, isDateBased(target.dataType())),
+                                id,
+                                ne.toAttribute()
+                            );
                         }
                         // handle literal
                         else if (target.foldable()) {
@@ -609,7 +639,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                             AggregateFunction af = (AggregateFunction) target;
                             Tuple<QueryContainer, AggPathInput> withAgg = addAggFunction(matchingGroup, af, compoundAggMap, queryC);
                             // make sure to add the inner id (to handle compound aggs)
-                            queryC = withAgg.v1().addColumn(withAgg.v2().context(), id);
+                            queryC = withAgg.v1().addColumn(withAgg.v2().context(), id, ne.toAttribute());
                         }
                     }
 
@@ -623,7 +653,11 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                         matchingGroup = groupingContext.groupFor(target);
                         Check.notNull(matchingGroup, "Cannot find group [{}]", Expressions.name(ne));
 
-                        queryC = queryC.addColumn(new GroupByRef(matchingGroup.id(), null, isDateBased(ne.dataType())), id);
+                        queryC = queryC.addColumn(
+                            new GroupByRef(matchingGroup.id(), null, isDateBased(ne.dataType())),
+                            id,
+                            ne.toAttribute()
+                        );
                     }
                     // fallback
                     else {
@@ -636,7 +670,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
             if (a.aggregates().stream().allMatch(e -> e.anyMatch(Expression::foldable))) {
                 for (Expression grouping : a.groupings()) {
                     GroupByKey matchingGroup = groupingContext.groupFor(grouping);
-                    queryC = queryC.addColumn(new GroupByRef(matchingGroup.id(), null, false), id);
+                    queryC = queryC.addColumn(new GroupByRef(matchingGroup.id(), null, false), id, null);
                 }
             }
             return new EsQueryExec(exec.source(), exec.index(), a.output(), queryC);
@@ -842,19 +876,20 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 // due to the Pivot structure - the column is the last entry in the grouping set
                 QueryContainer query = fold.queryContainer();
 
-                List<Tuple<FieldExtraction, String>> fields = new ArrayList<>(query.fields());
+                List<QueryContainer.FieldInfo> fields = new ArrayList<>(query.fields());
                 int startingIndex = fields.size() - p.aggregates().size() - 1;
                 // pivot grouping
-                Tuple<FieldExtraction, String> groupTuple = fields.remove(startingIndex);
+                QueryContainer.FieldInfo groupField = fields.remove(startingIndex);
                 AttributeMap<Literal> values = p.valuesToLiterals();
 
                 for (int i = startingIndex; i < fields.size(); i++) {
-                    Tuple<FieldExtraction, String> tuple = fields.remove(i);
+                    QueryContainer.FieldInfo field = fields.remove(i);
                     for (Map.Entry<Attribute, Literal> entry : values.entrySet()) {
                         fields.add(
-                            new Tuple<>(
-                                new PivotColumnRef(groupTuple.v1(), tuple.v1(), entry.getValue().value()),
-                                Expressions.id(entry.getKey())
+                            new QueryContainer.FieldInfo(
+                                new PivotColumnRef(groupField.extraction(), field.extraction(), entry.getValue().value()),
+                                Expressions.id(entry.getKey()),
+                                entry.getKey()
                             )
                         );
                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/GlobalCountRef.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/GlobalCountRef.java
@@ -15,6 +15,8 @@ import org.elasticsearch.xpack.ql.execution.search.AggRef;
 public final class GlobalCountRef extends AggRef {
     public static final GlobalCountRef INSTANCE = new GlobalCountRef();
 
+    private GlobalCountRef() {}
+
     @Override
     public String toString() {
         return "#_Total_Hits_#";

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.sql.plan.physical.LocalExec;
 import org.elasticsearch.xpack.sql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.sql.querydsl.container.GroupByRef;
+import org.elasticsearch.xpack.sql.querydsl.container.PivotColumnRef;
 import org.elasticsearch.xpack.sql.querydsl.container.QueryContainer;
 import org.elasticsearch.xpack.sql.session.EmptyExecutable;
 import org.elasticsearch.xpack.sql.session.SingletonExecutable;
@@ -551,6 +553,57 @@ public class QueryFolderTests extends ESTestCase {
         assertThat(a, containsString("\"terms\":{\"field\":\"bool\""));
         assertThat(a, containsString("\"terms\":{\"field\":\"keyword\""));
         assertThat(a, containsString("{\"avg\":{\"field\":\"int\"}"));
+    }
+
+    public void testFoldingOfPivotWithPivotedColumnFirst() {
+        PhysicalPlan p = plan(
+            "SELECT a, bool FROM (SELECT int, keyword, bool FROM test) PIVOT(AVG(int) FOR keyword IN ('A' AS a, 'B' AS b))"
+        );
+        assertEquals(EsQueryExec.class, p.getClass());
+        EsQueryExec ee = (EsQueryExec) p;
+
+        assertEquals(asList("a", "bool"), Expressions.names(ee.output()));
+
+        List<QueryContainer.FieldInfo> fields = ee.queryContainer().fields();
+        assertEquals(3, fields.size());
+        assertEquals(PivotColumnRef.class, fields.get(0).extraction().getClass());
+        assertEquals("A", ((PivotColumnRef) fields.get(0).extraction()).value());
+        assertEquals(GroupByRef.class, fields.get(1).extraction().getClass());
+        assertEquals(PivotColumnRef.class, fields.get(2).extraction().getClass());
+        assertEquals("B", ((PivotColumnRef) fields.get(2).extraction()).value());
+    }
+
+    public void testFoldingOfPivotWithPivotedColumnDuplicated() {
+        PhysicalPlan p = plan(
+            "SELECT a as c1, a as c2 FROM (SELECT int, keyword, bool FROM test) PIVOT(AVG(int) FOR keyword IN ('A' AS a, 'B' AS b))"
+        );
+        assertEquals(EsQueryExec.class, p.getClass());
+        EsQueryExec ee = (EsQueryExec) p;
+
+        assertEquals(asList("c1", "c2"), Expressions.names(ee.output()));
+
+        List<QueryContainer.FieldInfo> fields = ee.queryContainer().fields();
+        assertEquals(4, fields.size());
+        assertEquals(PivotColumnRef.class, fields.get(0).extraction().getClass());
+        assertEquals("A", ((PivotColumnRef) fields.get(0).extraction()).value());
+        assertEquals(PivotColumnRef.class, fields.get(1).extraction().getClass());
+        assertEquals("A", ((PivotColumnRef) fields.get(1).extraction()).value());
+        assertEquals(GroupByRef.class, fields.get(2).extraction().getClass());
+        assertEquals(PivotColumnRef.class, fields.get(3).extraction().getClass());
+        assertEquals("B", ((PivotColumnRef) fields.get(3).extraction()).value());
+    }
+
+    public void testFoldingOfPivotDroppingPivotedColumn() {
+        PhysicalPlan p = plan("SELECT bool FROM (SELECT int, keyword, bool FROM test) PIVOT(AVG(int) FOR keyword IN ('A' AS a, 'B' AS b))");
+
+        assertEquals(EsQueryExec.class, p.getClass());
+        EsQueryExec ee = (EsQueryExec) p;
+
+        assertEquals(asList("bool"), Expressions.names(ee.output()));
+
+        List<QueryContainer.FieldInfo> fields = ee.queryContainer().fields();
+        assertEquals(1, fields.size());
+        assertEquals(GroupByRef.class, fields.get(0).extraction().getClass());
     }
 
     public void testPivotHasSameQueryAsGroupBy() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -1167,7 +1167,7 @@ public class QueryTranslatorTests extends ESTestCase {
             assertEquals(funcName + "(int)", eqe.output().get(0).qualifiedName());
             assertEquals(DOUBLE, eqe.output().get(0).dataType());
 
-            FieldExtraction fe = eqe.queryContainer().fields().get(0).v1();
+            FieldExtraction fe = eqe.queryContainer().fields().get(0).extraction();
             assertEquals(MetricAggRef.class, fe.getClass());
             assertEquals(((MetricAggRef) fe).property(), metricToAgg.get(funcName));
 
@@ -1293,7 +1293,7 @@ public class QueryTranslatorTests extends ESTestCase {
             .stream()
             .collect(Collectors.toMap(AggregationBuilder::getName, ab -> ab));
         return IntStream.range(0, fieldCount).mapToObj(i -> {
-            String percentileAggName = ((MetricAggRef) ee.queryContainer().fields().get(i).v1()).name();
+            String percentileAggName = ((MetricAggRef) ee.queryContainer().fields().get(i).extraction()).name();
             return (AbstractPercentilesAggregationBuilder) aggsByName.get(percentileAggName);
         }).collect(Collectors.toList());
     }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - SQL: Fix rearranging columns in PIVOT queries (#81032)