### PR TITLE
[DOCS] Update snapshot vers compat table to use minor versions

### DIFF
--- a/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
+++ b/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
@@ -2,7 +2,7 @@
 [cols="^,^,^,^,^"]
 |====
 | 4+^h| Cluster version
-h| Snapshot version         | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
+h| Index version            | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
 | 5.0–5.6                   | {yes-icon} | {yes-icon} | {no-icon}             | {no-icon}
 | 6.0–6.8                   | {no-icon}  | {yes-icon} | {yes-icon}            | {no-icon}
 | 7.0–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}

--- a/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
+++ b/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
@@ -2,7 +2,7 @@
 [cols="^,^,^,^,^"]
 |====
 | 4+^h| Cluster version
-h| Index version            | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
+h| Index creation version   | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
 | 5.0–5.6                   | {yes-icon} | {yes-icon} | {no-icon}             | {no-icon}
 | 6.0–6.8                   | {no-icon}  | {yes-icon} | {yes-icon}            | {no-icon}
 | 7.0–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}

--- a/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
+++ b/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
@@ -2,9 +2,11 @@
 [cols="^,^,^,^,^"]
 |====
 | 4+^h| Cluster version
-h| Index creation version   | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
-| 5.0–5.6                   | {yes-icon} | {yes-icon} | {no-icon}             | {no-icon}
-| 6.0–6.8                   | {no-icon}  | {yes-icon} | {yes-icon}            | {no-icon}
-| 7.0–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}
+h| Index creation version   | 6.8        | 7.0–7.1    | 7.2–{prev-major-last} | 8.0–{minor-version}
+| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}             | {no-icon}
+| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}            | {no-icon}
+| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}            | {no-icon}
+| 7.0–7.1                   | {no-icon}  | {yes-icon} | {yes-icon}            | {yes-icon}
+| 7.2–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}
 | 8.0–{minor-version}       | {no-icon}  | {no-icon}  | {no-icon}             | {yes-icon}
 |====

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -114,19 +114,40 @@ any restored indices must be compatible.
 
 include::snapshot-vers-compat.asciidoc[]
 
+You can't restore a snapshot to an earlier version of {es}. For example, you
+can't restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
+
+ifeval::["{release-state}"!="released"]
+[[snapshot-prerelease-build-compatibility]]
+NOTE: This documentation is for {es} version {version}, which is not yet
+released. The compatibility table above applies only to snapshots taken in a
+released version of {es}. If you're testing a pre-release build of {es} then you
+can still restore snapshots taken in earlier released builds as permitted by
+this compatibility table. You can also take snapshots using your pre-release
+build, and restore them using the same build. However once a pre-release build
+of {es} has written to a snapshot repository you must not use the same
+repository with other builds of {es}, even if the builds have the same version.
+Different pre-release builds of {es} may use different and incompatible
+repository layouts. If the repository layout is incompatible with the {es} build
+in use then taking and restoring snapshots may result in errors or may appear to
+succeed having silently lost some data. You should discard your repository
+before using a different build.
+endif::[]
+
 [discrete]
 [[snapshot-index-compatibility]]
 === Index compatibility
 
-A cluster is only compatible with indices created in the previous major version
-of {es}. Any data stream or index you restore from a snapshot must be compatible
+Any data stream or index you restore from a snapshot must also be compatible
 with the current cluster's version. If you try to restore an index created in an
 incompatible version, the restore attempt will fail.
 
-A snapshot can contain indices created in a previous major version. For example,
-a snapshot of a 6.x cluster can contain an index created in 5.x. If you try to
-restore the 5.x index to a 7.x cluster, the restore attempt will fail. Keep this
-in mind if you take a snapshot before upgrading a cluster.
+include::cluster-index-compat.asciidoc[]
+
+A compatible snapshot can contain indices created in an incompatible version.
+For example, a snapshot of a 7.16 cluster can contain an index created in 6.8.
+If you try to restore the 6.8 index to a 8.0 cluster, the restore attempt will
+fail. Keep this in mind if you take a snapshot before upgrading a cluster.
 
 As a workaround, you can first restore the data stream or index to another
 cluster running the latest version of {es} that's compatible with both the index

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -112,36 +112,7 @@ any restored indices must be compatible.
 [[snapshot-cluster-compatibility]]
 === Snapshot version compatibility
 
-[cols="6"]
-|===
-| 5+^h| Cluster version
-^h| Snapshot version ^| 2.x ^| 5.x ^| 6.x ^| 7.x ^| 8.x
-^| *1.x* -> ^|{yes-icon} ^|{no-icon}  ^|{no-icon}  ^|{no-icon}  ^|{no-icon}
-^| *2.x* -> ^|{yes-icon} ^|{yes-icon} ^|{no-icon}  ^|{no-icon}  ^|{no-icon}
-^| *5.x* -> ^|{no-icon}  ^|{yes-icon} ^|{yes-icon} ^|{no-icon}  ^|{no-icon}
-^| *6.x* -> ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon} ^|{no-icon}
-^| *7.x* -> ^|{no-icon}  ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon}
-|===
-
-You can't restore a snapshot to an earlier version of {es}. For example, you
-can't restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
-
-ifeval::["{release-state}"!="released"]
-[[snapshot-prerelease-build-compatibility]]
-NOTE: This documentation is for {es} version {version}, which is not yet
-released. The compatibility table above applies only to snapshots taken in a
-released version of {es}. If you're testing a pre-release build of {es} then you
-can still restore snapshots taken in earlier released builds as permitted by
-this compatibility table. You can also take snapshots using your pre-release
-build, and restore them using the same build. However once a pre-release build
-of {es} has written to a snapshot repository you must not use the same
-repository with other builds of {es}, even if the builds have the same version.
-Different pre-release builds of {es} may use different and incompatible
-repository layouts. If the repository layout is incompatible with the {es} build
-in use then taking and restoring snapshots may result in errors or may appear to
-succeed having silently lost some data. You should discard your repository
-before using a different build.
-endif::[]
+include::snapshot-vers-compat.asciidoc[]
 
 [discrete]
 [[snapshot-index-compatibility]]
@@ -170,7 +141,7 @@ to estimate your time requirements.
 
 [discrete]
 [[snapshot-restore-warnings]]
-=== Warnings
+== Warnings
 
 [discrete]
 [[other-backup-methods]]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -146,7 +146,7 @@ include::cluster-index-compat.asciidoc[]
 
 A compatible snapshot can contain indices created in an incompatible version.
 For example, a snapshot of a 7.16 cluster can contain an index created in 6.8.
-If you try to restore the 6.8 index to a 8.0 cluster, the restore attempt will
+If you try to restore the 6.8 index to an 8.0 cluster, the restore attempt will
 fail. Keep this in mind if you take a snapshot before upgrading a cluster.
 
 As a workaround, you can first restore the index to another cluster running the

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -138,9 +138,9 @@ endif::[]
 [[snapshot-index-compatibility]]
 === Index compatibility
 
-Any data stream or index you restore from a snapshot must also be compatible
-with the current cluster's version. If you try to restore an index created in an
-incompatible version, the restore attempt will fail.
+Any index you restore from a snapshot must also be compatible with the current
+cluster's version. If you try to restore an index created in an incompatible
+version, the restore attempt will fail.
 
 include::cluster-index-compat.asciidoc[]
 
@@ -149,12 +149,11 @@ For example, a snapshot of a 7.16 cluster can contain an index created in 6.8.
 If you try to restore the 6.8 index to a 8.0 cluster, the restore attempt will
 fail. Keep this in mind if you take a snapshot before upgrading a cluster.
 
-As a workaround, you can first restore the data stream or index to another
-cluster running the latest version of {es} that's compatible with both the index
-and your current cluster. You can then use
-<<reindex-from-remote,reindex-from-remote>> to rebuild the data stream or index
-on your current cluster. Reindex from remote is only possible if the index's
-<<mapping-source-field,`_source`>> is enabled.
+As a workaround, you can first restore the index to another cluster running the
+latest version of {es} that's compatible with both the index and your current
+cluster. You can then use <<reindex-from-remote,reindex-from-remote>> to rebuild
+the index on your current cluster. Reindex from remote is only possible if the
+index's <<mapping-source-field,`_source`>> is enabled.
 
 Reindexing from remote can take significantly longer than restoring a snapshot.
 Before you start, test the reindex from remote process with a subset of the data

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -144,6 +144,9 @@ version, the restore attempt will fail.
 
 include::cluster-index-compat.asciidoc[]
 
+You can't restore an index to an earlier version of {es}. For example, you can't
+restore an index created in 7.6.0 to a cluster running 7.5.0.
+
 A compatible snapshot can contain indices created in an incompatible version.
 For example, a snapshot of a 7.16 cluster can contain an index created in 6.8.
 If you try to restore the 6.8 index to an 8.0 cluster, the restore attempt will

--- a/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
+++ b/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
@@ -2,9 +2,11 @@
 [cols="^,^,^,^,^"]
 |====
 | 4+^h| Cluster version
-h| Snapshot version         | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
-| 5.0–5.6                   | {yes-icon} | {yes-icon} | {no-icon}             | {no-icon}
-| 6.0–6.8                   | {no-icon}  | {yes-icon} | {yes-icon}            | {no-icon}
-| 7.0–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}
+h| Snapshot version         | 6.8        | 7.0–7.1    | 7.2–{prev-major-last} | 8.0–{minor-version}
+| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}             | {no-icon}
+| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}            | {no-icon}
+| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}            | {no-icon}
+| 7.0–7.1                   | {no-icon}  | {yes-icon} | {yes-icon}            | {yes-icon}
+| 7.2–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}
 | 8.0–{minor-version}       | {no-icon}  | {no-icon}  | {no-icon}             | {yes-icon}
 |====

--- a/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
+++ b/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
@@ -1,0 +1,30 @@
+
+[cols="^,^,^,^,^"]
+|====
+| 4+^h| Cluster version
+h| Snapshot version         | 5.0–5.6    | 6.0–6.8    | 7.0–{prev-major-last} | 8.0–{minor-version}
+| 5.0–5.6                   | {yes-icon} | {yes-icon} | {no-icon}             | {no-icon}
+| 6.0–6.8                   | {no-icon}  | {yes-icon} | {yes-icon}            | {no-icon}
+| 7.0–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon}
+| 8.0–{minor-version}       | {no-icon}  | {no-icon}  | {no-icon}             | {yes-icon}
+|====
+
+You can't restore a snapshot to an earlier version of {es}. For example, you can't
+restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
+
+ifeval::["{release-state}"!="released"]
+[[snapshot-prerelease-build-compatibility]]
+NOTE: This documentation is for {es} version {version}, which is not yet
+released. The compatibility table above applies only to snapshots taken in a
+released version of {es}. If you're testing a pre-release build of {es} then you
+can still restore snapshots taken in earlier released builds as permitted by
+this compatibility table. You can also take snapshots using your pre-release
+build, and restore them using the same build. However once a pre-release build
+of {es} has written to a snapshot repository you must not use the same
+repository with other builds of {es}, even if the builds have the same version.
+Different pre-release builds of {es} may use different and incompatible
+repository layouts. If the repository layout is incompatible with the {es} build
+in use then taking and restoring snapshots may result in errors or may appear to
+succeed having silently lost some data. You should discard your repository
+before using a different build.
+endif::[]


### PR DESCRIPTION
### Changes

* Updates the snapshot version compatibility table to use minor versions rather than major versions.
* Adds a index creation version and cluster compatibility table. Updates the index compatibility section to use minor versions.
* Moves the tables to separate files. This'll help prevent merge conflicts.
* Fixes the heading level for the "Warnings" section.

### Preview
https://elasticsearch_81885.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshot-restore.html#snapshot-restore-version-compatibility