### PR TITLE
Make ForbiddenApisPrecommitPlugin plugin Gradle 8.0 compatible

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.precommit;
+
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis;
+
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
+
+/**
+ * This implementation is used to fix gradle 8 compatibility of
+ * the CheckForbiddenApis task which is built with gradle 4 support
+ * in mind.
+ * */
+public class CheckForbiddenApisTask extends CheckForbiddenApis {
+
+    /**
+     * Add additional annotation to make this input gradle 8 compliant.
+     * Otherwise we see a deprecation warning here starting with gradle 7.4
+     * */
+    @Override
+    @IgnoreEmptyDirectories
+    public FileTree getClassFiles() {
+        return super.getClassFiles();
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -8,19 +8,19 @@
 
 package org.elasticsearch.gradle.internal.precommit;
 
-import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis;
-import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin;
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApisExtension;
 import groovy.lang.Closure;
 
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask;
 import org.elasticsearch.gradle.internal.InternalPlugin;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParams;
-import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
-import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -29,10 +29,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin.FORBIDDEN_APIS_EXTENSION_NAME;
+import static de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME;
+
 public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin implements InternalPlugin {
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
-        project.getPluginManager().apply(ForbiddenApisPlugin.class);
+        project.getPluginManager().apply(JavaBasePlugin.class);
+
+        // create Extension for defaults:
+        var checkForbiddenApisExtension = project.getExtensions()
+            .create(FORBIDDEN_APIS_EXTENSION_NAME, CheckForbiddenApisExtension.class, project);
+
+        // Create a convenience task for all checks (this does not conflict with extension, as it has higher priority in DSL):
+        var forbiddenTask = project.getTasks()
+            .register(FORBIDDEN_APIS_TASK_NAME, task -> { task.setDescription("Runs forbidden-apis checks."); });
+
+        JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+        // Define our tasks (one for each SourceSet):
 
         TaskProvider<ExportElasticsearchBuildResourcesTask> resourcesTask = project.getTasks()
             .register("forbiddenApisResources", ExportElasticsearchBuildResourcesTask.class);
@@ -47,76 +61,69 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin implements Int
             t.copy("forbidden/es-server-signatures.txt");
             t.copy("forbidden/snakeyaml-signatures.txt");
         });
-        project.getTasks().withType(CheckForbiddenApis.class).configureEach(t -> {
-            t.dependsOn(resourcesTask);
 
-            assert t.getName().startsWith(ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME);
-            String sourceSetName;
-            if (ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME.equals(t.getName())) {
-                sourceSetName = "main";
-            } else {
-                // parse out the sourceSetName
-                char[] chars = t.getName().substring(ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME.length()).toCharArray();
-                chars[0] = Character.toLowerCase(chars[0]);
-                sourceSetName = new String(chars);
-            }
-
-            SourceSetContainer sourceSets = GradleUtils.getJavaSourceSets(project);
-            SourceSet sourceSet = sourceSets.getByName(sourceSetName);
-            t.setClasspath(project.files(sourceSet.getRuntimeClasspath()).plus(sourceSet.getCompileClasspath()));
-
-            t.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion().getMajorVersion());
-            t.setBundledSignatures(Set.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out"));
-            t.setSignaturesFiles(
-                project.files(
-                    resourcesDir.resolve("forbidden/jdk-signatures.txt"),
-                    resourcesDir.resolve("forbidden/es-all-signatures.txt"),
-                    resourcesDir.resolve("forbidden/jdk-deprecated.txt")
-                )
-            );
-            t.setSuppressAnnotations(Set.of("**.SuppressForbidden"));
-            if (t.getName().endsWith("Test")) {
+        project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+            String sourceSetTaskName = sourceSet.getTaskName(FORBIDDEN_APIS_TASK_NAME, null);
+            var sourceSetTask = project.getTasks().register(sourceSetTaskName, CheckForbiddenApisTask.class, t -> {
+                t.setDescription("Runs forbidden-apis checks on '${sourceSet.name}' classes.");
+                t.dependsOn(sourceSet.getOutput());
+                t.getOutputs().upToDateWhen(Specs.SATISFIES_ALL);
+                t.setClassesDirs(sourceSet.getOutput().getClassesDirs());
+                t.dependsOn(resourcesTask);
+                t.setClasspath(project.files(sourceSet.getRuntimeClasspath()).plus(sourceSet.getCompileClasspath()));
+                t.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion().getMajorVersion());
+                t.setBundledSignatures(Set.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out"));
                 t.setSignaturesFiles(
-                    t.getSignaturesFiles()
-                        .plus(
-                            project.files(
-                                resourcesDir.resolve("forbidden/es-test-signatures.txt"),
-                                resourcesDir.resolve("forbidden/http-signatures.txt")
+                    project.files(
+                        resourcesDir.resolve("forbidden/jdk-signatures.txt"),
+                        resourcesDir.resolve("forbidden/es-all-signatures.txt"),
+                        resourcesDir.resolve("forbidden/jdk-deprecated.txt")
+                    )
+                );
+                t.setSuppressAnnotations(Set.of("**.SuppressForbidden"));
+                if (t.getName().endsWith("Test")) {
+                    t.setSignaturesFiles(
+                        t.getSignaturesFiles()
+                            .plus(
+                                project.files(
+                                    resourcesDir.resolve("forbidden/es-test-signatures.txt"),
+                                    resourcesDir.resolve("forbidden/http-signatures.txt")
+                                )
                             )
-                        )
-                );
-            } else {
-                t.setSignaturesFiles(
-                    t.getSignaturesFiles().plus(project.files(resourcesDir.resolve("forbidden/es-server-signatures.txt")))
-                );
-            }
-            ExtraPropertiesExtension ext = t.getExtensions().getExtraProperties();
-            ext.set("replaceSignatureFiles", new Closure<Void>(t) {
-                @Override
-                public Void call(Object... names) {
-                    List<Path> resources = new ArrayList<>(names.length);
-                    for (Object name : names) {
-                        resources.add(resourcesDir.resolve("forbidden/" + name + ".txt"));
-                    }
-                    t.setSignaturesFiles(project.files(resources));
-                    return null;
+                    );
+                } else {
+                    t.setSignaturesFiles(
+                        t.getSignaturesFiles().plus(project.files(resourcesDir.resolve("forbidden/es-server-signatures.txt")))
+                    );
                 }
+                ExtraPropertiesExtension ext = t.getExtensions().getExtraProperties();
+                ext.set("replaceSignatureFiles", new Closure<Void>(t) {
+                    @Override
+                    public Void call(Object... names) {
+                        List<Path> resources = new ArrayList<>(names.length);
+                        for (Object name : names) {
+                            resources.add(resourcesDir.resolve("forbidden/" + name + ".txt"));
+                        }
+                        t.setSignaturesFiles(project.files(resources));
+                        return null;
+                    }
+
+                });
+                ext.set("addSignatureFiles", new Closure<Void>(t) {
+                    @Override
+                    public Void call(Object... names) {
+                        List<Path> resources = new ArrayList<>(names.length);
+                        for (Object name : names) {
+                            resources.add(resourcesDir.resolve("forbidden/" + name + ".txt"));
+                        }
+                        t.setSignaturesFiles(t.getSignaturesFiles().plus(project.files(resources)));
+                        return null;
+                    }
+                });
 
             });
-            ext.set("addSignatureFiles", new Closure<Void>(t) {
-                @Override
-                public Void call(Object... names) {
-                    List<Path> resources = new ArrayList<>(names.length);
-                    for (Object name : names) {
-                        resources.add(resourcesDir.resolve("forbidden/" + name + ".txt"));
-                    }
-                    t.setSignaturesFiles(t.getSignaturesFiles().plus(project.files(resources)));
-                    return null;
-                }
-            });
+            forbiddenTask.configure(t -> t.dependsOn(sourceSetTask));
         });
-        TaskProvider<Task> forbiddenApis = project.getTasks().named("forbiddenApis");
-        forbiddenApis.configure(t -> t.setGroup(""));
-        return forbiddenApis;
+        return forbiddenTask;
     }
 }


### PR DESCRIPTION
This makes the forbidden apis precommit plugin compatible with Gradle 8.0 (fixing deprecation warnings we start seeing with Gradle 7.4). Furthermore we port the task and plugin implementation to support configuration on demand better. (#57918)