### PR TITLE
[7.11] [DOCS] Fix ordered list formatting in data stream docs (#81667)

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -385,10 +385,11 @@ Follow these steps:
 . Choose a name or index pattern for a new data stream. This new data
 stream will contain data from your existing stream.
 +
+--
 You can use the resolve index API to check if the name or pattern matches any
 existing indices, index aliases, or data streams. If so, you should consider
 using another name or pattern.
---
+
 The following resolve index API request checks for any existing indices, index
 aliases, or data streams that start with `new-data-stream`. If not, the
 `new-data-stream*` index pattern can be used to create a new data stream.


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix ordered list formatting in data stream docs (#81667)