### PR TITLE
[8.0] Disallow explicitly requesting system indices in snapshots (#81235)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -323,6 +323,36 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         );
     }
 
+    public void testSnapshottingSystemIndexByNameIsRejected() throws Exception {
+        createRepository(REPO_NAME, "fs");
+        // put a document in system index
+        indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "1", "purpose", "pre-snapshot doc");
+        refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
+
+        IllegalArgumentException error = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
+                .setIndices(SystemIndexTestPlugin.SYSTEM_INDEX_NAME)
+                .setWaitForCompletion(true)
+                .setIncludeGlobalState(randomBoolean())
+                .get()
+        );
+        assertThat(
+            error.getMessage(),
+            equalTo(
+                "the [indices] parameter includes system indices [.test-system-idx]; to include or exclude system indices from a snapshot, "
+                    + "use the [include_global_state] or [feature_states] parameters"
+            )
+        );
+
+        // And create a successful snapshot so we don't upset the test framework
+        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
+            .setWaitForCompletion(true)
+            .setIncludeGlobalState(true)
+            .get();
+        assertSnapshotSuccess(createSnapshotResponse);
+    }
+
     /**
      * Check that directly requesting a system index in a restore request throws an Exception.
      */

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -305,9 +305,26 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName, "create snapshot");
                 ensureBelowConcurrencyLimit(repositoryName, snapshotName, snapshots, deletionsInProgress);
                 // Store newSnapshot here to be processed in clusterStateProcessed
-                List<String> indices = Arrays.stream(indexNameExpressionResolver.concreteIndexNames(currentState, request))
-                    .filter(indexName -> systemIndices.isSystemIndex(indexName) == false) // Only resolve system indices via Features
-                    .collect(Collectors.toList());
+                Map<Boolean, List<String>> requestedIndices = Arrays.stream(
+                    indexNameExpressionResolver.concreteIndexNames(currentState, request)
+                ).collect(Collectors.partitioningBy(systemIndices::isSystemIndex));
+
+                List<String> requestedSystemIndices = requestedIndices.get(true);
+                if (requestedSystemIndices.isEmpty() == false) {
+                    Set<String> explicitlyRequestedSystemIndices = new HashSet<>(requestedSystemIndices);
+                    explicitlyRequestedSystemIndices.retainAll(Arrays.asList(request.indices()));
+                    if (explicitlyRequestedSystemIndices.isEmpty() == false) {
+                        throw new IllegalArgumentException(
+                            new ParameterizedMessage(
+                                "the [indices] parameter includes system indices {}; to include or exclude system indices from a "
+                                    + "snapshot, use the [include_global_state] or [feature_states] parameters",
+                                explicitlyRequestedSystemIndices
+                            ).getFormattedMessage()
+                        );
+                    }
+                }
+
+                List<String> indices = requestedIndices.get(false);
 
                 final Set<SnapshotFeatureInfo> featureStates = new HashSet<>();
                 final Set<String> systemDataStreamNames = new HashSet<>();


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Disallow explicitly requesting system indices in snapshots (#81235)