### PR TITLE
[ML] Cache model size on the config when first doc is put

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartAction.java
@@ -151,6 +151,10 @@ public class PutTrainedModelDefinitionPartAction extends ActionType<Acknowledged
             return totalParts;
         }
 
+        public boolean isEos() {
+            return part == totalParts - 1;
+        }
+
         public static class Builder {
             private BytesReference definition;
             private long totalDefinitionLength;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -622,6 +622,9 @@ public class PyTorchModelIT extends ESRestTestCase {
                 + "}"
         );
         client().performRequest(request);
+
+        Response getModelResponse = client().performRequest(new Request("GET", "_ml/trained_models/" + modelId));
+        assertThat(EntityUtils.toString(getModelResponse.getEntity()), containsString("\"model_size_bytes\":" + RAW_MODEL_SIZE));
     }
 
     private void putVocabulary(List<String> vocabulary, String modelId) throws IOException {


### PR DESCRIPTION
For native models it is typical that when the model config is
put the model size is not known. However, it is required when
each model definition doc is put. In order to capture the
model size and make it visible with the model config, this
commit updates the model config doc when the first model definition
doc is put.

This makes it easier to users to see how much memory a model
needs before the start a deployment.
