### PR TITLE
[DOCS] Fix anchor for 'Shrink an index' section

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -104,7 +104,7 @@ A shrink operation:
   had just been re-opened.
 
 
-[[shrink-index]]
+[[_shrinking_an_index]]
 ===== Shrink an index
 
 To shrink `my_source_index` into a new index called `my_target_index`, issue


### PR DESCRIPTION
Reverts an anchor change from #46711.

Previous versions of the docs use the `_shrinking_an_index` anchor for this
section. Preserving that anchor prevents potential doc build breaks.