### PR TITLE
Add Optimized Method for Merging two Settings Instances

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
@@ -94,8 +94,8 @@ final class SettingsUpdater {
             clusterSettings.validate(persistentFinalSettings, true);
 
             Metadata.Builder metadata = Metadata.builder(currentState.metadata())
-                .transientSettings(Settings.builder().put(transientFinalSettings).put(unknownOrInvalidTransientSettings).build())
-                .persistentSettings(Settings.builder().put(persistentFinalSettings).put(unknownOrInvalidPersistentSettings).build());
+                .transientSettings(transientFinalSettings.merge(unknownOrInvalidTransientSettings))
+                .persistentSettings(persistentFinalSettings.merge(unknownOrInvalidPersistentSettings));
 
             ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
             boolean updatedReadOnly = Metadata.SETTING_READ_ONLY_SETTING.get(metadata.persistentSettings())
@@ -150,10 +150,8 @@ final class SettingsUpdater {
             (e, ex) -> logInvalidSetting(settingsType, e, ex, logger)
         );
         return Tuple.tuple(
-            Settings.builder()
-                .put(settingsWithUnknownOrInvalidArchived.filter(k -> k.startsWith(ARCHIVED_SETTINGS_PREFIX) == false))
-                .put(existingArchivedSettings)
-                .build(),
+            settingsWithUnknownOrInvalidArchived.filter(k -> k.startsWith(ARCHIVED_SETTINGS_PREFIX) == false)
+                .merge(existingArchivedSettings),
             settingsWithUnknownOrInvalidArchived.filter(k -> k.startsWith(ARCHIVED_SETTINGS_PREFIX))
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -358,13 +358,10 @@ public class MetadataRolloverService {
         CreateIndexRequest createIndexRequest,
         Settings settings
     ) {
-        Settings.Builder b = Settings.builder().put(createIndexRequest.settings());
-        if (settings != null) {
-            b.put(settings);
-        }
+        final Settings s = settings == null ? createIndexRequest.settings() : createIndexRequest.settings().merge(settings);
         return new CreateIndexClusterStateUpdateRequest(cause, targetIndexName, providedIndexName).ackTimeout(createIndexRequest.timeout())
             .masterNodeTimeout(createIndexRequest.masterNodeTimeout())
-            .settings(b.build())
+            .settings(s)
             .aliases(createIndexRequest.aliases())
             .waitForActiveShards(ActiveShardCount.NONE) // not waiting for shards here, will wait on the alias switch operation
             .mappings(createIndexRequest.mappings())

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1456,7 +1456,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 if (indexMetadata == null) {
                     throw new IndexNotFoundException(index);
                 }
-                put(IndexMetadata.builder(indexMetadata).settings(Settings.builder().put(indexMetadata.getSettings()).put(settings)));
+                put(IndexMetadata.builder(indexMetadata).settings(indexMetadata.getSettings().merge(settings)));
             }
             return this;
         }
@@ -1691,7 +1691,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 coordinationMetadata,
                 transientSettings,
                 persistentSettings,
-                Settings.builder().put(persistentSettings).put(transientSettings).build(),
+                persistentSettings.merge(transientSettings),
                 hashesOfConsistentSettings,
                 totalNumberOfShards,
                 totalOpenIndexShards,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -866,7 +866,7 @@ public class MetadataCreateIndexService {
         final Settings.Builder indexSettingsBuilder = Settings.builder();
         if (sourceMetadata == null) {
             final Settings.Builder additionalIndexSettings = Settings.builder();
-            final Settings templateAndRequestSettings = Settings.builder().put(combinedTemplateSettings).put(request.settings()).build();
+            final Settings templateAndRequestSettings = combinedTemplateSettings.merge(request.settings());
             final boolean newDataStream = isDataStreamIndex
                 && currentState.getMetadata().dataStreams().containsKey(request.dataStreamName()) == false;
 

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -143,8 +143,8 @@ public abstract class AbstractScopedSettings {
      * method will not change any settings but will fail if any of the settings can't be applied.
      */
     public synchronized Settings validateUpdate(Settings settingsToValidate) {
-        final Settings current = Settings.builder().put(this.settings).put(settingsToValidate).build();
-        final Settings previous = Settings.builder().put(this.settings).put(this.lastSettingsApplied).build();
+        final Settings current = this.settings.merge(settingsToValidate);
+        final Settings previous = this.settings.merge(this.lastSettingsApplied);
         List<RuntimeException> exceptions = new ArrayList<>();
         for (SettingUpdater<?> settingUpdater : settingUpdaters) {
             try {
@@ -173,8 +173,8 @@ public abstract class AbstractScopedSettings {
             // nothing changed in the settings, ignore
             return newSettings;
         }
-        final Settings current = Settings.builder().put(this.settings).put(newSettings).build();
-        final Settings previous = Settings.builder().put(this.settings).put(this.lastSettingsApplied).build();
+        final Settings current = this.settings.merge(newSettings);
+        final Settings previous = this.settings.merge(this.lastSettingsApplied);
         try {
             List<Runnable> applyRunnables = new ArrayList<>();
             for (SettingUpdater<?> settingUpdater : settingUpdaters) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -699,7 +699,7 @@ public final class IndexSettings {
     public IndexSettings(final IndexMetadata indexMetadata, final Settings nodeSettings, IndexScopedSettings indexScopedSettings) {
         scopedSettings = indexScopedSettings.copy(nodeSettings, indexMetadata);
         this.nodeSettings = nodeSettings;
-        this.settings = Settings.builder().put(nodeSettings).put(indexMetadata.getSettings()).build();
+        this.settings = nodeSettings.merge(indexMetadata.getSettings());
         this.index = indexMetadata.getIndex();
         version = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
         logger = Loggers.getLogger(getClass(), index);
@@ -953,7 +953,7 @@ public final class IndexSettings {
             throw new IllegalArgumentException("uuid mismatch on settings update expected: " + restoreUUID + " but was: " + newRestoreUUID);
         }
         this.indexMetadata = indexMetadata;
-        final Settings newIndexSettings = Settings.builder().put(nodeSettings).put(newSettings).build();
+        final Settings newIndexSettings = nodeSettings.merge(newSettings);
         if (same(this.settings, newIndexSettings)) {
             // nothing to update, same settings
             return false;

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -332,7 +332,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
         settings = Objects.isNull(settings) ? Settings.EMPTY : settings;
 
         if (settings.hasValue(IndexMetadata.SETTING_INDEX_HIDDEN) == false) {
-            settings = Settings.builder().put(settings).put(DEFAULT_SETTINGS).build();
+            settings = settings.merge(DEFAULT_SETTINGS);
         }
 
         if (settings.getAsBoolean(IndexMetadata.SETTING_INDEX_HIDDEN, false)) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2163,8 +2163,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public String startMasterOnlyNode(Settings settings) {
-        Settings settings1 = Settings.builder().put(settings).put(masterOnlyNode(settings)).build();
-        return startNode(settings1);
+        return startNode(settings.merge(masterOnlyNode(settings)));
     }
 
     public String startDataOnlyNode() {
@@ -2172,8 +2171,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public String startDataOnlyNode(Settings settings) {
-        Settings settings1 = Settings.builder().put(settings).put(dataOnlyNode(settings)).build();
-        return startNode(settings1);
+        return startNode(settings.merge(dataOnlyNode(settings)));
     }
 
     private synchronized void publishNode(NodeAndClient nodeAndClient) {


### PR DESCRIPTION
Merging two settings shows up hot in some many shards benchmarking due to the
setting interning running on all node settings over and over in `IndexSettings` updates.
This adds a method for merging two settings that exploits the fact that we do not have to
intern settings coming from a `Settings` instance since we know them to be safe.

Relates #77466
