### PR TITLE
Revert some EQL shadowed var changes and improve HiddenField rule

### DIFF
--- a/build-tools-internal/src/main/resources/checkstyle.xml
+++ b/build-tools-internal/src/main/resources/checkstyle.xml
@@ -112,11 +112,13 @@
     <module name="org.elasticsearch.gradle.internal.checkstyle.HiddenFieldCheck">
         <property name="ignoreConstructorParameter" value="true" />
         <property name="ignoreConstructorBody" value="true"/>
+        <property name="ignoreConstructorMethods" value="(?:ConstructingObjectParser)$"/>
         <property name="ignoreSetter" value="true" />
-        <property name="setterCanReturnItsClass" value="true"/>
+        <property name="minLineCount" value="5" />
         <property name="ignoreFormat" value="^(?:threadPool)$"/>
         <property name="ignoreAbstractMethods" value="true"/>
-        <property name="ignoredMethodNames" value="^(?:createParser)$"/>
+        <property name="ignoreMethodNames" value="^(?:createParser)$"/>
+        <property name="setterCanReturnItsClass" value="true"/>
         <message key="hidden.field" value="''{0}'' hides a field." />
     </module>
     -->

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
@@ -93,15 +93,12 @@ public class Criterion<Q extends QueryRequest> {
             tbreaker = (Comparable<Object>) tb;
         }
 
-        Object extractedImplicitTiebreaker = implicitTiebreaker.extract(hit);
-        if (extractedImplicitTiebreaker instanceof Number == false) {
-            throw new EqlIllegalArgumentException(
-                "Expected _shard_doc/implicit tiebreaker as long but got [{}]",
-                extractedImplicitTiebreaker
-            );
+        Object implicitTbreaker = implicitTiebreaker.extract(hit);
+        if (implicitTbreaker instanceof Number == false) {
+            throw new EqlIllegalArgumentException("Expected _shard_doc/implicit tiebreaker as long but got [{}]", implicitTbreaker);
         }
-        long implicitTiebreakerValue = ((Number) extractedImplicitTiebreaker).longValue();
-        return new Ordinal((Timestamp) ts, tbreaker, implicitTiebreakerValue);
+        long timebreakerValue = ((Number) implicitTbreaker).longValue();
+        return new Ordinal((Timestamp) ts, tbreaker, timebreakerValue);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
@@ -54,8 +54,8 @@ public class StringContainsFunctionPipe extends Pipe {
         return string.resolved() && substring.resolved();
     }
 
-    protected StringContainsFunctionPipe replaceChildren(Pipe pipeString, Pipe pipeSubstring) {
-        return new StringContainsFunctionPipe(source(), expression(), pipeString, pipeSubstring, caseInsensitive);
+    protected StringContainsFunctionPipe replaceChildren(Pipe string, Pipe substring) {
+        return new StringContainsFunctionPipe(source(), expression(), string, substring, caseInsensitive);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
@@ -125,8 +125,8 @@ public class Join extends LogicalPlan {
         return direction;
     }
 
-    public Join with(List<KeyedFilter> keyedFilterQueries, KeyedFilter untilFilter, OrderDirection orderDirection) {
-        return new Join(source(), keyedFilterQueries, untilFilter, timestamp, tiebreaker, orderDirection);
+    public Join with(List<KeyedFilter> queries, KeyedFilter until, OrderDirection direction) {
+        return new Join(source(), queries, until, timestamp, tiebreaker, direction);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
@@ -43,8 +43,8 @@ public class EsQueryExec extends LeafExec {
         return NodeInfo.create(this, EsQueryExec::new, output, queryContainer);
     }
 
-    public EsQueryExec with(QueryContainer container) {
-        return new EsQueryExec(source(), output, container);
+    public EsQueryExec with(QueryContainer queryContainer) {
+        return new EsQueryExec(source(), output, queryContainer);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
@@ -112,8 +112,8 @@ public class SequenceExec extends PhysicalPlan {
         return direction;
     }
 
-    public SequenceExec with(Limit limitValue) {
-        return new SequenceExec(source(), children(), keys(), timestamp(), tiebreaker(), limitValue, direction, maxSpan);
+    public SequenceExec with(Limit limit) {
+        return new SequenceExec(source(), children(), keys(), timestamp(), tiebreaker(), limit, direction, maxSpan);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
@@ -101,8 +101,8 @@ public class QueryContainer {
         return new QueryContainer(q, fields, attributes, sort, trackHits, includeFrozen, limit);
     }
 
-    public QueryContainer with(Limit limitValue) {
-        return new QueryContainer(query, fields, attributes, sort, trackHits, includeFrozen, limitValue);
+    public QueryContainer with(Limit limit) {
+        return new QueryContainer(query, fields, attributes, sort, trackHits, includeFrozen, limit);
     }
 
     public QueryContainer addColumn(Attribute attr) {


### PR DESCRIPTION
Change our fork of `HiddenFieldCheck` rule to allow it to ignore
shadowed variables for methods shorter than a configured minimim line
count. While this technically defeats the point of the rule, in practice
short methods are easier to verify by eye, compared to longer methods
where accidentally referencing the wrong variable is harder to spot.

Following this, revert some changes in the EQL code which were required
to pass the `HiddenField` check before the `minLineCount` change.

Additionally, introduce a mechanism for ignoring shadowed variables when
used created a new object. This allowed us to ignore variables in usages
of e.g. `ConstructingObjectParser` whose purpose, as the name suggests,
is to build objects, and object shadows variables in the course of
building objects.