### PR TITLE
Mute CacheFileTests.testCacheFileCreatedAsSparseFile for aarch64

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
@@ -394,9 +394,16 @@ public class CacheFileTests extends ESTestCase {
     private static void assumeLinux64bitsOrWindows() {
         assumeTrue(
             "This test uses native methods implemented only for Windows & Linux 64bits non-aarch64",
-            Constants.WINDOWS
-                || Constants.LINUX && Constants.JRE_IS_64BIT && "aarch64".equals(Constants.OS_ARCH.toLowerCase(Locale.ROOT)) == false
+            Constants.WINDOWS || Constants.LINUX && Constants.JRE_IS_64BIT
+            // see testCacheFileCreatedAsSparseFileOnAarch64() comment
+                && "aarch64".equals(Constants.OS_ARCH.toLowerCase(Locale.ROOT)) == false
         );
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81362")
+    public void testCacheFileCreatedAsSparseFileOnAarch64() {
+        // testCacheFileCreatedAsSparseFile() should also be executed on aarch64 architectures but this is disabled in
+        // assumeLinux64bitsOrWindows() until https://github.com/elastic/elasticsearch/issues/81362 is resolved.
     }
 
     public void testCacheFileCreatedAsSparseFile() throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
@@ -393,8 +393,9 @@ public class CacheFileTests extends ESTestCase {
 
     private static void assumeLinux64bitsOrWindows() {
         assumeTrue(
-            "This test uses native methods implemented only for Windows & Linux 64bits",
-            Constants.WINDOWS || Constants.LINUX && Constants.JRE_IS_64BIT
+            "This test uses native methods implemented only for Windows & Linux 64bits non-aarch64",
+            Constants.WINDOWS
+                || Constants.LINUX && Constants.JRE_IS_64BIT && "aarch64".equals(Constants.OS_ARCH.toLowerCase(Locale.ROOT)) == false
         );
     }
 


### PR DESCRIPTION
The native method added in fails on `aarch64` platforms. This commit mutes the test while I investigate if I can make it work on `aarch64`

Relates #81362