### PR TITLE
Fix testValidateFrozenPhase

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -180,6 +180,8 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         Map<String, LifecycleAction> actions = randomSubsetOf(VALID_FROZEN_ACTIONS).stream()
             .map(this::getTestAction)
             .collect(Collectors.toMap(LifecycleAction::getWriteableName, Function.identity()));
+        // regardless of the randomised actions, we must have a SearchableSnapshotAction in frozen
+        actions.put(SearchableSnapshotAction.NAME, getTestAction(SearchableSnapshotAction.NAME));
         if (randomBoolean()) {
             invalidAction = getTestAction(randomFrom("rollover", "delete", "forcemerge", "shrink"));
             actions.put(invalidAction.getWriteableName(), invalidAction);


### PR DESCRIPTION
Always add the `searchable_snapshot` action in the frozen phase.

Fixes #81477