### PR TITLE
Fix Serialization version check in Shutdown Status

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class ShutdownShardMigrationStatus implements Writeable, ToXContentObject {
-    private static final Version ALLOCATION_DECISION_ADDED_VERSION = Version.V_8_0_0;
+    private static final Version ALLOCATION_DECISION_ADDED_VERSION = Version.V_7_16_0;
 
     private final SingleNodeShutdownMetadata.Status status;
     private final long shardsRemaining;


### PR DESCRIPTION
The version used to determine whether we should serialize the
allocation decisions as part of the Shutdown Status response
was not updated after #78727 was merged. This causes very
confusing errors in mixed 8.x/7.16.x clusters.

Note: The version constant was updated in the backport to 7.16,
but not in 8.x. This is good, as at time of writing, 7.16 has
shipped, but 8.0 has not.