### PR TITLE
[DOC] Thread pool settings are static

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -112,10 +112,10 @@ There are several thread pools, but the important ones include:
     `min(5 * (`<<node.processors, `# of allocated processors`>>`), 50)`
     and queue_size of `1000`.
 
-Thread pool settings are static and can be changed by editing `elasticsearch.yml`.
-Changing a specific thread pool can be done by setting its type-specific
-parameters; for example, changing the number of threads in the `write` thread
-pool:
+Thread pool settings are <<static-cluster-setting,static>> and can be changed by
+editing `elasticsearch.yml`. Changing a specific thread pool can be done by
+setting its type-specific parameters; for example, changing the number of
+threads in the `write` thread pool:
 
 [source,yaml]
 --------------------------------------------------

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -112,6 +112,7 @@ There are several thread pools, but the important ones include:
     `min(5 * (`<<node.processors, `# of allocated processors`>>`), 50)`
     and queue_size of `1000`.
 
+Thread Pool settings are static and can be changed by editing your `elasticsearch.yml`.
 Changing a specific thread pool can be done by setting its type-specific
 parameters; for example, changing the number of threads in the `write` thread
 pool:

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -112,7 +112,7 @@ There are several thread pools, but the important ones include:
     `min(5 * (`<<node.processors, `# of allocated processors`>>`), 50)`
     and queue_size of `1000`.
 
-Thread Pool settings are static and can be changed by editing your `elasticsearch.yml`.
+Thread pool settings are static and can be changed by editing `elasticsearch.yml`.
 Changing a specific thread pool can be done by setting its type-specific
 parameters; for example, changing the number of threads in the `write` thread
 pool:


### PR DESCRIPTION
Starting in 5.1 Thread Pools can no longer be dynamically updated, [doc](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_settings_changes.html#_threadpool_settings). This explicates it in the doc. 

Missing link to static & probably formatting if you'll kindly help 🙏🏼