### PR TITLE
Checkstyle shadows vars pt9 (#81296)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -460,8 +460,8 @@ public class CancellableTasksIT extends ESIntegTestCase {
         }
 
         @Override
-        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new CancellableTask(id, type, action, taskDescription(), parentTaskId, headers);
+        public Task createTask(long someId, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(someId, type, action, taskDescription(), parentTaskId, headers);
         }
 
         @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -235,11 +235,11 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
             ClusterState state = client().admin().cluster().prepareState().get().getState();
             IndexRoutingTable indexRoutingTable = state.routingTable().index(index);
             List<ShardRouting> startedShards = indexRoutingTable.shardsWithState(ShardRoutingState.STARTED);
-            Set<String> nodesWithShard = new HashSet<>();
+            Set<String> nodesNamesWithShard = new HashSet<>();
             for (ShardRouting startedShard : startedShards) {
-                nodesWithShard.add(state.nodes().get(startedShard.currentNodeId()).getName());
+                nodesNamesWithShard.add(state.nodes().get(startedShard.currentNodeId()).getName());
             }
-            return nodesWithShard;
+            return nodesNamesWithShard;
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchProgressActionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchProgressActionListenerIT.java
@@ -107,12 +107,12 @@ public class SearchProgressActionListenerIT extends ESSingleNodeTestCase {
         SearchProgressActionListener listener = new SearchProgressActionListener() {
             @Override
             public void onListShards(
-                List<SearchShard> shards,
+                List<SearchShard> searchShards,
                 List<SearchShard> skippedShards,
                 SearchResponse.Clusters clusters,
                 boolean fetchPhase
             ) {
-                shardsListener.set(shards);
+                shardsListener.set(searchShards);
                 assertEquals(fetchPhase, hasFetchPhase);
             }
 
@@ -141,12 +141,12 @@ public class SearchProgressActionListenerIT extends ESSingleNodeTestCase {
             }
 
             @Override
-            public void onPartialReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
+            public void onPartialReduce(List<SearchShard> searchShards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
                 numReduces.incrementAndGet();
             }
 
             @Override
-            public void onFinalReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
+            public void onFinalReduce(List<SearchShard> searchShards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
                 numReduces.incrementAndGet();
             }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -675,7 +675,7 @@ public class TransportSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        public Aggregator subAggregator(String name) {
+        public Aggregator subAggregator(String aggregatorName) {
             return null;
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -278,12 +278,12 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
             IndexShardState newState,
             @Nullable String reason
         ) {
-            List<IndexShardState> shardStates = this.shardStates.putIfAbsent(
+            List<IndexShardState> shardStateList = this.shardStates.putIfAbsent(
                 indexShard.shardId(),
                 new CopyOnWriteArrayList<>(new IndexShardState[] { newState })
             );
-            if (shardStates != null) {
-                shardStates.add(newState);
+            if (shardStateList != null) {
+                shardStateList.add(newState);
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
@@ -449,7 +449,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             )
             .setRefreshPolicy(IMMEDIATE)
             .get();
-        FunctionScoreQueryBuilder baseQuery = functionScoreQuery(
+        FunctionScoreQueryBuilder baseQueryBuilder = functionScoreQuery(
             constantScoreQuery(termQuery("test", "value")),
             ScoreFunctionBuilders.weightFactorFunction(randomIntBetween(1, 10))
         );
@@ -458,7 +458,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("loc", point, "1000km")).boostMode(CombineFunction.REPLACE)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", point, "1000km")).boostMode(CombineFunction.REPLACE)
                     )
                 )
         );
@@ -473,7 +473,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("loc", coords, "1000km")).boostMode(CombineFunction.REPLACE)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", coords, "1000km")).boostMode(CombineFunction.REPLACE)
                     )
                 )
         );
@@ -510,7 +510,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .setSource(jsonBuilder().startObject().field("test", "value value").field("num", 1.0).endObject())
             .get();
-        FunctionScoreQueryBuilder baseQuery = functionScoreQuery(
+        FunctionScoreQueryBuilder baseQueryBuilder = functionScoreQuery(
             constantScoreQuery(termQuery("test", "value")),
             ScoreFunctionBuilders.weightFactorFunction(2)
         );
@@ -519,7 +519,9 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MULTIPLY)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                            CombineFunction.MULTIPLY
+                        )
                     )
                 )
         );
@@ -533,7 +535,9 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.REPLACE)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                            CombineFunction.REPLACE
+                        )
                     )
                 )
         );
@@ -547,7 +551,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.SUM)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.SUM)
                     )
                 )
         );
@@ -562,7 +566,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.AVG)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.AVG)
                     )
                 )
         );
@@ -576,7 +580,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MIN)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MIN)
                     )
                 )
         );
@@ -590,7 +594,7 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
                 .source(
                     searchSource().query(
-                        functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MAX)
+                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MAX)
                     )
                 )
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -1023,11 +1023,11 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             .put("index.analysis.filter.suggest_stop_filter.type", "stop")
             .put("index.analysis.filter.suggest_stop_filter.remove_trailing", false);
 
-        CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
-        completionMappingBuilder.preserveSeparators(true).preservePositionIncrements(true);
-        completionMappingBuilder.searchAnalyzer("stoptest");
-        completionMappingBuilder.indexAnalyzer("simple");
-        createIndexAndMappingAndSettings(settingsBuilder.build(), completionMappingBuilder);
+        CompletionMappingBuilder builder = new CompletionMappingBuilder();
+        builder.preserveSeparators(true).preservePositionIncrements(true);
+        builder.searchAnalyzer("stoptest");
+        builder.indexAnalyzer("simple");
+        createIndexAndMappingAndSettings(settingsBuilder.build(), builder);
 
         client().prepareIndex(INDEX, TYPE, "1")
             .setSource(
@@ -1071,8 +1071,8 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testThatIndexingInvalidFieldsInCompletionFieldResultsInException() throws Exception {
-        CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
-        createIndexAndMapping(completionMappingBuilder);
+        CompletionMappingBuilder builder = new CompletionMappingBuilder();
+        createIndexAndMapping(builder);
 
         try {
             client().prepareIndex(INDEX, TYPE, "1")
@@ -1229,7 +1229,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         return names;
     }
 
-    private void createIndexAndMappingAndSettings(Settings settings, CompletionMappingBuilder completionMappingBuilder) throws IOException {
+    private void createIndexAndMappingAndSettings(Settings settings, CompletionMappingBuilder builder) throws IOException {
         XContentBuilder mapping = jsonBuilder().startObject()
             .startObject(TYPE)
             .startObject("properties")
@@ -1241,14 +1241,14 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             .endObject()
             .startObject(FIELD)
             .field("type", "completion")
-            .field("analyzer", completionMappingBuilder.indexAnalyzer)
-            .field("search_analyzer", completionMappingBuilder.searchAnalyzer)
-            .field("preserve_separators", completionMappingBuilder.preserveSeparators)
-            .field("preserve_position_increments", completionMappingBuilder.preservePositionIncrements);
+            .field("analyzer", builder.indexAnalyzer)
+            .field("search_analyzer", builder.searchAnalyzer)
+            .field("preserve_separators", builder.preserveSeparators)
+            .field("preserve_position_increments", builder.preservePositionIncrements);
 
-        if (completionMappingBuilder.contextMappings != null) {
+        if (builder.contextMappings != null) {
             mapping = mapping.startArray("contexts");
-            for (Map.Entry<String, ContextMapping<?>> contextMapping : completionMappingBuilder.contextMappings.entrySet()) {
+            for (Map.Entry<String, ContextMapping<?>> contextMapping : builder.contextMappings.entrySet()) {
                 mapping = mapping.startObject()
                     .field("name", contextMapping.getValue().name())
                     .field("type", contextMapping.getValue().type().name());
@@ -1279,8 +1279,8 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         );
     }
 
-    private void createIndexAndMapping(CompletionMappingBuilder completionMappingBuilder) throws IOException {
-        createIndexAndMappingAndSettings(Settings.EMPTY, completionMappingBuilder);
+    private void createIndexAndMapping(CompletionMappingBuilder builder) throws IOException {
+        createIndexAndMappingAndSettings(Settings.EMPTY, builder);
     }
 
     // see #3555
@@ -1601,8 +1601,8 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             return this;
         }
 
-        public CompletionMappingBuilder context(LinkedHashMap<String, ContextMapping<?>> contextMappings) {
-            this.contextMappings = contextMappings;
+        public CompletionMappingBuilder context(LinkedHashMap<String, ContextMapping<?>> mappings) {
+            this.contextMappings = mappings;
             return this;
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -379,8 +379,10 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
         }
 
         public void consume(Version version) {
-            if (version == null) return;
-            this.current.updateAndGet(current -> version.compareTo(current) <= 0 ? current : version);
+            if (version == null) {
+                return;
+            }
+            this.current.updateAndGet(currentVersion -> version.compareTo(currentVersion) <= 0 ? currentVersion : version);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -691,8 +691,8 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
             return this;
         }
 
-        public Builder setThreadPools(ExecutorNames executorNames) {
-            this.executorNames = executorNames;
+        public Builder setThreadPools(ExecutorNames threadPoolExecutorNames) {
+            this.executorNames = threadPoolExecutorNames;
             return this;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockResponse.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockResponse.java
@@ -29,11 +29,11 @@ public class MockResponse {
     }
 
     /**
-     * @param statusCode The status code to be returned if the response is sent by the webserver, defaults to 200
+     * @param responseCode The status code to be returned if the response is sent by the webserver, defaults to 200
      * @return The updated mock response
      */
-    public MockResponse setResponseCode(int statusCode) {
-        this.statusCode = statusCode;
+    public MockResponse setResponseCode(int responseCode) {
+        this.statusCode = responseCode;
         return this;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
@@ -77,8 +77,8 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        public void setExpirationTime(long expirationTimeMillis) {
-            this.expirationTimeMillis = expirationTimeMillis;
+        public void setExpirationTime(long expirationTime) {
+            this.expirationTimeMillis = expirationTime;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -214,11 +214,11 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             return limit;
         }
 
-        void adjustLimit(long limit) {
-            if (limit < used) {
-                throw new IllegalArgumentException("Limit must not be smaller than used; used=" + used + "; limit=" + limit);
+        void adjustLimit(long newLimit) {
+            if (newLimit < used) {
+                throw new IllegalArgumentException("Limit must not be smaller than used; used=" + used + "; limit=" + newLimit);
             }
-            this.limit = limit;
+            this.limit = newLimit;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
@@ -99,10 +99,7 @@ public class AbstractAuditorTests extends ESTestCase {
     }
 
     public void testInfo() throws IOException {
-        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(
-            client,
-            Version.CURRENT
-        );
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(Version.CURRENT);
         auditor.info("foo", "Here is my info");
 
         verify(client).execute(eq(IndexAction.INSTANCE), indexRequestCaptor.capture(), any());
@@ -121,10 +118,7 @@ public class AbstractAuditorTests extends ESTestCase {
     }
 
     public void testWarning() throws IOException {
-        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(
-            client,
-            Version.CURRENT
-        );
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(Version.CURRENT);
         auditor.warning("bar", "Here is my warning");
 
         verify(client).execute(eq(IndexAction.INSTANCE), indexRequestCaptor.capture(), any());
@@ -143,10 +137,7 @@ public class AbstractAuditorTests extends ESTestCase {
     }
 
     public void testError() throws IOException {
-        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(
-            client,
-            Version.CURRENT
-        );
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled(Version.CURRENT);
         auditor.error("foobar", "Here is my error");
 
         verify(client).execute(eq(IndexAction.INSTANCE), indexRequestCaptor.capture(), any());
@@ -168,7 +159,7 @@ public class AbstractAuditorTests extends ESTestCase {
         CountDownLatch writeSomeDocsBeforeTemplateLatch = new CountDownLatch(1);
         AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor =
             // TODO: Both this call and the called method can be simplified in versions that will never have to talk to 7.13
-            createTestAuditorWithoutTemplate(client, randomFrom(Version.CURRENT, Version.V_7_13_0), writeSomeDocsBeforeTemplateLatch);
+            createTestAuditorWithoutTemplate(randomFrom(Version.CURRENT, Version.V_7_13_0), writeSomeDocsBeforeTemplateLatch);
 
         auditor.error("foobar", "Here is my error to queue");
         auditor.warning("foobar", "Here is my warning to queue");
@@ -192,7 +183,6 @@ public class AbstractAuditorTests extends ESTestCase {
     public void testMaxBufferSize() throws Exception {
         CountDownLatch writeSomeDocsBeforeTemplateLatch = new CountDownLatch(1);
         AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithoutTemplate(
-            client,
             Version.CURRENT,
             writeSomeDocsBeforeTemplateLatch
         );
@@ -219,7 +209,7 @@ public class AbstractAuditorTests extends ESTestCase {
         return AbstractAuditMessageTests.TestAuditMessage.PARSER.apply(parser, null);
     }
 
-    private TestAuditor createTestAuditorWithTemplateInstalled(Client client, Version minNodeVersion) {
+    private TestAuditor createTestAuditorWithTemplateInstalled(Version minNodeVersion) {
         ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templates = ImmutableOpenMap.builder(1);
         templates.put(TEST_INDEX, mock(IndexTemplateMetadata.class));
         Map<String, ComposableIndexTemplate> templatesV2 = Collections.singletonMap(TEST_INDEX, mock(ComposableIndexTemplate.class));
@@ -238,7 +228,7 @@ public class AbstractAuditorTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private TestAuditor createTestAuditorWithoutTemplate(Client client, Version minNodeVersion, CountDownLatch latch) {
+    private TestAuditor createTestAuditorWithoutTemplate(Version minNodeVersion, CountDownLatch latch) {
         if (Mockito.mockingDetails(client).isMock() == false) {
             throw new AssertionError("client should be a mock");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -76,7 +76,7 @@ public class PhaseCacheManagementTests extends ESTestCase {
             );
 
         IndexMetadata meta = buildIndexMetadata("my-policy", exState);
-        String index = meta.getIndex().getName();
+        String indexName = meta.getIndex().getName();
 
         Map<String, LifecycleAction> actions = new HashMap<>();
         actions.put("rollover", new RolloverAction(null, null, null, 1L));
@@ -90,9 +90,9 @@ public class PhaseCacheManagementTests extends ESTestCase {
             .metadata(Metadata.builder(Metadata.EMPTY_METADATA).put(meta, false).build())
             .build();
 
-        ClusterState changedState = refreshPhaseDefinition(existingState, index, policyMetadata);
+        ClusterState changedState = refreshPhaseDefinition(existingState, indexName, policyMetadata);
 
-        IndexMetadata newIdxMeta = changedState.metadata().index(index);
+        IndexMetadata newIdxMeta = changedState.metadata().index(indexName);
         LifecycleExecutionState afterExState = LifecycleExecutionState.fromIndexMetadata(newIdxMeta);
         Map<String, String> beforeState = new HashMap<>(exState.build().asMap());
         beforeState.remove("phase_definition");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepRequestTests.java
@@ -46,13 +46,13 @@ public class MoveToStepRequestTests extends AbstractSerializingTestCase<Request>
 
     @Override
     protected Request mutateInstance(Request request) {
-        String index = request.getIndex();
+        String indexName = request.getIndex();
         StepKey currentStepKey = request.getCurrentStepKey();
         Request.PartialStepKey nextStepKey = request.getNextStepKey();
 
         switch (between(0, 2)) {
             case 0:
-                index += randomAlphaOfLength(5);
+                indexName += randomAlphaOfLength(5);
                 break;
             case 1:
                 currentStepKey = stepKeyTests.mutateInstance(currentStepKey);
@@ -64,7 +64,7 @@ public class MoveToStepRequestTests extends AbstractSerializingTestCase<Request>
                 throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new Request(index, currentStepKey, nextStepKey);
+        return new Request(indexName, currentStepKey, nextStepKey);
     }
 
     private static Request.PartialStepKey randomStepSpecification() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -195,6 +195,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             this.maxDocsPerSecond = maxDocsPerSecond;
         }
 
+        @SuppressWarnings("HiddenField")
         public void rethrottle(float maxDocsPerSecond) {
             this.maxDocsPerSecond = maxDocsPerSecond;
             rethrottle();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasActionRequestTests.java
@@ -48,7 +48,7 @@ public class PutTrainedModelAliasActionRequestTests extends AbstractWireSerializ
             assertThat(ex.getMessage(), containsString("model_alias [foo] cannot equal model_id [foo]"));
         }
         { // model_alias cannot end in numbers
-            String modelAlias = randomAlphaOfLength(10) + randomIntBetween(0, Integer.MAX_VALUE);
+            modelAlias = randomAlphaOfLength(10) + randomIntBetween(0, Integer.MAX_VALUE);
             ActionRequestValidationException ex = new Request(modelAlias, "foo", randomBoolean()).validate();
             assertThat(ex, not(nullValue()));
             assertThat(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/NamedXContentObjectsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/NamedXContentObjectsTests.java
@@ -84,8 +84,8 @@ public class NamedXContentObjectsTests extends AbstractXContentTestCase<NamedXCo
             this.trainedModel = trainedModel.get(0);
         }
 
-        void setModel(TrainedModel trainedModel) {
-            this.trainedModel = trainedModel;
+        void setModel(TrainedModel model) {
+            this.trainedModel = model;
         }
 
         void setUseExplicitPreprocessorOrder(boolean value) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModelTests.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.nullValue;
 public class EnsembleInferenceModelTests extends ESTestCase {
 
     private static final int NUMBER_OF_TEST_RUNS = 20;
-    private final double eps = 1.0E-8;
 
     public static EnsembleInferenceModel serializeFromTrainedModel(Ensemble ensemble) throws IOException {
         NamedXContentRegistry registry = new NamedXContentRegistry(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
@@ -515,6 +514,7 @@ public class EnsembleInferenceModelTests extends ESTestCase {
         ensemble.rewriteFeatureIndices(Collections.emptyMap());
 
         double[][] featureImportance = ensemble.featureImportance(new double[] { 0.0, 0.9 });
+        final double eps = 1.0E-8;
         assertThat(featureImportance[0][0], closeTo(-1.653200025, eps));
         assertThat(featureImportance[1][0], closeTo(-0.12444978, eps));
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.nullValue;
 public class TreeInferenceModelTests extends ESTestCase {
 
     private static final int NUMBER_OF_TEST_RUNS = 20;
-    private final double eps = 1.0E-8;
 
     public static TreeInferenceModel serializeFromTrainedModel(Tree tree) throws IOException {
         NamedXContentRegistry registry = new NamedXContentRegistry(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
@@ -192,7 +191,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         Tree treeObject = builder.setFeatureNames(featureNames).setClassificationLabels(Arrays.asList("cat", "dog")).build();
         TreeInferenceModel tree = deserializeFromTrainedModel(treeObject, xContentRegistry(), TreeInferenceModel::fromXContent);
         tree.rewriteFeatureIndices(Collections.emptyMap());
-        double eps = 0.000001;
+        final double eps = 0.000001;
         // This feature vector should hit the right child of the root node
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
         List<Double> expectedProbs = Arrays.asList(1.0, 0.0);
@@ -271,6 +270,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         tree.rewriteFeatureIndices(Collections.emptyMap());
 
         double[][] featureImportance = tree.featureImportance(new double[] { 0.25, 0.25 });
+        final double eps = 1.0E-8;
         assertThat(featureImportance[0][0], closeTo(-5.0, eps));
         assertThat(featureImportance[1][0], closeTo(-2.5, eps));
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -109,8 +109,9 @@ public class MlIndexAndAliasTests extends ESTestCase {
 
         clusterAdminClient = mock(ClusterAdminClient.class);
         doAnswer(invocationOnMock -> {
-            ActionListener<ClusterHealthResponse> listener = (ActionListener<ClusterHealthResponse>) invocationOnMock.getArguments()[1];
-            listener.onResponse(new ClusterHealthResponse());
+            ActionListener<ClusterHealthResponse> actionListener = (ActionListener<ClusterHealthResponse>) invocationOnMock
+                .getArguments()[1];
+            actionListener.onResponse(new ClusterHealthResponse());
             return null;
         }).when(clusterAdminClient).health(any(ClusterHealthRequest.class), any(ActionListener.class));
 
@@ -122,8 +123,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.admin()).thenReturn(adminClient);
         doAnswer(invocationOnMock -> {
-            ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocationOnMock.getArguments()[2];
-            listener.onResponse(AcknowledgedResponse.TRUE);
+            ActionListener<AcknowledgedResponse> actionListener = (ActionListener<AcknowledgedResponse>) invocationOnMock.getArguments()[2];
+            actionListener.onResponse(AcknowledgedResponse.TRUE);
             return null;
         }).when(client)
             .execute(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetReaderTests.java
@@ -164,9 +164,9 @@ public class DocumentSubsetReaderTests extends ESTestCase {
         IndexWriterConfig iwc = new IndexWriterConfig(null);
         IndexWriter iw = new IndexWriter(dir, iwc);
         iw.close();
-        DirectoryReader directoryReader = DocumentSubsetReader.wrap(DirectoryReader.open(dir), bitsetCache, new MatchAllDocsQuery());
+        DirectoryReader dirReader = DocumentSubsetReader.wrap(DirectoryReader.open(dir), bitsetCache, new MatchAllDocsQuery());
         try {
-            DocumentSubsetReader.wrap(directoryReader, bitsetCache, new MatchAllDocsQuery());
+            DocumentSubsetReader.wrap(dirReader, bitsetCache, new MatchAllDocsQuery());
             fail("shouldn't be able to wrap DocumentSubsetDirectoryReader twice");
         } catch (IllegalArgumentException e) {
             assertThat(
@@ -179,7 +179,7 @@ public class DocumentSubsetReaderTests extends ESTestCase {
         }
 
         bitsetCache.close();
-        directoryReader.close();
+        dirReader.close();
         dir.close();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/AbstractSerializingTransformTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/AbstractSerializingTransformTestCase.java
@@ -104,7 +104,7 @@ public abstract class AbstractSerializingTransformTestCase<T extends ToXContent 
 
     protected <X extends Writeable, Y extends Writeable> Y writeAndReadBWCObject(
         X original,
-        NamedWriteableRegistry namedWriteableRegistry,
+        NamedWriteableRegistry registry,
         Writeable.Writer<X> writer,
         Writeable.Reader<Y> reader,
         Version version

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/AbstractWireSerializingTransformTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/AbstractWireSerializingTransformTestCase.java
@@ -72,7 +72,7 @@ public abstract class AbstractWireSerializingTransformTestCase<T extends Writeab
 
     protected <X extends Writeable, Y extends Writeable> Y writeAndReadBWCObject(
         X original,
-        NamedWriteableRegistry namedWriteableRegistry,
+        NamedWriteableRegistry registry,
         Writeable.Writer<X> writer,
         Writeable.Reader<Y> reader,
         Version version

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/DestConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/DestConfigTests.java
@@ -55,10 +55,10 @@ public class DestConfigTests extends AbstractSerializingTransformTestCase<DestCo
     }
 
     public void testFailOnEmptyIndex() throws IOException {
-        boolean lenient = randomBoolean();
+        boolean lenient2 = randomBoolean();
         String json = "{ \"index\": \"\" }";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
-            DestConfig dest = DestConfig.fromXContent(parser, lenient);
+            DestConfig dest = DestConfig.fromXContent(parser, lenient2);
             assertThat(dest.getIndex(), is(emptyString()));
             ValidationException validationException = dest.validate(null);
             assertThat(validationException, is(notNullValue()));

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorSpecTests.java
@@ -44,15 +44,15 @@ public class QueryTranslatorSpecTests extends AbstractQueryTranslatorTestCase {
         EsQueryExec eqe = (EsQueryExec) p;
         assertEquals(0, eqe.output().size());
 
-        final String query = eqe.queryContainer().toString().replaceAll("\\s+", "");
+        final String queryWithoutWhitespace = eqe.queryContainer().toString().replaceAll("\\s+", "");
 
         // test query term
-        matchers.forEach(m -> assertThat(query, m));
+        matchers.forEach(m -> assertThat(queryWithoutWhitespace, m));
 
         // test common term
-        assertThat(query, containsString("\"term\":{\"event.category\":{\"value\":\"process\""));
+        assertThat(queryWithoutWhitespace, containsString("\"term\":{\"event.category\":{\"value\":\"process\""));
 
         // test field source extraction
-        assertThat(query, not(containsString("\"_source\":{\"includes\":[],\"excludes\":[]")));
+        assertThat(queryWithoutWhitespace, not(containsString("\"_source\":{\"includes\":[],\"excludes\":[]")));
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/stats/VerifierMetricsTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/stats/VerifierMetricsTests.java
@@ -222,8 +222,8 @@ public class VerifierMetricsTests extends ESTestCase {
             }
         }
 
-        void set(Set<FeatureMetric> metrics) {
-            for (FeatureMetric metric : metrics) {
+        void set(Set<FeatureMetric> metricSet) {
+            for (FeatureMetric metric : metricSet) {
                 set(metric);
             }
         }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/IdentityProviderPlugin.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/IdentityProviderPlugin.java
@@ -151,7 +151,7 @@ public class IdentityProviderPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,
@@ -175,16 +175,16 @@ public class IdentityProviderPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        List<Setting<?>> settings = new ArrayList<>();
-        settings.add(ENABLED_SETTING);
-        settings.addAll(SamlIdentityProviderBuilder.getSettings());
-        settings.addAll(ServiceProviderCacheSettings.getSettings());
-        settings.addAll(ServiceProviderDefaults.getSettings());
-        settings.addAll(WildcardServiceProviderResolver.getSettings());
-        settings.addAll(ApplicationActionsResolver.getSettings());
-        settings.addAll(X509KeyPairSettings.withPrefix("xpack.idp.signing.", false).getAllSettings());
-        settings.addAll(X509KeyPairSettings.withPrefix("xpack.idp.metadata_signing.", false).getAllSettings());
-        return Collections.unmodifiableList(settings);
+        List<Setting<?>> settingList = new ArrayList<>();
+        settingList.add(ENABLED_SETTING);
+        settingList.addAll(SamlIdentityProviderBuilder.getSettings());
+        settingList.addAll(ServiceProviderCacheSettings.getSettings());
+        settingList.addAll(ServiceProviderDefaults.getSettings());
+        settingList.addAll(WildcardServiceProviderResolver.getSettings());
+        settingList.addAll(ApplicationActionsResolver.getSettings());
+        settingList.addAll(X509KeyPairSettings.withPrefix("xpack.idp.signing.", false).getAllSettings());
+        settingList.addAll(X509KeyPairSettings.withPrefix("xpack.idp.metadata_signing.", false).getAllSettings());
+        return Collections.unmodifiableList(settingList);
     }
 
     protected XPackLicenseState getLicenseState() {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
@@ -147,14 +147,14 @@ public class SamlIdentityProvider {
         }, listener::onFailure));
     }
 
-    private void resolveWildcardService(String entityId, String acs, ActionListener<SamlServiceProvider> listener) {
+    private void resolveWildcardService(String spEntityId, String acs, ActionListener<SamlServiceProvider> listener) {
         if (acs == null) {
-            logger.debug("No ACS provided for [{}], skipping wildcard matching", entityId);
+            logger.debug("No ACS provided for [{}], skipping wildcard matching", spEntityId);
             listener.onResponse(null);
         } else {
             try {
-                final SamlServiceProvider sp = wildcardServiceResolver.resolve(entityId, acs);
-                logger.debug("Wildcard service provider for [{}][{}] is [{}]", entityId, acs, sp);
+                final SamlServiceProvider sp = wildcardServiceResolver.resolve(spEntityId, acs);
+                logger.debug("Wildcard service provider for [{}][{}] is [{}]", spEntityId, acs, sp);
                 listener.onResponse(sp);
             } catch (Exception e) {
                 listener.onFailure(e);

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
@@ -240,13 +240,13 @@ public class SamlIdentityProviderBuilder {
         return this;
     }
 
-    public SamlIdentityProviderBuilder singleSignOnEndpoints(Map<String, URL> ssoEndpoints) {
-        this.ssoEndpoints = ssoEndpoints;
+    public SamlIdentityProviderBuilder singleSignOnEndpoints(Map<String, URL> ssoEndpointsMap) {
+        this.ssoEndpoints = ssoEndpointsMap;
         return this;
     }
 
-    public SamlIdentityProviderBuilder singleLogoutEndpoints(Map<String, URL> sloEndpoints) {
-        this.sloEndpoints = sloEndpoints;
+    public SamlIdentityProviderBuilder singleLogoutEndpoints(Map<String, URL> sloEndpointsMap) {
+        this.sloEndpoints = sloEndpointsMap;
         return this;
     }
 

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -95,17 +95,17 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        Settings.Builder settings = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
-        settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
-        settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
-        settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
-        settings.put(XPackSettings.GRAPH_ENABLED.getKey(), false);
-        settings.put(LifecycleSettings.LIFECYCLE_POLL_INTERVAL, "1s");
+        Settings.Builder nodeSettings = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
+        nodeSettings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
+        nodeSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
+        nodeSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
+        nodeSettings.put(XPackSettings.GRAPH_ENABLED.getKey(), false);
+        nodeSettings.put(LifecycleSettings.LIFECYCLE_POLL_INTERVAL, "1s");
 
         // This is necessary to prevent ILM and SLM installing a lifecycle policy, these tests assume a blank slate
-        settings.put(LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED, false);
-        settings.put(LifecycleSettings.SLM_HISTORY_INDEX_ENABLED_SETTING.getKey(), false);
-        return settings.build();
+        nodeSettings.put(LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED, false);
+        nodeSettings.put(LifecycleSettings.SLM_HISTORY_INDEX_ENABLED_SETTING.getKey(), false);
+        return nodeSettings.build();
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
@@ -103,8 +103,8 @@ public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
             this.value = value;
         }
 
-        void validate(String value) {
-            if (value.equals(INVALID_VALUE)) {
+        void validate(String valueToCheck) {
+            if (valueToCheck.equals(INVALID_VALUE)) {
                 throw new IllegalArgumentException("[" + INVALID_VALUE + "] is not supported");
             }
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -342,7 +342,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -71,8 +71,8 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
      * {@link #onClusterStateProcessed(String, ClusterState, ClusterState)} or the {@link #handleFailure(String, Exception)} hooks are
      * executed.
      */
-    public final void addListener(ActionListener<Void> listener) {
-        this.listener.addListener(listener);
+    public final void addListener(ActionListener<Void> actionListener) {
+        this.listener.addListener(actionListener);
     }
 
     /**

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -131,16 +131,16 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
 
         indexName = randomAlphaOfLength(5);
         lifecycleMetadata = new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING);
-        indexMetadata = setupIndexPolicy(mixedPolicyName);
+        setupIndexPolicy(mixedPolicyName);
     }
 
-    private IndexMetadata setupIndexPolicy(String policyName) {
+    private void setupIndexPolicy(String policyName) {
         // Reset the index to use the "allClusterPolicyName"
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase("new");
         lifecycleState.setAction("init");
         lifecycleState.setStep("init");
-        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+        indexMetadata = IndexMetadata.builder(indexName)
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
             .numberOfShards(randomIntBetween(1, 5))
@@ -163,7 +163,6 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .build();
         policyStepsRegistry.update(clusterState.metadata().custom(IndexLifecycleMetadata.TYPE));
-        return indexMetadata;
     }
 
     public void testNeverExecuteNonClusterStateStep() throws Exception {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -1216,8 +1216,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             super(lifecyclePolicyMap, firstStepMap, stepMap, xContentRegistry, client, null);
         }
 
-        public void setResolver(BiFunction<IndexMetadata, StepKey, Step> fn) {
-            this.fn = fn;
+        public void setResolver(BiFunction<IndexMetadata, StepKey, Step> resolver) {
+            this.fn = resolver;
         }
 
         @Override

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
@@ -146,11 +146,11 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         assertThat(newState, sameInstance(clusterState));
     }
 
-    private void setStatePolicy(String policy) {
+    private void setStatePolicy(String policyValue) {
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())
-                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), index.getName())
+                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyValue).build(), index.getName())
             )
             .build();
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -195,11 +195,11 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         }
     }
 
-    private void setStatePolicy(String policy) {
+    private void setStatePolicy(String policyValue) {
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())
-                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), index.getName())
+                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyValue).build(), index.getName())
             )
             .build();
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -140,11 +140,11 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         }
     }
 
-    private void setStatePolicy(String policy) {
+    private void setStatePolicy(String policyValue) {
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())
-                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), index.getName())
+                    .updateSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyValue).build(), index.getName())
             )
             .build();
 

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -204,7 +204,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         @Override
         public Query fuzzyQuery(
-            Object value,
+            Object term,
             Fuzziness fuzziness,
             int prefixLength,
             int maxExpansions,
@@ -215,7 +215,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                 return new MatchNoDocsQuery();
             }
 
-            final String termAsString = BytesRefs.toString(value);
+            final String termAsString = BytesRefs.toString(term);
             final int maxEdits = fuzziness.asDistance(termAsString);
 
             final int[] termText = new int[termAsString.codePointCount(0, termAsString.length())];
@@ -240,7 +240,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         @Override
         public Query regexpQuery(
-            String value,
+            String regexp,
             int syntaxFlags,
             int matchFlags,
             int maxDeterminizedStates,
@@ -251,7 +251,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                 return new MatchNoDocsQuery();
             }
 
-            final Automaton automaton = new RegExp(value, syntaxFlags, matchFlags).toAutomaton(maxDeterminizedStates);
+            final Automaton automaton = new RegExp(regexp, syntaxFlags, matchFlags).toAutomaton(maxDeterminizedStates);
             final CharacterRunAutomaton runAutomaton = new CharacterRunAutomaton(automaton);
             if (runAutomaton.run(this.value)) {
                 return new MatchAllDocsQuery();

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongDocValuesField.java
@@ -79,13 +79,13 @@ public class UnsignedLongDocValuesField implements UnsignedLongField, DocValuesF
             return Collections.emptyList();
         }
 
-        List<Long> values = new ArrayList<>(count);
+        List<Long> longValues = new ArrayList<>(count);
 
         for (int index = 0; index < count; ++index) {
-            values.add(toFormatted(index));
+            longValues.add(toFormatted(index));
         }
 
-        return values;
+        return longValues;
     }
 
     @Override
@@ -112,13 +112,13 @@ public class UnsignedLongDocValuesField implements UnsignedLongField, DocValuesF
             return Collections.emptyList();
         }
 
-        List<BigInteger> values = new ArrayList<>(count);
+        List<BigInteger> bigIntegerValues = new ArrayList<>(count);
 
         for (int index = 0; index < count; ++index) {
-            values.add(toBigInteger(index));
+            bigIntegerValues.add(toBigInteger(index));
         }
 
-        return values;
+        return bigIntegerValues;
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -95,6 +95,7 @@ import static org.hamcrest.Matchers.notNullValue;
     transportClientRatio = 0.0,
     supportsDedicatedMasters = false
 )
+@SuppressWarnings("HiddenField")
 public class HttpExporterIT extends MonitoringIntegTestCase {
 
     private final List<String> clusterAlertBlacklist = rarely()

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
@@ -210,7 +210,7 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,
@@ -223,24 +223,24 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
 
     @Override
     public List<Setting<?>> getSettings() {
-        List<Setting<?>> settings = new ArrayList<>();
-        settings.add(MonitoringField.HISTORY_DURATION);
-        settings.add(CLEAN_WATCHER_HISTORY);
-        settings.add(MonitoringService.ENABLED);
-        settings.add(MonitoringService.ELASTICSEARCH_COLLECTION_ENABLED);
-        settings.add(MonitoringService.INTERVAL);
-        settings.add(Collector.INDICES);
-        settings.add(ClusterStatsCollector.CLUSTER_STATS_TIMEOUT);
-        settings.add(IndexRecoveryCollector.INDEX_RECOVERY_TIMEOUT);
-        settings.add(IndexRecoveryCollector.INDEX_RECOVERY_ACTIVE_ONLY);
-        settings.add(IndexStatsCollector.INDEX_STATS_TIMEOUT);
-        settings.add(JobStatsCollector.JOB_STATS_TIMEOUT);
-        settings.add(StatsCollector.CCR_STATS_TIMEOUT);
-        settings.add(NodeStatsCollector.NODE_STATS_TIMEOUT);
-        settings.add(EnrichStatsCollector.STATS_TIMEOUT);
-        settings.addAll(Exporters.getSettings());
-        settings.add(Monitoring.MIGRATION_DECOMMISSION_ALERTS);
-        return Collections.unmodifiableList(settings);
+        List<Setting<?>> settingList = new ArrayList<>();
+        settingList.add(MonitoringField.HISTORY_DURATION);
+        settingList.add(CLEAN_WATCHER_HISTORY);
+        settingList.add(MonitoringService.ENABLED);
+        settingList.add(MonitoringService.ELASTICSEARCH_COLLECTION_ENABLED);
+        settingList.add(MonitoringService.INTERVAL);
+        settingList.add(Collector.INDICES);
+        settingList.add(ClusterStatsCollector.CLUSTER_STATS_TIMEOUT);
+        settingList.add(IndexRecoveryCollector.INDEX_RECOVERY_TIMEOUT);
+        settingList.add(IndexRecoveryCollector.INDEX_RECOVERY_ACTIVE_ONLY);
+        settingList.add(IndexStatsCollector.INDEX_STATS_TIMEOUT);
+        settingList.add(JobStatsCollector.JOB_STATS_TIMEOUT);
+        settingList.add(StatsCollector.CCR_STATS_TIMEOUT);
+        settingList.add(NodeStatsCollector.NODE_STATS_TIMEOUT);
+        settingList.add(EnrichStatsCollector.STATS_TIMEOUT);
+        settingList.addAll(Exporters.getSettings());
+        settingList.add(Monitoring.MIGRATION_DECOMMISSION_ALERTS);
+        return Collections.unmodifiableList(settingList);
     }
 
     @Override
@@ -250,10 +250,12 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
     }
 
     @Override
-    public void reload(Settings settings) throws Exception {
-        final List<String> changedExporters = HttpExporter.loadSettings(settings);
+    public void reload(Settings settingsToLoad) throws Exception {
+        final List<String> changedExporters = HttpExporter.loadSettings(settingsToLoad);
         for (String changedExporter : changedExporters) {
-            final Settings settingsForChangedExporter = settings.filter(x -> x.startsWith("xpack.monitoring.exporters." + changedExporter));
+            final Settings settingsForChangedExporter = settingsToLoad.filter(
+                x -> x.startsWith("xpack.monitoring.exporters." + changedExporter)
+            );
             exporters.setExportersSetting(settingsForChangedExporter);
         }
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
@@ -127,13 +127,13 @@ public class MonitoringService extends AbstractLifecycleComponent {
         HttpExporter.loadSettings(settings);
     }
 
-    void setElasticsearchCollectionEnabled(final boolean enabled) {
-        this.elasticsearchCollectionEnabled = enabled;
+    void setElasticsearchCollectionEnabled(final boolean collectionEnabled) {
+        this.elasticsearchCollectionEnabled = collectionEnabled;
         scheduleExecution();
     }
 
-    void setMonitoringActive(final boolean enabled) {
-        this.enabled = enabled;
+    void setMonitoringActive(final boolean monitoringActive) {
+        this.enabled = monitoringActive;
         scheduleExecution();
     }
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 
 public class Exporters extends AbstractLifecycleComponent {
-    private static final Logger logger = LogManager.getLogger(Exporters.class);
+    private static final Logger LOGGER = LogManager.getLogger(Exporters.class);
 
     private final Settings settings;
     private final Map<String, Exporter.Factory> factories;
@@ -94,23 +94,23 @@ public class Exporters extends AbstractLifecycleComponent {
 
     public void setExportersSetting(Settings exportersSetting) {
         if (this.lifecycle.started()) {
-            InitializedExporters exporters = initExporters(exportersSetting);
-            Map<String, Exporter> updated = exporters.enabledExporters;
-            closeExporters(logger, this.exporters.getAndSet(updated));
-            this.disabledExporterConfigs.getAndSet(exporters.disabledExporters);
+            InitializedExporters initializedExporters = initExporters(exportersSetting);
+            Map<String, Exporter> updated = initializedExporters.enabledExporters;
+            closeExporters(LOGGER, this.exporters.getAndSet(updated));
+            this.disabledExporterConfigs.getAndSet(initializedExporters.disabledExporters);
         }
     }
 
     @Override
     protected void doStart() {
-        InitializedExporters exporters = initExporters(settings);
-        this.exporters.set(exporters.enabledExporters);
-        this.disabledExporterConfigs.set(exporters.disabledExporters);
+        InitializedExporters initializedExporters = initExporters(settings);
+        this.exporters.set(initializedExporters.enabledExporters);
+        this.disabledExporterConfigs.set(initializedExporters.disabledExporters);
     }
 
     @Override
     protected void doStop() {
-        closeExporters(logger, exporters.get());
+        closeExporters(LOGGER, exporters.get());
     }
 
     @Override
@@ -161,12 +161,12 @@ public class Exporters extends AbstractLifecycleComponent {
         }
     }
 
-    InitializedExporters initExporters(Settings settings) {
+    InitializedExporters initExporters(Settings settingsToUse) {
         Set<String> singletons = new HashSet<>();
-        Map<String, Exporter> exporters = new HashMap<>();
+        Map<String, Exporter> exportersMap = new HashMap<>();
         Map<String, Exporter.Config> disabled = new HashMap<>();
         boolean hasDisabled = false;
-        Settings exportersSettings = settings.getByPrefix("xpack.monitoring.exporters.");
+        Settings exportersSettings = settingsToUse.getByPrefix("xpack.monitoring.exporters.");
         for (String name : exportersSettings.names()) {
             Settings exporterSettings = exportersSettings.getAsSettings(name);
             String type = exporterSettings.get("type");
@@ -177,11 +177,11 @@ public class Exporters extends AbstractLifecycleComponent {
             if (factory == null) {
                 throw new SettingsException("unknown exporter type [" + type + "] set for exporter [" + name + "]");
             }
-            Exporter.Config config = new Exporter.Config(name, type, settings, clusterService, licenseState);
+            Exporter.Config config = new Exporter.Config(name, type, settingsToUse, clusterService, licenseState);
             if (config.enabled() == false) {
                 hasDisabled = true;
-                if (logger.isDebugEnabled()) {
-                    logger.debug("exporter [{}/{}] is disabled", type, name);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("exporter [{}/{}] is disabled", type, name);
                 }
                 disabled.put(config.name(), config);
                 continue;
@@ -197,7 +197,7 @@ public class Exporters extends AbstractLifecycleComponent {
                 }
                 singletons.add(type);
             }
-            exporters.put(config.name(), exporter);
+            exportersMap.put(config.name(), exporter);
         }
 
         // no exporters are configured, lets create a default local one.
@@ -205,18 +205,18 @@ public class Exporters extends AbstractLifecycleComponent {
         // NOTE: if there are exporters configured and they're all disabled, we don't
         // fallback on the default
         //
-        if (exporters.isEmpty() && hasDisabled == false) {
+        if (exportersMap.isEmpty() && hasDisabled == false) {
             Exporter.Config config = new Exporter.Config(
                 "default_" + LocalExporter.TYPE,
                 LocalExporter.TYPE,
-                settings,
+                settingsToUse,
                 clusterService,
                 licenseState
             );
-            exporters.put(config.name(), factories.get(LocalExporter.TYPE).create(config));
+            exportersMap.put(config.name(), factories.get(LocalExporter.TYPE).create(config));
         }
 
-        return new InitializedExporters(exporters, disabled);
+        return new InitializedExporters(exportersMap, disabled);
     }
 
     /**
@@ -231,7 +231,7 @@ public class Exporters extends AbstractLifecycleComponent {
         if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)
             || ClusterState.UNKNOWN_UUID.equals(state.metadata().clusterUUID())
             || state.version() == ClusterState.UNKNOWN_VERSION) {
-            logger.trace("skipping exporters because the cluster state is not loaded");
+            LOGGER.trace("skipping exporters because the cluster state is not loaded");
 
             listener.onResponse(null);
             return;
@@ -351,7 +351,7 @@ public class Exporters extends AbstractLifecycleComponent {
         @Override
         public void onResponse(final ExportBulk exportBulk) {
             if (exportBulk == null) {
-                logger.debug("skipping exporter [{}] as it is not ready yet", name);
+                LOGGER.debug("skipping exporter [{}] as it is not ready yet", name);
             } else {
                 accumulatedBulks.set(indexPosition, exportBulk);
             }
@@ -361,7 +361,7 @@ public class Exporters extends AbstractLifecycleComponent {
 
         @Override
         public void onFailure(Exception e) {
-            logger.error((Supplier<?>) () -> new ParameterizedMessage("exporter [{}] failed to open exporting bulk", name), e);
+            LOGGER.error((Supplier<?>) () -> new ParameterizedMessage("exporter [{}] failed to open exporting bulk", name), e);
 
             delegateIfComplete();
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListener.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListener.java
@@ -30,12 +30,12 @@ class NodeFailureListener extends RestClient.FailureListener {
      * The optional {@link Sniffer} associated with the {@link RestClient}.
      */
     @Nullable
-    private SetOnce<Sniffer> sniffer = new SetOnce<>();
+    private final SetOnce<Sniffer> snifferHolder = new SetOnce<>();
     /**
      * The optional {@link HttpResource} associated with the {@link RestClient}.
      */
     @Nullable
-    private SetOnce<HttpResource> resource = new SetOnce<>();
+    private final SetOnce<HttpResource> resourceHolder = new SetOnce<>();
 
     /**
      * Get the {@link Sniffer} that is notified upon node failure.
@@ -44,7 +44,7 @@ class NodeFailureListener extends RestClient.FailureListener {
      */
     @Nullable
     public Sniffer getSniffer() {
-        return sniffer.get();
+        return snifferHolder.get();
     }
 
     /**
@@ -54,7 +54,7 @@ class NodeFailureListener extends RestClient.FailureListener {
      * @throws SetOnce.AlreadySetException if called more than once
      */
     public void setSniffer(@Nullable final Sniffer sniffer) {
-        this.sniffer.set(sniffer);
+        this.snifferHolder.set(sniffer);
     }
 
     /**
@@ -64,7 +64,7 @@ class NodeFailureListener extends RestClient.FailureListener {
      */
     @Nullable
     public HttpResource getResource() {
-        return resource.get();
+        return resourceHolder.get();
     }
 
     /**
@@ -74,7 +74,7 @@ class NodeFailureListener extends RestClient.FailureListener {
      * @throws SetOnce.AlreadySetException if called more than once
      */
     public void setResource(@Nullable final HttpResource resource) {
-        this.resource.set(resource);
+        this.resourceHolder.set(resource);
     }
 
     @Override
@@ -82,8 +82,8 @@ class NodeFailureListener extends RestClient.FailureListener {
         HttpHost host = node.getHost();
         logger.warn("connection failed to node at [{}://{}:{}]", host.getSchemeName(), host.getHostName(), host.getPort());
 
-        final HttpResource resource = this.resource.get();
-        final Sniffer sniffer = this.sniffer.get();
+        final HttpResource resource = this.resourceHolder.get();
+        final Sniffer sniffer = this.snifferHolder.get();
 
         if (resource != null) {
             resource.markDirty();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
@@ -91,12 +91,12 @@ public class MonitoringBulkDocTests extends ESTestCase {
 
         final List<EqualsHashCodeTestUtils.MutateFunction<MonitoringBulkDoc>> mutations = new ArrayList<>();
         mutations.add(doc -> {
-            MonitoredSystem system;
+            MonitoredSystem randomSystem;
             do {
-                system = randomFrom(MonitoredSystem.values());
-            } while (system == doc.getSystem());
+                randomSystem = randomFrom(MonitoredSystem.values());
+            } while (randomSystem == doc.getSystem());
             return new MonitoringBulkDoc(
-                system,
+                randomSystem,
                 doc.getType(),
                 doc.getId(),
                 doc.getTimestamp(),
@@ -106,13 +106,13 @@ public class MonitoringBulkDocTests extends ESTestCase {
             );
         });
         mutations.add(doc -> {
-            String type;
+            String randomType;
             do {
-                type = randomAlphaOfLength(5);
-            } while (type.equals(doc.getType()));
+                randomType = randomAlphaOfLength(5);
+            } while (randomType.equals(doc.getType()));
             return new MonitoringBulkDoc(
                 doc.getSystem(),
-                type,
+                randomType,
                 doc.getId(),
                 doc.getTimestamp(),
                 doc.getIntervalMillis(),
@@ -121,14 +121,14 @@ public class MonitoringBulkDocTests extends ESTestCase {
             );
         });
         mutations.add(doc -> {
-            String id;
+            String randomId;
             do {
-                id = randomAlphaOfLength(10);
-            } while (id.equals(doc.getId()));
+                randomId = randomAlphaOfLength(10);
+            } while (randomId.equals(doc.getId()));
             return new MonitoringBulkDoc(
                 doc.getSystem(),
                 doc.getType(),
-                id,
+                randomId,
                 doc.getTimestamp(),
                 doc.getIntervalMillis(),
                 doc.getSource(),
@@ -136,52 +136,52 @@ public class MonitoringBulkDocTests extends ESTestCase {
             );
         });
         mutations.add(doc -> {
-            long timestamp;
+            long randomTimestamp;
             do {
-                timestamp = randomNonNegativeLong();
-            } while (timestamp == doc.getTimestamp());
+                randomTimestamp = randomNonNegativeLong();
+            } while (randomTimestamp == doc.getTimestamp());
             return new MonitoringBulkDoc(
                 doc.getSystem(),
                 doc.getType(),
                 doc.getId(),
-                timestamp,
+                randomTimestamp,
                 doc.getIntervalMillis(),
                 doc.getSource(),
                 doc.getXContentType()
             );
         });
         mutations.add(doc -> {
-            long interval;
+            long randomInterval;
             do {
-                interval = randomNonNegativeLong();
-            } while (interval == doc.getIntervalMillis());
+                randomInterval = randomNonNegativeLong();
+            } while (randomInterval == doc.getIntervalMillis());
             return new MonitoringBulkDoc(
                 doc.getSystem(),
                 doc.getType(),
                 doc.getId(),
                 doc.getTimestamp(),
-                interval,
+                randomInterval,
                 doc.getSource(),
                 doc.getXContentType()
             );
         });
         mutations.add(doc -> {
-            final BytesReference source = RandomObjects.randomSource(random(), doc.getXContentType());
+            final BytesReference randomSource = RandomObjects.randomSource(random(), doc.getXContentType());
             return new MonitoringBulkDoc(
                 doc.getSystem(),
                 doc.getType(),
                 doc.getId(),
                 doc.getTimestamp(),
                 doc.getIntervalMillis(),
-                source,
+                randomSource,
                 doc.getXContentType()
             );
         });
         mutations.add(doc -> {
-            XContentType xContentType;
+            XContentType randomXContentType;
             do {
-                xContentType = randomFrom(XContentType.values());
-            } while (xContentType == doc.getXContentType());
+                randomXContentType = randomFrom(XContentType.values());
+            } while (randomXContentType == doc.getXContentType());
             return new MonitoringBulkDoc(
                 doc.getSystem(),
                 doc.getType(),
@@ -189,7 +189,7 @@ public class MonitoringBulkDocTests extends ESTestCase {
                 doc.getTimestamp(),
                 doc.getIntervalMillis(),
                 doc.getSource(),
-                xContentType
+                randomXContentType
             );
         });
 
@@ -215,13 +215,21 @@ public class MonitoringBulkDocTests extends ESTestCase {
      *  Test that we allow strings to be "" because Logstash 5.2 - 5.3 would submit empty _id values for time-based documents
      */
     public void testEmptyIdBecomesNull() {
-        final String id = randomFrom("", null, randomAlphaOfLength(5));
-        final MonitoringBulkDoc doc = new MonitoringBulkDoc(MonitoredSystem.ES, "_type", id, 1L, 2L, BytesArray.EMPTY, XContentType.JSON);
+        final String randomId = randomFrom("", null, randomAlphaOfLength(5));
+        final MonitoringBulkDoc doc = new MonitoringBulkDoc(
+            MonitoredSystem.ES,
+            "_type",
+            randomId,
+            1L,
+            2L,
+            BytesArray.EMPTY,
+            XContentType.JSON
+        );
 
-        if (Strings.isNullOrEmpty(id)) {
+        if (Strings.isNullOrEmpty(randomId)) {
             assertNull(doc.getId());
         } else {
-            assertSame(id, doc.getId());
+            assertSame(randomId, doc.getId());
         }
     }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
@@ -214,7 +214,7 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
         }
 
         doAnswer((i) -> {
-            final Collection<MonitoringDoc> exportedDocs = (Collection) i.getArguments()[0];
+            final Collection<MonitoringDoc> exportedDocs = (Collection<MonitoringDoc>) i.getArguments()[0];
             assertEquals(nbDocs, exportedDocs.size());
             exportedDocs.forEach(exportedDoc -> {
                 assertThat(exportedDoc, instanceOf(BytesReferenceMonitoringDoc.class));
@@ -227,8 +227,8 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
                 assertThat(exportedDoc.getCluster(), equalTo(clusterUUID));
             });
 
-            final ActionListener<?> listener = (ActionListener) i.getArguments()[1];
-            listener.onResponse(null);
+            final ActionListener<?> actionListener = (ActionListener<?>) i.getArguments()[1];
+            actionListener.onResponse(null);
             return Void.TYPE;
         }).when(exporters).export(any(Collection.class), any(ActionListener.class));
 
@@ -399,11 +399,11 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
         }
 
         doAnswer((i) -> {
-            final Collection<MonitoringDoc> exportedDocs = (Collection) i.getArguments()[0];
+            final Collection<MonitoringDoc> exportedDocs = (Collection<MonitoringDoc>) i.getArguments()[0];
             assertThat(exportedDocs, is(docs));
 
-            final ActionListener<?> listener = (ActionListener) i.getArguments()[1];
-            listener.onResponse(null);
+            final ActionListener<?> actionListener = (ActionListener<?>) i.getArguments()[1];
+            actionListener.onResponse(null);
             return Void.TYPE;
         }).when(exporters).export(any(Collection.class), any(ActionListener.class));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
@@ -572,14 +572,14 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         return Arrays.stream(MonitoringTemplateUtils.TEMPLATE_IDS).map(MonitoringTemplateUtils::templateName).collect(Collectors.toList());
     }
 
-    private void enqueueWatcherResponses(final MockWebServer webServer, final boolean remoteClusterAllowsWatcher) throws IOException {
+    private void enqueueWatcherResponses(final MockWebServer mockWebServer, final boolean remoteClusterAllowsWatcher) throws IOException {
         // if the remote cluster doesn't allow watcher, then we only check for it and we're done
         if (remoteClusterAllowsWatcher) {
             // X-Pack exists and Watcher can be used
-            enqueueResponse(webServer, 200, "{\"features\":{\"watcher\":{\"available\":true,\"enabled\":true}}}");
+            enqueueResponse(mockWebServer, 200, "{\"features\":{\"watcher\":{\"available\":true,\"enabled\":true}}}");
 
             // add delete responses
-            enqueueDeleteClusterAlertResponses(webServer);
+            enqueueDeleteClusterAlertResponses(mockWebServer);
         } else {
             // X-Pack exists but Watcher just cannot be used
             if (randomBoolean()) {
@@ -589,25 +589,25 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
                     "{}"
                 );
 
-                enqueueResponse(webServer, 200, responseBody);
+                enqueueResponse(mockWebServer, 200, responseBody);
             } else {
                 // X-Pack is not installed
-                enqueueResponse(webServer, 404, "{}");
+                enqueueResponse(mockWebServer, 404, "{}");
             }
         }
     }
 
-    private void enqueueDeleteClusterAlertResponses(final MockWebServer webServer) throws IOException {
+    private void enqueueDeleteClusterAlertResponses(final MockWebServer mockWebServer) throws IOException {
         for (final String watchId : ClusterAlertsUtil.WATCH_IDS) {
-            enqueueDeleteClusterAlertResponse(webServer, watchId);
+            enqueueDeleteClusterAlertResponse(mockWebServer, watchId);
         }
     }
 
-    private void enqueueDeleteClusterAlertResponse(final MockWebServer webServer, final String watchId) throws IOException {
+    private void enqueueDeleteClusterAlertResponse(final MockWebServer mockWebServer, final String watchId) throws IOException {
         if (randomBoolean()) {
-            enqueueResponse(webServer, 404, "watch [" + watchId + "] did not exist");
+            enqueueResponse(mockWebServer, 404, "watch [" + watchId + "] did not exist");
         } else {
-            enqueueResponse(webServer, 200, "watch [" + watchId + "] deleted");
+            enqueueResponse(mockWebServer, 200, "watch [" + watchId + "] deleted");
         }
     }
 
@@ -623,8 +623,8 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         return "filter_path=" + CLUSTER_ALERT_VERSION_PARAMETERS.get("filter_path");
     }
 
-    private void assertMonitorWatches(final MockWebServer webServer, final boolean remoteClusterAllowsWatcher) {
-        MockRequest request = webServer.takeRequest();
+    private void assertMonitorWatches(final MockWebServer mockWebServer, final boolean remoteClusterAllowsWatcher) {
+        MockRequest request = mockWebServer.takeRequest();
 
         // GET /_xpack
         assertThat(request.getMethod(), equalTo("GET"));
@@ -635,7 +635,7 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
             for (final Tuple<String, String> watch : monitoringWatches()) {
                 final String uniqueWatchId = ClusterAlertsUtil.createUniqueWatchId(clusterService(), watch.v1());
 
-                request = webServer.takeRequest();
+                request = mockWebServer.takeRequest();
 
                 // GET / PUT if we are allowed to use it
                 assertThat(request.getMethod(), equalTo("DELETE"));

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -118,11 +118,11 @@ public class CleanerServiceTests extends ESTestCase {
         CountDownLatch latch = new CountDownLatch(nbExecutions);
 
         logger.debug("--> creates a cleaner service that cleans every second");
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        XPackLicenseState mockLicenseState = mock(XPackLicenseState.class);
         CleanerService service = new CleanerService(
             Settings.EMPTY,
             clusterSettings,
-            licenseState,
+            mockLicenseState,
             threadPool,
             new TestExecutionScheduler(1_000)
         );

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -260,7 +260,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
     @Override
     public void testToXContent() throws IOException {
         final String clusterUuid = "_cluster";
-        final ClusterName clusterName = new ClusterName("_cluster_name");
+        final ClusterName testClusterName = new ClusterName("_cluster_name");
         final TransportAddress transportAddress = new TransportAddress(TransportAddress.META_ADDRESS, 9300);
         final DiscoveryNode discoveryNode = new DiscoveryNode(
             "_node_name",
@@ -274,7 +274,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             Version.V_6_0_0_beta1
         );
 
-        final ClusterState clusterState = ClusterState.builder(clusterName)
+        final ClusterState testClusterState = ClusterState.builder(testClusterName)
             .metadata(
                 Metadata.builder()
                     .clusterUUID(clusterUuid)
@@ -286,7 +286,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             .nodes(DiscoveryNodes.builder().masterNodeId("_node").localNodeId("_node").add(discoveryNode).build())
             .build();
 
-        final License license = License.builder()
+        final License testLicense = License.builder()
             .uid("442ca961-9c00-4bb2-b5c9-dfaacd547403")
             .type("trial")
             .issuer("elasticsearch")
@@ -296,7 +296,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             .maxNodes(2)
             .build();
 
-        final List<XPackFeatureSet.Usage> usages = singletonList(new MonitoringFeatureSetUsage(false, null));
+        final List<XPackFeatureSet.Usage> usageList = singletonList(new MonitoringFeatureSetUsage(false, null));
 
         final NodeInfo mockNodeInfo = mock(NodeInfo.class);
         when(mockNodeInfo.getVersion()).thenReturn(Version.V_6_0_0_alpha2);
@@ -402,11 +402,11 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
         when(mockNodeResponse.nodeStats()).thenReturn(mockNodeStats);
         when(mockNodeResponse.shardsStats()).thenReturn(new ShardStats[] { mockShardStats });
 
-        final Metadata metadata = clusterState.metadata();
-        final ClusterStatsResponse clusterStats = new ClusterStatsResponse(
+        final Metadata metadata = testClusterState.metadata();
+        final ClusterStatsResponse clusterStatsResponse = new ClusterStatsResponse(
             1451606400000L,
             "_cluster",
-            clusterName,
+            testClusterName,
             singletonList(mockNodeResponse),
             emptyList(),
             MappingStats.of(metadata, () -> {}),
@@ -421,14 +421,14 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             1502107402133L,
             1506593717631L,
             node,
-            clusterName.value(),
+            testClusterName.value(),
             "_version",
             ClusterHealthStatus.GREEN,
-            license,
+            testLicense,
             apmIndicesExist,
-            usages,
-            clusterStats,
-            clusterState,
+            usageList,
+            clusterStatsResponse,
+            testClusterState,
             needToEnableTLS
         );
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
@@ -42,13 +42,13 @@ import static org.mockito.Mockito.mock;
 
 public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<IndexRecoveryMonitoringDoc> {
 
-    private RecoveryResponse recoveryResponse;
+    private RecoveryResponse mockRecoveryResponse;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        recoveryResponse = mock(RecoveryResponse.class);
+        mockRecoveryResponse = mock(RecoveryResponse.class);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
         String type,
         String id
     ) {
-        return new IndexRecoveryMonitoringDoc(cluster, timestamp, interval, node, recoveryResponse);
+        return new IndexRecoveryMonitoringDoc(cluster, timestamp, interval, node, mockRecoveryResponse);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
         assertThat(document.getType(), is(IndexRecoveryMonitoringDoc.TYPE));
         assertThat(document.getId(), nullValue());
 
-        assertThat(document.getRecoveryResponse(), is(recoveryResponse));
+        assertThat(document.getRecoveryResponse(), is(mockRecoveryResponse));
     }
 
     public void testConstructorRecoveryResponseMustNotBeNull() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -111,20 +111,20 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
     }
 
     public void testConstructorMetadataMustNotBeNull() {
-        final IndexStats indexStats = randomFrom(this.indexStats, null);
+        final IndexStats randomIndexStats = randomFrom(this.indexStats, null);
 
         expectThrows(
             NullPointerException.class,
-            () -> new IndexStatsMonitoringDoc(cluster, timestamp, interval, node, indexStats, null, routingTable)
+            () -> new IndexStatsMonitoringDoc(cluster, timestamp, interval, node, randomIndexStats, null, routingTable)
         );
     }
 
     public void testConstructorRoutingTableMustNotBeNull() {
-        final IndexStats indexStats = randomFrom(this.indexStats, null);
+        final IndexStats randomIndexStats = randomFrom(this.indexStats, null);
 
         expectThrows(
             NullPointerException.class,
-            () -> new IndexStatsMonitoringDoc(cluster, timestamp, interval, node, indexStats, metadata, null)
+            () -> new IndexStatsMonitoringDoc(cluster, timestamp, interval, node, randomIndexStats, metadata, null)
         );
     }
 
@@ -278,15 +278,15 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
 
     public void testToXContentWithNullStats() throws IOException {
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
-        final IndexStats indexStats;
+        final IndexStats maybeNullIndexStats;
 
         if (randomBoolean()) {
-            indexStats = this.indexStats;
+            maybeNullIndexStats = this.indexStats;
 
-            when(indexStats.getTotal()).thenReturn(null);
-            when(indexStats.getPrimaries()).thenReturn(null);
+            when(maybeNullIndexStats.getTotal()).thenReturn(null);
+            when(maybeNullIndexStats.getPrimaries()).thenReturn(null);
         } else {
-            indexStats = null;
+            maybeNullIndexStats = null;
         }
 
         final IndexStatsMonitoringDoc document = new IndexStatsMonitoringDoc(
@@ -294,7 +294,7 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
             1502266739402L,
             1506593717631L,
             node,
-            indexStats,
+            maybeNullIndexStats,
             metadata,
             routingTable
         );

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
@@ -43,13 +43,13 @@ import static org.mockito.Mockito.mock;
  */
 public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobStatsMonitoringDoc> {
 
-    private JobStats jobStats;
+    private JobStats mockJobStats;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        jobStats = mock(JobStats.class);
+        mockJobStats = mock(JobStats.class);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobSta
         final String type,
         final String id
     ) {
-        return new JobStatsMonitoringDoc(cluster, timestamp, interval, node, jobStats);
+        return new JobStatsMonitoringDoc(cluster, timestamp, interval, node, mockJobStats);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobSta
         assertThat(document.getType(), is(JobStatsMonitoringDoc.TYPE));
         assertThat(document.getId(), nullValue());
 
-        assertThat(document.getJobStats(), is(jobStats));
+        assertThat(document.getJobStats(), is(mockJobStats));
     }
 
     public void testConstructorJobStatsMustNotBeNull() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -111,7 +111,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
     @Override
     public void testToXContent() throws IOException {
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
-        final NodeStats nodeStats = mockNodeStats();
+        final NodeStats mockNodeStats = mockNodeStats();
 
         final NodeStatsMonitoringDoc doc = new NodeStatsMonitoringDoc(
             "_cluster",
@@ -120,7 +120,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
             node,
             "_node_id",
             true,
-            nodeStats,
+            mockNodeStats,
             false
         );
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsMonitoringDocTests.java
@@ -90,28 +90,28 @@ public class ShardsMonitoringDocTests extends BaseFilteredMonitoringDocTestCase<
     }
 
     public void testIdWithPrimaryShardAssigned() {
-        final ShardRouting shardRouting = newShardRouting("_index_0", 123, "_node_0", randomAlphaOfLength(5), true, INITIALIZING);
+        shardRouting = newShardRouting("_index_0", 123, "_node_0", randomAlphaOfLength(5), true, INITIALIZING);
         assertEquals("_state_uuid_0:_node_0:_index_0:123:p", ShardMonitoringDoc.id("_state_uuid_0", shardRouting));
     }
 
     public void testIdWithReplicaShardAssigned() {
-        final ShardRouting shardRouting = newShardRouting("_index_1", 456, "_node_1", randomAlphaOfLength(5), false, INITIALIZING);
+        shardRouting = newShardRouting("_index_1", 456, "_node_1", randomAlphaOfLength(5), false, INITIALIZING);
         assertEquals("_state_uuid_1:_node_1:_index_1:456:r", ShardMonitoringDoc.id("_state_uuid_1", shardRouting));
     }
 
     public void testIdWithPrimaryShardUnassigned() {
-        final ShardRouting shardRouting = newShardRouting("_index_2", 789, null, randomAlphaOfLength(5), true, UNASSIGNED);
+        shardRouting = newShardRouting("_index_2", 789, null, randomAlphaOfLength(5), true, UNASSIGNED);
         assertEquals("_state_uuid_2:_na:_index_2:789:p", ShardMonitoringDoc.id("_state_uuid_2", shardRouting));
     }
 
     public void testIdWithReplicaShardUnassigned() {
-        final ShardRouting shardRouting = newShardRouting("_index_3", 159, null, randomAlphaOfLength(5), false, UNASSIGNED);
+        shardRouting = newShardRouting("_index_3", 159, null, randomAlphaOfLength(5), false, UNASSIGNED);
         assertEquals("_state_uuid_3:_na:_index_3:159:r", ShardMonitoringDoc.id("_state_uuid_3", shardRouting));
     }
 
     @Override
     public void testToXContent() throws IOException {
-        final ShardRouting shardRouting = newShardRouting("_index", 1, "_index_uuid", "_node_uuid", true, INITIALIZING);
+        shardRouting = newShardRouting("_index", 1, "_index_uuid", "_node_uuid", true, INITIALIZING);
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
         final ShardMonitoringDoc doc = new ShardMonitoringDoc(
             "_cluster",

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -171,15 +171,15 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
     }
 
     public void testMonitoringNodeConstructor() {
-        final String id = randomAlphaOfLength(5);
+        id = randomAlphaOfLength(5);
         final String name = randomAlphaOfLengthBetween(3, 10);
         final TransportAddress fakeTransportAddress = buildNewFakeTransportAddress();
         final String host = fakeTransportAddress.address().getHostString();
         final String transportAddress = fakeTransportAddress.toString();
         final String ip = fakeTransportAddress.getAddress();
-        final long timestamp = randomNonNegativeLong();
+        timestamp = randomNonNegativeLong();
 
-        final MonitoringDoc.Node node = new MonitoringDoc.Node(id, host, transportAddress, ip, name, timestamp);
+        node = new MonitoringDoc.Node(id, host, transportAddress, ip, name, timestamp);
 
         assertThat(node.getUUID(), equalTo(id));
         assertThat(node.getHost(), equalTo(host));
@@ -190,7 +190,7 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
     }
 
     public void testMonitoringNodeToXContent() throws IOException {
-        final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
+        node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
 
         final BytesReference xContent = XContentHelper.toXContent(node, XContentType.JSON, randomBoolean());
         assertEquals(
@@ -207,22 +207,22 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
     }
 
     public void testMonitoringNodeEqualsAndHashcode() {
-        final EqualsHashCodeTestUtils.CopyFunction<MonitoringDoc.Node> copy = node -> new MonitoringDoc.Node(
-            node.getUUID(),
-            node.getHost(),
-            node.getTransportAddress(),
-            node.getIp(),
-            node.getName(),
-            node.getTimestamp()
+        final EqualsHashCodeTestUtils.CopyFunction<MonitoringDoc.Node> copy = _node -> new MonitoringDoc.Node(
+            _node.getUUID(),
+            _node.getHost(),
+            _node.getTransportAddress(),
+            _node.getIp(),
+            _node.getName(),
+            _node.getTimestamp()
         );
 
         final List<EqualsHashCodeTestUtils.MutateFunction<MonitoringDoc.Node>> mutations = new ArrayList<>();
         mutations.add(n -> {
-            String id;
+            String randomId;
             do {
-                id = UUIDs.randomBase64UUID();
-            } while (id.equals(n.getUUID()));
-            return new MonitoringDoc.Node(id, n.getHost(), n.getTransportAddress(), n.getIp(), n.getName(), n.getTimestamp());
+                randomId = UUIDs.randomBase64UUID();
+            } while (randomId.equals(n.getUUID()));
+            return new MonitoringDoc.Node(randomId, n.getHost(), n.getTransportAddress(), n.getIp(), n.getName(), n.getTimestamp());
         });
         mutations.add(n -> {
             String host;
@@ -253,11 +253,11 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
             return new MonitoringDoc.Node(n.getUUID(), n.getHost(), n.getTransportAddress(), n.getIp(), name, n.getTimestamp());
         });
         mutations.add(n -> {
-            long timestamp;
+            long randomTimestamp;
             do {
-                timestamp = randomBoolean() ? randomNonNegativeLong() : 0L;
-            } while (timestamp == n.getTimestamp());
-            return new MonitoringDoc.Node(n.getUUID(), n.getHost(), n.getTransportAddress(), n.getIp(), n.getName(), timestamp);
+                randomTimestamp = randomBoolean() ? randomNonNegativeLong() : 0L;
+            } while (randomTimestamp == n.getTimestamp());
+            return new MonitoringDoc.Node(n.getUUID(), n.getHost(), n.getTransportAddress(), n.getIp(), n.getName(), randomTimestamp);
         });
 
         final MonitoringDoc.Node sourceNode = MonitoringTestUtils.randomMonitoringNode(random());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
@@ -139,10 +139,10 @@ public class ClusterAlertsUtilTests extends ESTestCase {
         final Settings settings = Settings.builder()
             .putList("xpack.monitoring.exporters." + name + ".cluster_alerts.management.blacklist", blacklist)
             .build();
-        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterService mockClusterService = mock(ClusterService.class);
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
 
-        return new Exporter.Config(name, "local", settings, clusterService, licenseState);
+        return new Exporter.Config(name, "local", settings, mockClusterService, licenseState);
     }
 
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -335,10 +335,10 @@ public class ExportersTests extends ESTestCase {
         final Settings.Builder settings = Settings.builder();
 
         for (int i = 0; i < nbExporters; i++) {
-            settings.put("xpack.monitoring.exporters._name" + String.valueOf(i) + ".type", "record");
+            settings.put("xpack.monitoring.exporters._name" + i + ".type", "record");
         }
 
-        final Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
+        exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
 
         // synchronously checks the cluster state
         exporters.wrapExportBulk(ActionListener.wrap(bulk -> assertThat(bulk, is(nullValue())), e -> fail(e.getMessage())));
@@ -354,7 +354,7 @@ public class ExportersTests extends ESTestCase {
             .put("xpack.monitoring.exporters.explicitly_disabled.type", "local")
             .put("xpack.monitoring.exporters.explicitly_disabled.enabled", false);
 
-        Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
+        exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
         exporters.start();
 
         assertThat(exporters.getEnabledExporters(), empty());
@@ -379,12 +379,12 @@ public class ExportersTests extends ESTestCase {
 
         Settings.Builder settings = Settings.builder();
         for (int i = 0; i < nbExporters; i++) {
-            settings.put("xpack.monitoring.exporters._name" + String.valueOf(i) + ".type", "record");
+            settings.put("xpack.monitoring.exporters._name" + i + ".type", "record");
         }
 
         factories.put("record", (s) -> new CountingExporter(s, threadContext));
 
-        Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
+        exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
         exporters.start();
 
         assertThat(exporters.getEnabledExporters(), hasSize(nbExporters));
@@ -452,10 +452,10 @@ public class ExportersTests extends ESTestCase {
     /**
      * Attempt to export a random number of documents via {@code exporters} from multiple threads.
      *
-     * @param exporters The setup / started exporters instance to use.
+     * @param exportersToUse The setup / started exporters instance to use.
      * @return The total number of documents sent to the {@code exporters}.
      */
-    private int assertExporters(final Exporters exporters) throws InterruptedException {
+    private int assertExporters(final Exporters exportersToUse) throws InterruptedException {
         final Thread[] threads = new Thread[3 + randomInt(7)];
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         final List<Throwable> exceptions = new CopyOnWriteArrayList<>();
@@ -492,7 +492,7 @@ public class ExportersTests extends ESTestCase {
                             )
                         );
                     }
-                    exporters.export(docs, ActionListener.wrap(r -> {
+                    exportersToUse.export(docs, ActionListener.wrap(r -> {
                         counter.decrementAndGet();
                         logger.debug("--> thread [{}] successfully exported {} documents", threadNum, threadDocs);
                     }, e -> {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
@@ -160,20 +160,20 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testShouldReplaceClusterAlertReturnsTrueVersionIsNotExpected() throws IOException {
-        final int minimumVersion = randomInt();
+        final int randomMinimumVersion = randomInt();
         final Response response = mock(Response.class);
-        final HttpEntity entity = entityForClusterAlert(false, minimumVersion);
+        final HttpEntity entity = entityForClusterAlert(false, randomMinimumVersion);
         final XContent xContent = XContentType.JSON.xContent();
 
         when(response.getEntity()).thenReturn(entity);
 
-        assertThat(resource.shouldReplaceClusterAlert(response, xContent, minimumVersion), is(true));
+        assertThat(resource.shouldReplaceClusterAlert(response, xContent, randomMinimumVersion), is(true));
     }
 
     public void testShouldReplaceCheckAlertChecksVersion() throws IOException {
-        final int minimumVersion = randomInt();
+        final int randomMinimumVersion = randomInt();
         final int version = randomInt();
-        final boolean shouldReplace = version < minimumVersion;
+        final boolean shouldReplace = version < randomMinimumVersion;
 
         final Response response = mock(Response.class);
         final HttpEntity entity = entityForClusterAlert(true, version);
@@ -181,7 +181,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
 
         when(response.getEntity()).thenReturn(entity);
 
-        assertThat(resource.shouldReplaceClusterAlert(response, xContent, minimumVersion), is(shouldReplace));
+        assertThat(resource.shouldReplaceClusterAlert(response, xContent, randomMinimumVersion), is(shouldReplace));
     }
 
     public void testParameters() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpHostBuilderTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpHostBuilderTests.java
@@ -141,28 +141,33 @@ public class HttpHostBuilderTests extends ESTestCase {
         assertPortThrows(randomIntBetween(65537, Integer.MAX_VALUE));
     }
 
+    @SuppressWarnings("HiddenField")
     private void assertHttpHost(final HttpHostBuilder host, final Scheme scheme, final String hostname, final int port) {
         assertHttpHost(host.build(), scheme, hostname, port);
     }
 
+    @SuppressWarnings("HiddenField")
     private void assertHttpHost(final HttpHost host, final Scheme scheme, final String hostname, final int port) {
         assertThat(host.getSchemeName(), equalTo(scheme.toString()));
         assertThat(host.getHostName(), equalTo(hostname));
         assertThat(host.getPort(), equalTo(port));
     }
 
+    @SuppressWarnings("HiddenField")
     private void assertBuilderPathThrows(final String uri, final String path) {
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> HttpHostBuilder.builder(uri));
 
         assertThat(e.getMessage(), containsString("[" + path + "]"));
     }
 
+    @SuppressWarnings("HiddenField")
     private void assertBuilderBadSchemeThrows(final String uri, final String scheme) {
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> HttpHostBuilder.builder(uri));
 
         assertThat(e.getMessage(), containsString(scheme));
     }
 
+    @SuppressWarnings("HiddenField")
     private void assertPortThrows(final int port) {
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> HttpHostBuilder.builder().port(port));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class HttpResourceTests extends ESTestCase {
 
     private final String owner = getTestName();
-    private final RestClient client = mock(RestClient.class);
+    private final RestClient mockClient = mock(RestClient.class);
 
     public void testConstructorRequiresOwner() {
         expectThrows(NullPointerException.class, () -> new HttpResource(null) {
@@ -77,7 +77,7 @@ public class HttpResourceTests extends ESTestCase {
         assertTrue(resource.isDirty());
 
         // if this fails, then the mocked resource needs to be fixed
-        resource.checkAndPublish(client, listener);
+        resource.checkAndPublish(mockClient, listener);
 
         verify(listener).onResponse(ResourcePublishResult.ready());
         assertFalse(resource.isDirty());
@@ -96,7 +96,7 @@ public class HttpResourceTests extends ESTestCase {
             }
         };
 
-        resource.checkAndPublish(client, listener);
+        resource.checkAndPublish(mockClient, listener);
 
         verify(listener).onResponse(expected);
     }
@@ -116,10 +116,10 @@ public class HttpResourceTests extends ESTestCase {
         };
 
         assertTrue(resource.isDirty());
-        resource.checkAndPublish(client, listener1);
+        resource.checkAndPublish(mockClient, listener1);
         verify(listener1).onResponse(ResourcePublishResult.ready());
         assertFalse(resource.isDirty());
-        resource.checkAndPublish(client, listener2);
+        resource.checkAndPublish(mockClient, listener2);
         verify(listener2).onResponse(ResourcePublishResult.notReady("test unready"));
 
         verify(supplier, times(2)).get();
@@ -161,8 +161,8 @@ public class HttpResourceTests extends ESTestCase {
             }
         };
 
-        resource.checkAndPublishIfDirty(client, wrapMockListener(listener));
-        resource.checkAndPublishIfDirty(client, checkingListener);
+        resource.checkAndPublishIfDirty(mockClient, wrapMockListener(listener));
+        resource.checkAndPublishIfDirty(mockClient, checkingListener);
 
         assertTrue(firstCheck.await(15, TimeUnit.SECONDS));
 
@@ -185,10 +185,10 @@ public class HttpResourceTests extends ESTestCase {
         };
 
         assertTrue(resource.isDirty());
-        resource.checkAndPublishIfDirty(client, wrapMockListener(listener1));
+        resource.checkAndPublishIfDirty(mockClient, wrapMockListener(listener1));
         verify(listener1).onResponse(true);
         assertFalse(resource.isDirty());
-        resource.checkAndPublishIfDirty(client, wrapMockListener(listener2));
+        resource.checkAndPublishIfDirty(mockClient, wrapMockListener(listener2));
         verify(listener2).onResponse(true);
 
         // once is the default!

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
@@ -49,8 +49,8 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
     private final String resourceName = ".my_thing";
     private final String resourceType = "thingamajig";
     private final Logger logger = mock(Logger.class);
-    private final HttpEntity entity = mock(HttpEntity.class);
-    private final Supplier<HttpEntity> body = () -> entity;
+    private final HttpEntity mockEntity = mock(HttpEntity.class);
+    private final Supplier<HttpEntity> body = () -> mockEntity;
 
     private final PublishableHttpResource resource = new MockHttpResource(owner, masterTimeout, PublishableHttpResource.NO_BODY_PARAMETERS);
 
@@ -194,7 +194,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final Exception e = randomFrom(new IOException("expected"), new RuntimeException("expected"));
         final Request request = new Request("PUT", endpoint);
         addParameters(request, resource.getDefaultParameters());
-        request.setEntity(entity);
+        request.setEntity(mockEntity);
 
         whenPerformRequestAsyncWith(client, request, e);
 
@@ -267,7 +267,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
     }
 
     public void testDoCheckAndPublishIgnoresPublishWhenCheckErrors() {
-        final PublishableHttpResource resource = new MockHttpResource(
+        final PublishableHttpResource mockResource = new MockHttpResource(
             owner,
             masterTimeout,
             PublishableHttpResource.NO_BODY_PARAMETERS,
@@ -275,7 +275,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
             true
         );
 
-        resource.doCheckAndPublish(client, wrapMockListener(publishListener));
+        mockResource.doCheckAndPublish(client, wrapMockListener(publishListener));
 
         verifyPublishListener(null);
     }
@@ -285,7 +285,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final boolean exists = randomBoolean();
         final boolean publish = randomBoolean();
 
-        final PublishableHttpResource resource = new MockHttpResource(
+        final PublishableHttpResource mockResource = new MockHttpResource(
             owner,
             masterTimeout,
             PublishableHttpResource.NO_BODY_PARAMETERS,
@@ -293,7 +293,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
             publish
         );
 
-        resource.doCheckAndPublish(client, wrapMockListener(publishListener));
+        mockResource.doCheckAndPublish(client, wrapMockListener(publishListener));
 
         verifyPublishListener(new ResourcePublishResult(exists || publish));
     }
@@ -432,7 +432,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final Response response = response("PUT", endpoint, status);
         final Request request = new Request("PUT", endpoint);
         addParameters(request, resource.getDefaultParameters());
-        request.setEntity(entity);
+        request.setEntity(mockEntity);
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -469,10 +469,10 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
             );
         }
 
-        verifyNoMoreInteractions(client, response, logger, entity);
+        verifyNoMoreInteractions(client, response, logger, mockEntity);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "HiddenField" })
     private void assertCheckForResource(
         final RestClient client,
         final Logger logger,
@@ -559,7 +559,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
             verifyCheckListener(null);
         }
 
-        verifyNoMoreInteractions(client, response, logger, entity);
+        verifyNoMoreInteractions(client, response, logger, mockEntity);
     }
 
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
@@ -35,9 +35,9 @@ import static org.mockito.Mockito.when;
 public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResourceTestCase {
 
     private final ClusterService clusterService = mock(ClusterService.class);
-    private final MultiHttpResource watches = mock(MultiHttpResource.class);
+    private final MultiHttpResource mockWatches = mock(MultiHttpResource.class);
 
-    private final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, watches);
+    private final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, mockWatches);
     private final Map<String, String> expectedParameters = getParameters(resource.getDefaultParameters(), GET_EXISTS, XPACK_DOES_NOT_EXIST);
 
     public void testDoCheckIgnoresClientWhenNotElectedMaster() {
@@ -137,9 +137,9 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
         final boolean publish = checkResponse == false;
         final MockHttpResource mockWatch = new MockHttpResource(owner, randomBoolean(), checkResponse, publish);
         final MultiHttpResource watches = new MultiHttpResource(owner, Collections.singletonList(mockWatch));
-        final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, watches);
+        final WatcherExistsHttpResource watcherExistsHttpResource = new WatcherExistsHttpResource(owner, clusterService, watches);
 
-        resource.doPublish(client, wrapMockListener(publishListener));
+        watcherExistsHttpResource.doPublish(client, wrapMockListener(publishListener));
 
         verifyPublishListener(ResourcePublishResult.ready());
 
@@ -150,9 +150,9 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     public void testDoPublishFalse() {
         final MockHttpResource mockWatch = new MockHttpResource(owner, true, false, false);
         final MultiHttpResource watches = new MultiHttpResource(owner, Collections.singletonList(mockWatch));
-        final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, watches);
+        final WatcherExistsHttpResource watcherExistsHttpResource = new WatcherExistsHttpResource(owner, clusterService, watches);
 
-        resource.doPublish(client, wrapMockListener(publishListener));
+        watcherExistsHttpResource.doPublish(client, wrapMockListener(publishListener));
 
         verifyPublishListener(new ResourcePublishResult(false));
 
@@ -163,9 +163,9 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     public void testDoPublishException() {
         final MockHttpResource mockWatch = new MockHttpResource(owner, true, false, null);
         final MultiHttpResource watches = new MultiHttpResource(owner, Collections.singletonList(mockWatch));
-        final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, watches);
+        final WatcherExistsHttpResource watcherExistsHttpResource = new WatcherExistsHttpResource(owner, clusterService, watches);
 
-        resource.doPublish(client, wrapMockListener(publishListener));
+        watcherExistsHttpResource.doPublish(client, wrapMockListener(publishListener));
 
         verifyPublishListener(null);
 
@@ -182,7 +182,7 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     }
 
     public void testGetResources() {
-        assertThat(resource.getWatches(), sameInstance(watches));
+        assertThat(resource.getWatches(), sameInstance(mockWatches));
     }
 
     private void whenElectedMaster() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTestCase.java
@@ -76,17 +76,17 @@ public abstract class LocalExporterIntegTestCase extends MonitoringIntegTestCase
      *
      * @return Never {@code null}.
      */
-    protected LocalExporter createLocalExporter(String exporterName, Settings exporterSettings) {
-        return createLocalExporter(exporterName, exporterSettings, new MonitoringMigrationCoordinator());
+    protected LocalExporter createLocalExporter(String localExporterName, Settings exporterSettings) {
+        return createLocalExporter(localExporterName, exporterSettings, new MonitoringMigrationCoordinator());
     }
 
     protected LocalExporter createLocalExporter(
-        String exporterName,
+        String localExporterName,
         Settings exporterSettings,
         MonitoringMigrationCoordinator coordinator
     ) {
         final XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        final Exporter.Config config = new Exporter.Config(exporterName, "local", exporterSettings, clusterService(), licenseState);
+        final Exporter.Config config = new Exporter.Config(localExporterName, "local", exporterSettings, clusterService(), licenseState);
         final CleanerService cleanerService = new CleanerService(
             exporterSettings,
             clusterService().getClusterSettings(),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -107,13 +107,13 @@ public class AsyncTaskManagementService<
         }
 
         @Override
-        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        public Task createTask(long id, String type, String actionName, TaskId parentTaskId, Map<String, String> headers) {
             Map<String, String> originHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
             return operation.createTask(
                 request,
                 id,
                 type,
-                action,
+                actionName,
                 parentTaskId,
                 headers,
                 originHeaders,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttribute.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttribute.java
@@ -80,8 +80,8 @@ public class UnresolvedAttribute extends Attribute implements Unresolvable {
         return this;
     }
 
-    public UnresolvedAttribute withUnresolvedMessage(String unresolvedMsg) {
-        return new UnresolvedAttribute(source(), name(), qualifier(), id(), unresolvedMsg, resolutionMetadata());
+    public UnresolvedAttribute withUnresolvedMessage(String unresolvedMessage) {
+        return new UnresolvedAttribute(source(), name(), qualifier(), id(), unresolvedMessage, resolutionMetadata());
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
@@ -119,9 +119,9 @@ public class In extends ScalarFunction {
         );
     }
 
-    protected List<Object> foldAndConvertListOfValues(List<Expression> list, DataType dataType) {
-        List<Object> values = new ArrayList<>(list.size());
-        for (Expression e : list) {
+    protected List<Object> foldAndConvertListOfValues(List<Expression> expressions, DataType dataType) {
+        List<Object> values = new ArrayList<>(expressions.size());
+        for (Expression e : expressions) {
             values.add(DataTypeConverter.convert(Foldables.valueOf(e), dataType));
         }
         return values;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolution.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolution.java
@@ -35,8 +35,8 @@ public final class IndexResolution {
         this.invalid = invalid;
     }
 
-    public boolean matches(String index) {
-        return isValid() && this.index.name().equals(index);
+    public boolean matches(String indexName) {
+        return isValid() && this.index.name().equals(indexName);
     }
 
     /**

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Filter.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Filter.java
@@ -64,11 +64,11 @@ public class Filter extends UnaryPlan {
         return Objects.equals(condition, other.condition) && Objects.equals(child(), other.child());
     }
 
-    public Filter with(Expression condition) {
-        return new Filter(source(), child(), condition);
+    public Filter with(Expression conditionExpr) {
+        return new Filter(source(), child(), conditionExpr);
     }
 
-    public Filter with(LogicalPlan child, Expression condition) {
-        return new Filter(source(), child, condition);
+    public Filter with(LogicalPlan child, Expression conditionExpr) {
+        return new Filter(source(), child, conditionExpr);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
@@ -62,7 +62,7 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
     }
 
     AsyncResultsService<AsyncTask, StoredAsyncResponse<Response>> createResultsService(
-        TransportService transportService,
+        TransportService transportServiceArg,
         ClusterService clusterService,
         NamedWriteableRegistry registry,
         Client client,
@@ -86,7 +86,7 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
             false,
             asyncTaskClass,
             (task, listener, timeout) -> AsyncTaskManagementService.addCompletionListener(threadPool, task, listener, timeout),
-            transportService.getTaskManager(),
+            transportServiceArg.getTaskManager(),
             clusterService
         );
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/container/Sort.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/container/Sort.java
@@ -63,17 +63,17 @@ public abstract class Sort {
         /**
          * Preferred order of null values in non-aggregation queries.
          */
-        public String searchOrder(Direction direction) {
+        public String searchOrder(Direction fallbackDirection) {
             if (searchOrder != null) {
                 return searchOrder;
             } else {
-                switch (direction) {
+                switch (fallbackDirection) {
                     case ASC:
                         return LAST.searchOrder;
                     case DESC:
                         return FIRST.searchOrder;
                     default:
-                        throw new IllegalArgumentException("Unknown direction [" + direction + "]");
+                        throw new IllegalArgumentException("Unknown direction [" + fallbackDirection + "]");
                 }
             }
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQuery.java
@@ -60,21 +60,21 @@ public class NestedQuery extends Query {
     }
 
     @Override
-    public boolean containsNestedField(String path, String field) {
-        boolean iContainThisField = this.path.equals(path) && fields.containsKey(field);
-        boolean myChildContainsThisField = child.containsNestedField(path, field);
+    public boolean containsNestedField(String otherPath, String field) {
+        boolean iContainThisField = this.path.equals(otherPath) && fields.containsKey(field);
+        boolean myChildContainsThisField = child.containsNestedField(otherPath, field);
         return iContainThisField || myChildContainsThisField;
     }
 
     @Override
-    public Query addNestedField(String path, String field, String format, boolean hasDocValues) {
-        if (false == this.path.equals(path)) {
+    public Query addNestedField(String otherPath, String field, String format, boolean hasDocValues) {
+        if (false == this.path.equals(otherPath)) {
             // I'm not at the right path so let my child query have a crack at it
-            Query rewrittenChild = child.addNestedField(path, field, format, hasDocValues);
+            Query rewrittenChild = child.addNestedField(otherPath, field, format, hasDocValues);
             if (rewrittenChild == child) {
                 return this;
             }
-            return new NestedQuery(source(), path, fields, rewrittenChild);
+            return new NestedQuery(source(), otherPath, fields, rewrittenChild);
         }
         if (fields.containsKey(field)) {
             // I already have the field, no rewriting needed
@@ -83,7 +83,7 @@ public class NestedQuery extends Query {
         Map<String, Map.Entry<Boolean, String>> newFields = new HashMap<>(fields.size() + 1);
         newFields.putAll(fields);
         newFields.put(field, new AbstractMap.SimpleImmutableEntry<>(hasDocValues, format));
-        return new NestedQuery(source(), path, unmodifiableMap(newFields), child);
+        return new NestedQuery(source(), otherPath, unmodifiableMap(newFields), child);
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/ScriptQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/ScriptQuery.java
@@ -58,7 +58,7 @@ public class ScriptQuery extends LeafQuery {
         return script.toString();
     }
 
-    protected ScriptTemplate nullSafeScript(ScriptTemplate script) {
-        return Scripts.nullSafeFilter(script);
+    protected ScriptTemplate nullSafeScript(ScriptTemplate scriptTemplate) {
+        return Scripts.nullSafeFilter(scriptTemplate);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
@@ -37,9 +37,9 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
             this.runs = maximumRuns;
         }
 
-        boolean reached(int runs) {
-            if (runs >= this.runs) {
-                throw new RuleExecutionException("Rule execution limit [{}] reached", runs);
+        boolean reached(int numberOfRuns) {
+            if (numberOfRuns >= this.runs) {
+                throw new RuleExecutionException("Rule execution limit [{}] reached", numberOfRuns);
             }
             return false;
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
@@ -342,6 +342,7 @@ public abstract class Node<T extends Node<T>> {
 
         sb.append(nodeString());
 
+        @SuppressWarnings("HiddenField")
         List<T> children = children();
         if (children.isEmpty() == false) {
             sb.append("\n");
@@ -365,6 +366,7 @@ public abstract class Node<T extends Node<T>> {
     public String propertiesToString(boolean skipIfChild) {
         StringBuilder sb = new StringBuilder();
 
+        @SuppressWarnings("HiddenField")
         List<?> children = children();
         // eliminate children (they are rendered as part of the tree)
         int remainingProperties = TO_STRING_MAX_PROP;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Holder.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Holder.java
@@ -21,6 +21,7 @@ public class Holder<T> {
         this.value = value;
     }
 
+    @SuppressWarnings("HiddenField")
     public void set(T value) {
         this.value = value;
     }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/CanonicalTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/CanonicalTests.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 
 public class CanonicalTests extends ESTestCase {
 
-    Comparator<? super Expression> c = Comparator.comparingInt(Object::hashCode);
+    Comparator<? super Expression> comparator = Comparator.comparingInt(Object::hashCode);
 
     public void testNonCommutativeBinary() throws Exception {
         Div div = new Div(EMPTY, of(2), of(1));
@@ -171,8 +171,8 @@ public class CanonicalTests extends ESTestCase {
 
         assertNotEquals(list, shuffle);
 
-        list.sort(c);
-        shuffle.sort(c);
+        list.sort(comparator);
+        shuffle.sort(comparator);
 
         assertEquals(list, shuffle);
     }

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/DecryptionPacketsInputStream.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/DecryptionPacketsInputStream.java
@@ -154,13 +154,13 @@ public final class DecryptionPacketsInputStream extends ChainingInputStream {
         // cipher used to decrypt only the current packetInputStream
         Cipher packetCipher = getPacketDecryptionCipher(packetBuffer);
         // read the rest of the packet, reusing the packetBuffer
-        int packetLength = readNBytes(packetInputStream, packetBuffer, 0, packetBuffer.length);
-        if (packetLength < GCM_TAG_LENGTH_IN_BYTES) {
+        int packetLen = readNBytes(packetInputStream, packetBuffer, 0, packetBuffer.length);
+        if (packetLen < GCM_TAG_LENGTH_IN_BYTES) {
             throw new IOException("Encrypted packet is too short");
         }
         try {
             // in-place decryption of the whole packet and return decrypted length
-            return packetCipher.doFinal(packetBuffer, 0, packetLength, packetBuffer);
+            return packetCipher.doFinal(packetBuffer, 0, packetLen, packetBuffer);
         } catch (ShortBufferException | IllegalBlockSizeException | BadPaddingException e) {
             throw new IOException("Exception during packet decryption", e);
         }

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -302,6 +302,7 @@ public class EncryptedRepository extends BlobStoreRepository {
         this.delegatedRepository.close();
     }
 
+    @SuppressWarnings("HiddenField")
     private Supplier<Tuple<BytesReference, SecretKey>> createDEKGenerator() throws GeneralSecurityException {
         // DEK and DEK Ids MUST be generated randomly (with independent random instances)
         // the rand algo is not pinned so that it goes well with various providers (eg FIPS)

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -137,7 +137,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
 
     @Override
     public List<RestHandler> getRestHandlers(
-        Settings settings,
+        Settings unused,
         RestController restController,
         ClusterSettings clusterSettings,
         IndexScopedSettings indexScopedSettings,
@@ -189,9 +189,9 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
     }
 
     @Override
-    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settingsToUse) {
         FixedExecutorBuilder indexing = new FixedExecutorBuilder(
-            settings,
+            settingsToUse,
             Rollup.TASK_THREAD_POOL_NAME,
             1,
             -1,

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.assertNoAuthorizationHea
 
 public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNodeAction<PutRollupJobAction.Request> {
 
-    private static final Logger logger = LogManager.getLogger(TransportPutRollupJobAction.class);
+    private static final Logger LOGGER = LogManager.getLogger(TransportPutRollupJobAction.class);
 
     private final PersistentTasksService persistentTasksService;
     private final Client client;
@@ -111,7 +111,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
             }
 
             RollupJob job = createRollupJob(request.getConfig(), threadPool);
-            createIndex(job, l, persistentTasksService, client, logger);
+            createIndex(job, l, persistentTasksService, client, LOGGER);
         }));
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
@@ -251,14 +251,14 @@ class RollupShardIndexer {
             .build();
     }
 
-    private Rounding createRounding(RollupActionDateHistogramGroupConfig config) {
-        DateHistogramInterval interval = config.getInterval();
-        ZoneId zoneId = config.getTimeZone() != null ? ZoneId.of(config.getTimeZone()) : null;
+    private Rounding createRounding(RollupActionDateHistogramGroupConfig groupConfig) {
+        DateHistogramInterval interval = groupConfig.getInterval();
+        ZoneId zoneId = groupConfig.getTimeZone() != null ? ZoneId.of(groupConfig.getTimeZone()) : null;
         Rounding.Builder tzRoundingBuilder;
-        if (config instanceof RollupActionDateHistogramGroupConfig.FixedInterval) {
+        if (groupConfig instanceof RollupActionDateHistogramGroupConfig.FixedInterval) {
             TimeValue timeValue = TimeValue.parseTimeValue(interval.toString(), null, getClass().getSimpleName() + ".interval");
             tzRoundingBuilder = Rounding.builder(timeValue);
-        } else if (config instanceof RollupActionDateHistogramGroupConfig.CalendarInterval) {
+        } else if (groupConfig instanceof RollupActionDateHistogramGroupConfig.CalendarInterval) {
             Rounding.DateTimeUnit dateTimeUnit = DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(interval.toString());
             tzRoundingBuilder = Rounding.builder(dateTimeUnit);
         } else {
@@ -543,9 +543,9 @@ class RollupShardIndexer {
             return PointValues.Relation.CELL_CROSSES_QUERY;
         }
 
-        private void checkMinRounding(long rounding) {
-            if (rounding > lastRounding) {
-                nextRounding = rounding;
+        private void checkMinRounding(long roundingValue) {
+            if (roundingValue > lastRounding) {
+                nextRounding = roundingValue;
                 throw new CollectionTerminatedException();
             }
         }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -101,25 +101,25 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
 
         if (randomBoolean()) {
             request.concurrency(between(1, 5));
-            blobStore.ensureMaxWriteConcurrency(request.getConcurrency());
+            blobStore.setMaxWriteConcurrency(request.getConcurrency());
         }
 
         if (randomBoolean()) {
             request.blobCount(between(1, 100));
-            blobStore.ensureMaxBlobCount(request.getBlobCount());
+            blobStore.setMaxBlobCount(request.getBlobCount());
         }
 
         if (request.getBlobCount() > 3 || randomBoolean()) {
             // only use the default blob size of 10MB if writing a small number of blobs, since this is all in-memory
             request.maxBlobSize(new ByteSizeValue(between(1, 2048)));
-            blobStore.ensureMaxBlobSize(request.getMaxBlobSize().getBytes());
+            blobStore.setMaxBlobSize(request.getMaxBlobSize().getBytes());
         }
 
         if (usually()) {
             request.maxTotalDataSize(
                 new ByteSizeValue(request.getMaxBlobSize().getBytes() + request.getBlobCount() - 1 + between(0, 1 << 20))
             );
-            blobStore.ensureMaxTotalBlobSize(request.getMaxTotalDataSize().getBytes());
+            blobStore.setMaxTotalBlobSize(request.getMaxTotalDataSize().getBytes());
         }
 
         request.timeout(TimeValue.timeValueSeconds(20));
@@ -250,19 +250,19 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
         @Override
         public void close() {}
 
-        public void ensureMaxWriteConcurrency(int concurrency) {
+        public void setMaxWriteConcurrency(int concurrency) {
             this.writeSemaphore = new Semaphore(concurrency);
         }
 
-        public void ensureMaxBlobCount(int maxBlobCount) {
+        public void setMaxBlobCount(int maxBlobCount) {
             this.maxBlobCount = maxBlobCount;
         }
 
-        public void ensureMaxBlobSize(long maxBlobSize) {
+        public void setMaxBlobSize(long maxBlobSize) {
             this.maxBlobSize = maxBlobSize;
         }
 
-        public void ensureMaxTotalBlobSize(long maxTotalBlobSize) {
+        public void setMaxTotalBlobSize(long maxTotalBlobSize) {
             this.maxTotalBlobSize = maxTotalBlobSize;
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
@@ -39,9 +39,9 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
     }
 
     @Override
-    protected List<Object> foldAndConvertListOfValues(List<Expression> list, DataType dataType) {
-        List<Object> values = new ArrayList<>(list.size());
-        for (Expression e : list) {
+    protected List<Object> foldAndConvertListOfValues(List<Expression> expressions, DataType dataType) {
+        List<Object> values = new ArrayList<>(expressions.size());
+        for (Expression e : expressions) {
             values.add(SqlDataTypeConverter.convert(Foldables.valueOf(e), dataType));
         }
         return values;


### PR DESCRIPTION
Backport of #81296.

Part of #19752. Fix more instances where local variable names were
shadowing field names.