### PR TITLE
[DOCS] Add description of X-Opaque-ID and trace.id

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -25,15 +25,19 @@ sent with a request. Responses are also UTF-8 encoded.
 the origin of the request with the {es} logs. It is emitted in deprecation
 logs as `elasticsearch.x-opaque-id` (both JSON log file and indexed logs)
 and is used together with `key` of the deprecation to deduplicate deprecation logs.
+
 See link:./server/src/main/java/org/elasticsearch/common/logging/RateLimitingFilter.java[RateLimitingFilter]
 which is used for both indexing deprecation logs and writing to a file.
 
 The use of `x-opaque-id` in deduplication can be turned off for indexed
 deprecation logs with the use of `cluster.deprecation_indexing.x_opaque_id_used.enabled`.
 This is intended to be used for small clusters which are limited in resources.
+
 This setting will not affect writing deprecation logs to file.
+
 It is emitted also in search slow logs as an `id` field and in audit logs as `opaque_id`.
 The value is also present in <<_identifying_running_tasks, `task api`>>.
+
 This header can contain any value, but should be from a fine set.
 If there is a lot of different x-opaque-id values, it will prevent deduplication from working
 
@@ -41,8 +45,10 @@ If there is a lot of different x-opaque-id values, it will prevent deduplication
 === traceparent requirements
 `traceparent` - a header used by ES to allow tracing capabilities across the stack.
 This field has a structure that has to be followed.
+
 ES uses the `trace-id field from that header.
 https://www.w3.org/TR/trace-context/#traceparent-header
+
 Example:
 `transparent`: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 `trace.id`: 0af7651916cd43dd8448eb211c80319c
@@ -50,6 +56,7 @@ Example:
 `trace-id` is emitted as `trace.id` in  ES’s JSON logs - server.json,
 search slow log, indexing slow log, deprecation logs
 and indexed deprecation logs.
+
 It is not used for deduplicating deprecation logs and can be a generated
 value per each request.
 

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -20,48 +20,49 @@ specified using the `source_content_type` query string parameter.
 sent with a request. Responses are also UTF-8 encoded.
 
 [discrete]
-=== X-Opaque-id requirements
-`X-opaque-id` - a header used by elasticsearch to allow identify and correlate
-the origin of the request with the {es} logs. It is emitted in deprecation
-logs as `elasticsearch.x-opaque-id` (both JSON log file and indexed logs)
-and is used together with `key` of the deprecation to deduplicate deprecation logs.
+[[x-opaque-id]]
+=== `X-Opaque-Id` HTTP header
 
-See link:./server/src/main/java/org/elasticsearch/common/logging/RateLimitingFilter.java[RateLimitingFilter]
-which is used for both indexing deprecation logs and writing to a file.
+You can pass an `X-Opaque-Id` HTTP header to track the origin of a request in
+{es} logs and tasks. If provided, {es} surfaces the `X-Opaque-Id` value in the:
 
-The use of `x-opaque-id` in deduplication can be turned off for indexed
-deprecation logs with the use of `cluster.deprecation_indexing.x_opaque_id_used.enabled`.
-This is intended to be used for small clusters which are limited in resources.
+* Response of any request that includes the header
+* <<_identifying_running_tasks,Task management API>> response
+* <<_identifying_search_slow_log_origin,Slow logs>>
+* <<deprecation-logging,Deprecation logs>>
 
-This setting will not affect writing deprecation logs to file.
+For the deprecation logs, {es} also uses the `X-Opaque-Id` value to throttle
+and deduplicate deprecation warnings. See <<_deprecation_logs_throttling>>.
 
-It is emitted also in search slow logs as an `id` field and in audit logs as `opaque_id`.
-The value is also present in <<_identifying_running_tasks, `task api`>>.
-
-This header can contain any value, but should be from a finite set.
-If there is a lot of different `x-opaque-id` values, it will prevent deduplication from working
+The `X-Opaque-Id` header accepts any arbitrary value. However, we recommend you
+limit these values to a finite set, such as an ID per client. Don't generate a
+unique `X-Opaque-Id` header for every request. Too many unique `X-Opaque-Id`
+values can prevent {es} from deduplicating warnings in the deprecation logs.
 
 [discrete]
-=== traceparent requirements
-`traceparent` - a header used by ES to allow tracing capabilities across the stack.
-This field has a structure that has to be followed.
+[[traceparent]]
+=== `traceparent` HTTP header
 
-ES uses the `trace-id field from that header.
-https://www.w3.org/TR/trace-context/#traceparent-header
+{es} also supports a `traceparent` HTTP header using the
+https://www.w3.org/TR/trace-context/#traceparent-header[official W3C trace
+context spec]. You can use the `traceparent` header to trace requests across
+Elastic products and other services. Because it's only used for traces, you can
+safely generate a unique `traceparent` header for each request.
 
-Example:
+If provided, {es} surfaces the header's `trace-id` value as `trace.id` in the:
+
+* <<logging,JSON {es} server logs>>
+* <<_identifying_search_slow_log_origin,Slow logs>>
+* <<deprecation-logging,Deprecation logs>>
+
+For example, the following `traceparent` value would produce the following
+`trade.id` value in the above logs.
+
 [source,txt]
-------------------------------
-`transparent`: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+----
+`traceparent`: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 `trace.id`: 0af7651916cd43dd8448eb211c80319c
-------------------------------
-
-`trace-id` is emitted as `trace.id` in  ES’s JSON logs - server.json,
-search slow log, indexing slow log, deprecation logs
-and indexed deprecation logs.
-
-It is not used for deduplicating deprecation logs and can be a generated
-value per each request.
+----
 
 [discrete]
 [[get-requests]]

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -20,14 +20,48 @@ specified using the `source_content_type` query string parameter.
 sent with a request. Responses are also UTF-8 encoded.
 
 [discrete]
+=== X-Opaque-id requirements
+`X-opaque-id` - a header used by elasticsearch to allow identify and correlate
+the origin of the request with the {es} logs. It is emitted in deprecation
+logs as `elasticsearch.x-opaque-id` (both JSON log file and indexed logs)
+and is used together with `key` of the deprecation to deduplicate deprecation logs.
+See link:./server/src/main/java/org/elasticsearch/common/logging/RateLimitingFilter.java[RateLimitingFilter]
+which is used for both indexing deprecation logs and writing to a file.
+
+The use of `x-opaque-id` in deduplication can be turned off for indexed
+deprecation logs with the use of `cluster.deprecation_indexing.x_opaque_id_used.enabled`.
+This is intended to be used for small clusters which are limited in resources.
+This setting will not affect writing deprecation logs to file.
+It is emitted also in search slow logs as an `id` field and in audit logs as `opaque_id`.
+The value is also present in <<_identifying_running_tasks, `task api`>>.
+This header can contain any value, but should be from a fine set.
+If there is a lot of different x-opaque-id values, it will prevent deduplication from working
+
+[discrete]
+=== traceparent requirements
+`traceparent` - a header used by ES to allow tracing capabilities across the stack.
+This field has a structure that has to be followed.
+ES uses the `trace-id field from that header.
+https://www.w3.org/TR/trace-context/#traceparent-header
+Example:
+`transparent`: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+`trace.id`: 0af7651916cd43dd8448eb211c80319c
+
+`trace-id` is emitted as `trace.id` in  ES’s JSON logs - server.json,
+search slow log, indexing slow log, deprecation logs
+and indexed deprecation logs.
+It is not used for deduplicating deprecation logs and can be a generated
+value per each request.
+
+[discrete]
 [[get-requests]]
 === GET and POST requests
 
-A number of {es} GET APIs--most notably the search API--support a request body. 
-While the GET action makes sense in the context of retrieving information, 
+A number of {es} GET APIs--most notably the search API--support a request body.
+While the GET action makes sense in the context of retrieving information,
 GET requests with a body are not supported by all HTTP libraries.
 All {es} GET APIs that require a body can also be submitted as POST requests.
-Alternatively, you can pass the request body as the 
+Alternatively, you can pass the request body as the
 <<api-request-body-query-string, `source` query string parameter>>
 when using GET.
 
@@ -190,11 +224,11 @@ Global index templates that match all indices are not applied to hidden indices.
 [[system-indices]]
 ==== System indices
 
-{es} modules and plugins can store configuration and state information in internal _system indices_. 
-You should not directly access or modify system indices 
+{es} modules and plugins can store configuration and state information in internal _system indices_.
+You should not directly access or modify system indices
 as they contain data essential to the operation of the system.
 
-IMPORTANT: Direct access to system indices is deprecated and 
+IMPORTANT: Direct access to system indices is deprecated and
 will no longer be allowed in the next major version.
 
 [discrete]
@@ -218,25 +252,25 @@ of the source, such as `application/json`.
 [[api-compatibility]]
 === REST API version compatibility
 
-Major version upgrades often include a number of breaking changes 
-that impact how you interact with {es}. 
-While we recommend that you monitor the deprecation logs and 
+Major version upgrades often include a number of breaking changes
+that impact how you interact with {es}.
+While we recommend that you monitor the deprecation logs and
 update applications before upgrading {es},
-having to coordinate the necessary changes can be an impediment to upgrading. 
+having to coordinate the necessary changes can be an impediment to upgrading.
 
 You can enable an existing application to function without modification after
 an upgrade by including API compatibility headers, which tell {es} you are still
-using the previous version of the REST API. Using these headers allows the 
+using the previous version of the REST API. Using these headers allows the
 structure of requests and responses to remain the same; it does not guarantee
-the same behavior. 
+the same behavior.
 
 
-You set version compatibility on a per-request basis in the `Content-Type` and `Accept` headers. 
-Setting `compatible-with` to the same major version as 
-the version you're running has no impact, 
-but ensures that the request will still work after {es} is upgraded. 
+You set version compatibility on a per-request basis in the `Content-Type` and `Accept` headers.
+Setting `compatible-with` to the same major version as
+the version you're running has no impact,
+but ensures that the request will still work after {es} is upgraded.
 
-To tell {es} 8.0 you are using the 7.x request and response format, 
+To tell {es} 8.0 you are using the 7.x request and response format,
 set `compatible-with=7`:
 
 [source,sh]

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -38,8 +38,8 @@ This setting will not affect writing deprecation logs to file.
 It is emitted also in search slow logs as an `id` field and in audit logs as `opaque_id`.
 The value is also present in <<_identifying_running_tasks, `task api`>>.
 
-This header can contain any value, but should be from a fine set.
-If there is a lot of different x-opaque-id values, it will prevent deduplication from working
+This header can contain any value, but should be from a finite set.
+If there is a lot of different `x-opaque-id` values, it will prevent deduplication from working
 
 [discrete]
 === traceparent requirements
@@ -50,8 +50,11 @@ ES uses the `trace-id field from that header.
 https://www.w3.org/TR/trace-context/#traceparent-header
 
 Example:
+[source,txt]
+------------------------------
 `transparent`: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 `trace.id`: 0af7651916cd43dd8448eb211c80319c
+------------------------------
 
 `trace-id` is emitted as `trace.id` in  ES’s JSON logs - server.json,
 search slow log, indexing slow log, deprecation logs


### PR DESCRIPTION
Documenting headers x-opaque-id and traceparent (emitted as trace.id)
and their usage in logs
