### PR TITLE
[Transform] Split testTransformUpdateRewrite into two parts: non-dryrun and dryrun.

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -260,8 +260,11 @@ public class TransformUpdaterTests extends ESTestCase {
                 assertEquals(stateDoc.getTransformStats(), storedDocAndVersion.v1().getTransformStats());
             }
         );
+    }
 
-        // same as dry run
+    public void testTransformUpdateDryRun() throws InterruptedException {
+        InMemoryTransformConfigManager transformConfigManager = new InMemoryTransformConfigManager();
+
         TransformConfig oldConfigForDryRunUpdate = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             VersionUtils.randomVersionBetween(
@@ -277,6 +280,7 @@ public class TransformUpdaterTests extends ESTestCase {
             config -> {}
         );
 
+        TransformConfigUpdate update = TransformConfigUpdate.EMPTY;
         assertUpdate(
             listener -> TransformUpdater.updateTransform(
                 securityContext,


### PR DESCRIPTION
Apart from making the tests for the two functionalities (non-dryrun and dryrun) independent which is good to have anyway, this PR fixes the bug in which the same id is being generated for both `oldConfig.getId()` and `oldConfigForDryRunUpdate.getId()`.

Fixes https://github.com/elastic/elasticsearch/issues/81660