### PR TITLE
[7.16] Readonly repos don't cache (#81674)

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -48,7 +48,9 @@ cluster should have write access to the repository. On other clusters, register
 the repository as read-only.
 
 This prevents multiple clusters from writing to the repository at the same time
-and corrupting the repository’s contents.
+and corrupting the repository’s contents. It also prevents {es} from caching the
+repository's contents, which means that changes made by other clusters will
+become visible straight away.
 // end::multi-cluster-repo[]
 --
 

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -603,7 +603,9 @@ To restore a snapshot, its repository must be
 <<snapshots-register-repository,registered>> and available to the new cluster.
 If the original cluster still has write access to the repository, register the
 repository as read-only. This prevents multiple clusters from writing to the
-repository at the same time and corrupting the repository's contents.
+repository at the same time and corrupting the repository's contents. It also
+prevents {es} from caching the repository's contents, which means that changes
+made by other clusters will become visible straight away.
 
 Before you start a restore operation, ensure the new cluster has enough capacity
 for any data streams or indices you want to restore. If the new cluster has a


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Readonly repos don't cache (#81674)