### PR TITLE
[ML] Track the number of inference failures

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStatsTests.java
@@ -34,6 +34,7 @@ public class AllocationStatsTests extends AbstractWireSerializingTestCase<Alloca
                         randomNonNegativeLong(),
                         randomBoolean() ? randomDoubleBetween(0.0, 100.0, true) : null,
                         randomIntBetween(0, 100),
+                        randomIntBetween(0, 100),
                         Instant.now(),
                         Instant.now()
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -302,6 +302,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
                     // avoid reporting the average time as 0 if count < 1
                     (stats.get().getTimingStats().getCount() > 0) ? stats.get().getTimingStats().getAverage() : null,
                     stats.get().getPendingCount(),
+                    stats.get().getErrorCount() > 0 ? stats.get().getErrorCount() : null,
                     stats.get().getLastUsed(),
                     stats.get().getStartTime()
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -100,15 +100,16 @@ public class DeploymentManager {
     }
 
     public Optional<ModelStats> getStats(TrainedModelDeploymentTask task) {
-        return Optional.ofNullable(processContextByAllocation.get(task.getId()))
-            .map(
-                processContext -> new ModelStats(
-                    processContext.startTime,
-                    processContext.getResultProcessor().getTimingStats(),
-                    processContext.getResultProcessor().getLastUsed(),
-                    processContext.executorService.queueSize() + processContext.getResultProcessor().numberOfPendingResults()
-                )
+        return Optional.ofNullable(processContextByAllocation.get(task.getId())).map(processContext -> {
+            var stats = processContext.getResultProcessor().getResultStats();
+            return new ModelStats(
+                processContext.startTime,
+                stats.timingStats(),
+                stats.lastUsed(),
+                processContext.executorService.queueSize() + stats.numberOfPendingResults(),
+                stats.errorCount()
             );
+        });
     }
 
     private void doStartDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> finalListener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
@@ -16,12 +16,14 @@ public class ModelStats {
     private final LongSummaryStatistics timingStats;
     private final Instant lastUsed;
     private final int pendingCount;
+    private final int errorCount;
 
-    ModelStats(Instant startTime, LongSummaryStatistics timingStats, Instant lastUsed, int pendingCount) {
+    ModelStats(Instant startTime, LongSummaryStatistics timingStats, Instant lastUsed, int pendingCount, int errorCount) {
         this.startTime = startTime;
         this.timingStats = timingStats;
         this.lastUsed = lastUsed;
         this.pendingCount = pendingCount;
+        this.errorCount = errorCount;
     }
 
     public Instant getStartTime() {
@@ -38,5 +40,9 @@ public class ModelStats {
 
     public int getPendingCount() {
         return pendingCount;
+    }
+
+    public int getErrorCount() {
+        return errorCount;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -356,6 +356,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 5,
                                 42.0,
                                 0,
+                                0,
                                 Instant.now(),
                                 Instant.now()
                             ),
@@ -363,6 +364,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 new DiscoveryNode("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3), Version.CURRENT),
                                 4,
                                 50.0,
+                                0,
                                 0,
                                 Instant.now(),
                                 Instant.now()

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
@@ -81,6 +81,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
                 randomNonNegativeLong(),
                 randomDoubleBetween(0.0, 100.0, true),
                 randomIntBetween(1, 100),
+                randomIntBetween(0, 100),
                 Instant.now(),
                 Instant.now()
             )
@@ -91,6 +92,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
                 randomNonNegativeLong(),
                 randomDoubleBetween(0.0, 100.0, true),
                 randomIntBetween(1, 100),
+                randomIntBetween(0, 100),
                 Instant.now(),
                 Instant.now()
             )
@@ -135,6 +137,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
                 randomNonNegativeLong(),
                 randomDoubleBetween(0.0, 100.0, true),
                 randomIntBetween(1, 100),
+                randomIntBetween(0, 100),
                 Instant.now(),
                 Instant.now()
             )
@@ -145,6 +148,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
                 randomNonNegativeLong(),
                 randomDoubleBetween(0.0, 100.0, true),
                 randomIntBetween(1, 100),
+                randomIntBetween(0, 100),
                 Instant.now(),
                 Instant.now()
             )
@@ -200,6 +204,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
                         randomNonNegativeLong(),
                         randomDoubleBetween(0.0, 100.0, true),
                         randomIntBetween(1, 100),
+                        randomIntBetween(0, 100),
                         Instant.now(),
                         Instant.now()
                     )


### PR DESCRIPTION
The number of successful inferences is counted but not the number of failures.
The most likely cause of a failure is where the input tensor is not properly constructed for the model 