### PR TITLE
[7.16] [DOCS] Remove experimental language from  HDR Histo percentiles/ranks (#81773)

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -308,8 +308,6 @@ the TDigest will use less memory.
 
 ==== HDR Histogram
 
-NOTE: This setting exposes the internal implementation of HDR Histogram and the syntax may change in the future.
-
 https://github.com/HdrHistogram/HdrHistogram[HDR Histogram] (High Dynamic Range Histogram) is an alternative implementation
 that can be useful when calculating percentiles for latency measurements as it can be faster than the t-digest implementation
 with the trade-off of a larger memory footprint. This implementation maintains a fixed worse-case percentage error (specified

--- a/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
@@ -170,8 +170,6 @@ GET latency/_search
 
 ==== HDR Histogram
 
-NOTE: This setting exposes the internal implementation of HDR Histogram and the syntax may change in the future.
-
 https://github.com/HdrHistogram/HdrHistogram[HDR Histogram] (High Dynamic Range Histogram) is an alternative implementation
 that can be useful when calculating percentile ranks for latency measurements as it can be faster than the t-digest implementation
 with the trade-off of a larger memory footprint. This implementation maintains a fixed worse-case percentage error (specified as a


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Remove experimental language from  HDR Histo percentiles/ranks (#81773)