### PR TITLE
[8.0] Increase Timeout in SnapshotSTressTestsIT (#82020)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -312,7 +312,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
             }
 
             assertTrue(shouldStop.compareAndSet(false, true));
-            final long permitDeadlineMillis = threadPool.relativeTimeInMillis() + TimeUnit.SECONDS.toMillis(30);
+            final long permitDeadlineMillis = threadPool.relativeTimeInMillis() + TimeUnit.MINUTES.toMillis(2);
 
             final List<String> failedPermitAcquisitions = new ArrayList<>();
             acquirePermitsAtEnd(


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Increase Timeout in SnapshotSTressTestsIT (#82020)