### PR TITLE
[DOCS] Clarify supported CCS configurations

### DIFF
--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -419,14 +419,19 @@ image:images/ccs/ccs-min-roundtrip-client-response.svg[]
 [[ccs-supported-configurations]]
 === Supported configurations
 
-Generally, <<gateway-nodes-selection,cross-cluster search>> can search remote
-clusters that are one major version ahead or behind the coordinating node's
-version.
+To run a {ccs}, the local and remote clusters must be compatible as outlined
+in the following matrix.
 
 IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
 clusters must use the same {es} version.
 
-Cross-cluster search can also search remote clusters that are being
+[%collapsible%open]
+.Version compatibility matrix
+====
+include::{es-repo-dir}/modules/remote-clusters-shared.asciidoc[tag=remote-cluster-compatibility-matrix]
+====
+
+{ccs} can also search remote clusters that are being
 <<rolling-upgrades, upgraded>> so long as both the "upgrade from" and
 "upgrade to" version are compatible with the gateway node.
 


### PR DESCRIPTION
The current CCS docs suggest that you can run searches on incompatible remote
clusters. This updates the docs to include the version compatibility matrix used
in the remote clusters docs.

We plan to update BWC support for CCS in 8.0+ so these changes will only apply to 7.16 and earlier branches.

### Preview

https://elasticsearch_81327.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.16/modules-cross-cluster-search.html#ccs-supported-configurations