### PR TITLE
Convert empty _tier_preference setting index deprecate check to a cluster deprecation check

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -61,7 +61,8 @@ public class DeprecationChecks {
             ClusterDeprecationChecks::checkClusterRoutingAllocationIncludeRelocationsSetting,
             ClusterDeprecationChecks::checkGeoShapeTemplates,
             ClusterDeprecationChecks::checkSparseVectorTemplates,
-            ClusterDeprecationChecks::checkILMFreezeActions
+            ClusterDeprecationChecks::checkILMFreezeActions,
+            ClusterDeprecationChecks::emptyDataTierPreferenceCheck
         )
     );
 
@@ -263,8 +264,7 @@ public class DeprecationChecks {
             (clusterState, indexMetadata) -> IndexDeprecationChecks.checkGeoShapeMappings(indexMetadata),
             (clusterState, indexMetadata) -> IndexDeprecationChecks.frozenIndexSettingCheck(indexMetadata),
             (clusterState, indexMetadata) -> IndexDeprecationChecks.httpContentTypeRequiredSettingCheck(indexMetadata),
-            (clusterState, indexMetadata) -> IndexDeprecationChecks.mapperDyamicSettingCheck(indexMetadata),
-            IndexDeprecationChecks::emptyDataTierPreferenceCheck
+            (clusterState, indexMetadata) -> IndexDeprecationChecks.mapperDyamicSettingCheck(indexMetadata)
         )
     );
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -9,10 +9,8 @@ package org.elasticsearch.xpack.deprecation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.joda.JodaDeprecationPatterns;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -725,24 +723,6 @@ public class IndexDeprecationChecks {
                 false,
                 null
             );
-        }
-        return null;
-    }
-
-    static DeprecationIssue emptyDataTierPreferenceCheck(ClusterState clusterState, IndexMetadata indexMetadata) {
-        if (DataTier.dataNodesWithoutAllDataRoles(clusterState).isEmpty() == false) {
-            final List<String> tierPreference = DataTier.parseTierList(DataTier.TIER_PREFERENCE_SETTING.get(indexMetadata.getSettings()));
-            if (tierPreference.isEmpty()) {
-                String indexName = indexMetadata.getIndex().getName();
-                return new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
-                    "No [" + DataTier.TIER_PREFERENCE + "] is set for index [" + indexName + "].",
-                    "https://ela.st/es-deprecation-7-empty-tier-preference",
-                    "Specify a data tier preference for this index.",
-                    false,
-                    null
-                );
-            }
         }
         return null;
     }


### PR DESCRIPTION
That way, we display a single issue for N indices rather than N issues, one for each index. There's a bit of trickery here because we need to truncate the list of indices if its bigger than a breadbox.