### PR TITLE
[Transform] Repair TransformSurvivesUpgradeIT for 7.16->7.16/17 upgrade

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
@@ -78,8 +78,8 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
 
     @Before
     public void waitForTemplates() throws Exception {
-        // no transform before 7.2
-        if (UPGRADE_FROM_VERSION.before(Version.V_7_2_0)) {
+        // no transform before 7.2, after 7.16 this check isn't required anymore
+        if (UPGRADE_FROM_VERSION.before(Version.V_7_2_0) || UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_16_0)) {
             return;
         }
 


### PR DESCRIPTION
don't check for audit template after 7.16

fixes #79230

Note: for master this is not required, the template check has been removed there, because it only support 7.16/17 -> 8.x., see #79493