### PR TITLE
[DOCS] Clarify when `index` parameter is required for Watcher index action

### DIFF
--- a/x-pack/docs/en/watcher/actions/index.asciidoc
+++ b/x-pack/docs/en/watcher/actions/index.asciidoc
@@ -37,7 +37,7 @@ The following snippet shows a simple `index` action definition:
 |======
 |Name                     |Required    | Default    | Description
 
-| `index`                 | yes        | -          | The Elasticsearch index to index into.
+| `index`                 | yes (not always, see `Multi-document support` )       | -          | The Elasticsearch index to index into.
 
 
 | `doc_id`                | no         | -          | The optional `_id` of the document.

--- a/x-pack/docs/en/watcher/actions/index.asciidoc
+++ b/x-pack/docs/en/watcher/actions/index.asciidoc
@@ -37,8 +37,10 @@ The following snippet shows a simple `index` action definition:
 |======
 |Name                     |Required    | Default    | Description
 
-| `index`                 | yes (not always, see `Multi-document support` )       | -          | The Elasticsearch index to index into.
+| `index`                 | yes^*^     | -         a| The Elasticsearch index to index into.
 
+^*^If you dynamically set an `_index` value, this parameter isn't required. See
+<<anatomy-actions-index-multi-doc-support>>.
 
 | `doc_id`                | no         | -          | The optional `_id` of the document.
 


### PR DESCRIPTION
This is just to make clear as Index action attributes (`index`) is not always required. could someone take a look at this PR ?

