### PR TITLE
[DOCS] Fix the weighed average documentation

### DIFF
--- a/docs/reference/aggregations/metrics/weighted-avg-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/weighted-avg-aggregation.asciidoc
@@ -210,8 +210,7 @@ Which should look like:
 The `missing` parameter defines how documents that are missing a value should be treated.
 The default behavior is different for `value` and `weight`:
 
-By default, if the `value` field is missing the document is ignored and the aggregation moves on to the next document.
-If the `weight` field is missing, it is assumed to have a weight of `1` (like a normal average).
+By default, if the `value` or `weight` field is missing the document is ignored and the aggregation moves on to the next document.
 
 Both of these defaults can be overridden with the `missing` parameter:
 

--- a/docs/reference/aggregations/metrics/weighted-avg-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/weighted-avg-aggregation.asciidoc
@@ -207,12 +207,8 @@ Which should look like:
 
 ==== Missing values
 
-The `missing` parameter defines how documents that are missing a value should be treated.
-The default behavior is different for `value` and `weight`:
-
-By default, if the `value` or `weight` field is missing the document is ignored and the aggregation moves on to the next document.
-
-Both of these defaults can be overridden with the `missing` parameter:
+By default, the aggregation excludes documents with a missing or `null` value for the `value` or `weight` field. Use the
+ `missing` parameter to specify a default value for these documents instead.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
This inconsistency has been found while working on #81306.

The documentations states that if the `weight` field is missing, and no
explicit missing configuration is provided, a default value of 1 is used.
This is incorrect and does not match the implementation of the weighted
average aggregator. In this specific case the document is skipped, instead.