### PR TITLE
[8.0] [DOCS] Clarify rolling upgrade support for minor versions (#81444)

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -16,13 +16,15 @@ endif::[]
 {es} can usually be upgraded using a <<rolling-upgrades,Rolling upgrade>>
 process so upgrading does not interrupt service. Rolling upgrades are supported:
 
-* Between minor versions
+// tag::rolling-upgrade-versions[]
+* Between minor versions of the same major version
 * From 5.6 to 6.8
 * From 6.8 to {prev-major-version}
 * From {prev-major-version} to {version}
 ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
+// end::rolling-upgrade-versions[]
 
 [TIP]
 ====

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -35,13 +35,7 @@ rejoin until they have been upgraded.
 
 Rolling upgrades are supported:
 
-* Between minor versions
-* {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
-* {stack-ref-70}/upgrading-elastic-stack.html[From 6.8 to 7.0]
-* From {prev-major-version} to {version}
-ifeval::[ "{bare_version}" != "{minor-version}.0" ]
-* From any version since {minor-version}.0 to {version}
-endif::[]
+include::{es-repo-dir}/upgrade.asciidoc[tag=rolling-upgrade-versions]
 
 Upgrading directly to {version} from 6.6 or earlier requires a
 <<restart-upgrade, full cluster restart>>.


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Clarify rolling upgrade support for minor versions (#81444)