### PR TITLE
[DOCS] Archived cluster settings block setting updates

### DIFF
--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -50,10 +50,11 @@ templates during an upgrade. Attempts to use a template that contains an
 unsupported index setting will fail and return an error. This includes automated
 operations, such the {ilm-init} rollover action.
 
-Archived index settings don't affect an index's configuration. However, they're
-still considered invalid settings. They're returned in relevant API responses,
-but you can't specify them when you configure an index. This applies even if the
-index already has the archived setting.
+Archived index settings don't affect an index's configuration or other index
+operations, such as indexing or search. However, they're still considered
+invalid settings. They're returned in relevant API responses, but you can't
+specify them when you configure an index. This applies even if the index already
+has the archived setting.
 
 You can view archived index settings using the <<indices-get-settings,get index
 settings API>>.

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -1,28 +1,31 @@
 [[archived-settings]]
 == Archived settings
 
-{es} typically removes support for deprecated settings at major version
-releases. If you upgrade a cluster with a deprecated persistent cluster setting
-to a version that no longer supports the setting, {es} automatically archives
-that setting. Similarly, if you upgrade a cluster that contains an index with an
+If you upgrade a cluster with a deprecated persistent cluster setting to a
+version that no longer supports the setting, {es} automatically archives the
+setting. Similarly, if you upgrade a cluster that contains an index with an
 unsupported index setting, {es} archives the index setting.
 
-Archived settings start with the `archived.` prefix and are ignored by {es}.
+Archived settings start with the `archived.` prefix.
 
 [discrete]
 [[archived-cluster-settings]]
 === Archived cluster settings
 
-After an upgrade, you can view archived cluster settings using the
-<<cluster-get-settings,cluster get settings API>>.
+Archived cluster settings block cluster setting updates. If your cluster
+contains any archived persistent cluster settings, you'll need to remove them
+before you can configure other cluster settings.
+
+You can view archived cluster settings using the <<cluster-get-settings,cluster
+get settings API>>.
 
 [source,console]
 ----
 GET _cluster/settings?flat_settings=true&filter_path=persistent.archived*
 ----
 
-You can remove archived cluster settings using the
-<<cluster-update-settings,cluster update settings API>>.
+To remove all archived cluster settings, use the following
+<<cluster-update-settings,cluster update settings>> request.
 
 [source,console]
 ----
@@ -48,8 +51,12 @@ templates during an upgrade. Attempts to use a template that contains an
 unsupported index setting will fail and return an error. This includes automated
 operations, such the {ilm-init} rollover action.
 
-You can view archived settings for an index using the <<indices-get-settings,get
-index settings API>>.
+An archived index setting doesn't affect an index's configuration. However, {es}
+will still reject requests that include an archived index setting. This
+applies even if the request targets an index that already has the setting.
+
+You can view archived index settings using the <<indices-get-settings,get index
+settings API>>.
 
 [source,console]
 ----
@@ -58,8 +65,8 @@ GET my-index/_settings?flat_settings=true&filter_path=**.settings.archived*
 // TEST[s/^/PUT my-index\n/]
 
 Removing archived index settings requires a reindex after the upgrade. However,
-reindexing can be resource intensive. Because {es} ignores archived settings,
-you can safely leave them in place if wanted.
+reindexing can be resource intensive. Because archived settings don't affect
+index configuration, you can safely leave them in place if wanted.
 
 [source,console]
 ----

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -50,9 +50,10 @@ templates during an upgrade. Attempts to use a template that contains an
 unsupported index setting will fail and return an error. This includes automated
 operations, such the {ilm-init} rollover action.
 
-An archived index setting doesn't affect an index's configuration. However, {es}
-will still reject requests that include an archived index setting. This
-applies even if the request targets an index that already has the setting.
+Archived index settings don't affect an index's configuration. However, they're
+still considered invalid settings. They're returned in relevant GET requests and
+responses, but you can't specify them when you configure an index. This applies
+even if the index already has the archived setting.
 
 You can view archived index settings using the <<indices-get-settings,get index
 settings API>>.

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -64,9 +64,9 @@ GET my-index/_settings?flat_settings=true&filter_path=**.settings.archived*
 ----
 // TEST[s/^/PUT my-index\n/]
 
-Removing archived index settings requires a reindex after the upgrade. However,
-reindexing can be resource intensive. Because archived settings don't affect
-an index's configuration, you can safely leave them in place if wanted.
+Removing archived index settings requires a reindex. However, reindexing can be
+resource intensive. Because archived settings don't affect an index's
+configuration, you can safely leave them in place if wanted.
 
 [source,console]
 ----

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -2,7 +2,7 @@
 == Archived settings
 
 If you upgrade a cluster with a deprecated persistent cluster setting to a
-version that no longer supports the setting, {es} automatically archives the
+version that no longer supports the setting, {es} automatically archives that
 setting. Similarly, if you upgrade a cluster that contains an index with an
 unsupported index setting, {es} archives the index setting.
 
@@ -65,8 +65,9 @@ GET my-index/_settings?flat_settings=true&filter_path=**.settings.archived*
 // TEST[s/^/PUT my-index\n/]
 
 Removing archived index settings requires a reindex. However, reindexing can be
-resource intensive. Because archived settings don't affect an index's
-configuration, you can safely leave them in place if wanted.
+resource intensive. Because archived settings don't affect the index's
+configuration, you can safely leave them in place as long as you don't
+include them in configuration requests.
 
 [source,console]
 ----

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -12,9 +12,8 @@ Archived settings start with the `archived.` prefix.
 [[archived-cluster-settings]]
 === Archived cluster settings
 
-Archived cluster settings block cluster setting updates. If your cluster
-contains any archived persistent cluster settings, you'll need to remove them
-before you can configure other cluster settings.
+If your cluster contains any archived persistent cluster settings, you'll need
+to remove them before you can configure other cluster settings.
 
 You can view archived cluster settings using the <<cluster-get-settings,cluster
 get settings API>>.

--- a/docs/reference/upgrade/archived-settings.asciidoc
+++ b/docs/reference/upgrade/archived-settings.asciidoc
@@ -12,8 +12,8 @@ Archived settings start with the `archived.` prefix.
 [[archived-cluster-settings]]
 === Archived cluster settings
 
-If your cluster contains any archived persistent cluster settings, you'll need
-to remove them before you can configure other cluster settings.
+If your cluster contains any archived cluster settings, you'll need to remove
+them before you can configure other cluster settings.
 
 You can view archived cluster settings using the <<cluster-get-settings,cluster
 get settings API>>.
@@ -51,9 +51,9 @@ unsupported index setting will fail and return an error. This includes automated
 operations, such the {ilm-init} rollover action.
 
 Archived index settings don't affect an index's configuration. However, they're
-still considered invalid settings. They're returned in relevant GET requests and
-responses, but you can't specify them when you configure an index. This applies
-even if the index already has the archived setting.
+still considered invalid settings. They're returned in relevant API responses,
+but you can't specify them when you configure an index. This applies even if the
+index already has the archived setting.
 
 You can view archived index settings using the <<indices-get-settings,get index
 settings API>>.
@@ -66,7 +66,7 @@ GET my-index/_settings?flat_settings=true&filter_path=**.settings.archived*
 
 Removing archived index settings requires a reindex after the upgrade. However,
 reindexing can be resource intensive. Because archived settings don't affect
-index configuration, you can safely leave them in place if wanted.
+an index's configuration, you can safely leave them in place if wanted.
 
 [source,console]
 ----


### PR DESCRIPTION
### Changes

* Notes that archived cluster settings block cluster setting updates. Previously, the docs stated that ES ignored archived cluster settings.
* Notes that you can't include archived index settings in requests.

CC @DaveCTurner

Closes #61175

Relates #78351

### Preview
https://elasticsearch_81908.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/archived-settings.html