### PR TITLE
[DOCS] Add CVE-2021-44228 security update to release notes

### DIFF
--- a/docs/reference/release-notes/7.16.asciidoc
+++ b/docs/reference/release-notes/7.16.asciidoc
@@ -1,6 +1,21 @@
 [[release-notes-7.16.1]]
 == {es} version 7.16.1
 
+[discrete]
+[[security-updates-7.16.1]]
+=== Security updates
+
+* A high severity vulnerability
+(https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228[CVE-2021-44228]) for
+https://logging.apache.org/log4j/2.x/[Apache Log4j 2] versions 2.0 to 2.14 was
+disclosed publicly on the project's
+https://github.com/apache/logging-log4j2/pull/608[GitHub] on December 9, 2021.
++
+For information about affected {es} versions and mitigation steps, see our
+related
+https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476[security
+announcement].
+
 [[enhancement-7.16.1]]
 [float]
 === Enhancements


### PR DESCRIPTION
Adds a security update for the Apache Log4j 2 CVE-2021-44228 vulnerability to
the 7.16.1 and 6.8.21 release notes.

### Preview
https://elasticsearch_81724.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/release-notes-7.16.1.html