### PR TITLE
[DOCS] SQL: Update JDBC/ODBC driver version compatability for 7.17

### DIFF
--- a/docs/reference/sql/endpoints/version-compat.asciidoc
+++ b/docs/reference/sql/endpoints/version-compat.asciidoc
@@ -9,7 +9,7 @@ For example, A 7.10.0 server is not compatible with {version} drivers.
 | Compatible driver versions
 | Example
 
-ifeval::[ "{major-version}" != "7.x" ]
+ifeval::[ "{major-version}" == "8.x" ]
 
 ifeval::[ "{minor-version}" != "8.0" ]
 | 8.0.0–{version}
@@ -28,8 +28,7 @@ ifeval::[ "{minor-version}" == "8.0" ]
 compatible with 7.7.0 and later 7.x drivers.
 endif::[]
 
-// After 8.0 release, replace 7.x with last 7.x version
-| 7.7.1-7.x
+| 7.7.1-{prev-major-last}
 | * The same version
   * An earlier 7.x version, back to 7.7.0.
 | A 7.10.0 server is compatible with 7.7.0-7.10.0 drivers.


### PR DESCRIPTION
Replaces a 7.x reference with the `{prev-major-last}` variable, which will use the last minor of the previous major (currently 7.17 for 8.x).

This won't affect 7.17 or 7.16, but I'll backport to those versions to avoid future merge conflicts.

Relates to #70451.

### Preview

https://elasticsearch_81869.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/sql-odbc-installation.html#odbc-compatibility

<details>
  <summary><strong>Before</strong></summary>
  <img width="747" alt="Screen Shot 2021-12-17 at 9 59 49 AM" src="https://user-images.githubusercontent.com/40268737/146563900-5a493931-9893-41df-b977-a61db89c2900.PNG">
</details>

<details>
  <summary><strong>After</strong></summary>
  <img width="751" alt="Screen Shot 2021-12-17 at 9 59 11 AM" src="https://user-images.githubusercontent.com/40268737/146563946-e8ce094c-4622-47bf-93aa-c2b6e4909c7c.PNG">
</details>