### PR TITLE
Fix use functional method from superInterface if exists

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -2142,6 +2143,15 @@ public final class PainlessLookupBuilder {
                 java.lang.reflect.Method javaMethod = javaMethods.get(0);
                 String painlessMethodKey = buildPainlessMethodKey(javaMethod.getName(), javaMethod.getParameterCount());
                 painlessClassBuilder.functionalInterfaceMethod = painlessClassBuilder.methods.get(painlessMethodKey);
+                if (painlessClassBuilder.functionalInterfaceMethod == null) {
+                    List<Class<?>> superInterfaces = new ArrayList<>(Arrays.asList(targetClass.getInterfaces()));
+                    while (painlessClassBuilder.functionalInterfaceMethod == null && superInterfaces.isEmpty() == false) {
+                        Class<?> superInterface = superInterfaces.remove(0);
+                        painlessClassBuilder.functionalInterfaceMethod = Optional.ofNullable(
+                            classesToPainlessClassBuilders.get(superInterface)
+                        ).map(superInterfaceBuilder -> superInterfaceBuilder.methods.get(painlessMethodKey)).orElse(null);
+                    }
+                }
             }
         }
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
@@ -46,6 +46,14 @@ public class LambdaTests extends ScriptTestCase {
 
     }
 
+    public void testLambdaForBinaryOperator() {
+        assertEquals(
+            "short",
+            exec("List l = new ArrayList(); l.add('looooong'); l.add('short'); " + "return l.stream().reduce((e1, e2) -> e2).get()")
+        );
+
+    }
+
     public void testPrimitiveLambdas() {
         assertEquals(4, exec("List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(x -> x + 1).sum();"));
     }


### PR DESCRIPTION
This is fix I could produce to a regression I encountered on Elasticsearch 7.16.0, see https://discuss.elastic.co/t/regression-painless-script-fails-for-binaryoperator-lamdba/291714 & #81696 .