### PR TITLE
[ML] Failed queued inference requests with cause if the process crashes

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -295,7 +295,7 @@ public class DeploymentManager {
 
         void onTimeout() {
             if (notified.compareAndSet(false, true)) {
-                processContext.getResultProcessor().ignoreResposeWithoutNotifying(String.valueOf(requestId));
+                processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
                 listener.onFailure(
                     new ElasticsearchStatusException("timeout [{}] waiting for inference result", RestStatus.REQUEST_TIMEOUT, timeout)
                 );
@@ -317,7 +317,7 @@ public class DeploymentManager {
         public void onFailure(Exception e) {
             timeoutHandler.cancel();
             if (notified.compareAndSet(false, true)) {
-                processContext.getResultProcessor().ignoreResposeWithoutNotifying(String.valueOf(requestId));
+                processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
                 listener.onFailure(e);
                 return;
             }
@@ -457,7 +457,7 @@ public class DeploymentManager {
             return reason -> {
                 logger.error("[{}] process crashed due to reason [{}]", task.getModelId(), reason);
                 resultProcessor.stop();
-                executorService.shutdown();
+                executorService.shutdownWithError(new IllegalStateException(reason));
                 processContextByAllocation.remove(task.getId());
                 task.setFailed("process crashed due to reason [" + reason + "]");
             };

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -46,7 +46,7 @@ public class PyTorchResultProcessor {
      *
      * @param requestId The request ID that is no longer being waited on
      */
-    public void ignoreResposeWithoutNotifying(String requestId) {
+    public void ignoreResponseWithoutNotifying(String requestId) {
         pendingResults.remove(requestId);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /*
  * Native ML processes can only handle a single operation at a time. In order to guarantee that, all
@@ -39,6 +40,7 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
     private final String processName;
     private final CountDownLatch awaitTermination = new CountDownLatch(1);
     private final BlockingQueue<Runnable> queue;
+    private final AtomicReference<Exception> error = new AtomicReference<>();
 
     private volatile boolean running = true;
 
@@ -57,6 +59,11 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
 
     public int queueSize() {
         return queue.size();
+    }
+
+    public void shutdownWithError(Exception e) {
+        error.set(e);
+        shutdown();
     }
 
     @Override
@@ -122,9 +129,14 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
                     queue.drainTo(notExecuted);
 
                     String msg = "unable to process as " + processName + " worker service has shutdown";
+                    Exception ex = error.get();
                     for (Runnable runnable : notExecuted) {
-                        if (runnable instanceof AbstractRunnable) {
-                            ((AbstractRunnable) runnable).onRejection(new EsRejectedExecutionException(msg, true));
+                        if (runnable instanceof AbstractRunnable ar) {
+                            if (ex != null) {
+                                ar.onFailure(ex);
+                            } else {
+                                ar.onRejection(new EsRejectedExecutionException(msg, true));
+                            }
                         }
                     }
                 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.job.process;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.test.ESTestCase;
@@ -13,19 +14,22 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isA;
 
 public class ProcessWorkerExecutorServiceTests extends ESTestCase {
 
     private static final String TEST_PROCESS = "test";
     private static final int QUEUE_SIZE = 100;
 
-    private ThreadPool threadPool = new TestThreadPool("AutodetectWorkerExecutorServiceTests");
+    private final ThreadPool threadPool = new TestThreadPool("AutodetectWorkerExecutorServiceTests");
 
     @After
     public void stopThreadPool() {
@@ -35,9 +39,28 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
     public void testAutodetectWorkerExecutorService_SubmitAfterShutdown() {
         ProcessWorkerExecutorService executor = createExecutorService();
 
-        threadPool.generic().execute(() -> executor.start());
+        threadPool.generic().execute(executor::start);
         executor.shutdown();
-        expectThrows(EsRejectedExecutionException.class, () -> executor.execute(() -> {}));
+        AtomicBoolean rejected = new AtomicBoolean(false);
+        executor.execute(new AbstractRunnable() {
+            @Override
+            public void onRejection(Exception e) {
+                assertThat(e, isA(EsRejectedExecutionException.class));
+                rejected.set(true);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("onFailure should not be called after the worker is shutdown");
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                fail("doRun should not be called after the worker is shutdown");
+            }
+        });
+
+        assertTrue(rejected.get());
     }
 
     public void testAutodetectWorkerExecutorService_TasksNotExecutedCallHandlerOnShutdown() throws Exception {
@@ -45,7 +68,7 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        Future<?> executorFinished = threadPool.generic().submit(() -> executor.start());
+        Future<?> executorFinished = threadPool.generic().submit(executor::start);
 
         // run a task that will block while the others are queued up
         executor.execute(() -> {
@@ -57,13 +80,13 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         AtomicBoolean runnableShouldNotBeCalled = new AtomicBoolean(false);
         executor.execute(() -> runnableShouldNotBeCalled.set(true));
 
-        AtomicInteger onFailureCallCount = new AtomicInteger();
+        ConcurrentLinkedQueue<Exception> exceptions = new ConcurrentLinkedQueue<>();
         AtomicInteger doRunCallCount = new AtomicInteger();
         for (int i = 0; i < 2; i++) {
             executor.execute(new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {
-                    onFailureCallCount.incrementAndGet();
+                    exceptions.add(e);
                 }
 
                 @Override
@@ -73,15 +96,27 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
             });
         }
 
+        boolean shutdownWithError = randomBoolean();
         // now shutdown
-        executor.shutdown();
+        if (shutdownWithError) {
+            executor.shutdownWithError(new ElasticsearchException("stopping the executor because an error occurred"));
+        } else {
+            executor.shutdown();
+        }
         latch.countDown();
         executorFinished.get();
 
         assertFalse(runnableShouldNotBeCalled.get());
         // the AbstractRunnables should have had their callbacks called
-        assertEquals(2, onFailureCallCount.get());
         assertEquals(0, doRunCallCount.get());
+        assertThat(exceptions, hasSize(2));
+        for (var e : exceptions) {
+            if (shutdownWithError) {
+                assertThat(e.getMessage(), containsString("stopping the executor because an error occurred"));
+            } else {
+                assertThat(e, isA(EsRejectedExecutionException.class));
+            }
+        }
     }
 
     public void testAutodetectWorkerExecutorServiceDoesNotSwallowErrors() {
@@ -91,7 +126,7 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         } else {
             executor.execute(() -> { throw new Error("future error"); });
         }
-        Error e = expectThrows(Error.class, () -> executor.start());
+        Error e = expectThrows(Error.class, executor::start);
         assertThat(e.getMessage(), containsString("future error"));
     }
 


### PR DESCRIPTION
If the native inference process crashes any queued requests are failed with a `EsRejectedExecutionException`. This change puts the crash reason into the failure message.

