### PR TITLE
Add trace.id to indexed deprecation logs

### DIFF
--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
@@ -38,7 +38,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "\"node.name\": \"%node_name\", "
                     + "\"message\": \"%notEmpty{%enc{%marker}{JSON} }%enc{%.-10000m}{JSON}\""
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id_json }"
+                    + "%notEmpty{, \"trace.id\": \"%trace_id\" }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )
@@ -63,7 +63,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "%notEmpty{, \"x-opaque-id\": \"%ESMessageField{x-opaque-id}\"}"
                     + "%notEmpty{, \"someOtherField\": \"%ESMessageField{someOtherField}\"}"
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id_json }"
+                    + "%notEmpty{, \"trace.id\": \"%trace_id\" }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )
@@ -86,7 +86,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "\"node.name\": \"%node_name\""
                     + "%notEmpty{, \"message\": \"%ESMessageField{message}\"}"
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id_json }"
+                    + "%notEmpty{, \"trace.id\": \"%trace_id\" }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
@@ -38,7 +38,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "\"node.name\": \"%node_name\", "
                     + "\"message\": \"%notEmpty{%enc{%marker}{JSON} }%enc{%.-10000m}{JSON}\""
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id }"
+                    + "%notEmpty{, %trace_id_json }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )
@@ -63,7 +63,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "%notEmpty{, \"x-opaque-id\": \"%ESMessageField{x-opaque-id}\"}"
                     + "%notEmpty{, \"someOtherField\": \"%ESMessageField{someOtherField}\"}"
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id }"
+                    + "%notEmpty{, %trace_id_json }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )
@@ -86,7 +86,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                     + "\"node.name\": \"%node_name\""
                     + "%notEmpty{, \"message\": \"%ESMessageField{message}\"}"
                     + "%notEmpty{, %node_and_cluster_id }"
-                    + "%notEmpty{, %trace_id }"
+                    + "%notEmpty{, %trace_id_json }"
                     + "%exceptionAsJson }"
                     + System.lineSeparator()
             )

--- a/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
@@ -109,7 +109,7 @@ public class ESJsonLayout extends AbstractStringLayout {
             separator = ", ";
         }
         sb.append(notEmpty(", %node_and_cluster_id "));
-        sb.append(notEmpty(", %trace_id "));
+        sb.append(notEmpty(", \"trace.id\": \"%trace_id\" "));
         sb.append("%exceptionAsJson ");
         sb.append("}");
         sb.append(System.lineSeparator());

--- a/server/src/main/java/org/elasticsearch/common/logging/TraceIdConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/TraceIdConverter.java
@@ -52,7 +52,7 @@ public final class TraceIdConverter extends LogEventPatternConverter {
     public void format(LogEvent event, StringBuilder toAppendTo) {
         String traceId = getTraceId();
         if (traceId != null) {
-            toAppendTo.append("\"trace.id\": \"" + traceId + "\"");
+            toAppendTo.append(traceId);
         }
     }
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -386,7 +387,8 @@ public class DeprecationHttpIT extends ESRestTestCase {
     // triggers two deprecations - endpoint and setting
     private Request deprecatedRequest(String method, String xOpaqueId) throws IOException {
         final Request getRequest = new Request(method, "/_test_cluster/deprecated_settings");
-        final RequestOptions options = getRequest.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build();
+        final RequestOptions options = getRequest.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId)
+            .addHeader("traceparent","00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01").build();
         getRequest.setOptions(options);
         getRequest.setEntity(
             buildSettingsRequest(
@@ -419,6 +421,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
                         hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationMessagesCanBeIndexed"),
+                        hasEntry(Task.TRACE_ID, "0af7651916cd43dd8448eb211c80319c"),
                         hasEntry("elasticsearch.event.category", "settings"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -437,6 +440,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
                         hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationMessagesCanBeIndexed"),
+                        hasEntry(Task.TRACE_ID, "0af7651916cd43dd8448eb211c80319c"),
                         hasEntry("elasticsearch.event.category", "api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -465,6 +469,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
         final RequestOptions options = request.getOptions()
             .toBuilder()
             .addHeader("X-Opaque-Id", "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed")
+            .addHeader("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
             .build();
         request.setOptions(options);
         request.setEntity(
@@ -489,6 +494,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
                         hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed"),
+                        hasEntry(Task.TRACE_ID, "0af7651916cd43dd8448eb211c80319c"),
                         hasEntry("elasticsearch.event.category", "settings"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -507,6 +513,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
                         hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed"),
+                        hasEntry(Task.TRACE_ID, "0af7651916cd43dd8448eb211c80319c"),
                         hasEntry("elasticsearch.event.category", "api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -387,8 +387,11 @@ public class DeprecationHttpIT extends ESRestTestCase {
     // triggers two deprecations - endpoint and setting
     private Request deprecatedRequest(String method, String xOpaqueId) throws IOException {
         final Request getRequest = new Request(method, "/_test_cluster/deprecated_settings");
-        final RequestOptions options = getRequest.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId)
-            .addHeader("traceparent","00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01").build();
+        final RequestOptions options = getRequest.getOptions()
+            .toBuilder()
+            .addHeader("X-Opaque-Id", xOpaqueId)
+            .addHeader("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+            .build();
         getRequest.setOptions(options);
         getRequest.setEntity(
             buildSettingsRequest(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/EcsJsonLayout.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/EcsJsonLayout.java
@@ -60,6 +60,7 @@ public class EcsJsonLayout extends AbstractStringLayout {
         map.put("elasticsearch.cluster.uuid", inQuotes("%cluster_id"));
         map.put("elasticsearch.node.id", inQuotes("%node_id"));
         map.put("elasticsearch.node.name", inQuotes("%node_name"));
+        map.put("trace.id", inQuotes("%notEmpty{%trace_id}"));
         map.put("message", inQuotes("%notEmpty{%enc{%marker}{JSON} }%enc{%.-10000m}{JSON}"));
         map.put("data_stream.type", inQuotes("logs"));
         map.put("data_stream.dataset", inQuotes("deprecation.elasticsearch"));


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/75331 missed adding
trace.id to indexed deprecation logs (these use ECSJsonLayout instead of
ESJsonLayout).

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
