### PR TITLE
[7.16] [DOCS] Clarify rolling upgrade support for minor versions (#81444)

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -6,12 +6,14 @@
 {es} can usually be upgraded using a <<rolling-upgrades,Rolling upgrade>>
 process so upgrading does not interrupt service. Rolling upgrades are supported:
 
-* Between minor versions
+// tag::rolling-upgrade-versions[]
+* Between minor versions of the same major version
 * From 5.6 to 6.8
 * From 6.8 to {version}
 ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
+// end::rolling-upgrade-versions[]
 
 [TIP]
 ====

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -31,12 +31,7 @@ rejoin until they have been upgraded.
 
 Rolling upgrades are supported:
 
-* Between minor versions
-* {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
-* From 6.8 to {version}
-ifeval::[ "{bare_version}" != "{minor-version}.0" ]
-* From any version since {minor-version}.0 to {version}
-endif::[]
+include::{es-repo-dir}/upgrade.asciidoc[tag=rolling-upgrade-versions]
 
 Upgrading directly to {version} from 6.7 or earlier requires a
 <<restart-upgrade, full cluster restart>>.


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Clarify rolling upgrade support for minor versions (#81444)