### PR TITLE
[8.0] Mute 3 cat/indices segment tests (#82025)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -25,6 +25,10 @@
 ---
 "Test cat segments output":
 
+  - skip:
+      version: all
+      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/81928"
+
   - do:
       cat.segments: {}
 
@@ -107,6 +111,10 @@
 
 ---
 "Test cat segments using wildcards":
+
+  - skip:
+      version: all
+      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/81928"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -15,6 +15,10 @@
 ---
 "basic segments test":
 
+  - skip:
+      version: all
+      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/81928"
+
   - do:
       indices.create:
         index: index1


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Mute 3 cat/indices segment tests (#82025)