### PR TITLE
Remove dead code from same-shard decider

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -48,10 +48,11 @@ one of the active allocation ids in the cluster state.
 [[cluster-routing-allocation-same-shard-host]]
 `cluster.routing.allocation.same_shard.host`::
       (<<dynamic-cluster-setting,Dynamic>>)
-      Allows to perform a check to prevent allocation of multiple instances of
-      the same shard on a single host, based on host name and host address.
-      Defaults to `false`, meaning that no check is performed by default. This
-      setting only applies if multiple nodes are started on the same machine.
+      If `true`, forbids multiple copies of a shard from being allocated to
+      distinct nodes on the same host, i.e. which have the same network
+      address. Defaults to `false`, meaning that copies of a shard may
+      sometimes be allocated to nodes on the same host. This setting is only
+      relevant if you run multiple nodes on each host.
 
 [[shards-rebalancing-settings]]
 ==== Shard rebalancing settings

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.node;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -222,6 +223,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         this.nodeId = nodeId.intern();
         this.ephemeralId = ephemeralId.intern();
         this.hostName = hostName.intern();
+        assert Strings.hasText(hostAddress);
         this.hostAddress = hostAddress.intern();
         this.address = address;
         if (version == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -91,26 +91,16 @@ public class SameShardAllocationDecider extends AllocationDecider {
                     continue;
                 }
                 // check if its on the same host as the one we want to allocate to
-                boolean checkNodeOnSameHostName = false;
-                boolean checkNodeOnSameHostAddress = false;
-                if (Strings.hasLength(checkNode.node().getHostAddress()) && Strings.hasLength(node.node().getHostAddress())) {
-                    if (checkNode.node().getHostAddress().equals(node.node().getHostAddress())) {
-                        checkNodeOnSameHostAddress = true;
-                    }
-                } else if (Strings.hasLength(checkNode.node().getHostName()) && Strings.hasLength(node.node().getHostName())) {
-                    if (checkNode.node().getHostName().equals(node.node().getHostName())) {
-                        checkNodeOnSameHostName = true;
-                    }
-                }
-                if (checkNodeOnSameHostAddress || checkNodeOnSameHostName) {
+                assert Strings.hasLength(checkNode.node().getHostAddress()) : checkNode;
+                assert Strings.hasLength(node.node().getHostAddress()) : node;
+                if (checkNode.node().getHostAddress().equals(node.node().getHostAddress())) {
                     for (ShardRouting assignedShard : assignedShards) {
                         if (checkNode.nodeId().equals(assignedShard.currentNodeId())) {
-                            return allocation.debugDecision()
-                                ? debugNoAlreadyAllocatedToHost(node, allocation, checkNodeOnSameHostAddress)
-                                : Decision.NO;
+                            return allocation.debugDecision() ? debugNoAlreadyAllocatedToHost(node, allocation) : Decision.NO;
                         }
                     }
                 }
+
             }
         }
         return YES_NONE_HOLD_COPY;
@@ -121,20 +111,13 @@ public class SameShardAllocationDecider extends AllocationDecider {
         return canAllocate(shardRouting, node, allocation);
     }
 
-    private static Decision debugNoAlreadyAllocatedToHost(
-        RoutingNode node,
-        RoutingAllocation allocation,
-        boolean checkNodeOnSameHostAddress
-    ) {
-        String hostType = checkNodeOnSameHostAddress ? "address" : "name";
-        String host = checkNodeOnSameHostAddress ? node.node().getHostAddress() : node.node().getHostName();
+    private static Decision debugNoAlreadyAllocatedToHost(RoutingNode node, RoutingAllocation allocation) {
         return allocation.decision(
             Decision.NO,
             NAME,
-            "a copy of this shard is already allocated to host %s [%s], on node [%s], and [%s] is [true] which "
+            "a copy of this shard is already allocated to host address [%s], on node [%s], and [%s] is [true] which "
                 + "forbids more than one node on this host from holding a copy of this shard",
-            hostType,
-            host,
+            node.node().getHostAddress(),
             node.nodeId(),
             CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey()
         );
@@ -169,7 +152,7 @@ public class SameShardAllocationDecider extends AllocationDecider {
         if (assignedShard.isSameAllocation(shardRouting)) {
             explanation = "this shard is already allocated to this node [" + shardRouting.toString() + "]";
         } else {
-            explanation = "a copy of this shard is already allocated to this node [" + assignedShard.toString() + "]";
+            explanation = "a copy of this shard is already allocated to this node [" + assignedShard + "]";
         }
         return Decision.single(Decision.Type.NO, NAME, explanation);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -86,13 +86,13 @@ public class SameShardAllocationDecider extends AllocationDecider {
             return YES_AUTO_EXPAND_ALL;
         }
         if (node.node() != null) {
+            assert Strings.hasLength(node.node().getHostAddress()) : node;
             for (RoutingNode checkNode : allocation.routingNodes()) {
                 if (checkNode.node() == null) {
                     continue;
                 }
                 // check if its on the same host as the one we want to allocate to
                 assert Strings.hasLength(checkNode.node().getHostAddress()) : checkNode;
-                assert Strings.hasLength(node.node().getHostAddress()) : node;
                 if (checkNode.node().getHostAddress().equals(node.node().getHostAddress())) {
                     for (ShardRouting assignedShard : assignedShards) {
                         if (checkNode.nodeId().equals(assignedShard.currentNodeId())) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -100,7 +100,6 @@ public class SameShardAllocationDecider extends AllocationDecider {
                         }
                     }
                 }
-
             }
         }
         return YES_NONE_HOLD_COPY;

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -282,7 +282,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
             "",
             "",
             "",
-            "",
+            "192.168.0.1",
             new TransportAddress(InetAddresses.forString("fdbd:dc00:111:222::333"), 9300),
             emptyMap(),
             emptySet(),
@@ -295,7 +295,17 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         Settings settings = shuffleSettings(Settings.builder().put("xxx._name", "fdbd:dc00:111:222:0:0:0:333").build());
         DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
-        DiscoveryNode node = new DiscoveryNode("", "", "", "fdbd:dc00:111:222::333", "", localAddress, emptyMap(), emptySet(), null);
+        DiscoveryNode node = new DiscoveryNode(
+            "",
+            "",
+            "",
+            "fdbd:dc00:111:222::333",
+            "192.168.0.1",
+            localAddress,
+            emptyMap(),
+            emptySet(),
+            null
+        );
         assertThat(filters.match(node), equalTo(false));
     }
 


### PR DESCRIPTION
Today the same-shard allocation decider falls back to checking the
hostname if the node has no host address. In practice nodes will always
have an address so the fallback is dead code. This commit removes that
dead code.

Relates #80702 which will add the ability to distinguish nodes by
hostname regardless of whether they have an address or not, and #80767
which optimizes this area of code - this refactoring should make the
optimization simpler.