### PR TITLE
Emit x-elastic-product-origin into logs backport(#81381)

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -68,7 +68,7 @@ class Netty4HttpClient implements Closeable {
     static Collection<String> returnOpaqueIds(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
         for (HttpResponse response : responses) {
-            list.add(response.headers().get(Task.X_OPAQUE_ID));
+            list.add(response.headers().get(Task.X_OPAQUE_ID_HTTP_HEADER));
         }
         return list;
     }

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
@@ -73,7 +73,7 @@ class NioHttpClient implements Closeable {
     static Collection<String> returnOpaqueIds(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
         for (HttpResponse response : responses) {
-            list.add(response.headers().get(Task.X_OPAQUE_ID));
+            list.add(response.headers().get(Task.X_OPAQUE_ID_HTTP_HEADER));
         }
         return list;
     }
@@ -99,7 +99,7 @@ class NioHttpClient implements Closeable {
         for (int i = 0; i < uris.length; i++) {
             final HttpRequest httpRequest = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, uris[i]);
             httpRequest.headers().add(HOST, "localhost");
-            httpRequest.headers().add(Task.X_OPAQUE_ID, String.valueOf(i));
+            httpRequest.headers().add(Task.X_OPAQUE_ID_HTTP_HEADER, String.valueOf(i));
             requests.add(httpRequest);
         }
         return sendRequests(remoteAddress, requests);

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -147,8 +147,9 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testCompatibleLog() throws Exception {
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "someId");
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, "someId");
             threadContext.putHeader(Task.TRACE_ID, "someTraceId");
+            threadContext.putHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, "kibana");
             final DeprecationLogger testLogger = DeprecationLogger.getLogger("org.elasticsearch.test");
             testLogger.critical(DeprecationCategory.OTHER, "someKey", "deprecated message1")
                 .compatibleCritical("compatibleKey", "compatible API message");
@@ -178,6 +179,7 @@ public class JsonLoggerTests extends ESTestCase {
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "someKey"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
                             hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "other")
                         ),
                         allOf(
@@ -195,6 +197,7 @@ public class JsonLoggerTests extends ESTestCase {
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "compatibleKey"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
                             hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "compatible_api")
                         )
                     )
@@ -207,8 +210,9 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testParseFieldEmittingDeprecatedLogs() throws Exception {
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "someId");
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, "someId");
             threadContext.putHeader(Task.TRACE_ID, "someTraceId");
+            threadContext.putHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, "kibana");
 
             ParseField deprecatedField = new ParseField("new_name", "deprecated_name");
             assertTrue(deprecatedField.match("deprecated_name", LoggingDeprecationHandler.INSTANCE));
@@ -247,6 +251,7 @@ public class JsonLoggerTests extends ESTestCase {
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "deprecated_field_deprecated_name"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
                             hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "api")
                         ),
                         // deprecation log for field deprecated_name2 (note it is not being throttled)
@@ -264,6 +269,7 @@ public class JsonLoggerTests extends ESTestCase {
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "deprecated_field_deprecated_name2"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
                             hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "api")
                         ),
                         // compatible log line
@@ -281,6 +287,7 @@ public class JsonLoggerTests extends ESTestCase {
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "deprecated_field_compatible_deprecated_name"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
                             hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "compatible_api")
                         )
                     )
@@ -301,8 +308,9 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testDeprecatedMessage() throws Exception {
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "someId");
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, "someId");
             threadContext.putHeader(Task.TRACE_ID, "someTraceId");
+            threadContext.putHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, "kibana");
             final DeprecationLogger testLogger = DeprecationLogger.getLogger("org.elasticsearch.test");
             testLogger.warn(DeprecationCategory.OTHER, "someKey", "deprecated message1");
 
@@ -330,6 +338,8 @@ public class JsonLoggerTests extends ESTestCase {
                             hasKey("ecs.version"),
                             hasEntry(DeprecatedMessage.KEY_FIELD_NAME, "someKey"),
                             hasEntry(DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME, "someId"),
+                            hasEntry(Task.TRACE_ID, "someTraceId"),
+                            hasEntry(DeprecatedMessage.ELASTIC_ORIGIN_FIELD_NAME, "kibana"),
                             hasEntry("elasticsearch.event.category", "other")
                         )
                     )
@@ -552,7 +562,7 @@ public class JsonLoggerTests extends ESTestCase {
 
         // For the same key and X-Opaque-ID deprecation should be once
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "ID1");
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, "ID1");
             deprecationLogger.critical(DeprecationCategory.OTHER, "key", "message1");
             deprecationLogger.critical(DeprecationCategory.OTHER, "key", "message2");
             assertCriticalWarnings("message1", "message2");
@@ -585,7 +595,7 @@ public class JsonLoggerTests extends ESTestCase {
         // For the same key and different X-Opaque-ID should be multiple times per key/x-opaque-id
         // continuing with message1-ID1 in logs already, adding a new deprecation log line with message2-ID2
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "ID2");
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, "ID2");
             deprecationLogger.critical(DeprecationCategory.OTHER, "key", "message1");
             deprecationLogger.critical(DeprecationCategory.OTHER, "key", "message2");
             assertCriticalWarnings("message1", "message2");

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -351,7 +351,7 @@ public class TasksIT extends ESIntegTestCase {
             .get();
 
         Map<String, String> headers = new HashMap<>();
-        headers.put(Task.X_OPAQUE_ID, "my_id");
+        headers.put(Task.X_OPAQUE_ID_HTTP_HEADER, "my_id");
         headers.put("Foo-Header", "bar");
         headers.put("Custom-Task-Header", "my_value");
         assertSearchResponse(client().filterWithHeader(headers).prepareSearch("test").setQuery(QueryBuilders.matchAllQuery()).get());
@@ -399,7 +399,7 @@ public class TasksIT extends ESIntegTestCase {
         int maxSize = Math.toIntExact(SETTING_HTTP_MAX_HEADER_SIZE.getDefault(Settings.EMPTY).getBytes() / 2 + 1);
 
         Map<String, String> headers = new HashMap<>();
-        headers.put(Task.X_OPAQUE_ID, "my_id");
+        headers.put(Task.X_OPAQUE_ID_HTTP_HEADER, "my_id");
         headers.put("Custom-Task-Header", randomAlphaOfLengthBetween(maxSize, maxSize + 100));
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
@@ -410,7 +410,7 @@ public class TasksIT extends ESIntegTestCase {
 
     private void assertTaskHeaders(TaskInfo taskInfo) {
         assertThat(taskInfo.getHeaders().keySet(), hasSize(2));
-        assertEquals("my_id", taskInfo.getHeaders().get(Task.X_OPAQUE_ID));
+        assertEquals("my_id", taskInfo.getHeaders().get(Task.X_OPAQUE_ID_HTTP_HEADER));
         assertEquals("my_value", taskInfo.getHeaders().get("Custom-Task-Header"));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -459,7 +459,11 @@ public class ActionModule extends AbstractModule {
         destructiveOperations = new DestructiveOperations(settings, clusterSettings);
         Set<RestHeaderDefinition> headers = Stream.concat(
             actionPlugins.stream().flatMap(p -> p.getRestHeaders().stream()),
-            Stream.of(new RestHeaderDefinition(Task.X_OPAQUE_ID, false), new RestHeaderDefinition(Task.TRACE_PARENT, false))
+            Stream.of(
+                new RestHeaderDefinition(Task.X_OPAQUE_ID_HTTP_HEADER, false),
+                new RestHeaderDefinition(Task.TRACE_PARENT_HTTP_HEADER, false),
+                new RestHeaderDefinition(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, false)
+            )
         ).collect(Collectors.toSet());
         UnaryOperator<RestHandler> restWrapper = null;
         for (ActionPlugin plugin : actionPlugins) {

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -19,18 +19,32 @@ import java.util.Locale;
  * Will populate the x-opaque-id field in JSON logs.
  */
 public class DeprecatedMessage {
+    public static final String ELASTIC_ORIGIN_FIELD_NAME = "elasticsearch.elastic_product_origin";
     public static final String KEY_FIELD_NAME = "event.code";
     public static final String X_OPAQUE_ID_FIELD_NAME = "elasticsearch.http.request.x_opaque_id";
     public static final String ECS_VERSION = "1.2.0";
 
     @SuppressLoggerChecks(reason = "safely delegates to logger")
-    public static ESLogMessage of(DeprecationCategory category, String key, String xOpaqueId, String messagePattern, Object... args) {
-        return getEsLogMessage(category, key, xOpaqueId, messagePattern, args);
+    public static ESLogMessage of(
+        DeprecationCategory category,
+        String key,
+        String xOpaqueId,
+        String productOrigin,
+        String messagePattern,
+        Object... args
+    ) {
+        return getEsLogMessage(category, key, xOpaqueId, productOrigin, messagePattern, args);
     }
 
     @SuppressLoggerChecks(reason = "safely delegates to logger")
-    public static ESLogMessage compatibleDeprecationMessage(String key, String xOpaqueId, String messagePattern, Object... args) {
-        return getEsLogMessage(DeprecationCategory.COMPATIBLE_API, key, xOpaqueId, messagePattern, args);
+    public static ESLogMessage compatibleDeprecationMessage(
+        String key,
+        String xOpaqueId,
+        String productOrigin,
+        String messagePattern,
+        Object... args
+    ) {
+        return getEsLogMessage(DeprecationCategory.COMPATIBLE_API, key, xOpaqueId, productOrigin, messagePattern, args);
     }
 
     @SuppressLoggerChecks(reason = "safely delegates to logger")
@@ -38,6 +52,7 @@ public class DeprecatedMessage {
         DeprecationCategory category,
         String key,
         String xOpaqueId,
+        String productOrigin,
         String messagePattern,
         Object[] args
     ) {
@@ -51,6 +66,6 @@ public class DeprecatedMessage {
             return esLogMessage;
         }
 
-        return esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId);
+        return esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId).field(ELASTIC_ORIGIN_FIELD_NAME, productOrigin);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -94,7 +94,9 @@ public class DeprecationLogger {
     private DeprecationLogger logDeprecation(Level level, DeprecationCategory category, String key, String msg, Object[] params) {
         assert category != DeprecationCategory.COMPATIBLE_API
             : "DeprecationCategory.COMPATIBLE_API should be logged with compatibleApiWarning method";
-        ESLogMessage deprecationMessage = DeprecatedMessage.of(category, key, HeaderWarning.getXOpaqueId(), msg, params);
+        String opaqueId = HeaderWarning.getXOpaqueId();
+        String productOrigin = HeaderWarning.getProductOrigin();
+        ESLogMessage deprecationMessage = DeprecatedMessage.of(category, key, opaqueId, productOrigin, msg, params);
         logger.log(level, deprecationMessage);
         return this;
     }
@@ -119,7 +121,8 @@ public class DeprecationLogger {
      */
     public DeprecationLogger compatible(final Level level, final String key, final String msg, final Object... params) {
         String opaqueId = HeaderWarning.getXOpaqueId();
-        ESLogMessage deprecationMessage = DeprecatedMessage.compatibleDeprecationMessage(key, opaqueId, msg, params);
+        String productOrigin = HeaderWarning.getProductOrigin();
+        ESLogMessage deprecationMessage = DeprecatedMessage.compatibleDeprecationMessage(key, opaqueId, productOrigin, msg, params);
         logger.log(level, deprecationMessage);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -302,11 +302,19 @@ public class HeaderWarning {
         }
     }
 
+    public static String getProductOrigin() {
+        return getSingleValue(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER);
+    }
+
     public static String getXOpaqueId() {
+        return getSingleValue(Task.X_OPAQUE_ID_HTTP_HEADER);
+    }
+
+    private static String getSingleValue(String headerName) {
         return THREAD_CONTEXT.stream()
-            .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
+            .filter(t -> t.getHeader(headerName) != null)
             .findFirst()
-            .map(t -> t.getHeader(Task.X_OPAQUE_ID))
+            .map(t -> t.getHeader(headerName))
             .orElse("");
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.http.HttpTransportSettings;
-import org.elasticsearch.tasks.Task;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +39,7 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_WARNING_HEADER_COUNT;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_WARNING_HEADER_SIZE;
+import static org.elasticsearch.tasks.Task.HEADERS_TO_COPY;
 
 /**
  * A ThreadContext is a map of string headers and a transient map of keyed objects that are associated with
@@ -110,14 +110,8 @@ public final class ThreadContext implements Writeable {
          * Otherwise when context is stash, it should be empty.
          */
 
-        if (context.requestHeaders.containsKey(Task.X_OPAQUE_ID) || context.requestHeaders.containsKey(Task.TRACE_ID)) {
-            Map<String, String> map = new HashMap<>(2, 1);
-            if (context.requestHeaders.containsKey(Task.X_OPAQUE_ID)) {
-                map.put(Task.X_OPAQUE_ID, context.requestHeaders.get(Task.X_OPAQUE_ID));
-            }
-            if (context.requestHeaders.containsKey(Task.TRACE_ID)) {
-                map.put(Task.TRACE_ID, context.requestHeaders.get(Task.TRACE_ID));
-            }
+        if (HEADERS_TO_COPY.stream().anyMatch(header -> context.requestHeaders.containsKey(header))) {
+            Map<String, String> map = headers(context, HEADERS_TO_COPY);
             ThreadContextStruct threadContextStruct = DEFAULT_CONTEXT.putHeaders(map);
             threadLocal.set(threadContextStruct);
         } else {
@@ -129,6 +123,16 @@ public final class ThreadContext implements Writeable {
             // uncaught exception
             threadLocal.set(context);
         };
+    }
+
+    private Map<String, String> headers(ThreadContextStruct context, Set<String> headersToCopy) {
+        Map<String, String> map = new HashMap<>(headersToCopy.size(), 1);
+        for (String header : headersToCopy) {
+            if (context.requestHeaders.containsKey(header)) {
+                map.put(header, context.requestHeaders.get(header));
+            }
+        }
+        return map;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -361,7 +361,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
             if (logThreshold > 0 && took > logThreshold) {
                 logger.warn(
                     "handling request [{}][{}][{}][{}] took [{}ms] which is above the warn threshold of [{}ms]",
-                    httpRequest.header(Task.X_OPAQUE_ID),
+                    httpRequest.header(Task.X_OPAQUE_ID_HTTP_HEADER),
                     httpRequest.method(),
                     httpRequest.uri(),
                     httpChannel,

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.tasks.Task.X_OPAQUE_ID;
+import static org.elasticsearch.tasks.Task.X_OPAQUE_ID_HTTP_HEADER;
 
 /**
  * The default rest channel for incoming requests. This class implements the basic logic for sending a rest
@@ -113,9 +113,9 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
 
             corsHandler.setCorsResponseHeaders(httpRequest, httpResponse);
 
-            opaque = request.header(X_OPAQUE_ID);
+            opaque = request.header(X_OPAQUE_ID_HTTP_HEADER);
             if (opaque != null) {
-                setHeaderField(httpResponse, X_OPAQUE_ID, opaque);
+                setHeaderField(httpResponse, X_OPAQUE_ID_HTTP_HEADER, opaque);
             }
 
             // Add all custom headers

--- a/server/src/main/java/org/elasticsearch/http/HttpTracer.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTracer.java
@@ -58,7 +58,7 @@ class HttpTracer {
                 new ParameterizedMessage(
                     "[{}][{}][{}][{}] received request from [{}]",
                     restRequest.getRequestId(),
-                    restRequest.header(Task.X_OPAQUE_ID),
+                    restRequest.header(Task.X_OPAQUE_ID_HTTP_HEADER),
                     restRequest.method(),
                     restRequest.uri(),
                     restRequest.getHttpChannel()
@@ -76,7 +76,7 @@ class HttpTracer {
      * @param restResponse  RestResponse
      * @param httpChannel   HttpChannel the response was sent on
      * @param contentLength Value of the response content length header
-     * @param opaqueHeader  Value of HTTP header {@link Task#X_OPAQUE_ID}
+     * @param opaqueHeader  Value of HTTP header {@link Task#X_OPAQUE_ID_HTTP_HEADER}
      * @param requestId     Request id as returned by {@link RestRequest#getRequestId()}
      * @param success       Whether the response was successfully sent
      */

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -196,7 +196,7 @@ public final class SearchSlowLog implements SearchOperationListener {
                 messageFields.put("elasticsearch.slowlog.source", "{}");
             }
 
-            messageFields.put("elasticsearch.slowlog.id", context.getTask().getHeader(Task.X_OPAQUE_ID));
+            messageFields.put("elasticsearch.slowlog.id", context.getTask().getHeader(Task.X_OPAQUE_ID_HTTP_HEADER));
             return messageFields;
         }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -722,7 +722,7 @@ public class Node implements Closeable {
             final Transport transport = networkModule.getTransportSupplier().get();
             Set<String> taskHeaders = Stream.concat(
                 pluginsService.filterPlugins(ActionPlugin.class).stream().flatMap(p -> p.getTaskHeaders().stream()),
-                Stream.of(Task.X_OPAQUE_ID, Task.TRACE_ID)
+                Stream.of(Task.X_OPAQUE_ID_HTTP_HEADER, Task.TRACE_ID, Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER)
             ).collect(Collectors.toSet());
             final TransportService transportService = newTransportService(
                 settings,

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -61,7 +61,6 @@ public class RestController implements HttpServerTransport.Dispatcher {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestController.class);
     static final String ELASTIC_PRODUCT_HTTP_HEADER = "X-elastic-product";
     static final String ELASTIC_PRODUCT_HTTP_HEADER_VALUE = "Elasticsearch";
-    private static final String ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER = "X-elastic-product-origin";
 
     private static final BytesReference FAVICON_RESPONSE;
 
@@ -372,7 +371,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 // The ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER indicates that the request is coming from an Elastic product and
                 // therefore we should allow a subset of external system index access.
                 // This header is intended for internal use only.
-                final String prodOriginValue = request.header(ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER);
+                final String prodOriginValue = request.header(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER);
                 if (prodOriginValue != null) {
                     threadContext.putHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY, Boolean.TRUE.toString());
                     threadContext.putHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY, prodOriginValue);
@@ -479,7 +478,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 final List<String> distinctHeaderValues = headerValues.stream().distinct().collect(Collectors.toList());
                 if (restHeader.isMultiValueAllowed() == false && distinctHeaderValues.size() > 1) {
                     throw new IllegalArgumentException("multiple values for single-valued header [" + name + "].");
-                } else if (name.equals(Task.TRACE_PARENT)) {
+                } else if (name.equals(Task.TRACE_PARENT_HTTP_HEADER)) {
                     String traceparent = distinctHeaderValues.get(0);
                     if (traceparent.length() >= 55) {
                         threadContext.putHeader(Task.TRACE_ID, traceparent.substring(3, 35));

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
@@ -144,7 +144,7 @@ public class RestTasksAction extends AbstractCatAction {
         table.addCell(node.getAddress().address().getPort());
         table.addCell(node == null ? "-" : node.getName());
         table.addCell(node == null ? "-" : node.getVersion().toString());
-        table.addCell(taskInfo.getHeaders().getOrDefault(Task.X_OPAQUE_ID, "-"));
+        table.addCell(taskInfo.getHeaders().getOrDefault(Task.X_OPAQUE_ID_HTTP_HEADER, "-"));
 
         if (detailed) {
             table.addCell(taskInfo.getDescription());

--- a/server/src/main/java/org/elasticsearch/search/SearchContextSourcePrinter.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchContextSourcePrinter.java
@@ -28,8 +28,8 @@ public class SearchContextSourcePrinter {
         } else {
             builder.append("source[], ");
         }
-        if (searchContext.getTask() != null && searchContext.getTask().getHeader(Task.X_OPAQUE_ID) != null) {
-            builder.append("id[").append(searchContext.getTask().getHeader(Task.X_OPAQUE_ID)).append("], ");
+        if (searchContext.getTask() != null && searchContext.getTask().getHeader(Task.X_OPAQUE_ID_HTTP_HEADER) != null) {
+            builder.append("id[").append(searchContext.getTask().getHeader(Task.X_OPAQUE_ID_HTTP_HEADER)).append("], ");
         } else {
             builder.append("id[], ");
         }

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.ToXContentObject;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Current task information
@@ -25,15 +26,26 @@ public class Task {
     /**
      * The request header to mark tasks with specific ids
      */
-    public static final String X_OPAQUE_ID = "X-Opaque-Id";
+    public static final String X_OPAQUE_ID_HTTP_HEADER = "X-Opaque-Id";
 
     /**
      * The request header which is contained in HTTP request. We parse trace.id from it and store it in thread context.
      * TRACE_PARENT once parsed in RestController.tryAllHandler is not preserved
      * has to be declared as a header copied over from http request.
      */
-    public static final String TRACE_PARENT = "traceparent";
+    public static final String TRACE_PARENT_HTTP_HEADER = "traceparent";
 
+    /**
+     * A request header that indicates the origin of the request from Elastic stack. The value will stored in ThreadContext
+     * and emitted to ES logs
+     */
+    public static final String X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER = "X-elastic-product-origin";
+
+    public static final Set<String> HEADERS_TO_COPY = Set.of(
+        X_OPAQUE_ID_HTTP_HEADER,
+        TRACE_PARENT_HTTP_HEADER,
+        X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER
+    );
     /**
      * Parsed part of traceparent. It is stored in thread context and emitted in logs.
      * Has to be declared as a header copied over for tasks.

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -54,9 +54,9 @@ public enum Transports {
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
         assert threadContext.getRequestHeadersOnly().isEmpty()
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID))
+            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER))
             || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.TRACE_ID))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID, Task.TRACE_ID))
+            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER, Task.TRACE_ID))
             : "expected empty context but was " + threadContext.getRequestHeadersOnly() + " on " + Thread.currentThread().getName();
         return true;
     }

--- a/server/src/test/java/org/elasticsearch/common/logging/RateLimitingFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/RateLimitingFilterTests.java
@@ -38,20 +38,20 @@ public class RateLimitingFilterTests extends ESTestCase {
     public void testMessagesAreRateLimitedByKey() {
         // Fill up the cache
         for (int i = 0; i < 128; i++) {
-            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key " + i, "", "msg " + i);
+            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key " + i, "", "", "msg " + i);
             assertThat("Expected key" + i + " to be accepted", filter.filter(message), equalTo(Result.ACCEPT));
         }
 
         // Should be rate-limited because it's still in the cache
-        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "", "msg " + 0);
+        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "", "", "msg " + 0);
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
         // Filter a message with a previously unseen key, in order to evict key0 as it's the oldest
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 129", "", "msg " + 129);
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 129", "", "", "msg " + 129);
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
         // Should be allowed because key0 was evicted from the cache
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "", "msg " + 0);
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "", "", "msg " + 0);
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
     }
 
@@ -61,20 +61,20 @@ public class RateLimitingFilterTests extends ESTestCase {
     public void testMessagesAreRateLimitedByXOpaqueId() {
         // Fill up the cache
         for (int i = 0; i < 128; i++) {
-            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id " + i, "msg " + i);
+            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id " + i, "", "msg " + i);
             assertThat("Expected key" + i + " to be accepted", filter.filter(message), equalTo(Result.ACCEPT));
         }
 
         // Should be rate-limited because it's still in the cache
-        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 0", "msg 0");
+        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 0", "", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
         // Filter a message with a previously unseen key, in order to evict key0 as it's the oldest
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 129", "msg 129");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 129", "", "msg 129");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
         // Should be allowed because key0 was evicted from the cache
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 0", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "", "id 0", "", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
     }
 
@@ -84,20 +84,20 @@ public class RateLimitingFilterTests extends ESTestCase {
     public void testMessagesAreRateLimitedByKeyAndXOpaqueId() {
         // Fill up the cache
         for (int i = 0; i < 128; i++) {
-            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key " + i, "opaque-id " + i, "msg " + i);
+            Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key " + i, "opaque-id " + i, "productName", "msg " + i);
             assertThat("Expected key" + i + " to be accepted", filter.filter(message), equalTo(Result.ACCEPT));
         }
 
         // Should be rate-limited because it's still in the cache
-        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
         // Filter a message with a previously unseen key, in order to evict key0 as it's the oldest
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 129", "opaque-id 129", "msg 129");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 129", "opaque-id 129", "productName", "msg 129");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
         // Should be allowed because key 0 was evicted from the cache
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
     }
 
@@ -106,18 +106,18 @@ public class RateLimitingFilterTests extends ESTestCase {
      * independently and checking that a message is not filtered.
      */
     public void testVariationsInKeyAndXOpaqueId() {
-        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         // Rejected because the "x-opaque-id" and "key" values are the same as above
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 1", "opaque-id 0", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 1", "opaque-id 0", "productName", "msg 0");
         // Accepted because the "key" value is different
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 1", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 1", "productName", "msg 0");
         // Accepted because the "x-opaque-id" value is different
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
     }
@@ -134,7 +134,7 @@ public class RateLimitingFilterTests extends ESTestCase {
      * Check that the filter can be reset, so that previously-seen keys are treated as new keys.
      */
     public void testFilterCanBeReset() {
-        final Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key", "", "msg");
+        final Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key", "", "", "msg");
 
         // First time, the message is a allowed
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
@@ -154,19 +154,19 @@ public class RateLimitingFilterTests extends ESTestCase {
         filter.start();
 
         // Should NOT be rate-limited because it's not in the cache
-        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        Message message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
 
         // Should be rate-limited because it was just added to the cache
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 0", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
         // Should be rate-limited because X-Opaque-Id is not used
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 1", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 0", "opaque-id 1", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.DENY));
 
         // Should NOT be rate-limited because "key 1" it not in the cache
-        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 1", "opaque-id 1", "msg 0");
+        message = DeprecatedMessage.of(DeprecationCategory.OTHER, "key 1", "opaque-id 1", "productName", "msg 0");
         assertThat(filter.filter(message), equalTo(Result.ACCEPT));
     }
 }

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -405,7 +405,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     RestRequest.Method.OPTIONS
                 )
                     .withPath("/internal/test")
-                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                     .withInboundException(inboundException)
                     .build();
 
@@ -422,7 +422,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     RestRequest.Method.OPTIONS
                 )
                     .withPath("/internal/testNotSeen")
-                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                     .withInboundException(inboundExceptionExcludedPath)
                     .build();
 
@@ -504,7 +504,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
 
             final FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(method)
                 .withPath(path)
-                .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                 .build();
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
             mockAppender.assertAllExpectationsMatched();
@@ -555,7 +555,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/internal/stats_test")
-                .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                .withHeaders(Map.of(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                 .build();
             transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
@@ -571,7 +571,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/internal/stats_test2")
-                .withHeaders(Map.of(Task.X_OPAQUE_ID.toUpperCase(Locale.ROOT), Collections.singletonList(opaqueId)))
+                .withHeaders(Map.of(Task.X_OPAQUE_ID_HTTP_HEADER.toUpperCase(Locale.ROOT), Collections.singletonList(opaqueId)))
                 .build();
             transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
@@ -630,7 +630,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/internal/stats_test")
-                .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                .withHeaders(Map.of(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                 .build();
             transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
@@ -654,7 +654,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/internal/stats_test")
-                .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                .withHeaders(Map.of(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                 .build();
             transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
@@ -671,7 +671,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/internal/stats_test")
-                .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                .withHeaders(Map.of(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList(opaqueId)))
                 .build();
             transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -134,7 +134,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     public void testHeadersSet() {
         Settings settings = Settings.builder().build();
         final TestHttpRequest httpRequest = new TestHttpRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");
-        httpRequest.getHeaders().put(Task.X_OPAQUE_ID, Collections.singletonList("abc"));
+        httpRequest.getHeaders().put(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList("abc"));
         final RestRequest request = RestRequest.request(xContentRegistry(), httpRequest, httpChannel);
         HttpHandlingSettings handlingSettings = HttpHandlingSettings.fromSettings(settings);
 
@@ -162,7 +162,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         Map<String, List<String>> headers = httpResponse.headers();
         assertNull(headers.get("non-existent-header"));
         assertEquals(customHeaderValue, headers.get(customHeader).get(0));
-        assertEquals("abc", headers.get(Task.X_OPAQUE_ID).get(0));
+        assertEquals("abc", headers.get(Task.X_OPAQUE_ID_HTTP_HEADER).get(0));
         assertEquals(Integer.toString(resp.content().length()), headers.get(DefaultRestChannel.CONTENT_LENGTH).get(0));
         assertEquals(resp.contentType(), headers.get(DefaultRestChannel.CONTENT_TYPE).get(0));
     }
@@ -170,7 +170,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     public void testCookiesSet() {
         Settings settings = Settings.builder().put(HttpTransportSettings.SETTING_HTTP_RESET_COOKIES.getKey(), true).build();
         final TestHttpRequest httpRequest = new TestHttpRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");
-        httpRequest.getHeaders().put(Task.X_OPAQUE_ID, Collections.singletonList("abc"));
+        httpRequest.getHeaders().put(Task.X_OPAQUE_ID_HTTP_HEADER, Collections.singletonList("abc"));
         final RestRequest request = RestRequest.request(xContentRegistry(), httpRequest, httpChannel);
         HttpHandlingSettings handlingSettings = HttpHandlingSettings.fromSettings(settings);
 

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -244,7 +244,9 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         SearchContext searchContext = createSearchContext(index, "group1");
         SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         searchContext.request().source(source);
-        searchContext.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+        searchContext.setTask(
+            new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, "my_id"))
+        );
 
         ESLogMessage p = SearchSlowLog.SearchSlowLogMessage.of(searchContext, 10);
         assertThat(p.get("elasticsearch.slowlog.stats"), equalTo("[\\\"group1\\\"]"));
@@ -252,7 +254,9 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         searchContext = createSearchContext(index, "group1", "group2");
         source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         searchContext.request().source(source);
-        searchContext.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+        searchContext.setTask(
+            new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, "my_id"))
+        );
         p = SearchSlowLog.SearchSlowLogMessage.of(searchContext, 10);
         assertThat(p.get("elasticsearch.slowlog.stats"), equalTo("[\\\"group1\\\", \\\"group2\\\"]"));
     }
@@ -506,7 +510,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         SearchContext ctx = createSearchContext(index);
         SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         ctx.request().source(source);
-        ctx.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+        ctx.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null, Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, "my_id")));
         return ctx;
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -172,10 +172,13 @@ public class RestControllerTests extends ESTestCase {
 
     public void testTraceParentAndTraceId() throws Exception {
         final ThreadContext threadContext = client.threadPool().getThreadContext();
-        Set<RestHeaderDefinition> headers = new HashSet<>(Arrays.asList(new RestHeaderDefinition(Task.TRACE_PARENT, false)));
+        Set<RestHeaderDefinition> headers = new HashSet<>(Arrays.asList(new RestHeaderDefinition(Task.TRACE_PARENT_HTTP_HEADER, false)));
         final RestController restController = new RestController(headers, null, null, circuitBreakerService, usageService);
         Map<String, List<String>> restHeaders = new HashMap<>();
-        restHeaders.put(Task.TRACE_PARENT, Collections.singletonList("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"));
+        restHeaders.put(
+            Task.TRACE_PARENT_HTTP_HEADER,
+            Collections.singletonList("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        );
         RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(restHeaders).build();
         final RestController spyRestController = spy(restController);
         when(spyRestController.getAllHandlers(null, fakeRequest.rawPath())).thenReturn(new Iterator<>() {
@@ -188,7 +191,7 @@ public class RestControllerTests extends ESTestCase {
             public MethodHandlers next() {
                 return new MethodHandlers("/").addMethod(GET, RestApiVersion.current(), (request, channel, client) -> {
                     assertEquals("0af7651916cd43dd8448eb211c80319c", threadContext.getHeader(Task.TRACE_ID));
-                    assertNull(threadContext.getHeader(Task.TRACE_PARENT));
+                    assertNull(threadContext.getHeader(Task.TRACE_PARENT_HTTP_HEADER));
                 });
             }
         });
@@ -197,7 +200,7 @@ public class RestControllerTests extends ESTestCase {
         // the rest controller relies on the caller to stash the context, so we should expect these values here as we didn't stash the
         // context in this test
         assertEquals("0af7651916cd43dd8448eb211c80319c", threadContext.getHeader(Task.TRACE_ID));
-        assertNull(threadContext.getHeader(Task.TRACE_PARENT));
+        assertNull(threadContext.getHeader(Task.TRACE_PARENT_HTTP_HEADER));
     }
 
     public void testRequestWithDisallowedMultiValuedHeaderButSameValues() {

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
@@ -247,7 +247,7 @@ public abstract class AbstractEqlBlockingIntegTestCase extends AbstractEqlIntegT
     protected TaskInfo getTaskInfoWithXOpaqueId(String id, String action) {
         ListTasksResponse tasks = client().admin().cluster().prepareListTasks().setActions(action).get();
         for (TaskInfo task : tasks.getTasks()) {
-            if (id.equals(task.getHeaders().get(Task.X_OPAQUE_ID))) {
+            if (id.equals(task.getHeaders().get(Task.X_OPAQUE_ID_HTTP_HEADER))) {
                 return task;
             }
         }

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
@@ -187,7 +187,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId))
             .execute(EqlSearchAction.INSTANCE, request)
             .get();
         assertThat(response.isRunning(), is(true));
@@ -243,7 +243,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId))
             .execute(EqlSearchAction.INSTANCE, request)
             .get();
         assertThat(response.isRunning(), is(true));

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
@@ -74,7 +74,9 @@ public class EqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
         logger.trace("Preparing search");
         // We might perform field caps on the same thread if it is local client, so we cannot use the standard mechanism
         Future<EqlSearchResponse> future = executorService.submit(
-            () -> client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, id)).execute(EqlSearchAction.INSTANCE, request).get()
+            () -> client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, id))
+                .execute(EqlSearchAction.INSTANCE, request)
+                .get()
         );
         logger.trace("Waiting for block to be established");
         if (cancelDuringSearch) {

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
@@ -117,7 +117,7 @@ public class RestEqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
 
         Request request = new Request("GET", "/test/_eql/search");
         request.setJsonEntity(Strings.toString(eqlSearchRequest));
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(Task.X_OPAQUE_ID, id));
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(Task.X_OPAQUE_ID_HTTP_HEADER, id));
         logger.trace("Preparing search");
 
         final PlainActionFuture<Response> future = PlainActionFuture.newFuture();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -1453,7 +1453,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         }
 
         LogEntryBuilder withOpaqueId(ThreadContext threadContext) {
-            final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID);
+            final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID_HTTP_HEADER);
             if (opaqueId != null) {
                 logEntry.with(OPAQUE_ID_FIELD_NAME, opaqueId);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -126,7 +126,7 @@ public class SecurityContextTests extends ESTestCase {
             randomAlphaOfLengthBetween(3, 10),
             randomAlphaOfLengthBetween(3, 8),
             randomAlphaOfLengthBetween(3, 8),
-            Task.X_OPAQUE_ID,
+            Task.X_OPAQUE_ID_HTTP_HEADER,
             randomAlphaOfLength(10),
             Task.TRACE_ID,
             randomAlphaOfLength(20)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -299,7 +299,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         commonFields = new LoggingAuditTrail.EntryCommonFields(settings, localNode).commonFields;
         threadContext = new ThreadContext(Settings.EMPTY);
         if (randomBoolean()) {
-            threadContext.putHeader(Task.X_OPAQUE_ID, randomAlphaOfLengthBetween(1, 4));
+            threadContext.putHeader(Task.X_OPAQUE_ID_HTTP_HEADER, randomAlphaOfLengthBetween(1, 4));
         }
         if (randomBoolean()) {
             threadContext.putHeader(
@@ -2634,7 +2634,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     private static void opaqueId(ThreadContext threadContext, MapBuilder<String, String> checkedFields) {
-        final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID);
+        final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID_HTTP_HEADER);
         if (opaqueId != null) {
             checkedFields.put(LoggingAuditTrail.OPAQUE_ID_FIELD_NAME, opaqueId);
         }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
@@ -260,7 +260,7 @@ public abstract class AbstractSqlBlockingIntegTestCase extends ESIntegTestCase {
     protected TaskInfo getTaskInfoWithXOpaqueId(String id, String action) {
         ListTasksResponse tasks = client().admin().cluster().prepareListTasks().setActions(action).get();
         for (TaskInfo task : tasks.getTasks()) {
-            if (id.equals(task.getHeaders().get(Task.X_OPAQUE_ID))) {
+            if (id.equals(task.getHeaders().get(Task.X_OPAQUE_ID_HTTP_HEADER))) {
                 return task;
             }
         }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
@@ -180,7 +180,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        SqlQueryResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        SqlQueryResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId))
             .execute(SqlQueryAction.INSTANCE, builder.request())
             .get();
         assertThat(response.isRunning(), is(true));
@@ -234,7 +234,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        SqlQueryResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        SqlQueryResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId))
             .execute(SqlQueryAction.INSTANCE, builder.request())
             .get();
         assertThat(response.isRunning(), is(true));

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/RestSqlCancellationIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/RestSqlCancellationIT.java
@@ -120,7 +120,7 @@ public class RestSqlCancellationIT extends AbstractSqlBlockingIntegTestCase {
 
         Request request = new Request("POST", Protocol.SQL_QUERY_REST_ENDPOINT);
         request.setJsonEntity(Strings.toString(sqlRequest));
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(Task.X_OPAQUE_ID, id));
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(Task.X_OPAQUE_ID_HTTP_HEADER, id));
         logger.trace("Preparing search");
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
@@ -76,7 +76,9 @@ public class SqlCancellationIT extends AbstractSqlBlockingIntegTestCase {
         logger.trace("Preparing search");
         // We might perform field caps on the same thread if it is local client, so we cannot use the standard mechanism
         Future<SqlQueryResponse> future = executorService.submit(
-            () -> client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, id)).execute(SqlQueryAction.INSTANCE, request).get()
+            () -> client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID_HTTP_HEADER, id))
+                .execute(SqlQueryAction.INSTANCE, request)
+                .get()
         );
         logger.trace("Waiting for block to be established");
         if (cancelDuringSearch) {


### PR DESCRIPTION
This commit emits the value of x-elastic-product-origin header into elasticsearch.elastic_product_origin field in ES deprecation logs and indexed deprecation logs.
x-elastic-product-origin header is intended to identify the elastic stack origin and allow to ignore deprecations emitted by the stack.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
