### PR TITLE
[7.16] Remove experimental flag from geo field format mvt (#81721)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -404,7 +404,7 @@ http://www.geojson.org[GeoJSON]
 {wikipedia}/Well-known_text_representation_of_geometry[Well Known Text]
 
 `mvt(<zoom>/<x>/<y>@<extent>)` or `mvt(<zoom>/<x>/<y>)`:::
-experimental:[] Binary
+Binary
 https://docs.mapbox.com/vector-tiles/specification[Mapbox vector tile]. The API
 returns the tile as a base64-encoded string.
 +


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Remove experimental flag from geo field format mvt (#81721)