### PR TITLE
[DOCS] Fixes link to language identification example

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -124,9 +124,8 @@ classes to the `probabilities` field. Both fields are contained in the
 `target_field` results object.
 
 Refer to the 
-{ml-docs}/ml-dfa-lang-ident.html#ml-lang-ident-example[language identification] 
-trained model documentation for a full example.
-
+{ml-docs}/ml-dfa-lang-ident.html[language identification] trained model
+documentation for a full example.
 
 [discrete]
 [[inference-processor-feature-importance]]


### PR DESCRIPTION
This PR removes a section anchor from a link in the inference processor documentation, since that anchor will break when https://github.com/elastic/stack-docs/pull/1903 is merged.