### PR TITLE
[7.16] Split testTransformUpdateRewrite into two parts: non-dryrun and dryrun. (#81711)

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -267,8 +267,11 @@ public class TransformUpdaterTests extends ESTestCase {
                 assertEquals(stateDoc.getTransformStats(), storedDocAndVersion.v1().getTransformStats());
             }
         );
+    }
 
-        // same as dry run
+    public void testTransformUpdateDryRun() throws InterruptedException {
+        InMemoryTransformConfigManager transformConfigManager = new InMemoryTransformConfigManager();
+
         TransformConfig oldConfigForDryRunUpdate = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             VersionUtils.randomVersionBetween(
@@ -284,6 +287,7 @@ public class TransformUpdaterTests extends ESTestCase {
             config -> {}
         );
 
+        TransformConfigUpdate update = TransformConfigUpdate.EMPTY;
         assertUpdate(
             listener -> TransformUpdater.updateTransform(
                 licenseState,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Split testTransformUpdateRewrite into two parts: non-dryrun and dryrun. (#81711)