### PR TITLE
Ignore InternalTestRerunPluginFuncTest

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
@@ -9,7 +9,9 @@
 package org.elasticsearch.gradle.internal.test.rerun
 
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import spock.lang.Ignore
 
+@Ignore
 class InternalTestRerunPluginFuncTest extends AbstractGradleFuncTest {
 
     def "does not rerun on failed tests"() {


### PR DESCRIPTION
Ignore these tests as we currently do not use the plugin due to it's flakiness based on
how things are implemented in gradle