### PR TITLE
Correct string formatting in failing PipelineConfigurationTests testGetVersion

### DIFF
--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -99,7 +99,7 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             // null version
             int version = randomInt();
             String configJson = """
-                {"version": %d, "description": "blah", "_meta" : {"foo": "bar"}}
+                {"version": %s, "description": "blah", "_meta" : {"foo": "bar"}}
                 """.formatted(version);
             PipelineConfiguration configuration = new PipelineConfiguration(
                 "1",


### PR DESCRIPTION
The `%d` format specifier results in incorrect character encoding in the JSON string.

Fixes #81804
