### PR TITLE
[8.0] Patch log4j JAR to remove JndiLookup class

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -275,6 +275,10 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         }
       }
     }
+    all {
+      resolutionStrategy.dependencySubstitution {
+        substitute module("org.apache.logging.log4j:log4j-core") using project(":libs:elasticsearch-log4j") because "patched to remove JndiLookup clas"}
+    }
   }
 
   dependencies {

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-subprojects {
+configure(subprojects - project('elasticsearch-log4j')) {
   /*
    * All subprojects are java projects using Elasticsearch's standard build
    * tools.

--- a/libs/log4j/build.gradle
+++ b/libs/log4j/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+  id 'base'
+  id 'elasticsearch.repositories'
+}
+
+configurations {
+  log4j {
+    transitive = false
+  }
+}
+
+dependencies {
+  log4j "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+}
+
+// Strip out JndiLookup class to avoid any possibility of exploitation of CVE-2021-44228
+// See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+// See: https://issues.apache.org/jira/browse/LOG4J2-3201
+def patchLog4j = tasks.register('patchLog4j', Zip) {
+  archiveExtension = 'jar'
+  from({ zipTree(configurations.log4j.singleFile) }) {
+    exclude '**/JndiLookup.class'
+  }
+}
+
+artifacts {
+  'default'(patchLog4j)
+}


### PR DESCRIPTION
Backport of #81629 