### PR TITLE
[7.16] SQL: Only resolve aliases if asked for local cluster (#81158)

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -216,7 +216,7 @@ public class IndexResolver {
 
         String[] indexWildcards = Strings.commaDelimitedListToStringArray(indexWildcard);
         Set<IndexInfo> indexInfos = new HashSet<>();
-        if (retrieveAliases) {
+        if (retrieveAliases && clusterIsLocal(clusterWildcard)) {
             GetAliasesRequest aliasRequest = new GetAliasesRequest().local(true)
                 .aliases(indexWildcards)
                 .indicesOptions(IndicesOptions.lenientExpandOpen());
@@ -268,7 +268,7 @@ public class IndexResolver {
         ActionListener<Set<IndexInfo>> listener
     ) {
         if (retrieveIndices || retrieveFrozenIndices) {
-            if (clusterWildcard == null || simpleMatch(clusterWildcard, clusterName)) { // resolve local indices
+            if (clusterIsLocal(clusterWildcard)) { // resolve local indices
                 GetIndexRequest indexRequest = new GetIndexRequest().local(true)
                     .indices(indexWildcards)
                     .features(Feature.SETTINGS)
@@ -353,6 +353,10 @@ public class IndexResolver {
             }
         }
         listener.onResponse(result);
+    }
+
+    private boolean clusterIsLocal(String clusterWildcard) {
+        return clusterWildcard == null || simpleMatch(clusterWildcard, clusterName);
     }
 
     /**

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -339,6 +339,24 @@ public class SysTablesTests extends ESTestCase {
         }, alias);
     }
 
+    public void testSysTablesWithCatalogPatternOnlyAliases() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE 'clus*' LIKE '%' TYPE 'VIEW'", r -> {
+            assertEquals(1, r.size());
+            assertEquals("alias", r.column(2));
+        }, alias);
+    }
+
+    public void testSysTablesWithNoCatalogOnlyAliases() throws Exception {
+        executeCommand("SYS TABLES TYPE 'VIEW'", r -> {
+            assertEquals(1, r.size());
+            assertEquals("alias", r.column(2));
+        }, alias);
+    }
+
+    public void testSysTablesWithNonExistentCatalogOnlyAliases() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE 'bogus' LIKE '%' TYPE 'VIEW'", r -> { assertEquals(0, r.size()); });
+    }
+
     public void testSysTablesWithInvalidType() throws Exception {
         executeCommand("SYS TABLES LIKE 'test' TYPE 'QUE HORA ES'", r -> { assertEquals(0, r.size()); }, new IndexInfo[0]);
     }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - SQL: Only resolve aliases if asked for local cluster (#81158)