### PR TITLE
Allow plugins permission to register MBeans

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -247,6 +247,7 @@ public class PolicyUtilTests extends ESTestCase {
         "javax.management.MBeanPermission * setAttribute",
         "javax.management.MBeanPermission * unregisterMBean",
         "javax.management.MBeanServerPermission *",
+        "javax.management.MBeanTrustPermission register",
         "javax.security.auth.AuthPermission doAs",
         "javax.security.auth.AuthPermission doAsPrivileged",
         "javax.security.auth.AuthPermission getSubject",

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import javax.management.MBeanPermission;
 import javax.management.MBeanServerPermission;
+import javax.management.MBeanTrustPermission;
 import javax.management.ObjectName;
 import javax.security.auth.AuthPermission;
 import javax.security.auth.PrivateCredentialPermission;
@@ -138,7 +139,8 @@ public class PolicyUtil {
                 "addNotificationListener,getAttribute,getDomains,getMBeanInfo,getObjectInstance,instantiate,invoke,"
                     + "isInstanceOf,queryMBeans,queryNames,registerMBean,removeNotificationListener,setAttribute,unregisterMBean"
             ),
-            new MBeanServerPermission("*")
+            new MBeanServerPermission("*"),
+            new MBeanTrustPermission("register")
         );
         // While it would be ideal to represent all allowed permissions with concrete instances so that we can
         // use the builtin implies method to match them against the parsed policy, this does not work in all


### PR DESCRIPTION
MBeans are sometimes used by third party libraries, e.g. to report
metrics through JMX. This commit builds upon the initial set of MBean
permissions added in #76329, to further alllow a plugin register an
MBean, i.e to allow plugins to grant MBeanTrustPermission("register").

To register a pre-existing object as an MBean with an MBean Server, two
permissions are required; the first, `MBeanPermission` "registerMBean",
and the second, `MBeanTrustPermission` "register". Plugins are already
allowed the first permission, this change simply adds the second.

The absence of the second permissions from #76329 is likely just an
oversight, since the order of permission checks is naturally the first
followed by the second. The denied first permission will show in
stacktraces and logs, possibly hiding the fact that the subsequent
second permission is required.