### PR TITLE
[7.17] [ML] Improve cleanup for model snapshot upgrades

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcher.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.core.action.util;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcher.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.action.util;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -173,6 +174,47 @@ public final class ExpandedIdsMatcher {
      */
     public boolean isOnlyExact() {
         return onlyExact;
+    }
+
+    /**
+     * A simple matcher with one purpose to test whether an id
+     * matches a expression that may contain wildcards.
+     * Use the {@link #idMatches(String)} function to
+     * test if the given id is matched by any of the matchers.
+     *
+     * Unlike {@link ExpandedIdsMatcher} there is no
+     * allowNoMatchForWildcards logic and the matchers
+     * are not be removed once they have been matched.
+     */
+    public static class SimpleIdsMatcher {
+
+        private final List<IdMatcher> matchers;
+
+        public SimpleIdsMatcher(String[] tokens) {
+
+            if (Strings.isAllOrWildcard(tokens)) {
+                matchers = Collections.singletonList(new WildcardMatcher("*"));
+                return;
+            }
+
+            matchers = Arrays.stream(tokens)
+                .map(token -> Regex.isSimpleMatchPattern(token) ? new WildcardMatcher(token) : new EqualsIdMatcher(token))
+                .collect(Collectors.toList());
+        }
+
+        public SimpleIdsMatcher(String expression) {
+            this(tokenizeExpression(expression));
+        }
+
+        /**
+         * Do any of the matchers match {@code id}?
+         *
+         * @param id Id to test
+         * @return True if the given id is matched by any of the matchers
+         */
+        public boolean idMatches(String id) {
+            return matchers.stream().anyMatch(idMatcher -> idMatcher.matches(id));
+        }
     }
 
     private abstract static class IdMatcher {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeAction.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class CancelJobModelSnapshotUpgradeAction extends ActionType<CancelJobModelSnapshotUpgradeAction.Response> {
+
+    public static final CancelJobModelSnapshotUpgradeAction INSTANCE = new CancelJobModelSnapshotUpgradeAction();
+
+    // Even though at the time of writing this action doesn't have a REST endpoint the action name is
+    // still "admin" rather than "internal". This is because there's no conceptual reason why this
+    // action couldn't have a REST endpoint in the future, and it's painful to change these action
+    // names after release. The only difference is that in 7.17 the last remaining transport client
+    // users will be able to call this endpoint. In 8.x there is no transport client, so in 8.x there
+    // is no difference between having "admin" and "internal" here in the period before a REST endpoint
+    // exists. Using "admin" just makes life easier if we ever decide to add a REST endpoint in the
+    // future.
+    public static final String NAME = "cluster:admin/xpack/ml/job/model_snapshots/upgrade/cancel";
+
+    private CancelJobModelSnapshotUpgradeAction() {
+        super(NAME, Response::new);
+    }
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+
+        public static final String ALL = "_all";
+
+        public static final ParseField SNAPSHOT_ID = new ParseField("snapshot_id");
+        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
+
+        static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
+
+        static {
+            PARSER.declareString(Request::setJobId, Job.ID);
+            PARSER.declareString(Request::setSnapshotId, SNAPSHOT_ID);
+            PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
+        }
+
+        private String jobId = ALL;
+        private String snapshotId = ALL;
+        private boolean allowNoMatch = true;
+
+        public Request() {}
+
+        public Request(String jobId, String snapshotId) {
+            setJobId(jobId);
+            setSnapshotId(snapshotId);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            snapshotId = in.readString();
+            allowNoMatch = in.readBoolean();
+        }
+
+        public final Request setJobId(String jobId) {
+            this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID);
+            return this;
+        }
+
+        public String getJobId() {
+            return jobId;
+        }
+
+        public final Request setSnapshotId(String snapshotId) {
+            this.snapshotId = ExceptionsHelper.requireNonNull(snapshotId, Job.ID);
+            return this;
+        }
+
+        public String getSnapshotId() {
+            return snapshotId;
+        }
+
+        public boolean allowNoMatch() {
+            return allowNoMatch;
+        }
+
+        public Request setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
+            return this;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(jobId);
+            out.writeString(snapshotId);
+            out.writeBoolean(allowNoMatch);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .field(Job.ID.getPreferredName(), jobId)
+                .field(SNAPSHOT_ID.getPreferredName(), snapshotId)
+                .field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch)
+                .endObject();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(jobId, snapshotId, allowNoMatch);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(jobId, other.jobId) && Objects.equals(snapshotId, other.snapshotId) && allowNoMatch == other.allowNoMatch;
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+    }
+
+    public static class Response extends ActionResponse implements Writeable, ToXContentObject {
+
+        private final boolean cancelled;
+
+        public Response(boolean cancelled) {
+            this.cancelled = cancelled;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            cancelled = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(cancelled);
+        }
+
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("cancelled", cancelled);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return cancelled == response.cancelled;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(cancelled);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeActionRequestTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction.Request;
+
+public class CancelJobModelSnapshotUpgradeActionRequestTests extends AbstractSerializingTestCase<Request> {
+
+    @Override
+    protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20));
+        if (randomBoolean()) {
+            request.setAllowNoMatch(randomBoolean());
+        }
+        return request;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request doParseInstance(XContentParser parser) {
+        return Request.PARSER.apply(parser, null);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeActionResponseTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction.Response;
+
+public class CancelJobModelSnapshotUpgradeActionResponseTests extends AbstractWireSerializingTestCase<Response> {
+
+    @Override
+    protected Response createTestInstance() {
+        return new Response(randomBoolean());
+    }
+
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return CancelJobModelSnapshotUpgradeAction.Response::new;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCancelJobModelSnapshotUpgradeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCancelJobModelSnapshotUpgradeAction.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher.SimpleIdsMatcher;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction.Request;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction.Response;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskParams;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class TransportCancelJobModelSnapshotUpgradeAction extends HandledTransportAction<Request, Response> {
+
+    private static final Logger logger = LogManager.getLogger(TransportCancelJobModelSnapshotUpgradeAction.class);
+
+    private final JobConfigProvider jobConfigProvider;
+    private final ClusterService clusterService;
+    private final PersistentTasksService persistentTasksService;
+
+    @Inject
+    public TransportCancelJobModelSnapshotUpgradeAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        JobConfigProvider jobConfigProvider,
+        ClusterService clusterService,
+        PersistentTasksService persistentTasksService
+    ) {
+        super(CancelJobModelSnapshotUpgradeAction.NAME, transportService, actionFilters, Request::new);
+        this.jobConfigProvider = jobConfigProvider;
+        this.clusterService = clusterService;
+        this.persistentTasksService = persistentTasksService;
+    }
+
+    @Override
+    public void doExecute(Task task, Request request, ActionListener<Response> listener) {
+
+        logger.debug("[{}] cancel model snapshot [{}] upgrades", request.getJobId(), request.getSnapshotId());
+
+        // 2. Now that we have the job IDs, find the relevant model snapshot upgrade tasks
+        ActionListener<List<Job.Builder>> expandIdsListener = ActionListener.wrap(jobs -> {
+            SimpleIdsMatcher matcher = new SimpleIdsMatcher(request.getSnapshotId());
+            Set<String> jobIds = jobs.stream().map(Job.Builder::getId).collect(Collectors.toSet());
+            PersistentTasksCustomMetadata tasksInProgress = clusterService.state().metadata().custom(PersistentTasksCustomMetadata.TYPE);
+            // allow_no_match plays no part here. The reason is that we have a principle that stopping
+            // a stopped entity is a no-op, and upgrades that have already completed won't have a task.
+            // This is a bit different to jobs and datafeeds, where the entity continues to exist even
+            // after it's stopped. Upgrades cease to exist after they're stopped so the match validation
+            // cannot be as thorough.
+            List<PersistentTasksCustomMetadata.PersistentTask<?>> upgradeTasksToCancel = MlTasks.snapshotUpgradeTasks(tasksInProgress)
+                .stream()
+                .filter(t -> jobIds.contains(((SnapshotUpgradeTaskParams) t.getParams()).getJobId()))
+                .filter(t -> matcher.idMatches(((SnapshotUpgradeTaskParams) t.getParams()).getSnapshotId()))
+                .collect(Collectors.toList());
+            removePersistentTasks(request, upgradeTasksToCancel, listener);
+        }, listener::onFailure);
+
+        // 1. Expand jobs - this will throw if a required job ID match isn't made. Jobs being deleted are included here.
+        jobConfigProvider.expandJobs(request.getJobId(), request.allowNoMatch(), false, expandIdsListener);
+    }
+
+    private void removePersistentTasks(
+        Request request,
+        List<PersistentTasksCustomMetadata.PersistentTask<?>> upgradeTasksToCancel,
+        ActionListener<Response> listener
+    ) {
+        final int numberOfTasks = upgradeTasksToCancel.size();
+        if (numberOfTasks == 0) {
+            listener.onResponse(new Response(true));
+            return;
+        }
+
+        final AtomicInteger counter = new AtomicInteger();
+        final AtomicArray<Exception> failures = new AtomicArray<>(numberOfTasks);
+
+        for (PersistentTasksCustomMetadata.PersistentTask<?> task : upgradeTasksToCancel) {
+            persistentTasksService.sendRemoveRequest(task.getId(), new ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>>() {
+                @Override
+                public void onResponse(PersistentTasksCustomMetadata.PersistentTask<?> task) {
+                    if (counter.incrementAndGet() == numberOfTasks) {
+                        sendResponseOrFailure(listener, failures);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    final int slot = counter.incrementAndGet();
+                    // Not found is not an error - it just means the upgrade completed before we could cancel it.
+                    if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException == false) {
+                        failures.set(slot - 1, e);
+                    }
+                    if (slot == numberOfTasks) {
+                        sendResponseOrFailure(listener, failures);
+                    }
+                }
+
+                private void sendResponseOrFailure(ActionListener<Response> listener, AtomicArray<Exception> failures) {
+                    List<Exception> caughtExceptions = failures.asList();
+                    if (caughtExceptions.isEmpty()) {
+                        listener.onResponse(new Response(true));
+                        return;
+                    }
+
+                    String msg = "Failed to cancel model snapshot upgrade for ["
+                        + request.getSnapshotId()
+                        + "] on job ["
+                        + request.getJobId()
+                        + "]. Total failures ["
+                        + caughtExceptions.size()
+                        + "], rethrowing first, all Exceptions: ["
+                        + caughtExceptions.stream().map(Exception::getMessage).collect(Collectors.joining(", "))
+                        + "]";
+
+                    ElasticsearchException e = new ElasticsearchException(msg, caughtExceptions.get(0));
+                    listener.onFailure(e);
+                }
+            });
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.CancelJobModelSnapshotUpgradeAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
@@ -477,9 +478,9 @@ public class JobManager {
     ) {
         final String jobId = request.getJobId();
 
-        // Step 4. When the job has been removed from the cluster state, return a response
+        // Step 5. When the job has been removed from the config index, return a response
         // -------
-        CheckedConsumer<Boolean, Exception> apiResponseHandler = jobDeleted -> {
+        CheckedConsumer<Boolean, Exception> configResponseHandler = jobDeleted -> {
             if (jobDeleted) {
                 logger.info("Job [" + jobId + "] deleted");
                 auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_DELETED));
@@ -489,28 +490,38 @@ public class JobManager {
             }
         };
 
-        // Step 3. When the physical storage has been deleted, delete the job config document
+        // Step 4. When the physical storage has been deleted, delete the job config document
         // -------
         // Don't report an error if the document has already been deleted
-        CheckedConsumer<Boolean, Exception> deleteJobStateHandler = response -> jobConfigProvider.deleteJob(
+        CheckedConsumer<Boolean, Exception> removeFromCalendarsHandler = response -> jobConfigProvider.deleteJob(
             jobId,
             false,
-            ActionListener.wrap(deleteResponse -> apiResponseHandler.accept(Boolean.TRUE), listener::onFailure)
+            ActionListener.wrap(deleteResponse -> configResponseHandler.accept(Boolean.TRUE), listener::onFailure)
         );
 
-        // Step 2. Remove the job from any calendars
-        CheckedConsumer<Boolean, Exception> removeFromCalendarsHandler = response -> jobResultsProvider.removeJobFromCalendars(
+        // Step 3. Remove the job from any calendars
+        CheckedConsumer<Boolean, Exception> deleteJobStateHandler = response -> jobResultsProvider.removeJobFromCalendars(
             jobId,
-            ActionListener.wrap(deleteJobStateHandler, listener::onFailure)
+            ActionListener.wrap(removeFromCalendarsHandler, listener::onFailure)
         );
 
-        // Step 1. Delete the physical storage
-        new JobDataDeleter(clientToUse, jobId).deleteJobDocuments(
-            jobConfigProvider,
-            indexNameExpressionResolver,
-            state,
-            removeFromCalendarsHandler,
+        // Step 2. Delete the physical storage
+        ActionListener<CancelJobModelSnapshotUpgradeAction.Response> cancelUpgradesListener = ActionListener.wrap(
+            r -> new JobDataDeleter(clientToUse, jobId).deleteJobDocuments(
+                jobConfigProvider,
+                indexNameExpressionResolver,
+                state,
+                deleteJobStateHandler,
+                listener::onFailure
+            ),
             listener::onFailure
+        );
+
+        // Step 1. Cancel any model snapshot upgrades that might be in progress
+        clientToUse.execute(
+            CancelJobModelSnapshotUpgradeAction.INSTANCE,
+            new CancelJobModelSnapshotUpgradeAction.Request(jobId, "_all"),
+            cancelUpgradesListener
         );
     }
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -156,6 +156,7 @@ public class Constants {
         "cluster:admin/xpack/ml/job/model_snapshots/revert",
         "cluster:admin/xpack/ml/job/model_snapshots/update",
         "cluster:admin/xpack/ml/job/model_snapshots/upgrade",
+        "cluster:admin/xpack/ml/job/model_snapshots/upgrade/cancel",
         "cluster:admin/xpack/ml/job/open",
         "cluster:admin/xpack/ml/job/persist",
         "cluster:admin/xpack/ml/job/put",

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
@@ -14,6 +14,9 @@ setup:
             "data_description" : {
                 "format":"xcontent",
                 "time_field":"time"
+            },
+            "analysis_limits" : {
+                "model_memory_limit":"20mb"
             }
           }
 
@@ -93,10 +96,6 @@ setup:
 
 ---
 "Test existing but corrupt snapshot":
-  - skip:
-      version: all
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/81578"
-
   - do:
       ml.upgrade_job_snapshot:
         job_id: "upgrade-model-snapshot"
@@ -110,3 +109,4 @@ setup:
   - match: { count: 1 }
   - match: { model_snapshot_upgrades.0.job_id: "upgrade-model-snapshot" }
   - match: { model_snapshot_upgrades.0.snapshot_id: "1234567890" }
+  - match: { model_snapshot_upgrades.0.state: /failed|loading_old_state/ }


### PR DESCRIPTION
If a model snapshot upgrade persistent task is cancelled then
we now kill any associated C++ process. Previously the C++ process
could hang indefinitely.

Additionally, ML feature reset now cancels any in-progress model
snapshot upgrades before cleaning up job data, and deleting an
anomaly detection job cancels any in-progress model snapshot
upgrades associated with that job before cleaning up the job's
data.

Backport of #81831