### PR TITLE
[Transform] Fix wire compatibility version for transform cluster state

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
@@ -54,7 +54,7 @@ public class TransformMetadata implements XPackPlugin.XPackMetadataCustom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion();
+        return Version.V_7_13_0;
     }
 
     @Override
@@ -112,6 +112,11 @@ public class TransformMetadata implements XPackPlugin.XPackMetadataCustom {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(resetMode);
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_13_0;
         }
 
         @Override


### PR DESCRIPTION
Since 7.13 transforms has had a very small custom cluster state that
records whether a feature reset is in progress. This should not be
sent to older nodes when the cluster state is serialized.

Fixes #81292