### PR TITLE
[7.16] Ignore temporary files when syncing test cluster distribution (#81482)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1207,13 +1207,17 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                         throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
                     }
                 } else {
+                    // Ignore these files that are sometimes let behind by the JVM
+                    if (relativeDestination.toFile().getName().startsWith(".attach_pid")) {
+                        return;
+                    }
+
                     try {
                         Files.createDirectories(destination.getParent());
                     } catch (IOException e) {
                         throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
                     }
                     syncMethod.accept(destination, source);
-
                 }
             });
         } catch (IOException e) {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Ignore temporary files when syncing test cluster distribution (#81482)