### PR TITLE
Mute SmokeTestMultiNodeClientYamlTestSuiteIT test {yaml=tsdb/40_search/ids query}

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
@@ -355,7 +355,7 @@ ids query:
               values: ["u1", "u3"]
 
   - match: {hits.total.value: 2}
-  - match: {hits.hits.0._id: "u1"}
-  - match: {hits.hits.0.fields.k8s\.pod\.network\.tx: [2001828691]}
-  - match: {hits.hits.1._id: "u3"}
-  - match: {hits.hits.1.fields.k8s\.pod\.network\.tx: [2001848691]}
+  #- match: {hits.hits.0._id: "u1"}
+  #- match: {hits.hits.0.fields.k8s\.pod\.network\.tx: [2001828691]}
+  #- match: {hits.hits.1._id: "u3"}
+  #- match: {hits.hits.1.fields.k8s\.pod\.network\.tx: [2001848691]}


### PR DESCRIPTION
The ordering of the output elements is not stable

Test failure: https://github.com/elastic/elasticsearch/issues/81712