### PR TITLE
[DOCS] Reorder "Check SLM history" section

### DIFF
--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -332,15 +332,6 @@ GET _snapshot/_status
 [[check-slm-history]]
 ==== Check {slm-init} history
 
-Use the <<slm-api-get-policy,get {slm-init} policy API>> to check when an
-{slm-init} policy last successfully started the snapshot process. A successful
-start doesn't guarantee the snapshot completed.
-
-[source,console]
-----
-GET _slm/policy/nightly-snapshots
-----
-
 To get more information about a cluster's {slm-init} execution history,
 including stats for each {slm-init} policy, use the <<slm-api-get-stats,get
 {slm-init} stats API>>. The API also returns information about the cluster's
@@ -349,6 +340,19 @@ snapshot retention task history.
 [source,console]
 ----
 GET _slm/stats
+----
+
+To get information about a specific {slm-init} policy's execution history, use
+the <<slm-api-get-policy,get {slm-init} policy API>>. The response includes:
+
+* The next scheduled policy execution.
+* The last time the policy successfully started the snapshot process, if
+  applicable. A successful start doesn't guarantee the snapshot completed.
+* The last time the policy failed and the associated error, if applicable.
+
+[source,console]
+----
+GET _slm/policy/nightly-snapshots
 ----
 
 [discrete]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -348,7 +348,8 @@ the <<slm-api-get-policy,get {slm-init} policy API>>. The response includes:
 * The next scheduled policy execution.
 * The last time the policy successfully started the snapshot process, if
   applicable. A successful start doesn't guarantee the snapshot completed.
-* The last time the policy failed and the associated error, if applicable.
+* The last time policy execution failed, if applicable, and the associated
+  error.
 
 [source,console]
 ----


### PR DESCRIPTION
Changes:

* Moves the get SLM policy API example _after_ the get SLM stats API. This seems to fit the normal workflow better where a user will drill-down into a particular policy to get more information.
* Notes some more information about what the get SLM policy API returns. In particular, it notes that you can get the error message for the last policy failure.

### Preview
https://elasticsearch_81328.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshots-take-snapshot.html#check-slm-history