### PR TITLE
Expand example in HLRC put-role docs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -1472,6 +1472,14 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             final Role role = Role.builder()
                 .name("testPutRole")
                 .clusterPrivileges(randomSubsetOf(1, Role.ClusterPrivilegeName.ALL_ARRAY))
+                .indicesPrivileges(IndicesPrivileges.builder()
+                    .indices("my-index-*")
+                    .allowRestrictedIndices(false)
+                    .privileges(Role.IndexPrivilegeName.READ)
+                    .grantedFields("*")
+                    .deniedFields("secret_field")
+                    .query("{ \"term\": { \"public\": true } }")
+                    .build())
                 .build();
             final PutRoleRequest request = new PutRoleRequest(role, RefreshPolicy.NONE);
             // end::put-role-request


### PR DESCRIPTION
This expands the example in the High Level Rest Client's Put Role
documentation to include an example of creating a role with index
privileges, include FLS and DLS.
