### PR TITLE
[Transform] refactor settings to use Optional

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/SettingsConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/SettingsConfigTests.java
@@ -33,7 +33,7 @@ public class SettingsConfigTests extends AbstractResponseTestCase<
         org.elasticsearch.xpack.core.transform.transforms.SettingsConfig serverTestInstance,
         SettingsConfig clientInstance
     ) {
-        assertEquals(serverTestInstance.getMaxPageSearchSize(), clientInstance.getMaxPageSearchSize());
+        assertEquals(serverTestInstance.getMaxPageSearchSize().orElse(null), clientInstance.getMaxPageSearchSize());
         assertEquals(serverTestInstance.getDocsPerSecond(), clientInstance.getDocsPerSecond());
         assertEquals(serverTestInstance.getDatesAsEpochMillis(), clientInstance.getDatesAsEpochMillis());
         assertEquals(serverTestInstance.getAlignCheckpoints(), clientInstance.getAlignCheckpoints());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -607,9 +607,7 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
 
             // find maxPageSearchSize value
             Integer maxPageSearchSizeDeprecated = builder.getPivotConfig().getMaxPageSearchSize();
-            Integer maxPageSearchSize = builder.getSettings().getMaxPageSearchSize() != null
-                ? builder.getSettings().getMaxPageSearchSize()
-                : maxPageSearchSizeDeprecated;
+            Integer maxPageSearchSize = builder.getSettings().getMaxPageSearchSize().orElse(maxPageSearchSizeDeprecated);
 
             // create a new pivot config but set maxPageSearchSize to null
             builder.setPivotConfig(
@@ -631,7 +629,7 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
         if (builder.getVersion() != null && builder.getVersion().before(Version.V_7_11_0)) {
             builder.setSettings(
                 new SettingsConfig(
-                    builder.getSettings().getMaxPageSearchSize(),
+                    builder.getSettings().getMaxPageSearchSize().orElse(null),
                     builder.getSettings().getDocsPerSecond(),
                     true,
                     builder.getSettings().getAlignCheckpoints(),
@@ -644,7 +642,7 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
         if (builder.getVersion() != null && builder.getVersion().before(Version.V_7_15_0)) {
             builder.setSettings(
                 new SettingsConfig(
-                    builder.getSettings().getMaxPageSearchSize(),
+                    builder.getSettings().getMaxPageSearchSize().orElse(null),
                     builder.getSettings().getDocsPerSecond(),
                     builder.getSettings().getDatesAsEpochMillis(),
                     false,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfigTests.java
@@ -77,9 +77,9 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
     public void testExplicitNullParsing() throws IOException {
 
         // explicit null
-        assertThat(fromString("{\"max_page_search_size\" : null}").getMaxPageSearchSize(), equalTo(-1));
+        assertThat(fromString("{\"max_page_search_size\" : null}").getMaxPageSearchSizeForUpdate(), equalTo(-1));
         // not set
-        assertNull(fromString("{}").getMaxPageSearchSize());
+        assertTrue(fromString("{}").getMaxPageSearchSize().isEmpty());
 
         assertThat(fromString("{\"docs_per_second\" : null}").getDocsPerSecond(), equalTo(-1F));
         assertNull(fromString("{}").getDocsPerSecond());
@@ -106,14 +106,14 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
         SettingsConfig.Builder builder = new SettingsConfig.Builder(config);
         builder.update(fromString("{\"max_page_search_size\" : 100}"));
 
-        assertThat(builder.build().getMaxPageSearchSize(), equalTo(100));
+        assertThat(builder.build().getMaxPageSearchSize().get(), equalTo(100));
         assertThat(builder.build().getDocsPerSecond(), equalTo(42F));
         assertThat(builder.build().getDatesAsEpochMillisForUpdate(), equalTo(1));
         assertThat(builder.build().getAlignCheckpointsForUpdate(), equalTo(0));
         assertThat(builder.build().getUsePitForUpdate(), equalTo(0));
 
         builder.update(fromString("{\"max_page_search_size\" : null}"));
-        assertNull(builder.build().getMaxPageSearchSize());
+        assertTrue(builder.build().getMaxPageSearchSize().isEmpty());
         assertThat(builder.build().getDocsPerSecond(), equalTo(42F));
         assertThat(builder.build().getDatesAsEpochMillisForUpdate(), equalTo(1));
         assertThat(builder.build().getAlignCheckpointsForUpdate(), equalTo(0));
@@ -128,7 +128,7 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
                     + "\"use_point_in_time\": null}"
             )
         );
-        assertThat(builder.build().getMaxPageSearchSize(), equalTo(77));
+        assertThat(builder.build().getMaxPageSearchSize().get(), equalTo(77));
         assertNull(builder.build().getDocsPerSecond());
         assertNull(builder.build().getDatesAsEpochMillisForUpdate());
         assertNull(builder.build().getAlignCheckpointsForUpdate());
@@ -138,13 +138,13 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
     public void testOmmitDefaultsOnWriteParser() throws IOException {
         // test that an explicit null is handled differently than not set
         SettingsConfig config = fromString("{\"max_page_search_size\" : null}");
-        assertThat(config.getMaxPageSearchSize(), equalTo(-1));
+        assertThat(config.getMaxPageSearchSizeForUpdate(), equalTo(-1));
 
         Map<String, Object> settingsAsMap = xContentToMap(config);
         assertTrue(settingsAsMap.isEmpty());
 
         SettingsConfig emptyConfig = fromString("{}");
-        assertNull(emptyConfig.getMaxPageSearchSize());
+        assertTrue(emptyConfig.getMaxPageSearchSize().isEmpty());
 
         settingsAsMap = xContentToMap(emptyConfig);
         assertTrue(settingsAsMap.isEmpty());
@@ -177,13 +177,13 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
     public void testOmmitDefaultsOnWriteBuilder() throws IOException {
         // test that an explicit null is handled differently than not set
         SettingsConfig config = new SettingsConfig.Builder().setMaxPageSearchSize(null).build();
-        assertThat(config.getMaxPageSearchSize(), equalTo(-1));
+        assertThat(config.getMaxPageSearchSizeForUpdate(), equalTo(-1));
 
         Map<String, Object> settingsAsMap = xContentToMap(config);
         assertTrue(settingsAsMap.isEmpty());
 
         SettingsConfig emptyConfig = new SettingsConfig.Builder().build();
-        assertNull(emptyConfig.getMaxPageSearchSize());
+        assertTrue(emptyConfig.getMaxPageSearchSize().isEmpty());
 
         settingsAsMap = xContentToMap(emptyConfig);
         assertTrue(settingsAsMap.isEmpty());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -506,8 +506,8 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         TransformConfig transformConfigRewritten = TransformConfig.rewriteForUpdate(transformConfig);
 
         assertNull(transformConfigRewritten.getPivotConfig().getMaxPageSearchSize());
-        assertNotNull(transformConfigRewritten.getSettings().getMaxPageSearchSize());
-        assertEquals(111L, transformConfigRewritten.getSettings().getMaxPageSearchSize().longValue());
+        assertTrue(transformConfigRewritten.getSettings().getMaxPageSearchSize().isPresent());
+        assertEquals(111L, transformConfigRewritten.getSettings().getMaxPageSearchSize().get().longValue());
         assertTrue(transformConfigRewritten.getSettings().getDatesAsEpochMillis());
         assertFalse(transformConfigRewritten.getSettings().getAlignCheckpoints());
 
@@ -581,8 +581,8 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         TransformConfig transformConfigRewritten = TransformConfig.rewriteForUpdate(transformConfig);
 
         assertNull(transformConfigRewritten.getPivotConfig().getMaxPageSearchSize());
-        assertNotNull(transformConfigRewritten.getSettings().getMaxPageSearchSize());
-        assertEquals(555L, transformConfigRewritten.getSettings().getMaxPageSearchSize().longValue());
+        assertTrue(transformConfigRewritten.getSettings().getMaxPageSearchSize().isPresent());
+        assertEquals(555L, transformConfigRewritten.getSettings().getMaxPageSearchSize().get().longValue());
         assertEquals(Version.CURRENT, transformConfigRewritten.getVersion());
         assertWarnings(TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
@@ -176,7 +176,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
 
         // for settings we allow partial updates, so changing 1 setting should not overwrite the other
         // the parser handles explicit nulls, tested in @link{SettingsConfigTests}
-        assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
+        assertThat(updatedConfig.getSettings().getMaxPageSearchSize().get(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(config.getSettings().getDocsPerSecond()));
         assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
         assertThat(updatedConfig.getSettings().getAlignCheckpoints(), equalTo(config.getSettings().getAlignCheckpoints()));
@@ -192,7 +192,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
             null
         );
         updatedConfig = update.apply(updatedConfig);
-        assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
+        assertThat(updatedConfig.getSettings().getMaxPageSearchSize().get(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
         assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
         assertThat(updatedConfig.getSettings().getAlignCheckpoints(), equalTo(config.getSettings().getAlignCheckpoints()));
@@ -209,7 +209,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
             null
         );
         updatedConfig = update.apply(updatedConfig);
-        assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
+        assertTrue(updatedConfig.getSettings().getMaxPageSearchSize().isEmpty());
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
         assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
         assertThat(updatedConfig.getSettings().getAlignCheckpoints(), equalTo(config.getSettings().getAlignCheckpoints()));
@@ -225,7 +225,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
             null
         );
         updatedConfig = update.apply(updatedConfig);
-        assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
+        assertTrue(updatedConfig.getSettings().getMaxPageSearchSize().isEmpty());
         assertNull(updatedConfig.getSettings().getDocsPerSecond());
         assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
         assertThat(updatedConfig.getSettings().getAlignCheckpoints(), equalTo(config.getSettings().getAlignCheckpoints()));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
@@ -223,11 +223,13 @@ public class RestCatTransformAction extends AbstractCatAction {
                 transformIndexerStats = stats.getIndexerStats();
             }
 
-            Integer maxPageSearchSize = config.getSettings() == null || config.getSettings().getMaxPageSearchSize() == null
-                ? config.getPivotConfig() == null || config.getPivotConfig().getMaxPageSearchSize() == null
-                    ? Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE
-                    : config.getPivotConfig().getMaxPageSearchSize()
-                : config.getSettings().getMaxPageSearchSize();
+            Integer maxPageSearchSize = config.getSettings()
+                .getMaxPageSearchSize()
+                .orElse(
+                    config.getPivotConfig() == null || config.getPivotConfig().getMaxPageSearchSize() == null
+                        ? Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE
+                        : config.getPivotConfig().getMaxPageSearchSize()
+                );
 
             Double progress = checkpointingInfo == null ? null
                 : checkpointingInfo.getNext().getCheckpointProgress() == null ? null

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -328,6 +328,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 mock(TransformContext.class),
                 false
             );
+            indexer.initializeFunction();
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
                 if (pitEnabled) {


### PR DESCRIPTION
refactor settings to use `Optional<?>` instead of using nullables which requires caller checks

follow up: #81368