### PR TITLE
Adjust CacheFileTests.testCacheFileCreatedAsSparseFile

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
@@ -25,7 +25,7 @@
           sudo cryptsetup open --key-file key.secret "$LOOP" secret --verbose
           sudo mkfs.ext2 /dev/mapper/secret
           sudo mkdir /mnt/secret
-          # Change /mnt/secret with care (at least a test makes assertion based on this name)
+          # Change /mnt/secret with care (at least a test uses this path to detect when encryption at rest is used)
           sudo mount /dev/mapper/secret /mnt/secret
           sudo chown -R jenkins /mnt/secret
           cp -r "$WORKSPACE" /mnt/secret


### PR DESCRIPTION
It looks like some `aarch64` architectures have a non `4KB` block size but the test expects that only encryption at rest tests use a non default block size. This change removes the check on EAR.

Sorry @DaveCTurner for the iterations required to adjust this test :( I hope that the assertions for non 4KB block size will work everywhere now but we'll have to wait for ARM tests to execute to be 100% sure.

Relates https://github.com/elastic/elasticsearch/issues/81362#issuecomment-992512732