### PR TITLE
--self-signed parameter implemented at create-certs.yml

### DIFF
--- a/docs/reference/setup/install/create-certs.yml
+++ b/docs/reference/setup/install/create-certs.yml
@@ -7,7 +7,7 @@ services:
     command: >
       bash -c '
         if [[ ! -f /certs/bundle.zip ]]; then
-          bin/elasticsearch-certutil cert --silent --pem --in config/certificates/instances.yml -out /certs/bundle.zip;
+          bin/elasticsearch-certutil cert --silent --self-signed --pem --in config/certificates/instances.yml -out /certs/bundle.zip;
           unzip /certs/bundle.zip -d /certs; 
         fi;
         chown -R 1000:0 /certs


### PR DESCRIPTION
Default use of current code throw-ed "ERROR: Must specify either --ca or --ca-cert/--ca-key or --self-signed"
"--self-signed" added

