### PR TITLE
[7.16] [DOCS] Final pipelines may not change target index (#76997)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -325,6 +325,9 @@ will fail if the final pipeline is set and the pipeline does not exist.
 The final pipeline always runs after the request pipeline (if specified) and
 the default pipeline (if it exists). The special pipeline name `_none`
 indicates no ingest pipeline will run.
++
+NOTE: You can't use a final pipeline to change the `_index` field. If the
+pipeline attempts to change the `_index` field, the indexing request will fail.
 
 [[index-hidden]] `index.hidden`::
 
@@ -332,6 +335,18 @@ indicates no ingest pipeline will run.
     returned by default when using a wildcard expression. This behavior is controlled
     per request through the use of the `expand_wildcards` parameter. Possible values are
     `true` and `false` (default).
+=======
++
+NOTE: You can't use a final pipelines to change the `_index` field. If the
+pipeline attempts to change the `_index` field, the indexing request will fail.
+
+[[index-mapping-dimension-fields-limit]]
+`index.mapping.dimension_fields.limit`::
+For internal use by Elastic only. Maximum number of time series dimensions for
+the index. Defaults to `16`.
++
+You can mark a field as a dimension using the `dimension` mapping parameter.
+>>>>>>> 4886753dec7... [DOCS] Final pipelines may not change target index (#76997)
 
 [discrete]
 === Settings in other index modules

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -335,18 +335,6 @@ pipeline attempts to change the `_index` field, the indexing request will fail.
     returned by default when using a wildcard expression. This behavior is controlled
     per request through the use of the `expand_wildcards` parameter. Possible values are
     `true` and `false` (default).
-=======
-+
-NOTE: You can't use a final pipelines to change the `_index` field. If the
-pipeline attempts to change the `_index` field, the indexing request will fail.
-
-[[index-mapping-dimension-fields-limit]]
-`index.mapping.dimension_fields.limit`::
-For internal use by Elastic only. Maximum number of time series dimensions for
-the index. Defaults to `16`.
-+
-You can mark a field as a dimension using the `dimension` mapping parameter.
->>>>>>> 4886753dec7... [DOCS] Final pipelines may not change target index (#76997)
 
 [discrete]
 === Settings in other index modules


### PR DESCRIPTION
Documents the restrictions on final pipelines added in #59522

Backport of #76997