### PR TITLE
[DOC] auto migrate only for default template

### DIFF
--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -24,7 +24,7 @@ indices to switch to node roles.
 [[cloud-migrate-to-node-roles]]
 === Automatically migrate to node roles on {ess} or {ece}
 
-If you are using node attributes on {ess} or {ece}, you will be
+If you are using node attributes from the default template {ess} or {ece}, you will be
 prompted to switch to node roles when you:
 
 * Upgrade to {es} 7.10 or higher

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -24,7 +24,7 @@ indices to switch to node roles.
 [[cloud-migrate-to-node-roles]]
 === Automatically migrate to node roles on {ess} or {ece}
 
-If you are using node attributes from the default template {ess} or {ece}, you will be
+If you are using node attributes from the default deployment template in {ess} or {ece}, you will be
 prompted to switch to node roles when you:
 
 * Upgrade to {es} 7.10 or higher


### PR DESCRIPTION
@DanRoscigno I'm not replicating [this](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/migrate-index-allocation-filters.html#on-prem-migrate-to-node-roles) in ECE, is it only for the default template?