### PR TITLE
Add failure metrics to SearchStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -116,7 +116,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             this.suggestCurrent = suggestCurrent;
         }
 
-        private Stats(StreamInput in) throws IOException { // TODO older stream?
+        private Stats(StreamInput in) throws IOException {
             queryCount = in.readVLong();
             queryTimeInMillis = in.readVLong();
             queryCurrent = in.readVLong();
@@ -140,10 +140,12 @@ public class SearchStats implements Writeable, ToXContentFragment {
             queryCount += stats.queryCount;
             queryTimeInMillis += stats.queryTimeInMillis;
             queryCurrent += stats.queryCurrent;
+            queryFailureCount += stats.queryFailureCount;
 
             fetchCount += stats.fetchCount;
             fetchTimeInMillis += stats.fetchTimeInMillis;
             fetchCurrent += stats.fetchCurrent;
+            fetchFailureCount += stats.fetchFailureCount;
 
             scrollCount += stats.scrollCount;
             scrollTimeInMillis += stats.scrollTimeInMillis;
@@ -157,9 +159,11 @@ public class SearchStats implements Writeable, ToXContentFragment {
         public void addForClosingShard(Stats stats) {
             queryCount += stats.queryCount;
             queryTimeInMillis += stats.queryTimeInMillis;
+            queryFailureCount += stats.queryFailureCount;
 
             fetchCount += stats.fetchCount;
             fetchTimeInMillis += stats.fetchTimeInMillis;
+            fetchFailureCount += stats.fetchFailureCount;
 
             scrollCount += stats.scrollCount;
             scrollTimeInMillis += stats.scrollTimeInMillis;
@@ -260,7 +264,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException { // TODO
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.QUERY_TOTAL, queryCount);
             builder.humanReadableField(Fields.QUERY_TIME_IN_MILLIS, Fields.QUERY_TIME, getQueryTime());
             builder.field(Fields.QUERY_CURRENT, queryCurrent);
@@ -299,7 +303,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.groupStats = groupStats;
     }
 
-    public SearchStats(StreamInput in) throws IOException { // TODO migration
+    public SearchStats(StreamInput in) throws IOException {
         totalStats = Stats.readStats(in);
         openContexts = in.readVLong();
         if (in.readBoolean()) {

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -190,6 +190,10 @@ public class SearchStats implements Writeable, ToXContentFragment {
             return queryCurrent;
         }
 
+        public long getQueryFailureCount() {
+            return queryFailureCount;
+        }
+
         public long getFetchCount() {
             return fetchCount;
         }
@@ -204,6 +208,10 @@ public class SearchStats implements Writeable, ToXContentFragment {
 
         public long getFetchCurrent() {
             return fetchCurrent;
+        }
+
+        public long getFetchFailureCount() {
+            return fetchFailureCount;
         }
 
         public long getScrollCount() {

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -30,10 +30,12 @@ public class SearchStats implements Writeable, ToXContentFragment {
         private long queryCount;
         private long queryTimeInMillis;
         private long queryCurrent;
+        private long queryFailureCount;
 
         private long fetchCount;
         private long fetchTimeInMillis;
         private long fetchCurrent;
+        private long fetchFailureCount;
 
         private long scrollCount;
         private long scrollTimeInMillis;
@@ -47,6 +49,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             // for internal use, initializes all counts to 0
         }
 
+        // left here for backward compatibility
         public Stats(
             long queryCount,
             long queryTimeInMillis,
@@ -78,14 +81,51 @@ public class SearchStats implements Writeable, ToXContentFragment {
             this.suggestCurrent = suggestCurrent;
         }
 
-        private Stats(StreamInput in) throws IOException {
+        public Stats(
+            long queryCount,
+            long queryTimeInMillis,
+            long queryCurrent,
+            long queryFailureCount,
+            long fetchCount,
+            long fetchTimeInMillis,
+            long fetchCurrent,
+            long fetchFailureCount,
+            long scrollCount,
+            long scrollTimeInMillis,
+            long scrollCurrent,
+            long suggestCount,
+            long suggestTimeInMillis,
+            long suggestCurrent
+        ) {
+            this.queryCount = queryCount;
+            this.queryTimeInMillis = queryTimeInMillis;
+            this.queryCurrent = queryCurrent;
+            this.queryFailureCount = queryFailureCount;
+
+            this.fetchCount = fetchCount;
+            this.fetchTimeInMillis = fetchTimeInMillis;
+            this.fetchCurrent = fetchCurrent;
+            this.fetchFailureCount = fetchFailureCount;
+
+            this.scrollCount = scrollCount;
+            this.scrollTimeInMillis = scrollTimeInMillis;
+            this.scrollCurrent = scrollCurrent;
+
+            this.suggestCount = suggestCount;
+            this.suggestTimeInMillis = suggestTimeInMillis;
+            this.suggestCurrent = suggestCurrent;
+        }
+
+        private Stats(StreamInput in) throws IOException { // TODO older stream?
             queryCount = in.readVLong();
             queryTimeInMillis = in.readVLong();
             queryCurrent = in.readVLong();
+            queryFailureCount = in.readVLong();
 
             fetchCount = in.readVLong();
             fetchTimeInMillis = in.readVLong();
             fetchCurrent = in.readVLong();
+            fetchFailureCount = in.readVLong();
 
             scrollCount = in.readVLong();
             scrollTimeInMillis = in.readVLong();
@@ -203,10 +243,12 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeVLong(queryCount);
             out.writeVLong(queryTimeInMillis);
             out.writeVLong(queryCurrent);
+            out.writeVLong(queryFailureCount);
 
             out.writeVLong(fetchCount);
             out.writeVLong(fetchTimeInMillis);
             out.writeVLong(fetchCurrent);
+            out.writeVLong(fetchFailureCount);
 
             out.writeVLong(scrollCount);
             out.writeVLong(scrollTimeInMillis);
@@ -218,14 +260,16 @@ public class SearchStats implements Writeable, ToXContentFragment {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException { // TODO
             builder.field(Fields.QUERY_TOTAL, queryCount);
             builder.humanReadableField(Fields.QUERY_TIME_IN_MILLIS, Fields.QUERY_TIME, getQueryTime());
             builder.field(Fields.QUERY_CURRENT, queryCurrent);
+            builder.field(Fields.QUERY_FAILURE_TOTAL, queryFailureCount);
 
             builder.field(Fields.FETCH_TOTAL, fetchCount);
             builder.humanReadableField(Fields.FETCH_TIME_IN_MILLIS, Fields.FETCH_TIME, getFetchTime());
             builder.field(Fields.FETCH_CURRENT, fetchCurrent);
+            builder.field(Fields.FETCH_FAILURE_TOTAL, fetchFailureCount);
 
             builder.field(Fields.SCROLL_TOTAL, scrollCount);
             builder.humanReadableField(Fields.SCROLL_TIME_IN_MILLIS, Fields.SCROLL_TIME, getScrollTime());
@@ -255,7 +299,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.groupStats = groupStats;
     }
 
-    public SearchStats(StreamInput in) throws IOException {
+    public SearchStats(StreamInput in) throws IOException { // TODO migration
         totalStats = Stats.readStats(in);
         openContexts = in.readVLong();
         if (in.readBoolean()) {
@@ -338,10 +382,12 @@ public class SearchStats implements Writeable, ToXContentFragment {
         static final String QUERY_TIME = "query_time";
         static final String QUERY_TIME_IN_MILLIS = "query_time_in_millis";
         static final String QUERY_CURRENT = "query_current";
+        static final String QUERY_FAILURE_TOTAL = "query_failure_total";
         static final String FETCH_TOTAL = "fetch_total";
         static final String FETCH_TIME = "fetch_time";
         static final String FETCH_TIME_IN_MILLIS = "fetch_time_in_millis";
         static final String FETCH_CURRENT = "fetch_current";
+        static final String FETCH_FAILURE_TOTAL = "fetch_failure_total";
         static final String SCROLL_TOTAL = "scroll_total";
         static final String SCROLL_TIME = "scroll_time";
         static final String SCROLL_TIME_IN_MILLIS = "scroll_time_in_millis";

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.search.stats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -49,38 +50,6 @@ public class SearchStats implements Writeable, ToXContentFragment {
             // for internal use, initializes all counts to 0
         }
 
-        // left here for backward compatibility
-        public Stats(
-            long queryCount,
-            long queryTimeInMillis,
-            long queryCurrent,
-            long fetchCount,
-            long fetchTimeInMillis,
-            long fetchCurrent,
-            long scrollCount,
-            long scrollTimeInMillis,
-            long scrollCurrent,
-            long suggestCount,
-            long suggestTimeInMillis,
-            long suggestCurrent
-        ) {
-            this.queryCount = queryCount;
-            this.queryTimeInMillis = queryTimeInMillis;
-            this.queryCurrent = queryCurrent;
-
-            this.fetchCount = fetchCount;
-            this.fetchTimeInMillis = fetchTimeInMillis;
-            this.fetchCurrent = fetchCurrent;
-
-            this.scrollCount = scrollCount;
-            this.scrollTimeInMillis = scrollTimeInMillis;
-            this.scrollCurrent = scrollCurrent;
-
-            this.suggestCount = suggestCount;
-            this.suggestTimeInMillis = suggestTimeInMillis;
-            this.suggestCurrent = suggestCurrent;
-        }
-
         public Stats(
             long queryCount,
             long queryTimeInMillis,
@@ -120,12 +89,16 @@ public class SearchStats implements Writeable, ToXContentFragment {
             queryCount = in.readVLong();
             queryTimeInMillis = in.readVLong();
             queryCurrent = in.readVLong();
-            queryFailureCount = in.readVLong();
+            if (in.getVersion().onOrAfter(Version.V_8_1_0)) {
+                queryFailureCount = in.readVLong();
+            }
 
             fetchCount = in.readVLong();
             fetchTimeInMillis = in.readVLong();
             fetchCurrent = in.readVLong();
-            fetchFailureCount = in.readVLong();
+            if (in.getVersion().onOrAfter(Version.V_8_1_0)) {
+                fetchFailureCount = in.readVLong();
+            }
 
             scrollCount = in.readVLong();
             scrollTimeInMillis = in.readVLong();
@@ -255,12 +228,16 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeVLong(queryCount);
             out.writeVLong(queryTimeInMillis);
             out.writeVLong(queryCurrent);
-            out.writeVLong(queryFailureCount);
+            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+                out.writeVLong(queryFailureCount);
+            }
 
             out.writeVLong(fetchCount);
             out.writeVLong(fetchTimeInMillis);
             out.writeVLong(fetchCurrent);
-            out.writeVLong(fetchFailureCount);
+            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+                out.writeVLong(fetchFailureCount);
+            }
 
             out.writeVLong(scrollCount);
             out.writeVLong(scrollTimeInMillis);

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -73,6 +73,7 @@ public final class ShardSearchStats implements SearchOperationListener {
                 statsHolder.suggestCurrent.dec();
             } else {
                 statsHolder.queryCurrent.dec();
+                statsHolder.queryFailureMetric.inc(1);
             }
         });
     }
@@ -97,7 +98,10 @@ public final class ShardSearchStats implements SearchOperationListener {
 
     @Override
     public void onFailedFetchPhase(SearchContext searchContext) {
-        computeStats(searchContext, statsHolder -> statsHolder.fetchCurrent.dec());
+        computeStats(searchContext, statsHolder -> {
+            statsHolder.fetchCurrent.dec();
+            statsHolder.fetchFailureMetric.inc(1);
+        });
     }
 
     @Override
@@ -156,6 +160,8 @@ public final class ShardSearchStats implements SearchOperationListener {
     static final class StatsHolder {
         final MeanMetric queryMetric = new MeanMetric();
         final MeanMetric fetchMetric = new MeanMetric();
+        final MeanMetric queryFailureMetric = new MeanMetric();
+        final MeanMetric fetchFailureMetric = new MeanMetric();
         /* We store scroll statistics in microseconds because with nanoseconds we run the risk of overflowing the total stats if there are
          * many scrolls. For example, on a system with 2^24 scrolls that have been executed, each executing for 2^10 seconds, then using
          * nanoseconds would require a numeric representation that can represent at least 2^24 * 2^10 * 10^9 > 2^24 * 2^10 * 2^29 = 2^63
@@ -175,9 +181,11 @@ public final class ShardSearchStats implements SearchOperationListener {
                 queryMetric.count(),
                 TimeUnit.NANOSECONDS.toMillis(queryMetric.sum()),
                 queryCurrent.count(),
+                queryFailureMetric.count(),
                 fetchMetric.count(),
                 TimeUnit.NANOSECONDS.toMillis(fetchMetric.sum()),
                 fetchCurrent.count(),
+                fetchFailureMetric.count(),
                 scrollMetric.count(),
                 TimeUnit.MICROSECONDS.toMillis(scrollMetric.sum()),
                 scrollCurrent.count(),

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -160,8 +160,8 @@ public final class ShardSearchStats implements SearchOperationListener {
     static final class StatsHolder {
         final MeanMetric queryMetric = new MeanMetric();
         final MeanMetric fetchMetric = new MeanMetric();
-        final MeanMetric queryFailureMetric = new MeanMetric();
-        final MeanMetric fetchFailureMetric = new MeanMetric();
+        final CounterMetric queryFailureMetric = new CounterMetric();
+        final CounterMetric fetchFailureMetric = new CounterMetric();
         /* We store scroll statistics in microseconds because with nanoseconds we run the risk of overflowing the total stats if there are
          * many scrolls. For example, on a system with 2^24 scrolls that have been executed, each executing for 2^10 seconds, then using
          * nanoseconds would require a numeric representation that can represent at least 2^24 * 2^10 * 10^9 > 2^24 * 2^10 * 2^29 = 2^63

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -482,6 +482,9 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("search.fetch_total", "sibling:pri;alias:sfto,searchFetchTotal;default:false;text-align:right;desc:total fetch ops");
         table.addCell("pri.search.fetch_total", "default:false;text-align:right;desc:total fetch ops");
 
+        table.addCell("search.fetch_failure_total", "sibling:pri;alias:sfto,searchFetchFailureTotal;default:false;text-align:right;desc:total fetch ops");
+        table.addCell("pri.search.fetch_failure_total", "default:false;text-align:right;desc:total fetch ops");
+
         table.addCell(
             "search.open_contexts",
             "sibling:pri;alias:so,searchOpenContexts;default:false;text-align:right;desc:open search contexts"
@@ -505,6 +508,12 @@ public class RestIndicesAction extends AbstractCatAction {
             "sibling:pri;alias:sqto,searchQueryTotal;default:false;text-align:right;desc:total query phase ops"
         );
         table.addCell("pri.search.query_total", "default:false;text-align:right;desc:total query phase ops");
+
+        table.addCell(
+            "search.query_failure_total",
+            "sibling:pri;alias:sqto,searchQueryFailureTotal;default:false;text-align:right;desc:total query phase ops"
+        );
+        table.addCell("pri.search.query_failure_total", "default:false;text-align:right;desc:total query phase ops");
 
         table.addCell(
             "search.scroll_current",

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -823,6 +823,9 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getTotal().getFetchCount());
             table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getTotal().getFetchCount());
 
+            table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getTotal().getFetchFailureCount());
+            table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getTotal().getFetchFailureCount());
+
             table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getOpenContexts());
             table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getOpenContexts());
 
@@ -834,6 +837,9 @@ public class RestIndicesAction extends AbstractCatAction {
 
             table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getTotal().getQueryCount());
             table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getTotal().getQueryCount());
+
+            table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getTotal().getQueryFailureCount());
+            table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getTotal().getQueryFailureCount());
 
             table.addCell(totalStats.getSearch() == null ? null : totalStats.getSearch().getTotal().getScrollCurrent());
             table.addCell(primaryStats.getSearch() == null ? null : primaryStats.getSearch().getTotal().getScrollCurrent());

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -478,10 +478,12 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(searchStats == null ? null : searchStats.getTotal().getFetchCurrent());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getFetchTime());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getFetchCount());
+            table.addCell(searchStats == null ? null : searchStats.getTotal().getFetchFailureCount());
             table.addCell(searchStats == null ? null : searchStats.getOpenContexts());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getQueryCurrent());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getQueryTime());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getQueryCount());
+            table.addCell(searchStats == null ? null : searchStats.getTotal().getQueryFailureCount());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getScrollCurrent());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getScrollTime());
             table.addCell(searchStats == null ? null : searchStats.getTotal().getScrollCount());

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -257,10 +257,12 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("search.fetch_current", "alias:sfc,searchFetchCurrent;default:false;text-align:right;desc:current fetch phase ops");
         table.addCell("search.fetch_time", "alias:sfti,searchFetchTime;default:false;text-align:right;desc:time spent in fetch phase");
         table.addCell("search.fetch_total", "alias:sfto,searchFetchTotal;default:false;text-align:right;desc:total fetch ops");
+        table.addCell("search.fetch_failure_total", "alias:sfto,searchFetchFailureTotal;default:false;text-align:right;desc:total fetch ops");
         table.addCell("search.open_contexts", "alias:so,searchOpenContexts;default:false;text-align:right;desc:open search contexts");
         table.addCell("search.query_current", "alias:sqc,searchQueryCurrent;default:false;text-align:right;desc:current query phase ops");
         table.addCell("search.query_time", "alias:sqti,searchQueryTime;default:false;text-align:right;desc:time spent in query phase");
         table.addCell("search.query_total", "alias:sqto,searchQueryTotal;default:false;text-align:right;desc:total query phase ops");
+        table.addCell("search.query_failure_total", "alias:sqto,searchQueryFailureTotal;default:false;text-align:right;desc:total query phase ops");
         table.addCell("search.scroll_current", "alias:scc,searchScrollCurrent;default:false;text-align:right;desc:open scroll contexts");
         table.addCell(
             "search.scroll_time",

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -239,7 +239,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private final QueryPhase queryPhase;
 
-    private final FetchPhase fetchPhase;
+    protected final FetchPhase fetchPhase;
 
     private volatile long defaultKeepAlive;
 
@@ -448,7 +448,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     /**
      * Try to load the query results from the cache or execute the query phase directly if the cache cannot be used.
      */
-    private void loadOrExecuteQueryPhase(final ShardSearchRequest request, final SearchContext context) throws Exception {
+    protected void loadOrExecuteQueryPhase(final ShardSearchRequest request, final SearchContext context) throws Exception {
         final boolean canCache = indicesService.canCache(request, context);
         context.getSearchExecutionContext().freezeContext();
         if (canCache) {
@@ -483,7 +483,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }));
     }
 
-    private <T> void ensureAfterSeqNoRefreshed(
+    protected <T> void ensureAfterSeqNoRefreshed(
         IndexShard shard,
         ShardSearchRequest request,
         CheckedSupplier<T, Exception> executable,
@@ -592,7 +592,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         runnable.run();
     }
 
-    private IndexShard getShard(ShardSearchRequest request) {
+    protected IndexShard getShard(ShardSearchRequest request) {
         final ShardSearchContextId contextId = request.readerId();
         if (contextId != null) {
             if (sessionId.equals(contextId.getSessionId())) {
@@ -1068,7 +1068,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
     }
 
-    private long getKeepAlive(ShardSearchRequest request) {
+    protected long getKeepAlive(ShardSearchRequest request) {
         if (request.scroll() != null) {
             return getScrollKeepAlive(request.scroll());
         } else if (request.keepAlive() != null) {
@@ -1350,7 +1350,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      * Shortcut ids to load, we load only "from" and up to "size". The phase controller
      * handles this as well since the result is always size * shards for Q_T_F
      */
-    private void shortcutDocIdsToLoad(SearchContext context) {
+    protected void shortcutDocIdsToLoad(SearchContext context) {
         final int[] docIdsToLoad;
         int docsOffset = 0;
         final Suggest suggest = context.queryResult().suggest();
@@ -1464,7 +1464,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         return canMatch(request, true);
     }
 
-    private CanMatchShardResponse canMatch(ShardSearchRequest request, boolean checkRefreshPending) throws IOException {
+    protected CanMatchShardResponse canMatch(ShardSearchRequest request, boolean checkRefreshPending) throws IOException {
         assert request.searchType() == SearchType.QUERY_THEN_FETCH : "unexpected search type: " + request.searchType();
         Releasable releasable = null;
         try {
@@ -1559,7 +1559,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void rewriteAndFetchShardRequest(IndexShard shard, ShardSearchRequest request, ActionListener<ShardSearchRequest> listener) {
+    protected void rewriteAndFetchShardRequest(IndexShard shard, ShardSearchRequest request, ActionListener<ShardSearchRequest> listener) {
         ActionListener<Rewriteable> actionListener = ActionListener.wrap(r -> {
             if (request.readerId() != null) {
                 listener.onResponse(request);
@@ -1625,7 +1625,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      * This helper class ensures we only execute either the success or the failure path for {@link SearchOperationListener}.
      * This is crucial for some implementations like {@link org.elasticsearch.index.search.stats.ShardSearchStats}.
      */
-    private static final class SearchOperationListenerExecutor implements AutoCloseable {
+    protected static final class SearchOperationListenerExecutor implements AutoCloseable {
         private final SearchOperationListener listener;
         private final SearchContext context;
         private final long time;

--- a/server/src/test/java/org/elasticsearch/index/search/stats/SearchStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/stats/SearchStatsTests.java
@@ -21,9 +21,9 @@ public class SearchStatsTests extends ESTestCase {
         // let's create two dummy search stats with groups
         Map<String, Stats> groupStats1 = new HashMap<>();
         Map<String, Stats> groupStats2 = new HashMap<>();
-        groupStats2.put("group1", new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
-        SearchStats searchStats1 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats1);
-        SearchStats searchStats2 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats2);
+        groupStats2.put("group1", new Stats(1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1));
+        SearchStats searchStats1 = new SearchStats(new Stats(1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1), 0, groupStats1);
+        SearchStats searchStats2 = new SearchStats(new Stats(1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1), 0, groupStats2);
 
         // adding these two search stats and checking group stats are correct
         searchStats1.add(searchStats2);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -400,7 +400,7 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
         final IndexingStats.Stats indexingStats = new IndexingStats.Stats(++iota, ++iota, no, no, no, no, no, no, false, ++iota);
         commonStats.getIndexing().add(new IndexingStats(indexingStats));
 
-        final SearchStats.Stats searchStats = new SearchStats.Stats(++iota, ++iota, no, no, no, no, no, no, no, no, no, no);
+        final SearchStats.Stats searchStats = new SearchStats.Stats(++iota, ++iota, no, no, no, no, no, no, no, no, no, no, no, no);
         commonStats.getSearch().add(new SearchStats(searchStats, no, null));
 
         final SegmentsStats segmentsStats = new SegmentsStats();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -185,7 +185,7 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
         final IndexingStats.Stats indexingStats = new IndexingStats.Stats(3L, 4L, 0L, 0L, 0L, 0L, 0L, 0L, true, 5L);
         commonStats.getIndexing().add(new IndexingStats(indexingStats));
 
-        final SearchStats.Stats searchStats = new SearchStats.Stats(6L, 7L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
+        final SearchStats.Stats searchStats = new SearchStats.Stats(6L, 7L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
         commonStats.getSearch().add(new SearchStats(searchStats, 0L, null));
 
         final BulkStats bulkStats = new BulkStats(0L, 0L, 0L, 0L, 0L);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -334,7 +334,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
         indicesCommonStats.getQueryCache().add(new QueryCacheStats(++iota, ++iota, ++iota, ++iota, no));
         indicesCommonStats.getRequestCache().add(new RequestCacheStats(++iota, ++iota, ++iota, ++iota));
 
-        final SearchStats.Stats searchStats = new SearchStats.Stats(++iota, ++iota, no, no, no, no, no, no, no, no, no, no);
+        final SearchStats.Stats searchStats = new SearchStats.Stats(++iota, ++iota, no, no, no, no, no, no, no, no, no, no, no, no);
         indicesCommonStats.getSearch().add(new SearchStats(searchStats, no, null));
 
         final SegmentsStats segmentsStats = new SegmentsStats();


### PR DESCRIPTION
Added query_failure_total and fetch_failure_total. 
The only concern I have is whether we need some migration for older versions. Or is it enough to leave it as is?
May be the test is not elegant enough, but that's the only way to test it that I've found.
