### PR TITLE
[ML] Remove BWC guard after backport

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -48,7 +48,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public MlScalingReason(StreamInput in) throws IOException {
         this.waitingAnalyticsJobs = in.readStringList();
         this.waitingAnomalyJobs = in.readStringList();
-        if (in.getVersion().onOrAfter(Version.V_7_16_1)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             this.waitingSnapshotUpgrades = in.readStringList();
         } else {
             this.waitingSnapshotUpgrades = List.of();
@@ -139,7 +139,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
-        if (out.getVersion().onOrAfter(Version.V_7_16_1)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeStringCollection(this.waitingSnapshotUpgrades);
         }
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -48,8 +48,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public MlScalingReason(StreamInput in) throws IOException {
         this.waitingAnalyticsJobs = in.readStringList();
         this.waitingAnomalyJobs = in.readStringList();
-        // TODO: change on backport
-        if (in.getVersion().onOrAfter(Version.V_8_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_1)) {
             this.waitingSnapshotUpgrades = in.readStringList();
         } else {
             this.waitingSnapshotUpgrades = List.of();
@@ -140,8 +139,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
-        // TODO: change version on backport
-        if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_1)) {
             out.writeStringCollection(this.waitingSnapshotUpgrades);
         }
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -48,11 +48,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public MlScalingReason(StreamInput in) throws IOException {
         this.waitingAnalyticsJobs = in.readStringList();
         this.waitingAnomalyJobs = in.readStringList();
-        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
-            this.waitingSnapshotUpgrades = in.readStringList();
-        } else {
-            this.waitingSnapshotUpgrades = List.of();
-        }
+        this.waitingSnapshotUpgrades = in.readStringList();
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             this.waitingModels = in.readStringList();
         } else {
@@ -139,9 +135,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
-        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
-            out.writeStringCollection(this.waitingSnapshotUpgrades);
-        }
+        out.writeStringCollection(this.waitingSnapshotUpgrades);
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
             out.writeStringCollection(this.waitingModels);
         }


### PR DESCRIPTION
Since we've decided to do a 7.17 release, 8.1 will never need to run in a mixed version cluster with 7.16, so it's safe to remove the version guard on the new field in the ML autoscaling reason.

Relates to #81123, #81303, #81304