### PR TITLE
[ML] Report correct memory requirements for PyTorch models in stats

### DIFF
--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -116,9 +116,11 @@ The desired number of nodes for model allocation.
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
-`model_size`:::
+`model_size_bytes`:::
 (<<byte-units,byte value>>)
-The size of the loaded model in bytes.
+The native memory size required to load this model in bytes.
+Note that this value may be significantly larger than the model
+size on disk.
 
 `nodes`:::
 (array of objects)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -317,7 +317,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         listener.onResponse(
             new AllocationStats(
                 task.getModelId(),
-                ByteSizeValue.ofBytes(task.getParams().getModelBytes()),
+                ByteSizeValue.ofBytes(task.estimateMemoryUsageBytes()),
                 task.getParams().getInferenceThreads(),
                 task.getParams().getModelThreads(),
                 task.getParams().getQueueCapacity(),


### PR DESCRIPTION
The trained models stats API returns `deployment_stats.model_size_bytes`
for deployed PyTorch models. That is intended to report the amount of memory
required for this model to be loaded. This should be the result of
the memory estimation that takes into consideration the doubling of
memory while the process is loading the model plus the process overhead.

Relates #81854
