### PR TITLE
docs: remove old APM ifeval 

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -59,12 +59,3 @@ Shared attribute values are pulled from elastic/docs
 ///////
 
 include::{docs-root}/shared/attributes.asciidoc[]
-
-///////
-APM does not build n.x documentation. Links from .x branches should point to master instead
-///////
-ifeval::["{source_branch}"=="7.x"]
-:apm-server-ref:       {apm-server-ref-m}
-:apm-server-ref-v:     {apm-server-ref-m}
-:apm-overview-ref-v:   {apm-overview-ref-m}
-endif::[]


### PR DESCRIPTION
Removes the old `ifeval` for links to 7.x APM documentation. 7.x no longer exists, so this code isn't needed.

Originally added in https://github.com/elastic/elasticsearch/pull/56538.