### PR TITLE
update monitoring template alias path

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -10,6 +10,18 @@
               "type": "keyword",
               "ignore_above": 1024
             },
+            "elasticsearch": {
+              "properties": {
+                "cluster": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
             "state": {
               "properties": {
                 "beat": {
@@ -2175,21 +2187,9 @@
             }
           }
         },
-        "elasticsearch": {
-          "properties": {
-            "cluster": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
         "cluster_uuid": {
           "type": "alias",
-          "path": "elasticsearch.cluster.id"
+          "path": "beat.elasticsearch.cluster.id"
         }
       }
     }

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -1808,7 +1808,7 @@
                           "type": "alias",
                           "path": "beat.stats.libbeat.pipeline.clients"
                         },
-                        "event": {
+                        "events": {
                           "properties": {
                             "active": {
                               "type": "alias",

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -22,18 +22,6 @@
             }
           }
         },
-        "elasticsearch": {
-          "properties": {
-            "cluster": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
         "service": {
           "properties": {
             "address": {
@@ -172,6 +160,18 @@
         },
         "kibana": {
           "properties": {
+            "elasticsearch": {
+              "properties": {
+                "cluster": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
             "stats": {
               "properties": {
                 "request": {
@@ -639,7 +639,7 @@
         },
         "cluster_uuid": {
           "type": "alias",
-          "path": "elasticsearch.cluster.id"
+          "path": "kibana.elasticsearch.cluster.id"
         }
       }
     },


### PR DESCRIPTION
### Summary
Rel https://github.com/elastic/kibana/issues/121518

New index templates [were recently introduced](https://github.com/elastic/elasticsearch/pull/81744) for stack monitoring to support metricbeat version 8.
This change applies a couple of updates to beats and kibana mappings.

### Testing
Applied the change to a running elasticsearch and verified the stack monitoring UI now successfully retrieves the aliased informations