### PR TITLE
Fix task manager tests, use reserved port range

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -42,6 +42,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.nio.MockNioTransport;
 import org.junit.After;
 import org.junit.Before;
@@ -76,8 +77,12 @@ public abstract class TaskManagerTestCase extends ESTestCase {
     public void setupTestNodes(Settings settings) {
         nodesCount = randomIntBetween(2, 10);
         testNodes = new TestNode[nodesCount];
+        final Settings reservedPortRangeSettings = Settings.builder()
+            .put(TransportSettings.PORT.getKey(), getPortRange())
+            .put(settings)
+            .build();
         for (int i = 0; i < testNodes.length; i++) {
-            testNodes[i] = new TestNode("node" + i, threadPool, settings);
+            testNodes[i] = new TestNode("node" + i, threadPool, reservedPortRangeSettings);
         }
     }
 


### PR DESCRIPTION
TransportTasksActionTests#testFailedTasksCount would rarely fail, with
symptoms looking like an external client connecting and doing a
handshake. Now switch to using the test worker specific port range.

Relates #69731
