### PR TITLE
[7.16] Allow the `unfollow` action in the frozen phase (#81434)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -88,7 +88,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         FreezeAction.NAME,
         RollupV2.isEnabled() ? RollupILMAction.NAME : null
     ).filter(Objects::nonNull).collect(toList());
-    static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(SearchableSnapshotAction.NAME);
+    static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(UnfollowAction.NAME, SearchableSnapshotAction.NAME);
     static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);
 
     static final Set<String> VALID_HOT_ACTIONS = Sets.newHashSet(ORDERED_VALID_HOT_ACTIONS);


### PR DESCRIPTION
The `unfollow` actions is injected before some of the actions that yield
the managed index unsafe to use in a CCR environment (eg. rollover,
searchable_snapshot, shrink).

This was not allowed in the `frozen` phase, however we do have the
`searchable_snapshot` action available.

This commit makes the `unfollow` action available in the frozen phase.

(cherry picked from commit 8ba6f55e0a7b3751355eb7e52f17a9cb80f2b7f7)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

# Conflicts:
#	x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java

Backport of #81434 