### PR TITLE
enable additional logging for remote cluster connection 

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -256,7 +256,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
 
             @Override
             public void onFailure(Exception e) {
-                logger.debug("initial connection to new remote cluster {} failed", clusterAlias);
+                logger.debug("connection to new remote cluster {} failed", clusterAlias);
             }
         }, latch::countDown));
 

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -248,7 +248,18 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     @Override
     protected void updateRemoteCluster(String clusterAlias, Settings settings) {
         CountDownLatch latch = new CountDownLatch(1);
-        updateRemoteCluster(clusterAlias, settings, ActionListener.wrap(latch::countDown));
+        updateRemoteCluster(clusterAlias, settings, ActionListener.runAfter(new ActionListener<Void>() {
+            @Override
+            public void onResponse(Void o) {
+                logger.debug("connected to new remote cluster {}", clusterAlias);
+            }
+
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.debug("initial connection to new remote cluster {} failed", clusterAlias);
+            }
+        }, latch::countDown));
 
         try {
             // Wait 10 seconds for a connections. We must use a latch instead of a future because we

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -254,7 +254,6 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
                 logger.debug("connected to new remote cluster {}", clusterAlias);
             }
 
-
             @Override
             public void onFailure(Exception e) {
                 logger.debug("initial connection to new remote cluster {} failed", clusterAlias);

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
@@ -78,10 +78,7 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
         }
 
         assertBusy(
-            () -> assertThat(
-                followerClient().prepareSearch("index2").get().getHits().getTotalHits().value,
-                equalTo(firstBatchNumDocs)
-            )
+            () -> assertThat(followerClient().prepareSearch("index2").get().getHits().getTotalHits().value, equalTo(firstBatchNumDocs))
         );
 
         getFollowerCluster().fullRestart();

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequ
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.RemoteConnectionInfo;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
 import org.elasticsearch.transport.TransportService;
@@ -32,6 +33,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
+@TestLogging(
+    value = "org.elasticsearch.transport.RemoteClusterService:DEBUG,org.elasticsearch.transport.SniffConnectionStrategy:TRACE",
+    reason = "https://github.com/elastic/elasticsearch/issues/81302"
+)
 public class RestartIndexFollowingIT extends CcrIntegTestCase {
 
     @Override
@@ -73,7 +78,10 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
         }
 
         assertBusy(
-            () -> { assertThat(followerClient().prepareSearch("index2").get().getHits().getTotalHits().value, equalTo(firstBatchNumDocs)); }
+            () -> assertThat(
+                followerClient().prepareSearch("index2").get().getHits().getTotalHits().value,
+                equalTo(firstBatchNumDocs)
+            )
         );
 
         getFollowerCluster().fullRestart();
@@ -137,5 +145,4 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
             assertThat(infos.size(), equalTo(0));
         });
     }
-
 }


### PR DESCRIPTION
There were no obvious reasons why `RestartIndexFollowingIT testFollowIndex` is failing ( #81302 ).

This change enables trace logging for the test class to collect additional clues.
Also added logs when connection to remote is established/failed.