### PR TITLE
[7.16] Change HLRC's LifecyclePolicy to allow all valid ILM actions (#81483)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicy.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicy.java
@@ -52,7 +52,18 @@ public class LifecyclePolicy implements ToXContentObject {
             PHASES_FIELD
         );
 
-        ALLOWED_ACTIONS.put("hot", Sets.newHashSet(UnfollowAction.NAME, SetPriorityAction.NAME, RolloverAction.NAME));
+        ALLOWED_ACTIONS.put(
+            "hot",
+            Sets.newHashSet(
+                UnfollowAction.NAME,
+                SetPriorityAction.NAME,
+                RolloverAction.NAME,
+                ReadOnlyAction.NAME,
+                ShrinkAction.NAME,
+                ForceMergeAction.NAME,
+                SearchableSnapshotAction.NAME
+            )
+        );
         ALLOWED_ACTIONS.put(
             "warm",
             Sets.newHashSet(
@@ -73,9 +84,11 @@ public class LifecyclePolicy implements ToXContentObject {
                 MigrateAction.NAME,
                 AllocateAction.NAME,
                 FreezeAction.NAME,
-                SearchableSnapshotAction.NAME
+                SearchableSnapshotAction.NAME,
+                ReadOnlyAction.NAME
             )
         );
+        ALLOWED_ACTIONS.put("frozen", Sets.newHashSet(UnfollowAction.NAME, SearchableSnapshotAction.NAME));
         ALLOWED_ACTIONS.put("delete", Sets.newHashSet(DeleteAction.NAME, WaitForSnapshotAction.NAME));
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/MigrateAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/MigrateAction.java
@@ -24,6 +24,7 @@ public class MigrateAction implements LifecycleAction, ToXContentObject {
 
     private static final ConstructingObjectParser<MigrateAction, Void> PARSER = new ConstructingObjectParser<>(
         NAME,
+        true,
         a -> new MigrateAction(a[0] == null ? true : (boolean) a[0])
     );
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/GetLifecyclePolicyResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/GetLifecyclePolicyResponseTests.java
@@ -86,7 +86,8 @@ public class GetLifecyclePolicyResponseTests extends AbstractXContentTestCase<Ge
                     new ParseField(SearchableSnapshotAction.NAME),
                     SearchableSnapshotAction::parse
                 ),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse)
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse)
             )
         );
         return new NamedXContentRegistry(entries);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyMetadataTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyMetadataTests.java
@@ -80,7 +80,8 @@ public class LifecyclePolicyMetadataTests extends AbstractXContentTestCase<Lifec
                     new ParseField(SearchableSnapshotAction.NAME),
                     SearchableSnapshotAction::parse
                 ),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse)
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse)
             )
         );
         return new NamedXContentRegistry(entries);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyTests.java
@@ -8,17 +8,19 @@
 package org.elasticsearch.client.indexlifecycle;
 
 import org.elasticsearch.cluster.ClusterModule;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,22 +31,11 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.equalTo;
 
 public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePolicy> {
-    private static final Set<String> VALID_HOT_ACTIONS = Sets.newHashSet(UnfollowAction.NAME, SetPriorityAction.NAME, RolloverAction.NAME);
-    private static final Set<String> VALID_WARM_ACTIONS = Sets.newHashSet(
-        UnfollowAction.NAME,
-        SetPriorityAction.NAME,
-        AllocateAction.NAME,
-        ForceMergeAction.NAME,
-        ReadOnlyAction.NAME,
-        ShrinkAction.NAME
-    );
-    private static final Set<String> VALID_COLD_ACTIONS = Sets.newHashSet(
-        UnfollowAction.NAME,
-        SetPriorityAction.NAME,
-        AllocateAction.NAME,
-        SearchableSnapshotAction.NAME
-    );
-    private static final Set<String> VALID_DELETE_ACTIONS = Sets.newHashSet(DeleteAction.NAME, WaitForSnapshotAction.NAME);
+    private static final Set<String> VALID_HOT_ACTIONS = new HashSet<>(TimeseriesLifecycleType.ORDERED_VALID_HOT_ACTIONS);
+    private static final Set<String> VALID_WARM_ACTIONS = new HashSet<>(TimeseriesLifecycleType.ORDERED_VALID_WARM_ACTIONS);
+    private static final Set<String> VALID_COLD_ACTIONS = new HashSet<>(TimeseriesLifecycleType.ORDERED_VALID_COLD_ACTIONS);
+    private static final Set<String> VALID_FROZEN_ACTIONS = new HashSet<>(TimeseriesLifecycleType.ORDERED_VALID_FROZEN_ACTIONS);
+    private static final Set<String> VALID_DELETE_ACTIONS = new HashSet<>(TimeseriesLifecycleType.ORDERED_VALID_DELETE_ACTIONS);
 
     private String lifecycleName;
 
@@ -87,7 +78,8 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
                     new ParseField(SearchableSnapshotAction.NAME),
                     SearchableSnapshotAction::parse
                 ),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse)
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse)
             )
         );
         return new NamedXContentRegistry(entries);
@@ -127,13 +119,17 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
             .map(this::getTestAction)
             .collect(Collectors.toMap(LifecycleAction::getName, Function.identity()));
         if (randomBoolean()) {
-            invalidAction = getTestAction(randomFrom("allocate", "forcemerge", "delete", "shrink"));
+            invalidAction = getTestAction(randomFrom("allocate", "migrate", "delete"));
             actions.put(invalidAction.getName(), invalidAction);
         }
         Map<String, Phase> hotPhase = Collections.singletonMap("hot", new Phase("hot", TimeValue.ZERO, actions));
 
         if (invalidAction != null) {
-            Exception e = expectThrows(IllegalArgumentException.class, () -> new LifecyclePolicy(lifecycleName, hotPhase));
+            Exception e = expectThrows(
+                IllegalArgumentException.class,
+                "expected " + invalidAction + " to throw but it didn't",
+                () -> new LifecyclePolicy(lifecycleName, hotPhase)
+            );
             assertThat(e.getMessage(), equalTo("invalid action [" + invalidAction.getName() + "] defined in phase [hot]"));
         } else {
             new LifecyclePolicy(lifecycleName, hotPhase);
@@ -146,7 +142,7 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
             .map(this::getTestAction)
             .collect(Collectors.toMap(LifecycleAction::getName, Function.identity()));
         if (randomBoolean()) {
-            invalidAction = getTestAction(randomFrom("rollover", "delete"));
+            invalidAction = getTestAction(randomFrom("rollover", "delete", "searchable_snapshot"));
             actions.put(invalidAction.getName(), invalidAction);
         }
         Map<String, Phase> warmPhase = Collections.singletonMap("warm", new Phase("warm", TimeValue.ZERO, actions));
@@ -173,6 +169,25 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
         if (invalidAction != null) {
             Exception e = expectThrows(IllegalArgumentException.class, () -> new LifecyclePolicy(lifecycleName, coldPhase));
             assertThat(e.getMessage(), equalTo("invalid action [" + invalidAction.getName() + "] defined in phase [cold]"));
+        } else {
+            new LifecyclePolicy(lifecycleName, coldPhase);
+        }
+    }
+
+    public void testValidateFrozenPhase() {
+        LifecycleAction invalidAction = null;
+        Map<String, LifecycleAction> actions = randomSubsetOf(VALID_FROZEN_ACTIONS).stream()
+            .map(this::getTestAction)
+            .collect(Collectors.toMap(LifecycleAction::getName, Function.identity()));
+        if (randomBoolean()) {
+            invalidAction = getTestAction(randomFrom("allocate", "rollover", "delete", "forcemerge", "shrink", "readonly"));
+            actions.put(invalidAction.getName(), invalidAction);
+        }
+        Map<String, Phase> coldPhase = Collections.singletonMap("cold", new Phase("frozen", TimeValue.ZERO, actions));
+
+        if (invalidAction != null) {
+            Exception e = expectThrows(IllegalArgumentException.class, () -> new LifecyclePolicy(lifecycleName, coldPhase));
+            assertThat(e.getMessage(), equalTo("invalid action [" + invalidAction.getName() + "] defined in phase [frozen]"));
         } else {
             new LifecyclePolicy(lifecycleName, coldPhase);
         }
@@ -259,12 +274,15 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
                 case UnfollowAction.NAME:
                     return new UnfollowAction();
                 case SearchableSnapshotAction.NAME:
-                    return SearchableSnapshotActionTests.randomInstance();
+                    return new SearchableSnapshotAction("repo", randomBoolean());
+                case MigrateAction.NAME:
+                    return new MigrateAction(randomBoolean());
                 default:
                     throw new IllegalArgumentException("invalid action [" + action + "]");
             }
         };
         TimeValue prev = null;
+        boolean searchableSnapshotSeen = false;
         for (String phase : phaseNames) {
             TimeValue after = prev == null
                 ? TimeValue.parseTimeValue(randomTimeValue(0, 10000, "s", "m", "h", "d"), "test_after")
@@ -276,6 +294,20 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
                 actionNames = randomSubsetOf(validActions.apply(phase));
             } else {
                 actionNames = randomSubsetOf(randomIntBetween(1, validActions.apply(phase).size()), validActions.apply(phase));
+            }
+            if ("hot".equals(phase)) {
+                actions.put(
+                    RolloverAction.NAME,
+                    new RolloverAction(null, new ByteSizeValue(randomNonNegativeLong()), null, randomNonNegativeLong())
+                );
+            }
+            if (searchableSnapshotSeen || actionNames.contains(SearchableSnapshotAction.NAME)) {
+                searchableSnapshotSeen = true;
+                // let's make sure phases don't configure actions that conflict with the `searchable_snapshot` action
+                actionNames.removeAll(TimeseriesLifecycleType.ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT);
+            }
+            if (actionNames.contains(MigrateAction.NAME)) {
+                actionNames.remove(AllocateAction.NAME);
             }
             for (String action : actionNames) {
                 actions.put(action, randomAction.apply(action));
@@ -309,6 +341,8 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
                 return SearchableSnapshotActionTests.randomInstance();
             case UnfollowAction.NAME:
                 return new UnfollowAction();
+            case MigrateAction.NAME:
+                return new MigrateAction(randomBoolean());
             default:
                 throw new IllegalArgumentException("unsupported phase action [" + actionName + "]");
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecyclePolicyTests.java
@@ -309,6 +309,10 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
             if (actionNames.contains(MigrateAction.NAME)) {
                 actionNames.remove(AllocateAction.NAME);
             }
+            // Remove since this will cause deprecation warnings and test failures
+            if (actionNames.contains(FreezeAction.NAME)) {
+                actionNames.remove(FreezeAction.NAME);
+            }
             for (String action : actionNames) {
                 actions.put(action, randomAction.apply(action));
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -54,12 +54,12 @@ public class TimeseriesLifecycleType implements LifecycleType {
     static final String COLD_PHASE = "cold";
     static final String FROZEN_PHASE = "frozen";
     static final String DELETE_PHASE = "delete";
-    static final List<String> ORDERED_VALID_PHASES = Arrays.asList(HOT_PHASE, WARM_PHASE, COLD_PHASE, FROZEN_PHASE, DELETE_PHASE);
+    public static final List<String> ORDERED_VALID_PHASES = Arrays.asList(HOT_PHASE, WARM_PHASE, COLD_PHASE, FROZEN_PHASE, DELETE_PHASE);
 
     public static final String FREEZE_ACTION_DEPRECATION_WARNING = "the freeze action has been deprecated and will be removed in a future"
         + " release";
 
-    static final List<String> ORDERED_VALID_HOT_ACTIONS = Stream.of(
+    public static final List<String> ORDERED_VALID_HOT_ACTIONS = Stream.of(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         RolloverAction.NAME,
@@ -69,7 +69,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         ForceMergeAction.NAME,
         SearchableSnapshotAction.NAME
     ).filter(Objects::nonNull).collect(toList());
-    static final List<String> ORDERED_VALID_WARM_ACTIONS = Arrays.asList(
+    public static final List<String> ORDERED_VALID_WARM_ACTIONS = Arrays.asList(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
@@ -78,7 +78,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         ShrinkAction.NAME,
         ForceMergeAction.NAME
     );
-    static final List<String> ORDERED_VALID_COLD_ACTIONS = Stream.of(
+    public static final List<String> ORDERED_VALID_COLD_ACTIONS = Stream.of(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
@@ -88,8 +88,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
         FreezeAction.NAME,
         RollupV2.isEnabled() ? RollupILMAction.NAME : null
     ).filter(Objects::nonNull).collect(toList());
-    static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(UnfollowAction.NAME, SearchableSnapshotAction.NAME);
-    static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);
+    public static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(UnfollowAction.NAME, SearchableSnapshotAction.NAME);
+    public static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);
 
     static final Set<String> VALID_HOT_ACTIONS = Sets.newHashSet(ORDERED_VALID_HOT_ACTIONS);
     static final Set<String> VALID_WARM_ACTIONS = Sets.newHashSet(ORDERED_VALID_WARM_ACTIONS);
@@ -119,8 +119,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
     );
     // Set of actions that cannot be defined (executed) after the managed index has been mounted as searchable snapshot.
     // It's ordered to produce consistent error messages which can be unit tested.
-    static final Set<String> ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT = new LinkedHashSet<>(
-        Arrays.asList(ForceMergeAction.NAME, FreezeAction.NAME, ShrinkAction.NAME, RollupILMAction.NAME)
+    public static final Set<String> ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT = Collections.unmodifiableSet(
+        new LinkedHashSet<>(Arrays.asList(ForceMergeAction.NAME, FreezeAction.NAME, ShrinkAction.NAME, RollupILMAction.NAME))
     );
 
     private TimeseriesLifecycleType() {}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -203,8 +203,8 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         Map<String, LifecycleAction> actions = randomSubsetOf(VALID_FROZEN_ACTIONS).stream()
             .map(this::getTestAction)
             .collect(Collectors.toMap(LifecycleAction::getWriteableName, Function.identity()));
-        // regardless of the randomised actions, we must have a SearchableSnapshotAction in frozen
-        actions.put(SearchableSnapshotAction.NAME, getTestAction(SearchableSnapshotAction.NAME));
+        // Frozen requires the searchable snapshot action to be present
+        actions.put(SearchableSnapshotAction.NAME, new SearchableSnapshotAction("repo", randomBoolean()));
         if (randomBoolean()) {
             invalidAction = getTestAction(randomFrom("rollover", "delete", "forcemerge", "shrink"));
             actions.put(invalidAction.getWriteableName(), invalidAction);


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Change HLRC's LifecyclePolicy to allow all valid ILM actions (#81483)