### PR TITLE
[7.17] [DOCS] Thread pool settings are static (#81887)

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -119,9 +119,10 @@ There are several thread pools, but the important ones include:
     `min(5 * (`<<node.processors, `# of allocated processors`>>`), 50)`
     and queue_size of `1000`.
 
-Changing a specific thread pool can be done by setting its type-specific
-parameters; for example, changing the number of threads in the `write` thread
-pool:
+Thread pool settings are <<static-cluster-setting,static>> and can be changed by
+editing `elasticsearch.yml`. Changing a specific thread pool can be done by
+setting its type-specific parameters; for example, changing the number of
+threads in the `write` thread pool:
 
 [source,yaml]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Thread pool settings are static (#81887)