### PR TITLE
Add doPrivileged section in deprecation logger

### DIFF
--- a/docs/changelog/81819.yaml
+++ b/docs/changelog/81819.yaml
@@ -1,6 +1,6 @@
 pr: 81819
 summary: Add `doPrivileged` section in deprecation logger
-area: "Infra/Scripting, Infra/Logging"
+area: Infra/Scripting
 type: bug
 issues:
  - 81708

--- a/docs/changelog/81819.yaml
+++ b/docs/changelog/81819.yaml
@@ -1,6 +1,6 @@
 pr: 81819
 summary: Add `doPrivileged` section in deprecation logger
-area: Infra/Scripting
+area: Infra/Logging
 type: bug
 issues:
  - 81708

--- a/docs/changelog/81819.yaml
+++ b/docs/changelog/81819.yaml
@@ -1,0 +1,6 @@
+pr: 81819
+summary: Add `doPrivileged` section in deprecation logger
+area: "Infra/Scripting, Infra/Logging"
+type: bug
+issues:
+ - 81708

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -173,7 +173,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                 deprecationEvents.get(i),
                 DeprecationLogger.CRITICAL,
-                "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
+                "org.elasticsearch.common.logging.DeprecationLogger.lambda\\$doPrivilegedLog\\$0",
                 "This is a maybe logged deprecation message" + i
             );
         }
@@ -206,7 +206,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                 deprecationEvents.get(0),
                 DeprecationLogger.CRITICAL,
-                "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
+                "org.elasticsearch.common.logging.DeprecationLogger.lambda\\$doPrivilegedLog\\$0",
                 "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! "
                     + "See the breaking changes documentation for the next major version."
             );

--- a/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -8,16 +8,35 @@
 
 package org.elasticsearch.common.logging;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mockito;
+
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.Permissions;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DeprecationLoggerTests extends ESTestCase {
 
     public void testMultipleSlowLoggersUseSingleLog4jLogger() {
-        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        org.apache.logging.log4j.core.LoggerContext context = (org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false);
 
         DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DeprecationLoggerTests.class);
         int numberOfLoggersBefore = context.getLoggers().size();
@@ -29,5 +48,42 @@ public class DeprecationLoggerTests extends ESTestCase {
         int numberOfLoggersAfter = context.getLoggers().size();
 
         assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore + 1));
+    }
+
+    public void testLogPermissions() {
+        final LoggerContextFactory originalFactory = LogManager.getFactory();
+        try {
+            AtomicBoolean supplierCalled = new AtomicBoolean(false);
+            // mocking the logger used inside DeprecationLogger requires heavy hacking...
+
+            Logger mockLogger = mock(Logger.class);
+            doAnswer(invocationOnMock -> {
+                supplierCalled.set(true);
+                createTempDir(); // trigger file permission, like rolling logs would
+                return null;
+            }).when(mockLogger).log(eq(Level.WARN), any(ESLogMessage.class));
+
+            final LoggerContext context = Mockito.mock(LoggerContext.class);
+            when(context.getLogger(anyString())).thenReturn(mockLogger);
+
+            // "extending" the existing factory to avoid creating new one which
+            // would result in LoaderUtil.getParent SM permission exception
+            final LoggerContextFactory spy = Mockito.spy(originalFactory);
+            Mockito.doReturn(context).when(spy).getContext(any(), any(), any(), anyBoolean(), any(), any());
+            LogManager.setFactory(spy);
+
+            DeprecationLogger deprecationLogger = DeprecationLogger.getLogger("name");
+
+            AccessControlContext noPermissionsAcc = new AccessControlContext(
+                new ProtectionDomain[] { new ProtectionDomain(null, new Permissions()) }
+            );
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                deprecationLogger.warn(DeprecationCategory.API, "key", "foo", "bar");
+                return null;
+            }, noPermissionsAcc);
+            assertThat("supplier called", supplierCalled.get(), is(true));
+        } finally {
+            LogManager.setFactory(originalFactory);
+        }
     }
 }


### PR DESCRIPTION
Scripts using deprecation logger can trigger log files rolling over.
Scripts also run with a very limited permissions and without
doPrivileged section would cause SM exception

closes #81708

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
