### PR TITLE
Correct docs on output_format option for date processor

### DIFF
--- a/docs/reference/ingest/processors/date.asciidoc
+++ b/docs/reference/ingest/processors/date.asciidoc
@@ -20,7 +20,7 @@ in the same order they were defined as part of the processor definition.
 | `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
 | `timezone`             | no        | UTC                 | The timezone to use when parsing the date. Supports <<template-snippets,template snippets>>.
 | `locale`               | no        | ENGLISH             | The locale to use when parsing the date, relevant when parsing month names or week days. Supports <<template-snippets,template snippets>>.
-| `output_format`        | no        | `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` | The format to use when writing the date to `target_field`. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
+| `output_format`        | no        | `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` | The format to use when writing the date to `target_field`. Must be a valid <<mapping-date-format,java time pattern>>.
 include::common-options.asciidoc[]
 |======
 


### PR DESCRIPTION
The docs incorrectly stated that `ISO8601`, `UNIX`, `UNIX_MS`, and `TAI64N` values were supported as date formats in additions to standard Java date format patterns.

Fixes #81058
