### PR TITLE
Xcontent filter: Add map and builder filter benchmark

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
@@ -16,8 +16,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.fetch.subphase.FetchSourcePhase;
-import org.elasticsearch.xcontent.DeprecationHandler;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -162,10 +160,7 @@ public class FilterContentBenchmark {
             excludes,
             XContentType.JSON.toParsedMediaType()
         );
-        try (
-            XContentParser parser = XContentType.JSON.xContent()
-                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source.streamInput())
-        ) {
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, source.streamInput())) {
             builder.copyCurrentStructure(parser);
             return BytesReference.bytes(builder);
         }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
@@ -8,11 +8,18 @@
 
 package org.elasticsearch.benchmark.xcontent;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.elasticsearch.search.fetch.subphase.FetchSourcePhase;
+import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.xcontent.DeprecationHandler;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -39,8 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Fork(1)
-@Warmup(iterations = 2)
-@Measurement(iterations = 3)
+@Warmup(iterations = 1)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
@@ -58,6 +65,7 @@ public class FilterContentBenchmark {
     private BytesReference source;
     private XContentParserConfiguration parserConfig;
     private Set<String> filters;
+    private FetchSourceContext fetchContext;
 
     @Setup
     public void setup() throws IOException {
@@ -78,6 +86,7 @@ public class FilterContentBenchmark {
         source = readSource(sourceFile);
         filters = buildFilters();
         parserConfig = buildParseConfig();
+        fetchContext = buildFetchSourceContext();
     }
 
     private Set<String> buildFilters() {
@@ -122,6 +131,62 @@ public class FilterContentBenchmark {
         return filter(contentParserConfiguration);
     }
 
+    @Benchmark
+    public BytesReference filterSourceLookupWithMap() throws IOException {
+        SourceLookup lookup = new SourceLookup();
+        lookup.setSource(source);
+        Object value = lookup.filter(fetchContext);
+        return FetchSourcePhase.objectToBytes(value, XContentType.JSON, Math.min(1024, lookup.internalSourceRef().length()));
+    }
+
+    @Benchmark
+    public BytesReference filterWithMap() throws IOException {
+        Map<String, Object> sourceMap = XContentHelper.convertToMap(source, false).v2();
+        String[] includes;
+        String[] excludes;
+        if (inclusive) {
+            includes = filters.toArray(Strings.EMPTY_ARRAY);
+            excludes = null;
+        } else {
+            includes = null;
+            excludes = filters.toArray(Strings.EMPTY_ARRAY);
+        }
+        Map<String, Object> filterMap = XContentMapValues.filter(sourceMap, includes, excludes);
+        try (BytesStreamOutput os = new BytesStreamOutput()) {
+            XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), os);
+            builder.map(filterMap);
+            return BytesReference.bytes(builder);
+        }
+    }
+
+    @Benchmark
+    public BytesReference filterWithBuilder() throws IOException {
+        BytesStreamOutput streamOutput = new BytesStreamOutput(Math.min(1024, source.length()));
+        Set<String> includes;
+        Set<String> excludes;
+        if (inclusive) {
+            includes = filters;
+            excludes = null;
+        } else {
+            includes = null;
+            excludes = filters;
+        }
+        XContentBuilder builder = new XContentBuilder(
+            XContentType.JSON.xContent(),
+            streamOutput,
+            includes,
+            excludes,
+            XContentType.JSON.toParsedMediaType()
+        );
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source.streamInput())
+        ) {
+            builder.copyCurrentStructure(parser);
+            return BytesReference.bytes(builder);
+        }
+    }
+
     private XContentParserConfiguration buildParseConfig() {
         Set<String> includes;
         Set<String> excludes;
@@ -133,6 +198,19 @@ public class FilterContentBenchmark {
             excludes = filters;
         }
         return XContentParserConfiguration.EMPTY.withFiltering(includes, excludes);
+    }
+
+    private FetchSourceContext buildFetchSourceContext() {
+        String[] includes;
+        String[] excludes;
+        if (inclusive) {
+            includes = filters.toArray(Strings.EMPTY_ARRAY);
+            excludes = null;
+        } else {
+            includes = null;
+            excludes = filters.toArray(Strings.EMPTY_ARRAY);
+        }
+        return new FetchSourceContext(true, includes, excludes);
     }
 
     private BytesReference filter(XContentParserConfiguration contentParserConfiguration) throws IOException {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
@@ -15,9 +15,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.FetchSourcePhase;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -65,7 +63,6 @@ public class FilterContentBenchmark {
     private BytesReference source;
     private XContentParserConfiguration parserConfig;
     private Set<String> filters;
-    private FetchSourceContext fetchContext;
 
     @Setup
     public void setup() throws IOException {
@@ -86,7 +83,6 @@ public class FilterContentBenchmark {
         source = readSource(sourceFile);
         filters = buildFilters();
         parserConfig = buildParseConfig();
-        fetchContext = buildFetchSourceContext();
     }
 
     private Set<String> buildFilters() {
@@ -186,19 +182,6 @@ public class FilterContentBenchmark {
             excludes = filters;
         }
         return XContentParserConfiguration.EMPTY.withFiltering(includes, excludes);
-    }
-
-    private FetchSourceContext buildFetchSourceContext() {
-        String[] includes;
-        String[] excludes;
-        if (inclusive) {
-            includes = filters.toArray(Strings.EMPTY_ARRAY);
-            excludes = null;
-        } else {
-            includes = null;
-            excludes = filters.toArray(Strings.EMPTY_ARRAY);
-        }
-        return new FetchSourceContext(true, includes, excludes);
     }
 
     private BytesReference filter(XContentParserConfiguration contentParserConfiguration) throws IOException {


### PR DESCRIPTION
I add the map and builder in the `FilterContentBenchmark`.  The result show that parser performance is much better than map and builder. Later my colleague and I will commit some PR, that It will replace from map and builder to parser.

In wildcard case, map filter is so slow:

```
Benchmark                                                  (fieldCount)  (inclusive)         (type)  Mode  Cnt         Score   Error  Units
FilterContentBenchmark.filterWithBuilder              10_wildcard_field         true  cluster_stats  avgt    2    229729.345          ns/op
FilterContentBenchmark.filterWithMap                  10_wildcard_field         true  cluster_stats  avgt    2  29668878.146          ns/op
FilterContentBenchmark.filterWithNewParserConfig      10_wildcard_field         true  cluster_stats  avgt    2    237100.911          ns/op
FilterContentBenchmark.filterWithParserConfigCreated  10_wildcard_field         true  cluster_stats  avgt    2    221254.827          ns/op
```

and parse filter has a little improvement with builder filter:
```
Benchmark                                                  (fieldCount)  (inclusive)         (type)  Mode  Cnt         Score   Error  Units
FilterContentBenchmark.filterWithBuilder                       10_field         true  cluster_stats  avgt    2    170686.503          ns/op
FilterContentBenchmark.filterWithMap                           10_field         true  cluster_stats  avgt    2    492973.006          ns/op
FilterContentBenchmark.filterWithNewParserConfig               10_field         true  cluster_stats  avgt    2    142003.739          ns/op
FilterContentBenchmark.filterWithParserConfigCreated           10_field         true  cluster_stats  avgt    2    127459.484          ns/op
```

Here is the full benchmark result:
```
Benchmark                                                  (fieldCount)  (inclusive)         (type)  Mode  Cnt         Score   Error  Units
FilterContentBenchmark.filterWithBuilder                       10_field         true  cluster_stats  avgt    2    170686.503          ns/op
FilterContentBenchmark.filterWithBuilder                       10_field         true    index_stats  avgt    2     19893.310          ns/op
FilterContentBenchmark.filterWithBuilder                       10_field         true     node_stats  avgt    2     26955.237          ns/op
FilterContentBenchmark.filterWithBuilder                     half_field         true  cluster_stats  avgt    2    399922.076          ns/op
FilterContentBenchmark.filterWithBuilder                     half_field         true    index_stats  avgt    2     34104.100          ns/op
FilterContentBenchmark.filterWithBuilder                     half_field         true     node_stats  avgt    2     45339.887          ns/op
FilterContentBenchmark.filterWithBuilder                      all_field         true  cluster_stats  avgt    2    541790.127          ns/op
FilterContentBenchmark.filterWithBuilder                      all_field         true    index_stats  avgt    2     50051.251          ns/op
FilterContentBenchmark.filterWithBuilder                      all_field         true     node_stats  avgt    2     66082.753          ns/op
FilterContentBenchmark.filterWithBuilder                 wildcard_field         true  cluster_stats  avgt    2    207682.012          ns/op
FilterContentBenchmark.filterWithBuilder                 wildcard_field         true    index_stats  avgt    2     20100.143          ns/op
FilterContentBenchmark.filterWithBuilder                 wildcard_field         true     node_stats  avgt    2     26076.856          ns/op
FilterContentBenchmark.filterWithBuilder              10_wildcard_field         true  cluster_stats  avgt    2    229729.345          ns/op
FilterContentBenchmark.filterWithBuilder              10_wildcard_field         true    index_stats  avgt    2     28191.823          ns/op
FilterContentBenchmark.filterWithBuilder              10_wildcard_field         true     node_stats  avgt    2     34450.794          ns/op
FilterContentBenchmark.filterWithMap                           10_field         true  cluster_stats  avgt    2    492973.006          ns/op
FilterContentBenchmark.filterWithMap                           10_field         true    index_stats  avgt    2    154447.596          ns/op
FilterContentBenchmark.filterWithMap                           10_field         true     node_stats  avgt    2    181779.656          ns/op
FilterContentBenchmark.filterWithMap                         half_field         true  cluster_stats  avgt    2   2370660.246          ns/op
FilterContentBenchmark.filterWithMap                         half_field         true    index_stats  avgt    2    401988.258          ns/op
FilterContentBenchmark.filterWithMap                         half_field         true     node_stats  avgt    2    483548.818          ns/op
FilterContentBenchmark.filterWithMap                          all_field         true  cluster_stats  avgt    2   3113373.152          ns/op
FilterContentBenchmark.filterWithMap                          all_field         true    index_stats  avgt    2    476683.420          ns/op
FilterContentBenchmark.filterWithMap                          all_field         true     node_stats  avgt    2    652082.500          ns/op
FilterContentBenchmark.filterWithMap                     wildcard_field         true  cluster_stats  avgt    2    459415.604          ns/op
FilterContentBenchmark.filterWithMap                     wildcard_field         true    index_stats  avgt    2     70230.935          ns/op
FilterContentBenchmark.filterWithMap                     wildcard_field         true     node_stats  avgt    2     89341.348          ns/op
FilterContentBenchmark.filterWithMap                  10_wildcard_field         true  cluster_stats  avgt    2  29668878.146          ns/op
FilterContentBenchmark.filterWithMap                  10_wildcard_field         true    index_stats  avgt    2  28205368.190          ns/op
FilterContentBenchmark.filterWithMap                  10_wildcard_field         true     node_stats  avgt    2  29332307.103          ns/op
FilterContentBenchmark.filterWithNewParserConfig               10_field         true  cluster_stats  avgt    2    142003.739          ns/op
FilterContentBenchmark.filterWithNewParserConfig               10_field         true    index_stats  avgt    2     18086.331          ns/op
FilterContentBenchmark.filterWithNewParserConfig               10_field         true     node_stats  avgt    2     23383.744          ns/op
FilterContentBenchmark.filterWithNewParserConfig             half_field         true  cluster_stats  avgt    2    389990.443          ns/op
FilterContentBenchmark.filterWithNewParserConfig             half_field         true    index_stats  avgt    2     34894.318          ns/op
FilterContentBenchmark.filterWithNewParserConfig             half_field         true     node_stats  avgt    2     45604.779          ns/op
FilterContentBenchmark.filterWithNewParserConfig              all_field         true  cluster_stats  avgt    2    549971.331          ns/op
FilterContentBenchmark.filterWithNewParserConfig              all_field         true    index_stats  avgt    2     51233.495          ns/op
FilterContentBenchmark.filterWithNewParserConfig              all_field         true     node_stats  avgt    2     67761.011          ns/op
FilterContentBenchmark.filterWithNewParserConfig         wildcard_field         true  cluster_stats  avgt    2    213109.821          ns/op
FilterContentBenchmark.filterWithNewParserConfig         wildcard_field         true    index_stats  avgt    2     20191.982          ns/op
FilterContentBenchmark.filterWithNewParserConfig         wildcard_field         true     node_stats  avgt    2     25866.681          ns/op
FilterContentBenchmark.filterWithNewParserConfig      10_wildcard_field         true  cluster_stats  avgt    2    237100.911          ns/op
FilterContentBenchmark.filterWithNewParserConfig      10_wildcard_field         true    index_stats  avgt    2     27744.183          ns/op
FilterContentBenchmark.filterWithNewParserConfig      10_wildcard_field         true     node_stats  avgt    2     34841.488          ns/op
FilterContentBenchmark.filterWithParserConfigCreated           10_field         true  cluster_stats  avgt    2    127459.484          ns/op
FilterContentBenchmark.filterWithParserConfigCreated           10_field         true    index_stats  avgt    2     15194.965          ns/op
FilterContentBenchmark.filterWithParserConfigCreated           10_field         true     node_stats  avgt    2     18798.854          ns/op
FilterContentBenchmark.filterWithParserConfigCreated         half_field         true  cluster_stats  avgt    2    238616.088          ns/op
FilterContentBenchmark.filterWithParserConfigCreated         half_field         true    index_stats  avgt    2     20972.354          ns/op
FilterContentBenchmark.filterWithParserConfigCreated         half_field         true     node_stats  avgt    2     28047.925          ns/op
FilterContentBenchmark.filterWithParserConfigCreated          all_field         true  cluster_stats  avgt    2    274096.558          ns/op
FilterContentBenchmark.filterWithParserConfigCreated          all_field         true    index_stats  avgt    2     24948.247          ns/op
FilterContentBenchmark.filterWithParserConfigCreated          all_field         true     node_stats  avgt    2     33163.017          ns/op
FilterContentBenchmark.filterWithParserConfigCreated     wildcard_field         true  cluster_stats  avgt    2    209233.272          ns/op
FilterContentBenchmark.filterWithParserConfigCreated     wildcard_field         true    index_stats  avgt    2     20056.664          ns/op
FilterContentBenchmark.filterWithParserConfigCreated     wildcard_field         true     node_stats  avgt    2     25519.848          ns/op
FilterContentBenchmark.filterWithParserConfigCreated  10_wildcard_field         true  cluster_stats  avgt    2    221254.827          ns/op
FilterContentBenchmark.filterWithParserConfigCreated  10_wildcard_field         true    index_stats  avgt    2     24113.686          ns/op
FilterContentBenchmark.filterWithParserConfigCreated  10_wildcard_field         true     node_stats  avgt    2     31885.001          ns/op
```