### PR TITLE
[DOC] ILM Searchable Snapshot action hot/cold

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -16,6 +16,8 @@ setting to mount the index directly to the phase's corresponding data tier. In
 the frozen phase, the action mounts a <<partially-mounted,partially mounted
 index>> prefixed with `partial-` to the frozen tier. In other phases, the action mounts a
 <<fully-mounted,fully mounted index>> prefixed with `restored-` to the corresponding data tier.
+The `searchable_snapshot` action should only be included in either hot or cold phases, but
+not both.
 
 If the `searchable_snapshot` action is used in the hot phase the subsequent
 phases cannot include the `shrink` or `forcemerge` actions.

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -16,8 +16,10 @@ setting to mount the index directly to the phase's corresponding data tier. In
 the frozen phase, the action mounts a <<partially-mounted,partially mounted
 index>> prefixed with `partial-` to the frozen tier. In other phases, the action mounts a
 <<fully-mounted,fully mounted index>> prefixed with `restored-` to the corresponding data tier.
-The `searchable_snapshot` action should only be included in either hot or cold phases, but
-not both.
+
+WARNING: Don't include the `searchable_snapshot` action in both the hot and cold
+phases. This can result in indices failing to automatically migrate to the cold
+tier during the cold phase.
 
 If the `searchable_snapshot` action is used in the hot phase the subsequent
 phases cannot include the `shrink` or `forcemerge` actions.


### PR DESCRIPTION
We've known but not Doc explicated [Searchable Snapshot](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-searchable-snapshot.html) shouldn't be listed to occur under both hot/cold phases.

Re: https://github.com/elastic/elasticsearch/issues/81604.

Preview: https://elasticsearch_82013.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-searchable-snapshot.html#ilm-searchable-snapshot