### PR TITLE
Improve kNN error message when index is disabled

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -139,6 +139,12 @@ GET my-approx-knn-index/_knn_search
 // TEST[s/"k": 10/"k": 3/]
 // TEST[s/"num_candidates": 100/"num_candidates": 3/]
 
+NOTE: Support for approximate kNN search was added in version 8.0. Before
+this, `dense_vector` fields did not support enabling `index` in the mapping.
+If you created an index prior to 8.0 containing `dense_vector` fields, then to
+support approximate kNN search the data must be reindexed using a new field
+mapping that sets `index: true`.
+
 [discrete]
 [[tune-approximate-knn-for-speed-accuracy]]
 ==== Tune approximate kNN for speed or accuracy

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -40,7 +40,6 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xpack.vectors.query.KnnVectorFieldExistsQuery;
-import org.elasticsearch.xpack.vectors.query.KnnVectorQueryBuilder;
 import org.elasticsearch.xpack.vectors.query.VectorIndexFieldData;
 
 import java.io.IOException;

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -295,13 +295,13 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support queries");
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support term queries");
         }
 
         public KnnVectorQuery createKnnQuery(float[] queryVector, int numCands) {
             if (isSearchable() == false) {
                 throw new IllegalArgumentException(
-                    "[" + KnnVectorQueryBuilder.NAME + "] " + "queries are not supported if [index] is disabled"
+                    "to perform knn search on field [" + name() + "], its mapping must have [index] set to [true]"
                 );
             }
 

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldTypeTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldTypeTests.java
@@ -73,7 +73,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             IllegalArgumentException.class,
             () -> unindexedField.createKnnQuery(new float[] { 0.3f, 0.1f, 1.0f }, 10)
         );
-        assertThat(e.getMessage(), containsString("[knn] queries are not supported if [index] is disabled"));
+        assertThat(e.getMessage(), containsString("to perform knn search on field [f], its mapping must have [index] set to [true]"));
 
         DenseVectorFieldType dotProductField = new DenseVectorFieldType(
             "f",


### PR DESCRIPTION
In order to perform a kNN search on a `dense_vector` field, it must have
`index: true` in its mapping. This commit clarifies the error message. Before
the message was confusing, because the user likely didn't touch the `index`
parameter and might not even be aware of it.

It adds a note to the docs clarifying that when coming from 7.x, you must
explicitly update `index: true` and reindex the vectors.