### PR TITLE
Adjust LinuxFileSystemNatives.allocatedSizeInBytes for aarch64 architectures

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/filesystem/LinuxFileSystemNatives.java
+++ b/server/src/main/java/org/elasticsearch/common/filesystem/LinuxFileSystemNatives.java
@@ -41,12 +41,21 @@ final class LinuxFileSystemNatives implements FileSystemNatives.Provider {
      * To allow the `struct stat' structure bits to vary without changing shared library major version number, the `stat' function is often
      * an inline wrapper around `xstat' which takes a leading version-number argument designating the data structure and bits used.
      *
-     * In glibc this version is defined in bits/stat.h (or bits/struct_stat.h in glibc 2.33) as:
+     * In glibc this version is defined in bits/stat.h (or bits/struct_stat.h in glibc 2.33, or bits/xstatver.h in more recent versions).
+     *
+     * For x86-64 the _STAT_VER used is:
      *  # define _STAT_VER_LINUX    1
      *  # define _STAT_VER _STAT_VER_LINUX
+     *
+     * For other architectures the _STAT_VER used is:
+     *  # define _STAT_VER_LINUX    0
+     *  # define _STAT_VER _STAT_VER_LINUX
      **/
-    private static final int STAT_VER_LINUX = 1;
-    private static final int STAT_VER = STAT_VER_LINUX;
+    private static int loadStatVersion() {
+        return "aarch64".equalsIgnoreCase(Constants.OS_ARCH) ? 0 : 1;
+    }
+
+    private static final int STAT_VER = loadStatVersion();
 
     private LinuxFileSystemNatives() {
         assert Constants.LINUX : Constants.OS_NAME;

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFileTests.java
@@ -393,17 +393,9 @@ public class CacheFileTests extends ESTestCase {
 
     private static void assumeLinux64bitsOrWindows() {
         assumeTrue(
-            "This test uses native methods implemented only for Windows & Linux 64bits non-aarch64",
+            "This test uses native methods implemented only for Windows & Linux 64bits",
             Constants.WINDOWS || Constants.LINUX && Constants.JRE_IS_64BIT
-            // see testCacheFileCreatedAsSparseFileOnAarch64() comment
-                && "aarch64".equals(Constants.OS_ARCH.toLowerCase(Locale.ROOT)) == false
         );
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81362")
-    public void testCacheFileCreatedAsSparseFileOnAarch64() {
-        // testCacheFileCreatedAsSparseFile() should also be executed on aarch64 architectures but this is disabled in
-        // assumeLinux64bitsOrWindows() until https://github.com/elastic/elasticsearch/issues/81362 is resolved.
     }
 
     public void testCacheFileCreatedAsSparseFile() throws Exception {


### PR DESCRIPTION
The native method added in #80437 requires some adjustments to work on `aarch64` architectures, which hopefully this change addresses. The stat version has been tested on AWS 64-bit ARM instances (on ubuntu-18.04 and on Amazon Linux 2).

Closes #81362