### PR TITLE
Fix classpath for example build integration tests

### DIFF
--- a/plugins/examples/custom-settings/build.gradle
+++ b/plugins/examples/custom-settings/build.gradle
@@ -21,3 +21,6 @@ testClusters.configureEach {
   keystore 'custom.secured', 'password'
 }
 
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/custom-significance-heuristic/build.gradle
+++ b/plugins/examples/custom-significance-heuristic/build.gradle
@@ -15,3 +15,7 @@ esplugin {
   licenseFile rootProject.file('SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
   noticeFile rootProject.file('NOTICE.txt')
 }
+
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/custom-suggester/build.gradle
+++ b/plugins/examples/custom-suggester/build.gradle
@@ -19,3 +19,7 @@ esplugin {
 testClusters.configureEach {
   numberOfNodes = 2
 }
+
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/painless-whitelist/build.gradle
+++ b/plugins/examples/painless-whitelist/build.gradle
@@ -19,6 +19,7 @@ esplugin {
 
 dependencies {
   compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${elasticsearchVersion}"
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
 }
 
 testClusters.configureEach {

--- a/plugins/examples/rescore/build.gradle
+++ b/plugins/examples/rescore/build.gradle
@@ -15,3 +15,7 @@ esplugin {
   licenseFile rootProject.file('SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
   noticeFile rootProject.file('NOTICE.txt')
 }
+
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/rest-handler/build.gradle
+++ b/plugins/examples/rest-handler/build.gradle
@@ -15,3 +15,7 @@ esplugin {
   licenseFile rootProject.file('SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
   noticeFile rootProject.file('NOTICE.txt')
 }
+
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/script-expert-scoring/build.gradle
+++ b/plugins/examples/script-expert-scoring/build.gradle
@@ -15,3 +15,7 @@ esplugin {
   licenseFile rootProject.file('SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
   noticeFile rootProject.file('NOTICE.txt')
 }
+
+dependencies {
+  yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+}

--- a/plugins/examples/security-authorization-engine/build.gradle
+++ b/plugins/examples/security-authorization-engine/build.gradle
@@ -12,14 +12,11 @@ esplugin {
 
 dependencies {
   compileOnly "org.elasticsearch.plugin:x-pack-core:${elasticsearchVersion}"
-  testImplementation "org.apache.logging.log4j:log4j-core:2.11.1"
+  testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
   testImplementation "org.elasticsearch.plugin:x-pack-core:${elasticsearchVersion}"
   javaRestTestImplementation "org.elasticsearch.plugin:x-pack-core:${elasticsearchVersion}"
-  javaRestTestImplementation "org.apache.logging.log4j:log4j-core:2.11.1"
-  javaRestTestImplementation("co.elastic.clients:elasticsearch-java:${elasticsearchVersion}") {
-    // See: https://github.com/elastic/elasticsearch-java/issues/47
-    exclude module: 'jakarta.json-api'
-  }
+  javaRestTestImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+  javaRestTestImplementation("co.elastic.clients:elasticsearch-java:${elasticsearchVersion}")
   javaRestTestImplementation "org.elasticsearch.client:elasticsearch-rest-client:${elasticsearchVersion}"
   javaRestTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
   javaRestTestImplementation "org.elasticsearch.test:framework:${elasticsearchVersion}"

--- a/plugins/examples/settings.gradle
+++ b/plugins/examples/settings.gradle
@@ -18,6 +18,7 @@ gradle.rootProject {
       def props = new Properties()
       props.load(is)
       elasticsearchVersion = "${props.get('elasticsearch')}-SNAPSHOT"
+      log4jVersion = props.get('log4j')
     }
   }
 }


### PR DESCRIPTION
This fixes two classpath issues for integration tests in the example build

1. adds log4j to the runtime classpath where needed
2. removes exclude of jakarta json which was added as a workaround for

https://github.com/elastic/elasticsearch-java/issues/47