### PR TITLE
[7.16.1] Stop auto-followers when metadata is resetted (#81290)

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -246,8 +246,10 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
     }
 
     void updateAutoFollowers(ClusterState followerClusterState) {
-        final AutoFollowMetadata autoFollowMetadata = followerClusterState.getMetadata().custom(AutoFollowMetadata.TYPE);
-        if (autoFollowMetadata == null) {
+        final AutoFollowMetadata autoFollowMetadata = followerClusterState.getMetadata()
+            .custom(AutoFollowMetadata.TYPE, AutoFollowMetadata.EMPTY);
+
+        if (autoFollowMetadata.getPatterns().isEmpty() && this.autoFollowers.isEmpty()) {
             return;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -78,6 +78,12 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
         return PARSER.parse(parser, null);
     }
 
+    public static final AutoFollowMetadata EMPTY = new AutoFollowMetadata(
+        org.elasticsearch.core.Map.of(),
+        org.elasticsearch.core.Map.of(),
+        org.elasticsearch.core.Map.of()
+    );
+
     private final Map<String, AutoFollowPattern> patterns;
     private final Map<String, List<String>> followedLeaderIndexUUIDs;
     private final Map<String, Map<String, String>> headers;


### PR DESCRIPTION
Backports the following commits to 7.16.1:
 - Stop auto-followers when metadata is resetted (#81290)