### PR TITLE
[6.8] [DOCS] Add CVE-2021-44228 security update to release notes (#81724)

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,6 +1,21 @@
 [[release-notes-6.8.21]]
 == {es} version 6.8.21
 
+[discrete]
+[[security-updates-6.8.21]]
+=== Security updates
+
+* A high severity vulnerability
+(https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228[CVE-2021-44228]) for
+https://logging.apache.org/log4j/2.x/[Apache Log4j 2] versions 2.0 to 2.14 was
+disclosed publicly on the project's
+https://github.com/apache/logging-log4j2/pull/608[GitHub] on December 9, 2021.
++
+For information about affected {es} versions and mitigation steps, see our
+related
+https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476[security
+announcement].
+
 [[enhancement-6.8.21]]
 [float]
 === Enhancements


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [DOCS] Add CVE-2021-44228 security update to release notes (#81724)