### PR TITLE
TSDB: disable _tsid in composite aggregation

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
@@ -287,6 +287,31 @@ aggregate a tag:
   - match: {aggregations.tsids.buckets.1.doc_count: 4}
 
 ---
+"composite aggregate the tsid fails":
+  - skip:
+      version: " - 8.00.99"
+      reason: _tsid support introduced in 8.1.0
+
+  - do:
+      catch: /\[_tsid\] cannot be used in composite aggregation/
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            tsids:
+              composite:
+                sources: [
+                  {
+                    "tsid": {
+                      "terms": {
+                        "field": "_tsid"
+                      }
+                    }
+                  }
+                ]
+
+---
 field capabilities:
   - skip:
       version: " - 8.00.99"

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.composite;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -187,6 +188,11 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
             if (source == null) {
                 throw new IllegalArgumentException("Composite source cannot be null");
             }
+
+            if (TimeSeriesIdFieldMapper.NAME.equals(source.field())) {
+                throw new IllegalArgumentException("[" + TimeSeriesIdFieldMapper.NAME + "] cannot be used in composite aggregation");
+            }
+
             boolean unique = names.add(source.name());
             if (unique == false) {
                 duplicates.add(source.name());


### PR DESCRIPTION
 in composite aggregation, group by _tsid will return the error:
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "unsupported_operation_exception",
        "reason" : null
      }
    ],
    "type" : "unsupported_operation_exception",
    "reason" : null,
    "suppressed" : [
      {
        "type" : "illegal_state_exception",
        "reason" : "Failed to close the XContentBuilder",
        "caused_by" : {
          "type" : "i_o_exception",
          "reason" : "Unclosed object or array found"
        }
      }
    ]
  },
  "status" : 500
}
```

reproduce:
```
PUT test
{
  "settings": {
    "index": {
      "time_series.start_time": 1,
      "time_series.end_time": 99999999999,
      "mode": "time_series",
      "routing_path": [
        "test"
      ]
    }
  },
  "mappings": {
    "properties": {
      "test": {
        "type": "keyword",
        "time_series_dimension": true
      }
    }
  }
}

POST test/_doc?refresh
{
  "test" : "test",
  "@timestamp" : 2
}

GET test/_search
{
  "aggs": {
    "1": {
      "composite": {
        "sources": [
          {
            "2": {
              "terms": {
                "field": "_tsid"
              }
            }
          }
        ]
      }
    }
  }
}
```

The reason why failed is that in `InternalComposite.getKeyAsString`, it will return a string for after key, but _tsid is a Map.

I think _tsid is not suitable for composite aggregation, so I add a check to failed composite aggregation with _tsid.