### PR TITLE
[8.0] Disable BWC tests to upgrade Lucene on 7.17 (#81930)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,9 +125,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/81900"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Disable BWC tests to upgrade Lucene on 7.17 (#81930)