### PR TITLE
[8.0] [DOCS] Fix formatting in get anomaly job API (#81682)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1385,7 +1385,7 @@ end::model-prune-window[]
 
 tag::model-snapshot-id[]
 A numerical character string that uniquely identifies the model snapshot. For
-example, `1575402236000 `.
+example, `1575402236000`.
 end::model-snapshot-id[]
 
 tag::model-snapshot-retention-days[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix formatting in get anomaly job API (#81682)