### PR TITLE
revert multiline string refactor in JsonThrowablePatternConverterTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -17,12 +17,11 @@ import org.hamcrest.Matchers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class JsonThrowablePatternConverterTests extends ESTestCase {
-    private static final Pattern NEWLINE = Pattern.compile("\\R");
+    private static final String LINE_SEPARATOR = System.lineSeparator();
     private JsonThrowablePatternConverter converter = JsonThrowablePatternConverter.newInstance(null, null);
 
     public void testNoStacktrace() throws IOException {
@@ -37,18 +36,26 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
     }
 
     public void testStacktraceWithJson() throws IOException {
-        String json = """
-            {
-              "terms": {
-                "user": [
-                  "u1",
-                  "u2",
-                  "u3"
-                ],
-                "boost": 1.0
-              }
-            }\
-            """;
+
+        String json = "{"
+            + LINE_SEPARATOR
+            + "  \"terms\" : {"
+            + LINE_SEPARATOR
+            + "    \"user\" : ["
+            + LINE_SEPARATOR
+            + "      \"u1\","
+            + LINE_SEPARATOR
+            + "      \"u2\","
+            + LINE_SEPARATOR
+            + "      \"u3\""
+            + LINE_SEPARATOR
+            + "    ],"
+            + LINE_SEPARATOR
+            + "    \"boost\" : 1.0"
+            + LINE_SEPARATOR
+            + "  }"
+            + LINE_SEPARATOR
+            + "}";
         Exception thrown = new Exception(json);
         LogEvent event = Log4jLogEvent.newBuilder().setMessage(new SimpleMessage("message")).setThrown(thrown).build();
 
@@ -60,7 +67,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("no logs parsed"));
 
-        int jsonLength = NEWLINE.split(json).length;
+        int jsonLength = json.split(LINE_SEPARATOR).length;
         int stacktraceLength = thrown.getStackTrace().length;
         assertThat(
             "stacktrace should formatted in multiple lines. JsonLogLine= " + jsonLogLine + " result= " + result,
@@ -74,18 +81,10 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
         converter.format(event, builder);
         String jsonStacktraceElement = builder.toString();
 
-        return """
-            {
-              "type": "console",
-              "timestamp": "2019-01-03T16:30:53,058+0100",
-              "level": "DEBUG",
-              "component": "o.e.a.s.TransportSearchAction",
-              "cluster.name": "clustername",
-              "node.name": "node-0",
-              "cluster.uuid": "OG5MkvOrR9azuClJhWvy6Q",
-              "node.id": "VTShUqmcQG6SzeKY5nn7qA",
-              "message": "msg msg"
-              %s
-            }""".formatted(jsonStacktraceElement);
+        return "{\"type\": \"console\", \"timestamp\": \"2019-01-03T16:30:53,058+0100\", \"level\": \"DEBUG\", "
+            + "\"component\": \"o.e.a.s.TransportSearchAction\", \"cluster.name\": \"clustername\", \"node.name\": \"node-0\", "
+            + "\"cluster.uuid\": \"OG5MkvOrR9azuClJhWvy6Q\", \"node.id\": \"VTShUqmcQG6SzeKY5nn7qA\",  \"message\": \"msg msg\" "
+            + jsonStacktraceElement
+            + "}";
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -36,26 +36,18 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
     }
 
     public void testStacktraceWithJson() throws IOException {
-
-        String json = "{"
-            + LINE_SEPARATOR
-            + "  \"terms\" : {"
-            + LINE_SEPARATOR
-            + "    \"user\" : ["
-            + LINE_SEPARATOR
-            + "      \"u1\","
-            + LINE_SEPARATOR
-            + "      \"u2\","
-            + LINE_SEPARATOR
-            + "      \"u3\""
-            + LINE_SEPARATOR
-            + "    ],"
-            + LINE_SEPARATOR
-            + "    \"boost\" : 1.0"
-            + LINE_SEPARATOR
-            + "  }"
-            + LINE_SEPARATOR
-            + "}";
+        String json = """
+            {
+              "terms": {
+                "user": [
+                  "u1",
+                  "u2",
+                  "u3"
+                ],
+                "boost": 1.0
+              }
+            }\
+            """.lines().collect(Collectors.joining(System.lineSeparator()));
         Exception thrown = new Exception(json);
         LogEvent event = Log4jLogEvent.newBuilder().setMessage(new SimpleMessage("message")).setThrown(thrown).build();
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -47,7 +47,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
                 "boost": 1.0
               }
             }\
-            """.lines().collect(Collectors.joining(System.lineSeparator()));
+            """.lines().collect(Collectors.joining(LINE_SEPARATOR));
         Exception thrown = new Exception(json);
         LogEvent event = Log4jLogEvent.newBuilder().setMessage(new SimpleMessage("message")).setThrown(thrown).build();
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -17,6 +17,7 @@ import org.hamcrest.Matchers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 


### PR DESCRIPTION
the test relies on line separator which is platform specific and use of
multiline string can cause it to fail in Windows

closes #81803
closes #81810

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
