### PR TITLE
[7.16][DOCS] Changes HLRC Client links

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -26,7 +26,7 @@ cluster.
 [[transport-client]]
 === Transport Client
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 The `TransportClient` connects remotely to an Elasticsearch cluster
 using the transport module. It does not join the cluster, but simply

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -6,7 +6,7 @@ include::{elasticsearch-root}/docs/Versions.asciidoc[]
 [preface]
 == Preface
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 This section describes the Java Transport Client that Elasticsearch provides. 
 All Elasticsearch operations are executed using a

--- a/docs/reference/migration/migrate_7_3.asciidoc
+++ b/docs/reference/migration/migrate_7_3.asciidoc
@@ -91,7 +91,7 @@ The `transport.profiles.*.xpack.security.type` setting is now deprecated. In
 HTTP interface instead.
 
 To avoid deprecation warnings,
-{java-rest}/java-rest-high-level-migration.html[migrate any code for the Java
+https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migrate any code for the Java
 transport client]. Then remove any transport profiles using the deprecated
 setting.
 // end::notable-breaking-changes[]

--- a/docs/reference/setup/setup-xclient.asciidoc
+++ b/docs/reference/setup/setup-xclient.asciidoc
@@ -2,7 +2,7 @@
 [[setup-xpack-client]]
 == Configuring {xpack} Java Clients
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 If you want to use a Java {javaclient}/transport-client.html[transport client] with a
 cluster where {xpack} is installed, then you must download and configure the
@@ -113,4 +113,4 @@ Then in your project's `pom.xml` if using maven, add the following repositories 
 
 . If you are using {stack} {security-features}, there are more configuration
 steps. Refer to 
-{java-rest}/java-rest-overview.html[the Java Client documentation].
+https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-overview.html[the Java Client documentation].

--- a/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
@@ -1,7 +1,7 @@
 [[java-clients]]
 === Java Client and security
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 The {es} {security-features} support the Java http://www.elastic.co/guide/en/elasticsearch/client/java-api/current/transport-client.html[transport client] for Elasticsearch.
 The transport client uses the same transport protocol that the cluster nodes use

--- a/x-pack/docs/en/watcher/java.asciidoc
+++ b/x-pack/docs/en/watcher/java.asciidoc
@@ -1,7 +1,7 @@
 [[api-java]]
 == Java API
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 {xpack} provides a Java client called `WatcherClient` that adds native Java
 support for the {watcher}.


### PR DESCRIPTION
## Overview

This PR hard-codes some links in Transport API deprecation messages that point to the HLRC Java REST client to 7.15 instead of current/7.16, as HLRC has been deprecated in 7.16.