### PR TITLE
[8.0] Remove JndiLookup.class from the SQL command line tool (#81879)

### DIFF
--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -46,6 +46,7 @@ tasks.named("shadowJar").configure {
   manifest {
     attributes 'Main-Class': 'org.elasticsearch.xpack.sql.cli.Cli'
   }
+  exclude '/org/apache/logging/log4j/core/lookup/JndiLookup.class'
 }
 
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove JndiLookup.class from the SQL command line tool (#81879)