### PR TITLE
[8.0] [DOCS] Fixes link to language identification example (#81347)

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -124,9 +124,8 @@ classes to the `probabilities` field. Both fields are contained in the
 `target_field` results object.
 
 Refer to the 
-{ml-docs}/ml-dfa-lang-ident.html#ml-lang-ident-example[language identification] 
-trained model documentation for a full example.
-
+{ml-docs}/ml-dfa-lang-ident.html[language identification] trained model
+documentation for a full example.
 
 [discrete]
 [[inference-processor-feature-importance]]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fixes link to language identification example (#81347)