### PR TITLE
Deduplicate authorizedIndices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngine.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.authz;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.transport.TransportRequest;
@@ -158,6 +159,15 @@ public interface AuthorizationEngine {
         Map<String, IndexAbstraction> indicesLookup,
         ActionListener<Set<String>> listener
     );
+
+    default void loadAuthorizedIndices(
+        RequestInfo requestInfo,
+        AuthorizationInfo authorizationInfo,
+        Metadata metadata,
+        ActionListener<Set<String>> listener
+    ) {
+        loadAuthorizedIndices(requestInfo, authorizationInfo, metadata.getIndicesLookup(), listener);
+    }
 
     /**
      * Asynchronously checks that the permissions a user would have for a given list of names do

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilege;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -65,6 +66,10 @@ public final class LimitedRole extends Role {
     @Override
     public boolean hasFieldOrDocumentLevelSecurity() {
         return super.hasFieldOrDocumentLevelSecurity() || limitedBy.hasFieldOrDocumentLevelSecurity();
+    }
+
+    public List<IndicesPermission> getIndicesPermissions() {
+        return List.of(super.indices(), limitedBy.indices());
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -407,15 +407,10 @@ public class AuthorizationService {
             final Metadata metadata = clusterService.state().metadata();
             final AsyncSupplier<Set<String>> authorizedIndicesSupplier = new CachingAsyncSupplier<>(authzIndicesListener -> {
                 LoadAuthorizedIndiciesTimeChecker timeChecker = LoadAuthorizedIndiciesTimeChecker.start(requestInfo, authzInfo);
-                authzEngine.loadAuthorizedIndices(
-                    requestInfo,
-                    authzInfo,
-                    metadata.getIndicesLookup(),
-                    authzIndicesListener.map(authzIndices -> {
-                        timeChecker.done(authzIndices);
-                        return authzIndices;
-                    })
-                );
+                authzEngine.loadAuthorizedIndices(requestInfo, authzInfo, metadata, authzIndicesListener.map(authzIndices -> {
+                    timeChecker.done(authzIndices);
+                    return authzIndices;
+                }));
             });
             final AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier = new CachingAsyncSupplier<>(resolvedIndicesListener -> {
                 final ResolvedIndices resolvedIndices = indicesAndAliasesResolver.tryResolveWithoutWildcards(action, request);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -465,7 +465,8 @@ public class RBACEngine implements AuthorizationEngine {
         throw new UnsupportedOperationException();
     }
 
-    private final ResultDeduplicator<AuthorizedIndicesCacheKey, Set<String>> authorizedIndicesDeduplicator = new ResultDeduplicator<>();
+    // package private for testing
+    final ResultDeduplicator<AuthorizedIndicesCacheKey, Set<String>> authorizedIndicesDeduplicator = new ResultDeduplicator<>();
 
     @Override
     public void loadAuthorizedIndices(
@@ -495,7 +496,7 @@ public class RBACEngine implements AuthorizationEngine {
             authorizedIndicesDeduplicator.executeOnce(
                 cacheKey,
                 listener,
-                (r, l) -> { l.onResponse(resolveAuthorizedIndicesFromRole(role, requestInfo, metadata.getIndicesLookup())); }
+                (r, l) -> l.onResponse(resolveAuthorizedIndicesFromRole(role, requestInfo, metadata.getIndicesLookup()))
             );
         } else {
             listener.onFailure(


### PR DESCRIPTION
Loading authorizedIndices can become more expensive with the increase of
index names (generally in proportion to the cluster size). 

The computations are repeated for every request even when they are identical. 
This PR adds a deduplicator so that if multiple requests come in during a short time
window (before the 1st request can complete) and result into the same set of 
authorizedIndices, only one computation is performed for all of them.

