### PR TITLE
Skip IndexingIT#testSyncedFlushTransition on 8.0+ nodes

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -283,10 +283,9 @@ public class IndexingIT extends ESRestTestCase {
         request.setJsonEntity("{\"indices\": \"" + index + "\"}");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/79930")
     public void testSyncedFlushTransition() throws Exception {
         Nodes nodes = buildNodeAndVersions();
-        assertTrue("bwc version is on 7.x", nodes.getBWCVersion().before(Version.V_8_0_0));
+        assumeTrue("bwc version is on 7.x", nodes.getBWCVersion().before(Version.V_8_0_0));
         assumeFalse("no new node found", nodes.getNewNodes().isEmpty());
         assumeFalse("no bwc node found", nodes.getBWCNodes().isEmpty());
         // Allocate shards to new nodes then verify synced flush requests processed by old nodes/new nodes


### PR DESCRIPTION
Closes #79930
