### PR TITLE
[7.16] Add optional body to ml.open_job and ml.forecast APIs (#81586)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[
@@ -41,6 +42,10 @@
         "required":false,
         "description":"The max memory able to be used by the forecast. Default is 20mb."
       }
+    },
+    "body":{
+      "description": "Query parameters can be specified in the body",
+      "required":false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.open_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.open_job.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[
@@ -24,6 +25,10 @@
           }
         }
       ]
+    },
+    "body":{
+      "description": "Query parameters can be specified in the body",
+      "required":false
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Add optional body to ml.open_job and ml.forecast APIs (#81586)