### PR TITLE
[Transform] Fix NPE in transform version check.

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -118,7 +118,7 @@ class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
             return identity();
         }
         // In case of transforms created before aligning timestamp optimization was introduced we assume the default was "false".
-        if (transformConfig.getVersion().before(Version.V_7_15_0)) {
+        if (transformConfig.getVersion() == null || transformConfig.getVersion().before(Version.V_7_15_0)) {
             return identity();
         }
         if (transformConfig.getPivotConfig() == null) {


### PR DESCRIPTION
Followup (fix) of https://github.com/elastic/elasticsearch/pull/81729

This PR does not have to be backported to `8.0` and `7.16` because the fix is also embedded in respective backport PRs of https://github.com/elastic/elasticsearch/pull/81729.