### PR TITLE
[7.16] Allow plugins MBeanTrustPermission (#81508)

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -256,6 +256,7 @@ public class PolicyUtilTests extends ESTestCase {
         "javax.management.MBeanPermission * setAttribute",
         "javax.management.MBeanPermission * unregisterMBean",
         "javax.management.MBeanServerPermission *",
+        "javax.management.MBeanTrustPermission register",
         "javax.security.auth.AuthPermission doAs",
         "javax.security.auth.AuthPermission doAsPrivileged",
         "javax.security.auth.AuthPermission getSubject",

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import javax.management.MBeanPermission;
 import javax.management.MBeanServerPermission;
+import javax.management.MBeanTrustPermission;
 import javax.management.ObjectName;
 import javax.security.auth.AuthPermission;
 import javax.security.auth.PrivateCredentialPermission;
@@ -139,7 +140,8 @@ public class PolicyUtil {
                 "addNotificationListener,getAttribute,getDomains,getMBeanInfo,getObjectInstance,instantiate,invoke,"
                     + "isInstanceOf,queryMBeans,queryNames,registerMBean,removeNotificationListener,setAttribute,unregisterMBean"
             ),
-            new MBeanServerPermission("*")
+            new MBeanServerPermission("*"),
+            new MBeanTrustPermission("register")
         );
         // While it would be ideal to represent all allowed permissions with concrete instances so that we can
         // use the builtin implies method to match them against the parsed policy, this does not work in all


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Allow plugins MBeanTrustPermission (#81508)