### PR TITLE
[DOCS] Fix formatting in get anomaly job API

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1385,7 +1385,7 @@ end::model-prune-window[]
 
 tag::model-snapshot-id[]
 A numerical character string that uniquely identifies the model snapshot. For
-example, `1575402236000 `.
+example, `1575402236000`.
 end::model-snapshot-id[]
 
 tag::model-snapshot-retention-days[]


### PR DESCRIPTION
There is a formatting typo in the model_snapshot_id example in https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html and https://github.com/elastic/elasticsearch/pull/81641

![image](https://user-images.githubusercontent.com/26471269/145885508-452ea6c2-2c28-4171-9457-4cb5d5574801.png)
