### PR TITLE
Clean up Dead Code in Http Response Implementations

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -219,7 +219,7 @@ public class Netty4HttpRequest implements HttpRequest {
 
     @Override
     public Netty4HttpResponse createResponse(RestStatus status, BytesReference contentRef) {
-        return new Netty4HttpResponse(request.headers(), request.protocolVersion(), status, contentRef);
+        return new Netty4HttpResponse(request.protocolVersion(), status, contentRef);
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpResponse.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpResponse.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.http.netty4;
 
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
@@ -20,11 +19,8 @@ import org.elasticsearch.transport.netty4.Netty4Utils;
 
 public class Netty4HttpResponse extends DefaultFullHttpResponse implements HttpResponse {
 
-    private final HttpHeaders requestHeaders;
-
-    Netty4HttpResponse(HttpHeaders requestHeaders, HttpVersion version, RestStatus status, BytesReference content) {
+    Netty4HttpResponse(HttpVersion version, RestStatus status, BytesReference content) {
         super(version, HttpResponseStatus.valueOf(status.getStatus()), Netty4Utils.toByteBuf(content));
-        this.requestHeaders = requestHeaders;
     }
 
     @Override
@@ -35,9 +31,5 @@ public class Netty4HttpResponse extends DefaultFullHttpResponse implements HttpR
     @Override
     public boolean containsHeader(String name) {
         return headers().contains(name);
-    }
-
-    public HttpHeaders requestHeaders() {
-        return requestHeaders;
     }
 }

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpRequest.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpRequest.java
@@ -218,16 +218,12 @@ public class NioHttpRequest implements HttpRequest {
 
     @Override
     public NioHttpResponse createResponse(RestStatus status, BytesReference contentRef) {
-        return new NioHttpResponse(request.headers(), request.protocolVersion(), status, contentRef);
+        return new NioHttpResponse(request.protocolVersion(), status, contentRef);
     }
 
     @Override
     public Exception getInboundException() {
         return inboundException;
-    }
-
-    public FullHttpRequest nettyRequest() {
-        return request;
     }
 
     /**

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponse.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponse.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.http.nio;
 
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
@@ -19,11 +18,8 @@ import org.elasticsearch.rest.RestStatus;
 
 public class NioHttpResponse extends DefaultFullHttpResponse implements HttpResponse {
 
-    private final HttpHeaders requestHeaders;
-
-    NioHttpResponse(HttpHeaders requestHeaders, HttpVersion version, RestStatus status, BytesReference content) {
+    NioHttpResponse(HttpVersion version, RestStatus status, BytesReference content) {
         super(version, HttpResponseStatus.valueOf(status.getStatus()), ByteBufUtils.toByteBuf(content));
-        this.requestHeaders = requestHeaders;
     }
 
     @Override
@@ -34,9 +30,5 @@ public class NioHttpResponse extends DefaultFullHttpResponse implements HttpResp
     @Override
     public boolean containsHeader(String name) {
         return headers().contains(name);
-    }
-
-    public HttpHeaders requestHeaders() {
-        return requestHeaders;
     }
 }


### PR DESCRIPTION
We never use the reference to the request headers.
