### PR TITLE
[DOCS] Fixes broken links to clients

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -41,8 +41,8 @@ https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
 client completeness].
 
 Any missing APIs can always be implemented today by using the
-link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
-level Java REST Client] with JSON request and response bodies.
+{java-rest}/java-rest-low.html[low level Java REST Client] with JSON request and
+response bodies.
 
 ===================================
 

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -35,8 +35,8 @@ https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
 client completeness].
 
 Any missing APIs can always be implemented today by using the
-link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
-level Java REST Client] with JSON request and response bodies.
+{java-rest}/java-rest-low.html[low level Java REST Client] with JSON request and
+response bodies.
 
 ===================================
 

--- a/docs/reference/setup/setup-xclient.asciidoc
+++ b/docs/reference/setup/setup-xclient.asciidoc
@@ -25,8 +25,8 @@ https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
 client completeness].
 
 Any missing APIs can always be implemented today by using the
-link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
-level Java REST Client] with JSON request and response bodies.
+{java-rest}/java-rest-low.html[low level Java REST Client] with JSON request and
+response bodies.
 
 ===================================
 

--- a/x-pack/docs/en/security/tribe-clients-integrations/java.asciidoc
+++ b/x-pack/docs/en/security/tribe-clients-integrations/java.asciidoc
@@ -2,8 +2,7 @@
 === Java Client and security
 
 The {es} {security-features} support the Java
-http://www.elastic.co/guide/en/elasticsearch/client/java-api/current/transport-client.html[transport client]
-for Elasticsearch.
+{javaclient}/transport-client.html[transport client] for Elasticsearch.
 
 The transport client uses the same transport protocol that the cluster nodes use
 for inter-node communication. It is very efficient as it does not have to marshall
@@ -34,8 +33,8 @@ https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
 client completeness].
 
 Any missing APIs can always be implemented today by using the
-link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
-level Java REST Client] with JSON request and response bodies.
+{java-rest}/java-rest-low.html[low level Java REST Client] with JSON request and
+response bodies.
 
 ===================================
 

--- a/x-pack/docs/en/watcher/java.asciidoc
+++ b/x-pack/docs/en/watcher/java.asciidoc
@@ -19,8 +19,8 @@ https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
 client completeness].
 
 Any missing APIs can always be implemented today by using the
-link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
-level Java REST Client] with JSON request and response bodies.
+{java-rest}/java-rest-low.html[low level Java REST Client] with JSON request and
+response bodies.
 
 ===================================
 


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2299

Fixes the following broken links:
> INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/5.6/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/5.6/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.0/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.0/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.1/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.1/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.2/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.2/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.3/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.3/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.4/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.4/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.5/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.5/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.6/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.6/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.7/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.7/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.8/client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/java-api/6.8/java-api.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/5.6/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.0/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.1/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.2/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.3/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.3/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.3/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.4/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.4/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.4/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.5/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.5/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.5/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.6/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.6/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.6/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.7/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.7/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.7/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.8/api-java.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.8/java-clients.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.8/setup-xpack-client.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/client/java-rest/current/java-rest-low.html