### PR TITLE
Fix merging of #81077 onto #81082

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -294,6 +294,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                         () -> null,
                         CommandLineHttpClient::responseBuilder
                     );
+                    break;
                 } catch (Exception e) {
                     terminal.errorPrint(
                         Terminal.Verbosity.NORMAL,


### PR DESCRIPTION
While merging the changes of #81077 onto #81082, a break statement
was unnecessarily removed from the loop that attempts to work
through all available addresses in an enrollment token in order to
talk to the existing node. That would mean that we would iterate
all addresses unintentionally and unnecessarily even when we had
already received a reply.
