### PR TITLE
[8.0] Split testTransformUpdateRewrite into two parts: non-dryrun and dryrun. (#81711)

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -260,8 +260,11 @@ public class TransformUpdaterTests extends ESTestCase {
                 assertEquals(stateDoc.getTransformStats(), storedDocAndVersion.v1().getTransformStats());
             }
         );
+    }
 
-        // same as dry run
+    public void testTransformUpdateDryRun() throws InterruptedException {
+        InMemoryTransformConfigManager transformConfigManager = new InMemoryTransformConfigManager();
+
         TransformConfig oldConfigForDryRunUpdate = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             VersionUtils.randomVersionBetween(
@@ -277,6 +280,7 @@ public class TransformUpdaterTests extends ESTestCase {
             config -> {}
         );
 
+        TransformConfigUpdate update = TransformConfigUpdate.EMPTY;
         assertUpdate(
             listener -> TransformUpdater.updateTransform(
                 securityContext,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Split testTransformUpdateRewrite into two parts: non-dryrun and dryrun. (#81711)