### PR TITLE
[8.0] Set correct version bounds for system features rest API tests (#81465)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/features.get_features/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/features.get_features/10_basic.yml
@@ -2,7 +2,7 @@
 "Get Features":
   - skip:
       features: contains
-      version: " - 7.99.99" # Adjust this after backport
+      version: " - 7.11.99"
       reason: "This API was added in 7.12.0"
   - do: { features.get_features: {}}
   - contains: {'features': {'name': 'tasks'}}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/features.reset_features/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/features.reset_features/10_basic.yml
@@ -2,7 +2,7 @@
 "Get Features":
   - skip:
       features: contains
-      version: " - 7.99.99" # Adjust this after backport
+      version: " - 7.12.99"
       reason: "This API was added in 7.13.0"
   - do: { features.get_features: {}}
   - contains: {'features': {'name': 'tasks'}}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/10_get_feature_upgrade_status.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/10_get_feature_upgrade_status.yml
@@ -1,8 +1,8 @@
 "Get feature upgrade status":
 
   - skip:
-      version: " - 7.99.99"
-      reason: "Not yet backported"
+      version: " - 7.15.99"
+      reason: "Endpoint added in 7.16.0"
 
   - do:
       migration.get_feature_upgrade_status: {}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/20_post_feature_upgrade.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/migration/20_post_feature_upgrade.yml
@@ -1,8 +1,8 @@
 "Get feature upgrade status":
 
   - skip:
-      version: " - 7.99.99"
-      reason: "Not yet backported"
+      version: " - 7.15.99"
+      reason: "Endpoint added in 7.16.0"
 
   - do:
       migration.get_feature_upgrade_status: {}


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Set correct version bounds for system features rest API tests (#81465)