### PR TITLE
Remove Strict Assertion on IndexMetadata Equality in CS Application

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -74,7 +74,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -522,11 +521,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             final IndexMetadata newIndexMetadata = state.metadata().index(index);
             assert newIndexMetadata != null : "index " + index + " should have been removed by deleteIndices";
             if (ClusterChangedEvent.indexMetadataChanged(currentIndexMetadata, newIndexMetadata)) {
-                assert Objects.equals(event.previousState().nodes().getMasterNode(), state.getNodes().getMasterNode()) == false
-                    || newIndexMetadata.equals(currentIndexMetadata) == false
-                    : "index metadata instance must not change if unchanged unless there was a master failover but saw change for ["
-                        + index
-                        + "]";
                 String reason = null;
                 try {
                     reason = "metadata update failed";


### PR DESCRIPTION
This assertion is too strict as of right now unfortunately, back to back
master failover can still trip it in tests.
Removing it here with the intention of adding it back once the implementation
of master failover handling has been improved.

closes #82059
