### PR TITLE
[8.0] Split get data stream api yaml test in two tests. (#81590)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -622,10 +622,10 @@ setup:
         index: logs-foobar
 
 ---
-"Get data stream api check existence of replicated and allow_custom_routing fields":
+"Get data stream api check existence of replicated field":
   - skip:
       version: " - 7.16.0"
-      reason: "replicated and allow_custom_routing fields only supported in 7.16+"
+      reason: "replicated field only supported in 7.16+"
 
   - do:
       indices.create_data_stream:
@@ -649,7 +649,6 @@ setup:
   - match: { data_streams.0.template: 'my-template1' }
   - match: { data_streams.0.hidden: false }
   - match: { data_streams.0.replicated: false }
-  - match: { data_streams.0.allow_custom_routing: false }
   - match: { data_streams.1.name: simple-data-stream2 }
   - match: { data_streams.1.timestamp_field.name: '@timestamp' }
   - match: { data_streams.1.generation: 1 }
@@ -658,6 +657,52 @@ setup:
   - match: { data_streams.1.template: 'my-template2' }
   - match: { data_streams.1.hidden: false }
   - match: { data_streams.1.replicated: false }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream2
+  - is_true: acknowledged
+
+---
+"Get data stream api check existence of allow_custom_routing field":
+  - skip:
+      version: " - 8.0.0"
+      reason: "allow_custom_routing field only supported in 8.0+"
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream2
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - match: { data_streams.0.timestamp_field.name: '@timestamp' }
+  - match: { data_streams.0.generation: 1 }
+  - length: { data_streams.0.indices: 1 }
+  - match: { data_streams.0.indices.0.index_name: '/\.ds-simple-data-stream1-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.0.status: 'GREEN' }
+  - match: { data_streams.0.template: 'my-template1' }
+  - match: { data_streams.0.hidden: false }
+  - match: { data_streams.0.allow_custom_routing: false }
+  - match: { data_streams.1.name: simple-data-stream2 }
+  - match: { data_streams.1.timestamp_field.name: '@timestamp' }
+  - match: { data_streams.1.generation: 1 }
+  - length: { data_streams.1.indices: 1 }
+  - match: { data_streams.1.indices.0.index_name: '/\.ds-simple-data-stream2-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.1.template: 'my-template2' }
+  - match: { data_streams.1.hidden: false }
   - match: { data_streams.1.allow_custom_routing: false }
 
   - do:


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Split get data stream api yaml test in two tests. (#81590)