### PR TITLE
[7.16] Add explicit warning not to touch repository contents (#81295)

### DIFF
--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -167,8 +167,12 @@ Before you start, test the reindex from remote process with a subset of the data
 to estimate your time requirements.
 
 [discrete]
+[[snapshot-restore-warnings]]
+=== Warnings
+
+[discrete]
 [[other-backup-methods]]
-== Other backup methods
+=== Other backup methods
 
 // tag::backup-warning[]
 **Taking a snapshot is the only reliable and supported way to back up a
@@ -186,6 +190,25 @@ point in time. You cannot fix this by shutting down nodes while making the
 copies, nor by taking atomic filesystem-level snapshots, because {es} has
 consistency requirements that span the whole cluster. You must use the built-in
 snapshot functionality for cluster backups.
+
+[discrete]
+[[snapshot-repository-contents]]
+=== Repository contents
+
+**Don’t modify anything within the repository or run processes that might
+interfere with its contents.** If something other than {es} modifies the
+contents of the repository then future snapshot or restore operations may fail,
+reporting corruption or other data inconsistencies, or may appear to succeed
+having silently lost some of your data.
+
+You may however safely <<snapshots-repository-backup,restore a repository from
+a backup>> as long as
+
+. The repository is not registered with {es} while you are restoring its
+contents.
+
+. When you have finished restoring the repository its contents are exactly as
+they were when you took the backup.
 
 include::register-repository.asciidoc[]
 include::take-snapshot.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Add explicit warning not to touch repository contents (#81295)