### PR TITLE
[ML] Preserve casing for never split tokens

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenizerTests.java
@@ -61,7 +61,7 @@ public class BasicTokenizerTests extends ESTestCase {
         assertThat(tokenStrings(tokens), contains("HaLLo", "!", "how", "Are", "yoU", "?"));
     }
 
-    public void testNeverSplit() {
+    public void testNeverSplit_GivenNoLowerCase() {
         BasicTokenizer tokenizer = new BasicTokenizer(false, false, false, Collections.singleton("[UNK]"));
         var tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]");
         assertThat(tokenStrings(tokens), contains("HeLLo", "!", "how", "Are", "yoU", "?", "[UNK]"));
@@ -77,8 +77,32 @@ public class BasicTokenizerTests extends ESTestCase {
 
         tokens = tokenizer.tokenize("Hello-[UNK]");
         assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]"));
-        tokens = tokenizer.tokenize("Hello-[UNK][UNK]");
-        assertThat(tokenStrings(tokens), contains("Hello", "-", "[UNK]", "[UNK]"));
+        tokens = tokenizer.tokenize("Hello~[UNK][UNK]");
+        assertThat(tokenStrings(tokens), contains("Hello", "~", "[UNK]", "[UNK]"));
+        tokens = tokenizer.tokenize("Hello-[unk]");
+        assertThat(tokenStrings(tokens), contains("Hello", "-", "[", "unk", "]"));
+    }
+
+    public void testNeverSplit_GivenLowerCase() {
+        BasicTokenizer tokenizer = new BasicTokenizer(true, false, false, Collections.singleton("[UNK]"));
+        var tokens = tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]");
+        assertThat(tokenStrings(tokens), contains("hello", "!", "how", "are", "you", "?", "[UNK]"));
+
+        tokens = tokenizer.tokenize("Hello [UNK].");
+        assertThat(tokenStrings(tokens), contains("hello", "[UNK]", "."));
+
+        tokens = tokenizer.tokenize("Hello [UNK]?");
+        assertThat(tokenStrings(tokens), contains("hello", "[UNK]", "?"));
+
+        tokens = tokenizer.tokenize("Hello [UNK]!!");
+        assertThat(tokenStrings(tokens), contains("hello", "[UNK]", "!", "!"));
+
+        tokens = tokenizer.tokenize("Hello-[UNK]");
+        assertThat(tokenStrings(tokens), contains("hello", "-", "[UNK]"));
+        tokens = tokenizer.tokenize("Hello~[UNK][UNK]");
+        assertThat(tokenStrings(tokens), contains("hello", "~", "[UNK]", "[UNK]"));
+        tokens = tokenizer.tokenize("Hello-[unk]");
+        assertThat(tokenStrings(tokens), contains("hello", "-", "[", "unk", "]"));
     }
 
     public void testSplitOnPunctuation() {


### PR DESCRIPTION
This fixes a bug introduced by #81254. We are now using
a token trie tree to merge tokens belonging to one of the
never-split tokens back together. However, if the tokenizer
is lower casing, then the merged token will also be lower case
and won't be matched against never split tokens that are expected
to be in upper case.

This commit fixes this by looking up the original text and only
merging tokens together when the original text is matching one
of the never split tokens.
