### PR TITLE
Quiesce test security manager and illegal access warnings

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -121,7 +121,6 @@ if (providers.systemProperty('idea.active').forUseAtConfigurationTime().getOrNul
             vmParameters = [
               '-ea',
               '-Djava.locale.providers=SPI,COMPAT',
-              "--illegal-access=deny",
               // TODO: only open these for mockito when it is modularized
               '--add-opens=java.base/java.security.cert=ALL-UNNAMED',
               '--add-opens=java.base/java.nio.channels=ALL-UNNAMED',

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -96,7 +96,6 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
             test.jvmArgs(
                 "-Xmx" + System.getProperty("tests.heap.size", "512m"),
                 "-Xms" + System.getProperty("tests.heap.size", "512m"),
-                "--illegal-access=deny",
                 "-Djava.security.manager=allow",
                 // TODO: only open these for mockito when it is modularized
                 "--add-opens=java.base/java.security.cert=ALL-UNNAMED",

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -161,7 +161,8 @@ public class BootstrapForTesting {
                             || runnerPolicy.implies(domain, permission);
                     }
                 });
-                System.setSecurityManager(SecureSM.createTestSecureSM());
+                Security.prepopulateSecurityCaller();
+                Security.setSecurityManager(SecureSM.createTestSecureSM());
                 Security.selfTest();
 
                 // guarantee plugin classes are initialized first, in case they have one-time hacks.


### PR DESCRIPTION
Update the test framework to set the security manager through
the preexisting helper, which is the single Elasticsearch
warning-free way to set the security manager.

Additionally, delete `--illegal-access=deny, since that option
has been removed in JDK 17.