### PR TITLE
[8.0] Use target runtime version for configuring forbidden APIs task (#81795)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -65,7 +65,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin implements Int
             SourceSet sourceSet = sourceSets.getByName(sourceSetName);
             t.setClasspath(project.files(sourceSet.getRuntimeClasspath()).plus(sourceSet.getCompileClasspath()));
 
-            t.setTargetCompatibility(BuildParams.getRuntimeJavaVersion().getMajorVersion());
+            t.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion().getMajorVersion());
             t.setBundledSignatures(Set.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out"));
             t.setSignaturesFiles(
                 project.files(


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Use target runtime version for configuring forbidden APIs task (#81795)