### PR TITLE
[8.0] Implement getMinimalSupportedVersion for all NameDiffs (#81374)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/NamedDiff.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NamedDiff.java
@@ -18,8 +18,6 @@ public interface NamedDiff<T extends Diffable<T>> extends Diff<T>, NamedWriteabl
     /**
      * The minimal version of the recipient this custom object can be sent to
      */
-    default Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion();
-    }
+    Version getMinimalSupportedVersion();
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -164,5 +164,10 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -165,5 +165,10 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -197,5 +197,10 @@ public class DataStreamMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -332,6 +332,11 @@ public final class IndexGraveyard implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -195,6 +195,12 @@ public class NodesShutdownMetadata implements Metadata.Custom {
         static Diff<SingleNodeShutdownMetadata> readNodesDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SingleNodeShutdownMetadata::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return NODE_SHUTDOWN_VERSION;
+        }
+
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -152,6 +152,11 @@ public final class IngestMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -125,6 +125,11 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXCont
         public void writeTo(StreamOutput out) throws IOException {
             pipelines.writeTo(out);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -189,6 +189,12 @@ public class FeatureMigrationResults implements Metadata.Custom {
         static Diff<SingleFeatureMigrationResult> readDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SingleFeatureMigrationResult::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return MIGRATION_ADDED_VERSION;
+        }
+
     }
 
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
@@ -165,6 +165,10 @@ public class AutoscalingMetadata implements Metadata.NonRestorableCustom {
             return AbstractDiffable.readDiffFrom(AutoscalingPolicyMetadata::new, in);
         }
 
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_8_0;
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -182,6 +182,11 @@ public class IndexLifecycleMetadata implements Metadata.Custom {
             return TYPE;
         }
 
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
+
         static Diff<LifecyclePolicyMetadata> readLifecyclePolicyDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(LifecyclePolicyMetadata::new, in);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -64,7 +64,7 @@ public class MlMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion();
+        return Version.CURRENT.minimumCompatibilityVersion();
     }
 
     @Override
@@ -173,6 +173,11 @@ public class MlMetadata implements Metadata.Custom {
         @Override
         public String getWriteableName() {
             return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
         }
 
         static Diff<Job> readJobDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -213,5 +213,11 @@ public class SnapshotLifecycleMetadata implements Metadata.Custom {
         static Diff<SnapshotLifecyclePolicyMetadata> readLifecyclePolicyDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SnapshotLifecyclePolicyMetadata::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_4_0;
+        }
+
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
@@ -53,7 +53,7 @@ public class TransformMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion();
+        return Version.CURRENT.minimumCompatibilityVersion();
     }
 
     @Override
@@ -116,6 +116,11 @@ public class TransformMetadata implements Metadata.Custom {
         @Override
         public String getWriteableName() {
             return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
@@ -161,6 +161,12 @@ public class ModelAliasMetadata implements Metadata.Custom {
         public void writeTo(StreamOutput out) throws IOException {
             modelAliasesDiff.writeTo(out);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_13_0;
+        }
+
     }
 
     public static class ModelAliasEntry extends AbstractDiffable<ModelAliasEntry> implements ToXContentObject {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadata.java
@@ -220,6 +220,11 @@ public class TrainedModelAllocationMetadata implements Metadata.Custom {
         }
 
         @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_8_0_0;
+        }
+
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             modelRoutingEntries.writeTo(out);
         }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Implement getMinimalSupportedVersion for all NameDiffs (#81374)