### PR TITLE
[7.16] [DOCS] Remove Windows MSI installer package (#81952)

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -17,6 +17,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 * <<breaking_716_settings_deprecations>>
 * <<breaking_716_indices_deprecations>>
 * <<breaking_716_cluster_deprecations>>
+* <<breaking_716_packaging_deprecations>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -426,6 +427,23 @@ cache do not expire.
 
 To override the defaults, configure the `script.cache.max_size`,
 `script.max_compilations_rate`, and `script.cache.expire` settings.
+====
+
+[discrete]
+[[breaking_716_packaging_deprecations]]
+==== Packaging deprecations
+
+.After 7.16.2, we'll no longer release a Windows MSI installer package.
+[%collapsible]
+====
+*Details* +
+After 7.16.2, we'll no longer release Windows MSI installer packages for {es}.
+These packages were previously released in beta and didn't receive widespread
+adoption.
+
+*Impact* +
+To install {es} on Windows, use the {ref}/zip-windows.html[`.zip` archive
+package] instead.
 ====
 // end::notable-breaking-changes[]
 

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -40,9 +40,11 @@ Elasticsearch website or from our RPM repository.
 +
 <<rpm>>
 
-`msi`::
+beta[] `msi`::
 
-beta[] The `msi` package is suitable for installation on Windows 64-bit systems with at least
+deprecated:[7.16.2,"After 7.16.2, we'll no longer release Windows MSI installer packages for {es}. To install {es} on Windows, use the <<zip-windows,`.zip` archive package>> instead."]
++
+The `msi` package is suitable for installation on Windows 64-bit systems with at least
 .NET 4.5 framework installed, and is the easiest choice for getting started with
 Elasticsearch on Windows. MSIs may be downloaded from the Elasticsearch website.
 +

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -1,7 +1,9 @@
 [[windows]]
 === Install Elasticsearch with Windows MSI Installer
 
-beta[]
+deprecated::[7.16.2,"After 7.16.2, we'll no longer release Windows MSI installer packages for {es}. To install {es} on Windows, use the <<zip-windows,`.zip` archive package>> instead."]
+
+beta::[]
 
 Elasticsearch can be installed on Windows using the `.msi` package. This can
 install Elasticsearch as a Windows service or allow it to be run manually using

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -5,10 +5,6 @@ Elasticsearch can be installed on Windows using the Windows `.zip` archive. This
 comes with a `elasticsearch-service.bat` command which will setup Elasticsearch to run as a
 service.
 
-TIP: Elasticsearch has historically been installed on Windows using the `.zip` archive.
-An <<windows, MSI installer package>> is available that provides the easiest getting started
-experience for Windows. You can continue using the `.zip` approach if you prefer.
-
 include::license.asciidoc[]
 
 NOTE: On Windows the Elasticsearch {ml} feature requires the Microsoft Universal

--- a/docs/reference/setup/starting.asciidoc
+++ b/docs/reference/setup/starting.asciidoc
@@ -53,6 +53,8 @@ production mode. See <<docker-cli-run>>.
 [[start-msi]]
 === MSI packages
 
+deprecated::[7.16.2,"After 7.16.2, we'll no longer release Windows MSI installer packages for {es}. To install {es} on Windows, use the <<zip-windows,`.zip` archive package>> instead."]
+
 If you installed {es} on Windows using the `.msi` package, you can start {es} 
 from the command line. If you want it to start automatically at boot time 
 without any user interaction, 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Remove Windows MSI installer package (#81952)