### PR TITLE
[8.0] Remove Requirement for Key Setting on Azure Client Settings (#82030)

### DIFF
--- a/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -93,7 +93,12 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
         final MockSecureSettings secureSettings = new MockSecureSettings();
         String accountName = DEFAULT_ACCOUNT_NAME;
         secureSettings.setString(AzureStorageSettings.ACCOUNT_SETTING.getConcreteSettingForNamespace("test").getKey(), accountName);
-        secureSettings.setString(AzureStorageSettings.KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), key);
+        secureSettings.setString(
+            (randomBoolean() ? AzureStorageSettings.KEY_SETTING : AzureStorageSettings.SAS_TOKEN_SETTING).getConcreteSettingForNamespace(
+                "test"
+            ).getKey(),
+            key
+        );
 
         // see com.azure.storage.blob.BlobUrlParts.parseIpUrl
         final String endpoint = "ignored;DefaultEndpointsProtocol=http;BlobEndpoint=" + httpServerUrl() + "/" + accountName;

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -61,8 +61,7 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "max_retries",
         (key) -> Setting.intSetting(key, DEFAULT_MAX_RETRIES, Setting.Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
     /**
      * Azure endpoint suffix. Default to core.windows.net (CloudStorageAccount.DEFAULT_DNS).
@@ -71,16 +70,14 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "endpoint_suffix",
         key -> Setting.simpleString(key, Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
 
     public static final AffixSetting<TimeValue> TIMEOUT_SETTING = Setting.affixKeySetting(
         AZURE_CLIENT_PREFIX_KEY,
         "timeout",
         (key) -> Setting.timeSetting(key, TimeValue.timeValueMinutes(-1), Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
 
     /** The type of the proxy to connect to azure through. Can be direct (no proxy, default), http or socks */
@@ -88,8 +85,7 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "proxy.type",
         (key) -> new Setting<>(key, "direct", s -> Proxy.Type.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
 
     /** The host name of a proxy to connect to azure through. */
@@ -97,7 +93,6 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "proxy.host",
         (key) -> Setting.simpleString(key, Property.NodeScope),
-        () -> KEY_SETTING,
         () -> ACCOUNT_SETTING,
         () -> PROXY_TYPE_SETTING
     );
@@ -108,7 +103,6 @@ final class AzureStorageSettings {
         "proxy.port",
         (key) -> Setting.intSetting(key, 0, 0, 65535, Setting.Property.NodeScope),
         () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING,
         () -> PROXY_TYPE_SETTING,
         () -> PROXY_HOST_SETTING
     );

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -830,7 +830,7 @@ public class Setting<T> implements ToXContentObject {
          * @return the raw list of dependencies for this setting
          */
         public Set<AffixSettingDependency> getDependencies() {
-            return Collections.unmodifiableSet(dependencies);
+            return dependencies;
         }
 
         @Override


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove Requirement for Key Setting on Azure Client Settings (#82030)