### PR TITLE
[ML] Rationalise trained models error messages

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -115,7 +115,7 @@ public final class Messages {
         "Configuration [{0}] requires minimum node version [{1}] (current minimum node version [{2}]";
     public static final String MODEL_DEFINITION_NOT_FOUND = "Could not find trained model definition [{0}]";
     public static final String MODEL_METADATA_NOT_FOUND = "Could not find trained model metadata {0}";
-    public static final String VOCABULARY_NOT_FOUND = "[{0}] Could not find vocabulary document [{1}] for model ";
+    public static final String VOCABULARY_NOT_FOUND = "Could not find vocabulary document [{1}] for trained model [{0}]";
     public static final String INFERENCE_CANNOT_DELETE_ML_MANAGED_MODEL =
         "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -604,7 +604,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         assertThat(
             response,
             allOf(
-                containsString("Task is configured with [pass_through] but received update of type [ner]"),
+                containsString("Trained model [deployed] is configured for task [pass_through] but called with task [ner]"),
                 containsString("error"),
                 not(containsString("warning"))
             )
@@ -628,7 +628,7 @@ public class PyTorchModelIT extends ESRestTestCase {
             """;
 
         response = EntityUtils.toString(client().performRequest(simulateRequest(source)).getEntity());
-        assertThat(response, containsString("no value could be found for input field [input]"));
+        assertThat(response, containsString("Input field [input] does not exist in the source document"));
         assertThat(response, containsString("status_exception"));
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -488,10 +488,7 @@ public class PyTorchModelIT extends ESRestTestCase {
                   }
             """);
         Exception ex = expectThrows(Exception.class, () -> client().performRequest(request));
-        assertThat(
-            ex.getMessage(),
-            containsString("model [not-deployed] must be deployed to use. Please deploy with the start trained model deployment API.")
-        );
+        assertThat(ex.getMessage(), containsString("Trained model [not-deployed] is not deployed."));
     }
 
     public void testTruncation() throws IOException {
@@ -607,7 +604,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         assertThat(
             response,
             allOf(
-                containsString("inference not possible. Task is configured with [pass_through] but received update of type [ner]"),
+                containsString("Task is configured with [pass_through] but received update of type [ner]"),
                 containsString("error"),
                 not(containsString("warning"))
             )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -83,14 +83,14 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
                     );
                     return;
                 }
-                String message = "Cannot perform requested action because deployment [" + deploymentId + "] is not started";
+                String message = "Trained model [" + deploymentId + "] is not deployed";
                 listener.onFailure(ExceptionsHelper.conflictStatusException(message));
             }, listener::onFailure));
             return;
         }
         String[] randomRunningNode = allocation.getStartedNodes();
         if (randomRunningNode.length == 0) {
-            String message = "Cannot perform requested action because deployment [" + deploymentId + "] is not yet running on any node";
+            String message = "Trained model [" + deploymentId + "] is not allocated to any nodes";
             listener.onFailure(ExceptionsHelper.conflictStatusException(message));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -115,7 +115,7 @@ public class DeploymentManager {
     }
 
     private void doStartDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> finalListener) {
-        logger.debug("[{}] Starting model deployment", task.getModelId());
+        logger.info("[{}] Starting model deployment", task.getModelId());
 
         ProcessContext processContext = new ProcessContext(task, executorServiceForProcess);
 
@@ -216,10 +216,10 @@ public class DeploymentManager {
             processContext = processContextByAllocation.get(task.getId());
         }
         if (processContext != null) {
-            logger.debug("[{}] Stopping deployment", task.getModelId());
+            logger.info("[{}] Stopping deployment", task.getModelId());
             processContext.stopProcess();
         } else {
-            logger.debug("[{}] No process context to stop", task.getModelId());
+            logger.warn("[{}] No process context to stop", task.getModelId());
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -120,7 +120,9 @@ public class DeploymentManager {
         ProcessContext processContext = new ProcessContext(task, executorServiceForProcess);
 
         if (processContextByAllocation.putIfAbsent(task.getId(), processContext) != null) {
-            finalListener.onFailure(ExceptionsHelper.serverError("[{}] Could not create process as one already exists", task.getModelId()));
+            finalListener.onFailure(
+                ExceptionsHelper.serverError("[{}] Could not create inference process as one already exists", task.getModelId())
+            );
             return;
         }
 
@@ -194,7 +196,7 @@ public class DeploymentManager {
         ) {
             return Vocabulary.createParser(true).apply(parser, null);
         } catch (IOException e) {
-            logger.error(new ParameterizedMessage("failed to parse vocabulary [{}]", hit.getId()), e);
+            logger.error(new ParameterizedMessage("failed to parse trained model vocabulary [{}]", hit.getId()), e);
             throw e;
         }
     }
@@ -214,7 +216,7 @@ public class DeploymentManager {
             processContext = processContextByAllocation.get(task.getId());
         }
         if (processContext != null) {
-            logger.info("[{}] Stopping deployment", task.getModelId());
+            logger.debug("[{}] Stopping deployment", task.getModelId());
             processContext.stopProcess();
         } else {
             logger.debug("[{}] No process context to stop", task.getModelId());
@@ -379,8 +381,8 @@ public class DeploymentManager {
                     );
                 processContext.process.get().writeInferenceRequest(request.processInput);
             } catch (IOException e) {
-                logger.error(new ParameterizedMessage("[{}] error writing to process", processContext.task.getModelId()), e);
-                onFailure(ExceptionsHelper.serverError("error writing to process", e));
+                logger.error(new ParameterizedMessage("[{}] error writing to inference process", processContext.task.getModelId()), e);
+                onFailure(ExceptionsHelper.serverError("Error writing to inference process", e));
             } catch (Exception e) {
                 onFailure(e);
             }
@@ -394,7 +396,12 @@ public class DeploymentManager {
             ActionListener<InferenceResults> resultsListener
         ) {
             if (inferenceResult.isError()) {
-                resultsListener.onFailure(new ElasticsearchStatusException(inferenceResult.getError(), RestStatus.INTERNAL_SERVER_ERROR));
+                resultsListener.onFailure(
+                    new ElasticsearchStatusException(
+                        "Error in inference process: [" + inferenceResult.getError() + "]",
+                        RestStatus.INTERNAL_SERVER_ERROR
+                    )
+                );
                 return;
             }
 
@@ -438,7 +445,7 @@ public class DeploymentManager {
             this.stateStreamer = new PyTorchStateStreamer(client, executorService, xContentRegistry);
             this.executorService = new ProcessWorkerExecutorService(
                 threadPool.getThreadContext(),
-                "pytorch_inference",
+                "inference process",
                 task.getParams().getQueueCapacity()
             );
         }
@@ -470,11 +477,11 @@ public class DeploymentManager {
 
         private Consumer<String> onProcessCrash() {
             return reason -> {
-                logger.error("[{}] process crashed due to reason [{}]", task.getModelId(), reason);
+                logger.error("[{}] inference process crashed due to reason [{}]", task.getModelId(), reason);
                 resultProcessor.stop();
                 executorService.shutdownWithError(new IllegalStateException(reason));
                 processContextByAllocation.remove(task.getId());
-                task.setFailed("process crashed due to reason [" + reason + "]");
+                task.setFailed("inference process crashed due to reason [" + reason + "]");
             };
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -112,14 +112,15 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
     public void infer(Map<String, Object> doc, InferenceConfigUpdate update, TimeValue timeout, ActionListener<InferenceResults> listener) {
         if (inferenceConfigHolder.get() == null) {
             listener.onFailure(
-                ExceptionsHelper.conflictStatusException("[{}] inference not possible against uninitialized model", params.getModelId())
+                // inference not possible against uninitialized model"
+                ExceptionsHelper.conflictStatusException("Trained model [{}] is not initialized", params.getModelId())
             );
             return;
         }
         if (update.isSupported(inferenceConfigHolder.get()) == false) {
             listener.onFailure(
                 new ElasticsearchStatusException(
-                    "[{}] inference not possible. Task is configured with [{}] but received update of type [{}]",
+                    "Trained model [{}] is configured for task [{}] but called with task [{}]",
                     RestStatus.FORBIDDEN,
                     params.getModelId(),
                     inferenceConfigHolder.get().getName(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -111,10 +111,7 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
 
     public void infer(Map<String, Object> doc, InferenceConfigUpdate update, TimeValue timeout, ActionListener<InferenceResults> listener) {
         if (inferenceConfigHolder.get() == null) {
-            listener.onFailure(
-                // inference not possible against uninitialized model"
-                ExceptionsHelper.conflictStatusException("Trained model [{}] is not initialized", params.getModelId())
-            );
+            listener.onFailure(ExceptionsHelper.conflictStatusException("Trained model [{}] is not initialized", params.getModelId()));
             return;
         }
         if (update.isSupported(inferenceConfigHolder.get()) == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -332,7 +332,7 @@ public class ModelLoadingService implements ClusterStateListener {
                     handleLoadFailure(
                         modelId,
                         new ElasticsearchStatusException(
-                            "model [{}] with type [{}] is currently not usable in search.",
+                            "Trained model [{}] with type [{}] is currently not usable in search.",
                             RestStatus.BAD_REQUEST,
                             modelId,
                             trainedModelConfig.getModelType()
@@ -342,11 +342,7 @@ public class ModelLoadingService implements ClusterStateListener {
                 }
                 handleLoadFailure(
                     modelId,
-                    new ElasticsearchStatusException(
-                        "model [{}] must be deployed to use. Please deploy with the start trained model deployment API.",
-                        RestStatus.BAD_REQUEST,
-                        modelId
-                    )
+                    new ElasticsearchStatusException("Trained model [{}] is not deployed.", RestStatus.BAD_REQUEST, modelId)
                 );
                 return;
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
@@ -124,12 +124,12 @@ public class NlpTask {
         String inputField = input.getFieldNames().get(0);
         Object inputValue = XContentMapValues.extractValue(inputField, doc);
         if (inputValue == null) {
-            throw ExceptionsHelper.badRequestException("no value could be found for input field [{}]", inputField);
+            throw ExceptionsHelper.badRequestException("Input field [{}] does not exist in the source document", inputField);
         }
         if (inputValue instanceof String) {
             return (String) inputValue;
         }
-        throw ExceptionsHelper.badRequestException("input value [{}] for field [{}] is not a string", inputValue, inputField);
+        throw ExceptionsHelper.badRequestException("Input value [{}] for field [{}] must be a string", inputValue, inputField);
     }
 
     public static class Request {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -104,7 +104,11 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
 
         boolean added = queue.offer(contextHolder.preserveContext(command));
         if (added == false) {
-            throw new ElasticsearchStatusException("Unable to execute on [{}] as queue is full", RestStatus.TOO_MANY_REQUESTS, processName);
+            throw new ElasticsearchStatusException(
+                processName + " queue is full. Unable to execute command",
+                RestStatus.TOO_MANY_REQUESTS,
+                processName
+            );
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.inference.nlp;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.results.FillMaskResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TopClassEntry;
@@ -102,7 +103,7 @@ public class FillMaskProcessorTests extends ESTestCase {
         FillMaskConfig config = new FillMaskConfig(new VocabularyConfig("test-index"), null, null, null);
         FillMaskProcessor processor = new FillMaskProcessor(tokenizer, config);
 
-        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> processor.validateInputs(input));
+        ValidationException e = expectThrows(ValidationException.class, () -> processor.validateInputs(input));
         assertThat(e.getMessage(), containsString("no [MASK] token could be found"));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskTests.java
@@ -42,7 +42,7 @@ public class NlpTaskTests extends ESTestCase {
         );
 
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), equalTo("no value could be found for input field [" + fieldName + "]"));
+        assertThat(e.getMessage(), equalTo("Input field [" + fieldName + "] does not exist in the source document"));
     }
 
     public void testExtractInput_GivenFieldIsNotString() {
@@ -57,6 +57,6 @@ public class NlpTaskTests extends ESTestCase {
         );
 
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), equalTo("input value [42] for field [" + fieldName + "] is not a string"));
+        assertThat(e.getMessage(), equalTo("Input value [42] for field [" + fieldName + "] must be a string"));
     }
 }


### PR DESCRIPTION
Consistently use the same language in the error messages from trained model inference.

- Use 'Trained model' rather than plain 'model' or variations 
- 'Inference process' rather than the 'native process' or 'process'
- Change all implementations of `NlpTask.Processor::validateInputs` to throw `ValidationException`