### PR TITLE
[8.0] [DOCS] Remove outdated APM ifeval  (#81402)

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -59,12 +59,3 @@ Shared attribute values are pulled from elastic/docs
 ///////
 
 include::{docs-root}/shared/attributes.asciidoc[]
-
-///////
-APM does not build n.x documentation. Links from .x branches should point to master instead
-///////
-ifeval::["{source_branch}"=="7.x"]
-:apm-server-ref:       {apm-server-ref-m}
-:apm-server-ref-v:     {apm-server-ref-m}
-:apm-overview-ref-v:   {apm-overview-ref-m}
-endif::[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove outdated APM ifeval  (#81402)