### PR TITLE
[DOCS] Remove experimental language from HDR Histo percentiles/ranks

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -308,8 +308,6 @@ the TDigest will use less memory.
 
 ==== HDR Histogram
 
-NOTE: This setting exposes the internal implementation of HDR Histogram and the syntax may change in the future.
-
 https://github.com/HdrHistogram/HdrHistogram[HDR Histogram] (High Dynamic Range Histogram) is an alternative implementation
 that can be useful when calculating percentiles for latency measurements as it can be faster than the t-digest implementation
 with the trade-off of a larger memory footprint. This implementation maintains a fixed worse-case percentage error (specified

--- a/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
@@ -170,8 +170,6 @@ GET latency/_search
 
 ==== HDR Histogram
 
-NOTE: This setting exposes the internal implementation of HDR Histogram and the syntax may change in the future.
-
 https://github.com/HdrHistogram/HdrHistogram[HDR Histogram] (High Dynamic Range Histogram) is an alternative implementation
 that can be useful when calculating percentile ranks for latency measurements as it can be faster than the t-digest implementation
 with the trade-off of a larger memory footprint. This implementation maintains a fixed worse-case percentage error (specified as a


### PR DESCRIPTION
This PR removes experimental language from the docs for HDR Histogram. Per issue #60780, decision from A&G team was to remove experimental language from HDR Histogram percentiles and ranks. The language specifically hinted that we might change the feature at any time. Now the feature has been in production for quite some time, and seems to be quite stable w/r to syntax. 

closes #60780
