### PR TITLE
[8.0] Enhance the validation for alias when creating index template or index (#71889)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Represents an alias, to be associated with an index
@@ -231,6 +232,18 @@ public class Alias implements Writeable, ToXContentFragment {
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
+                // check if there are any unknown fields
+                Set<String> knownFieldNames = Set.of(
+                    FILTER.getPreferredName(),
+                    ROUTING.getPreferredName(),
+                    INDEX_ROUTING.getPreferredName(),
+                    SEARCH_ROUTING.getPreferredName(),
+                    IS_WRITE_INDEX.getPreferredName(),
+                    IS_HIDDEN.getPreferredName()
+                );
+                if (knownFieldNames.contains(currentFieldName) == false) {
+                    throw new IllegalArgumentException("Unknown field [" + currentFieldName + "] in alias [" + alias.name + "]");
+                }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (FILTER.match(currentFieldName, parser.getDeprecationHandler())) {
                     Map<String, Object> filter = parser.mapOrdered();
@@ -250,6 +263,8 @@ public class Alias implements Writeable, ToXContentFragment {
                 } else if (IS_HIDDEN.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.isHidden(parser.booleanValue());
                 }
+            } else {
+                throw new IllegalArgumentException("Unknown token [" + token + "] in alias [" + alias.name + "]");
             }
         }
         return alias;
@@ -276,7 +291,9 @@ public class Alias implements Writeable, ToXContentFragment {
             }
         }
 
-        builder.field(IS_WRITE_INDEX.getPreferredName(), writeIndex);
+        if (writeIndex != null) {
+            builder.field(IS_WRITE_INDEX.getPreferredName(), writeIndex);
+        }
 
         if (isHidden != null) {
             builder.field(IS_HIDDEN.getPreferredName(), isHidden);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
@@ -191,5 +191,39 @@ public class PutIndexTemplateRequestTests extends ESTestCase {
             .endObject();
         e = expectThrows(IllegalArgumentException.class, () -> new PutIndexTemplateRequest().source(extraField));
         assertThat(e.getCause().getMessage(), containsString("unknown key [extra-field] in the template"));
+
+        XContentBuilder aliases1 = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("aliases")
+            .startObject("filtered-data")
+            .startObject("bool")
+            .startObject("filter")
+            .startObject("term")
+            .field("a", "b")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        e = expectThrows(IllegalArgumentException.class, () -> new PutIndexTemplateRequest().source(aliases1));
+        assertThat(e.getCause().getMessage(), containsString("Unknown field [bool] in alias [filtered-data]"));
+
+        XContentBuilder aliases2 = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("aliases")
+            .startObject("filtered-data")
+            .startArray("filter")
+            .startObject()
+            .startObject("term")
+            .field("a", "b")
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject();
+        e = expectThrows(IllegalArgumentException.class, () -> new PutIndexTemplateRequest().source(aliases2));
+        assertThat(e.getCause().getMessage(), containsString("Unknown token [START_ARRAY] in alias [filtered-data]"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Enhance the validation for alias when creating index template or index (#71889)