### PR TITLE
Use target runtime version for configuring forbidden APIs task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -65,7 +65,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin implements Int
             SourceSet sourceSet = sourceSets.getByName(sourceSetName);
             t.setClasspath(project.files(sourceSet.getRuntimeClasspath()).plus(sourceSet.getCompileClasspath()));
 
-            t.setTargetCompatibility(BuildParams.getRuntimeJavaVersion().getMajorVersion());
+            t.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion().getMajorVersion());
             t.setBundledSignatures(Set.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out"));
             t.setSignaturesFiles(
                 project.files(


### PR DESCRIPTION
We're incorrectly configuring ForbiddenAPIs to use the current runtime Java version instead of the _minimum_ Java version. We test on newer Java versions than our code targets but that's irrelevant for the purposes of validating API usages. This should fix build failures like [this one](https://gradle-enterprise.elastic.co/s/wlcifbawvyoxy).