### PR TITLE
[7.16] Implement getMinimalSupportedVersion for all NameDiffs (#81374)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/NamedDiff.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NamedDiff.java
@@ -18,8 +18,6 @@ public interface NamedDiff<T extends Diffable<T>> extends Diff<T>, NamedWriteabl
     /**
      * The minimal version of the recipient this custom object can be sent to
      */
-    default Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion();
-    }
+    Version getMinimalSupportedVersion();
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -164,5 +164,10 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -165,5 +165,10 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -215,5 +215,10 @@ public class DataStreamMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_7_0;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -332,6 +332,11 @@ public final class IndexGraveyard implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -195,6 +195,12 @@ public class NodesShutdownMetadata implements Metadata.Custom {
         static Diff<SingleNodeShutdownMetadata> readNodesDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SingleNodeShutdownMetadata::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return NODE_SHUTDOWN_VERSION;
+        }
+
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -152,6 +152,11 @@ public final class IngestMetadata implements Metadata.Custom {
         public String getWriteableName() {
             return TYPE;
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -125,6 +125,11 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXCont
         public void writeTo(StreamOutput out) throws IOException {
             pipelines.writeTo(out);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -189,6 +189,12 @@ public class FeatureMigrationResults implements Metadata.Custom {
         static Diff<SingleFeatureMigrationResult> readDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SingleFeatureMigrationResult::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return MIGRATION_ADDED_VERSION;
+        }
+
     }
 
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
@@ -166,6 +166,10 @@ public class AutoscalingMetadata implements XPackPlugin.XPackMetadataCustom, Met
             return AbstractDiffable.readDiffFrom(AutoscalingPolicyMetadata::new, in);
         }
 
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_8_0;
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -109,7 +109,7 @@ public class IndexLifecycleMetadata implements XPackMetadataCustom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_6_6_0;
+        return Version.CURRENT.minimumCompatibilityVersion();
     }
 
     @Override
@@ -181,6 +181,11 @@ public class IndexLifecycleMetadata implements XPackMetadataCustom {
         @Override
         public String getWriteableName() {
             return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
         }
 
         static Diff<LifecyclePolicyMetadata> readLifecyclePolicyDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -130,7 +130,7 @@ public class MlMetadata implements XPackPlugin.XPackMetadataCustom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_6_0_0_alpha1;
+        return Version.CURRENT.minimumCompatibilityVersion();
     }
 
     @Override
@@ -285,6 +285,11 @@ public class MlMetadata implements XPackPlugin.XPackMetadataCustom {
         @Override
         public String getWriteableName() {
             return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT.minimumCompatibilityVersion();
         }
 
         static Diff<Job> readJobDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/ModelAliasMetadata.java
@@ -162,6 +162,12 @@ public class ModelAliasMetadata implements XPackPlugin.XPackMetadataCustom {
         public void writeTo(StreamOutput out) throws IOException {
             modelAliasesDiff.writeTo(out);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_13_0;
+        }
+
     }
 
     public static class ModelAliasEntry extends AbstractDiffable<ModelAliasEntry> implements ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -226,5 +226,11 @@ public class SnapshotLifecycleMetadata implements XPackMetadataCustom {
         static Diff<SnapshotLifecyclePolicyMetadata> readLifecyclePolicyDiffFrom(StreamInput in) throws IOException {
             return AbstractDiffable.readDiffFrom(SnapshotLifecyclePolicyMetadata::new, in);
         }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_7_4_0;
+        }
+
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
@@ -176,7 +176,7 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
     }
 
     public void testMinimumSupportedVersion() {
-        assertEquals(Version.V_6_6_0, createTestInstance().getMinimalSupportedVersion());
+        assertEquals(Version.V_6_8_0, createTestInstance().getMinimalSupportedVersion());
     }
 
     public void testcontext() {


### PR DESCRIPTION
This removes the default implementation of `getMinimalSupportedVersion`
and implements it in all `NameDiffs` implementations.

The default implementation was rather broad, `minimumIndexCompatibilityVersion`
as the index compatibility are wider than our wire compatibility.
Having a default implementation also had the implementors forget about
adjusting the wire compatibility to the correct version.

(cherry picked from commit 5546d5a267d9464d0703b075fbddfd963ee9db0d)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

# Conflicts:
#	x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
#	x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
#	x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadata.java

Backport of #81374 