### PR TITLE
Report close connection exceptions at INFO

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ccr.action;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -620,9 +621,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
     }
 
     static boolean shouldRetry(final Exception e) {
-        if (NetworkExceptionHelper.isConnectException(e)) {
-            return true;
-        } else if (NetworkExceptionHelper.isCloseConnectionException(e)) {
+        if (NetworkExceptionHelper.isConnectException(e) || NetworkExceptionHelper.getCloseConnectionExceptionLevel(e) != Level.OFF) {
             return true;
         }
 


### PR DESCRIPTION
In #51612 we promoted certain log messages regarding unexpected network
exceptions from `TRACE` to `DEBUG`. In fact it's often useful to see
these exceptions by default, so with this commit we show the message
(but not the stack trace) at `INFO` level. This commit also adds some
commentary about what each of the exceptions means.

Closes #66473