### PR TITLE
[8.0] Fix typo in field_caps API (#81280)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 7.99.99"
-      reason: introduced in 8.0.0
+      version: " - 8.00.99"
+      reason: field was renamed in introduced in 8.1.0
 
   - do:
       indices.create:
@@ -100,8 +100,8 @@ setup:
 "Get simple time series field caps":
 
   - skip:
-      version: " - 7.99.99"
-      reason: introduced in 8.0.0
+      version: " - 8.00.99"
+      reason: field was renamed in introduced in 8.1.0
 
   - do:
       field_caps:
@@ -162,8 +162,8 @@ setup:
 "Get time series field caps with conflicts":
 
   - skip:
-      version: " - 7.99.99"
-      reason: introduced in 8.0.0
+      version: " - 8.00.99"
+      reason: field was renamed in introduced in 8.1.0
 
   - do:
       field_caps:
@@ -178,7 +178,7 @@ setup:
   - is_false: fields.metricset.keyword.non_searchable_indices
   - is_false: fields.metricset.keyword.non_aggregatable_indices
   - match: {fields.metricset.keyword.non_dimension_indices: ["tsdb_index2"]}
-  - is_false: fields.metricset.keyword.mertric_conflicts_indices
+  - is_false: fields.metricset.keyword.metric_conflicts_indices
 
   - match: {fields.non_tsdb_field.keyword.searchable: true}
   - match: {fields.non_tsdb_field.keyword.aggregatable: true}
@@ -188,44 +188,44 @@ setup:
   - is_false: fields.non_tsdb_field.keyword.non_searchable_indices
   - is_false: fields.non_tsdb_field.keyword.non_aggregatable_indices
   - is_false: fields.non_tsdb_field.keyword.non_dimension_indices
-  - is_false: fields.non_tsdb_field.keyword.mertric_conflicts_indices
+  - is_false: fields.non_tsdb_field.keyword.metric_conflicts_indices
 
   - match: {fields.k8s\.pod\.availability_zone.short.time_series_dimension: true}
   - is_false: fields.k8s\.pod\.availability_zone.short.time_series_metric
   - is_false: fields.k8s\.pod\.availability_zone.short.non_dimension_indices
-  - is_false: fields.k8s\.pod\.availability_zone.short.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.availability_zone.short.metric_conflicts_indices
 
   - match: {fields.k8s\.pod\.uid.keyword.time_series_dimension: true}
   - is_false: fields.k8s\.pod\.uid.keyword.time_series_metric
   - is_false: fields.k8s\.pod\.uid.keyword.non_dimension_indices
-  - is_false: fields.k8s\.pod\.uid.keyword.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.uid.keyword.metric_conflicts_indices
 
   - is_false: fields.k8s\.pod\.name.keyword.time_series_dimension
   - is_false: fields.k8s\.pod\.name.keyword.time_series_metric
   - is_false: fields.k8s\.pod\.name.keyword.non_dimension_indices
-  - is_false: fields.k8s\.pod\.name.keyword.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.name.keyword.metric_conflicts_indices
 
   - match: {fields.k8s\.pod\.ip.ip.time_series_dimension: true}
   - is_false: fields.k8s\.pod\.ip.ip.time_series_metric
   - is_false: fields.k8s\.pod\.ip.ip.non_dimension_indices
-  - is_false: fields.k8s\.pod\.ip.ip.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.ip.ip.metric_conflicts_indices
 
   - is_false: fields.k8s\.pod\.network\.tx.long.time_series_dimension
   - is_false: fields.k8s\.pod\.network\.tx.long.time_series_metric
   - is_false: fields.k8s\.pod\.network\.tx.long.non_dimension_indices
-  - match: {fields.k8s\.pod\.network\.tx.long.mertric_conflicts_indices: ["tsdb_index1", "tsdb_index2"]}
+  - match: {fields.k8s\.pod\.network\.tx.long.metric_conflicts_indices: ["tsdb_index1", "tsdb_index2"]}
 
   - is_false: fields.k8s\.pod\.network\.rx.integer.time_series_dimension
   - is_false: fields.k8s\.pod\.network\.rx.integer.time_series_metric
   - is_false: fields.k8s\.pod\.network\.rx.integer.non_dimension_indices
-  - match: {fields.k8s\.pod\.network\.rx.integer.mertric_conflicts_indices: ["tsdb_index1", "tsdb_index2"]}
+  - match: {fields.k8s\.pod\.network\.rx.integer.metric_conflicts_indices: ["tsdb_index1", "tsdb_index2"]}
 
   - is_false: fields.k8s\.pod\.network\.packets_dropped.long.time_series_dimension
   - match: {fields.k8s\.pod\.network\.packets_dropped.long.time_series_metric: gauge}
   - is_false: fields.k8s\.pod\.network\.packets_dropped.long.non_dimension_indices
-  - is_false: fields.k8s\.pod\.network\.packets_dropped.long.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.network\.packets_dropped.long.metric_conflicts_indices
 
   - is_false: fields.k8s\.pod\.network\.latency.double.time_series_dimension
   - match: {fields.k8s\.pod\.network\.latency.double.time_series_metric: gauge}
   - is_false: fields.k8s\.pod\.network\.latency.double.non_dimension_indices
-  - is_false: fields.k8s\.pod\.network\.latency.double.mertric_conflicts_indices
+  - is_false: fields.k8s\.pod\.network\.latency.double.metric_conflicts_indices

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 8.00.99"
-      reason: field was renamed in introduced in 8.1.0
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0
 
   - do:
       indices.create:
@@ -162,8 +162,8 @@ setup:
 "Get time series field caps with conflicts":
 
   - skip:
-      version: " - 8.00.99"
-      reason: field was renamed in introduced in 8.1.0
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0
 
   - do:
       field_caps:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -100,8 +100,8 @@ setup:
 "Get simple time series field caps":
 
   - skip:
-      version: " - 8.00.99"
-      reason: field was renamed in introduced in 8.1.0
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0
 
   - do:
       field_caps:

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -54,7 +54,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
     private static final ParseField NON_SEARCHABLE_INDICES_FIELD = new ParseField("non_searchable_indices");
     private static final ParseField NON_AGGREGATABLE_INDICES_FIELD = new ParseField("non_aggregatable_indices");
     private static final ParseField NON_DIMENSION_INDICES_FIELD = new ParseField("non_dimension_indices");
-    private static final ParseField METRIC_CONFLICTS_INDICES_FIELD = new ParseField("mertric_conflicts_indices");
+    private static final ParseField METRIC_CONFLICTS_INDICES_FIELD = new ParseField("metric_conflicts_indices");
     private static final ParseField META_FIELD = new ParseField("meta");
 
     private final String name;
@@ -480,7 +480,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         private boolean isAggregatable;
         private boolean isDimension;
         private TimeSeriesParams.MetricType metricType;
-        private boolean mertricTypeIsSet;
+        private boolean metricTypeIsSet;
         private List<IndexCaps> indiceList;
         private Map<String, Set<String>> meta;
 
@@ -491,7 +491,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             this.isAggregatable = true;
             this.isDimension = true;
             this.metricType = null;
-            this.mertricTypeIsSet = false;
+            this.metricTypeIsSet = false;
             this.indiceList = new ArrayList<>();
             this.meta = new HashMap<>();
         }
@@ -516,12 +516,12 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             this.isDimension &= isDimension;
             // If we have discrepancy in metric types or in some indices this field is not marked as a metric field - we will
             // treat is a non-metric field and report this discrepancy in metricConflictsIndices
-            if (this.mertricTypeIsSet) {
+            if (this.metricTypeIsSet) {
                 if (this.metricType != metricType) {
                     this.metricType = null;
                 }
             } else {
-                this.mertricTypeIsSet = true;
+                this.metricTypeIsSet = true;
                 this.metricType = metricType;
             }
             for (Map.Entry<String, String> entry : meta.entrySet()) {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix typo in field_caps API (#81280)