### PR TITLE
[8.0] [DOCS] Fix anchor for 'Shrink an index' section (#81665)

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -104,7 +104,7 @@ A shrink operation:
   had just been re-opened.
 
 
-[[shrink-index]]
+[[_shrinking_an_index]]
 ===== Shrink an index
 
 To shrink `my_source_index` into a new index called `my_target_index`, issue


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix anchor for 'Shrink an index' section (#81665)