### PR TITLE
Fix version resolution and encoding in LLRC

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -17,6 +17,8 @@
  * under the License.
  */
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersTask
 
 apply plugin: 'elasticsearch.build'
@@ -48,7 +50,9 @@ dependencies {
 }
 
 tasks.named("processResources").configure {
-  expand versions: versions
+  expand versions: [
+    elasticsearch: VersionProperties.getElasticsearch()
+  ]
 }
 
 tasks.withType(CheckForbiddenApis).configureEach {

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -53,7 +53,7 @@ public final class RestClientBuilder {
     public static final int DEFAULT_MAX_CONN_PER_ROUTE = 10;
     public static final int DEFAULT_MAX_CONN_TOTAL = 30;
 
-    static final String VERSION;
+    public static final String VERSION;
     static final String META_HEADER_NAME = "X-Elastic-Client-Meta";
     private static final String META_HEADER_VALUE;
     private static final String USER_AGENT_HEADER_VALUE;
@@ -111,13 +111,20 @@ public final class RestClientBuilder {
             // Keep unknown
         }
 
+        // Use a single 'p' suffix for all prerelease versions (snapshot, beta, etc).
+        String metaVersion = version;
+        int dashPos = metaVersion.indexOf('-');
+        if (dashPos > 0) {
+            metaVersion = metaVersion.substring(0, dashPos) + "p";
+        }
+
         // service, language, transport, followed by additional information
         META_HEADER_VALUE = "es="
-            + VERSION
+            + metaVersion
             + ",jv="
             + System.getProperty("java.specification.version")
             + ",t="
-            + VERSION
+            + metaVersion
             + ",hc="
             + (httpClientVersion == null ? "" : httpClientVersion.getRelease())
             + LanguageRuntimeVersions.getRuntimeMetadata();

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -365,7 +365,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         Request request = new Request("GET", "/200");
         Response esResponse = RestClientSingleHostTests.performRequestSyncOrAsync(restClient, request);
         String header = esResponse.getHeader(RestClientBuilder.META_HEADER_NAME);
-        assertTrue(header.matches("^es=[^,]*,jv=[^,]+,t=[^,]*,hc=.*"));
+        assertTrue(header.matches("^es=[0-9]+\\.[0-9]+\\.[0-9]+p?,jv=[^,]+,t=[^,]*,hc=.*"));
 
         // Also check user-agent
         header = esResponse.getHeader("User-Agent");


### PR DESCRIPTION
The value of `versions.elasticsearch` in the Gradle build is always suffixed with `-SNAPSHOT` even for release builds, which led LLRC to incorrectly always report a snapshot version.

This PR updates version resolution to use `VersionProperties.getElasticsearch()`, which is based on the processed `version.properties` file (and is used to set the version in [Elasticsearch's jar manifests](https://github.com/elastic/elasticsearch/blob/62d2df4f6a6399ea964afe436c627f902ea808d6/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java#L107)).

This PR also fixes version encoding in the client meta header, where prerelease versions should be encoded with a single 'p' suffix instead of the full suffix (e.g. `-beta`, `-SNAPSHOT`) and makes the LLRC version field public for use by other libraries like the new Java client.