### PR TITLE
Fix flaky DynamicMappingIT testDynamicRuntimeObjectFields (#80999)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -419,7 +419,9 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 "{\"dynamic\":{\"type\":\"object\", \"dynamic\":true}}}}}}}}", XContentType.JSON));
 
         //the parent object has been mapped dynamic:true, hence the field gets indexed
-        assertEquals(RestStatus.CREATED, client().prepareIndex("test", "_doc").setSource("obj.runtime.dynamic.number", 1)
+        // we use a fixed doc id here to make sure this document and the one we sent later with a conflicting type
+        // target the same shard where we are sure the mapping update has been applied
+        assertEquals(RestStatus.CREATED, client().prepareIndex("test", "_doc").setSource("obj.runtime.dynamic.number", 1).setId("id")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get().status());
 
         {


### PR DESCRIPTION
The final part of this test checks that we throw a MapperParsingException when
we try to index into a dynamic runtime object that has already been mapped to a
different type. Under very rare circumstances this can fail when the mapping
update that a previous document index operation has triggered hasn't been
completely applied on the shard the second document is targeted at. In this
case, indexing the second document can itself trigger a mapping merge operation
that can fail with a different exception type (IAE) with a very similar message.
In order to simplify the test and make it more robust we can use the same
document id for both index requests, making sure we target the same shard group.

Closes #80722
