### PR TITLE
_tier_preference docs changes for 8.0

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -118,7 +118,6 @@ settings in the create index request or index template that matches the new inde
 
 You can also explicitly set `index.routing.allocation.include._tier_preference`
 to opt out of the default tier-based allocation.
-If you set the tier preference to `null`, {es} ignores the data tier roles during allocation.
 
 [discrete]
 [[data-tier-migration]]

--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -112,10 +112,6 @@ by default {es} sets
 <<tier-preference-allocation-filter, `index.routing.allocation.include._tier_preference`>>
 to `data_hot` to automatically allocate the index shards to the hot tier.
 
-You can override the automatic tier-based allocation by specifying
-<<shard-allocation-filtering, shard allocation filtering>>
-settings in the create index request or index template that matches the new index.
-
 You can also explicitly set `index.routing.allocation.include._tier_preference`
 to opt out of the default tier-based allocation.
 

--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -122,6 +122,6 @@ to opt out of the default tier-based allocation.
 {ilm-init} automatically transitions managed
 indices through the available data tiers using the <<ilm-migrate, migrate>> action.
 By default, this action is automatically injected in every phase.
-You can explicitly specify the migrate action to disable automatic migration,
+You can explicitly specify the migrate action with `"enabled": false` to disable automatic migration,
 for example, if you're using the <<ilm-allocate, allocate action>> to manually
 specify allocation rules.

--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -122,5 +122,6 @@ to opt out of the default tier-based allocation.
 {ilm-init} automatically transitions managed
 indices through the available data tiers using the <<ilm-migrate, migrate>> action.
 By default, this action is automatically injected in every phase.
-You can explicitly specify the migrate action to override the default behavior,
-or use the <<ilm-allocate, allocate action>> to manually specify allocation rules.
+You can explicitly specify the migrate action to disable automatic migration,
+for example, if you're using the <<ilm-allocate, allocate action>> to manually
+specify allocation rules.

--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -112,7 +112,7 @@ by default {es} sets
 <<tier-preference-allocation-filter, `index.routing.allocation.include._tier_preference`>>
 to `data_hot` to automatically allocate the index shards to the hot tier.
 
-You can also explicitly set `index.routing.allocation.include._tier_preference`
+You can explicitly set `index.routing.allocation.include._tier_preference`
 to opt out of the default tier-based allocation.
 
 [discrete]

--- a/docs/reference/index-modules/allocation/data_tier_allocation.asciidoc
+++ b/docs/reference/index-modules/allocation/data_tier_allocation.asciidoc
@@ -2,12 +2,10 @@
 [[data-tier-shard-filtering]]
 === Index-level data tier allocation filtering
 
-You can use index-level allocation settings to control which <<data-tiers, data tier>>
-the index is allocated to. The data tier allocator is a
-<<shard-allocation-filtering, shard allocation filter>> that uses two built-in
-node attributes:  `_tier` and `_tier_preference`.
+You can use the index-level `_tier_preference` setting to control
+which <<data-tiers, data tier>> an index is allocated to.
 
-These tier attributes are set using the data node roles:
+This setting corresponds to the data node roles:
 
 * <<data-content-node, data_content>>
 * <<data-hot-node, data_hot>>
@@ -16,7 +14,7 @@ These tier attributes are set using the data node roles:
 * <<data-frozen-node, data_frozen>>
 
 NOTE: The <<data-node, data>> role is not a valid data tier and cannot be used
-for data tier filtering. The frozen tier stores <<partially-mounted,partially
+with the `_tier_preference` setting. The frozen tier stores <<partially-mounted,partially
 mounted indices>> exclusively.
 
 [discrete]
@@ -34,3 +32,4 @@ mounted indices>> exclusively.
     are nodes with the `data_warm` role. If there are no nodes in the warm tier,
     but there are nodes with the `data_hot` role, the index is allocated to
     the hot tier.
+    Used in conjuction with <<data-tier-allocation,data tiers>>.


### PR DESCRIPTION
Related to #76147 and particularly #79751

Remove some places that mention setting the `_tier_preference` to `null`, as well as conditionals around the injection of the `migrate` action -- on 8.0, newly created indices will always get either an explicitly-set or defaulted `_tier_preference`, and the `migrate` action is always inserted.

Also fixes some vestigial documentation that still references the `_tier` filters which had already been removed from 8.0 (see #73074).