### PR TITLE
[DOCS] Combine 8.0 breaking changes for mapping type endpoints

### DIFF
--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -20,6 +20,149 @@ Use the replacement REST API endpoints. Requests submitted to the `_xpack`
 API endpoints will return an error.
 ====
 
+[[remove-mapping-type-api-endpoints]]
+.REST API endpoints containing mapping types have been removed.
+[%collapsible]
+====
+*Details* +
+Mapping types have been removed. API endpoints that contain a mapping type have
+also been removed. Use a typeless endpoint instead.
+
+[options="header",cols="<1,<3,<1"]
+|====
+| API   | Typed API endpoint  | Typeless API endpoint
+
+| {ref}/docs-bulk.html[Bulk]
+| `<target>/<type>/_bulk`
+| `<target>/_bulk`
+
+| {ref}/search-count.html[Count]
+| `<target>/<type>/_count`
+| `<target>/_count`
+
+| {ref}/docs-delete.html[Delete]
+| `<index>/<type>/<_id>`
+| `<index>/_doc/<_id>`
+
+| {ref}/docs-delete-by-query.html[Delete by query]
+| `<target>/<type>/_delete_by_query`
+| `<target>/_delete_by_query`
+
+| {ref}/search-explain.html[Explain]
+| `<index>/<type>/<_id>/_explain`
+| `<index>/_explain/<_id>`
+
+| {ref}/docs-get.html[Get]
+| `<index>/<type>/<_id>`
+| `<index>/_doc/<_id>`
+
+|
+| `<index>/<type>/<_id>/_source`
+| `<index>/_source/<_id>`
+
+| {ref}/indices-get-field-mapping.html[Get field mapping]
+| `_mapping/<type>/field/<field>`
+| `_mapping/field/<field>`
+
+|
+| `<target>/_mapping/<type>/field/<field>`
+| `<target>/_mapping/field/<field>`
+
+| {ref}/indices-get-mapping.html[Get mapping]
+| `_mapping/<type>`
+| `_mapping` or `<target>/_mapping`
+
+|
+| `<target>/<type>/_mapping`
+| `<target>/_mapping`
+
+|
+| `<target>/_mapping/<type>`
+| `<target>/_mapping`
+
+| {ref}/graph-explore-api.html[Graph explore]
+| `<index>/<type>/_graph/explore`
+| `<index>/_graph/explore`
+
+| {ref}/docs-index_.html[Index]
+| `<target>/<type>/<_id>/_create`
+| `<target>/_create/<_id>`
+
+|
+| `<target>/<type>`
+| `<target>/_doc`
+
+|
+| `<target>/<type>/<_id>`
+| `<target>/_doc/<_id>`
+
+| {ref}/docs-multi-get.html[Multi get]
+| `<index>/<type>/_mget`
+| `<index>/_mget`
+
+| {ref}/search-multi-search.html[Multi search]
+| `<target>/<type>/_msearch`
+| `<target>/_msearch`
+
+| {ref}/multi-search-template.html[Multi search template]
+| `<target>/<type>/_msearch/template`
+| `<target>/_msearch/template`
+
+| {ref}/docs-multi-termvectors.html[Multi term vectors]
+| `<index>/<type>/_mtermvectors`
+| `<index>/_mtermvectors`
+
+| {ref}/rollup-search.html[Rollup search]
+| `<target>/<type>/_rollup_search`
+| `<target>/_rollup_search`
+
+| {ref}/search-search.html[Search]
+| `<target>/<type>/_search`
+| `<target>/_search`
+
+| {ref}/search-template-api.html[Search template]
+| `<target>/<type>/_search/template`
+| `<target>/_search/template`
+
+| {ref}/docs-termvectors.html[Term vectors]
+| `<index>/<mapping_type>/<_id>/_termvectors`
+| `<index>/_termvectors<_id>`
+
+|
+| `<index>/<mapping_type>/_termvectors`
+| `<index>/_termvectors`
+
+| {ref}/docs-update.html[Update]
+| `<index>/<type>/<_id>/_update`
+| `<index>/_update/<_id>`
+
+| {ref}/docs-update-by-query.html[Update by query]
+| `<target>/<type>/_update_by_query`
+| `<target>/_update_by_query`
+
+| {ref}/indices-put-mapping.html[Update mapping]
+| `<target>/<type>/_mapping`
+| `<target>/_mapping`
+
+|
+| `<target>/_mapping/<type>`
+| `<target>/_mapping`
+
+|
+| `_mapping/<type>`
+| `<target>/_mapping`
+
+| {ref}/search-validate.html[Validate]
+| `<target>/<type>/_validate/query`
+| `<target>/_validate/query`
+
+|====
+
+*Impact* +
+Update your application to use typeless REST API endpoints. Requests to
+endpoints that contain a mapping type will return an error.
+====
+
 [[remove-term-order-key]]
 .The `terms` aggregation no longer supports the `_term` order key.
 [%collapsible]
@@ -309,19 +452,6 @@ To avoid deprecation warnings, remove the parameter from your ingest pipelines.
 If a pipeline specifies an `ecs` value, the value is ignored.
 ====
 
-.Mapping API endpoints containing mapping types have been removed.
-[%collapsible]
-====
-*Details* +
-The typed REST endpoints of the update mapping, get mapping and get field mapping
-APIs have been removed in favour of their typeless REST endpoints, since indexes
-no longer contain types, these typed endpoints are obsolete.
-
-*Impact* +
-Use the typeless REST endpoints to update and retrieve mappings. Requests
-submitted to the typed mapping API endpoints will return an error.
-====
-
 .The `include_type_name` query parameter has been removed.
 [%collapsible]
 ====
@@ -347,17 +477,6 @@ reindex generates remote search requests.
 
 *Impact* +
 Specify unencoded index names for reindex from remote requests.
-====
-
-.Reindex-related REST API endpoints containing mapping types have been removed.
-[%collapsible]
-====
-*Details* +
-The `/{index}/{type}/_delete_by_query` and `/{index}/{type}/_update_by_query` REST endpoints have been removed in favour of `/{index}/_delete_by_query` and `/{index}/_update_by_query`, since indexes no longer contain types, these typed endpoints are obsolete.
-
-*Impact* +
-Use the replacement REST API endpoints. Requests submitted to API endpoints
-that contain a mapping type will return an error.
 ====
 
 .In the reindex, delete by query, and update by query APIs, the `size` parameter has been renamed.
@@ -627,21 +746,6 @@ Aggregating and sorting on `_id` should be avoided. As an alternative, the
 enabled (note that this does not apply to auto-generated IDs).
 ====
 
-.Search-related REST API endpoints containing mapping types have been removed.
-[%collapsible]
-====
-*Details* +
-The `/{index}/{type}/_search`, `/{index}/{type}/_msearch`, `/{index}/{type}/_search/template` and `/{index}/{type}/_msearch/template` REST endpoints have been removed in favour of `/{index}/_search`, `/{index}/_msearch`, `/{index}/_search/template` and `/{index}/_msearch/template`; since indexes no longer contain types, these typed endpoints are obsolete..
-
-The `/{index}/{type}/_termvectors`, `/{index}/{type}/{id}/_termvectors` and `/{index}/{type}/_mtermvectors` REST endpoints have been removed in favour of `/{index}/_termvectors`, `/{index}/{id}/_termvectors` and `/{index}/_mtermvectors`; since indexes no longer contain types, these typed endpoints are obsolete..
-
-The `/{index}/{type}/{doc}` and `/{index}/{type}/_mget` REST endpoints have been removed in favour of `/{index}/_doc/{doc}` and `/{index}/_mget`; since indexes no longer contain types, these typed endpoints are obsolete.
-
-*Impact* +
-Use the replacement REST API endpoints. Requests submitted to API endpoints that
-contain a mapping type will return an error.
-====
-
 .The `common` query has been removed.
 [%collapsible]
 ====
@@ -893,7 +997,7 @@ snapshot request. Requests that include these parameters will return an error.
 ====
 *Details* +
 The repository stats API has been removed. We deprecated this experimental API
-in 7.10.0. 
+in 7.10.0.
 
 *Impact* +
 Use the {ref}/repositories-metering-apis.html[repositories metering APIs]


### PR DESCRIPTION
Combines several 8.0 breaking changes for the removal of API endpoints that contain mapping types. These items were separate because we previously organized breaking changes by area.

This is a follow-on to #79162.


### Preview
https://elasticsearch_81730.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#remove-mapping-type-api-endpoints