### PR TITLE
[7.16] [DOCS] Fix formatting in get anomaly job API (#81682)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1240,7 +1240,7 @@ end::model-prune-window[]
 
 tag::model-snapshot-id[]
 A numerical character string that uniquely identifies the model snapshot. For
-example, `1575402236000 `.
+example, `1575402236000`.
 end::model-snapshot-id[]
 
 tag::model-snapshot-retention-days[]


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Fix formatting in get anomaly job API (#81682)