### PR TITLE
[8.0] LLRC: expose http client and allow overriding meta header (#81955)

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -20,14 +20,12 @@
 package org.elasticsearch.client;
 
 import org.apache.http.Header;
-import org.apache.http.HttpRequest;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.nio.conn.SchemeIOSessionStrategy;
-import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.VersionInfo;
 
 import java.io.IOException;
@@ -55,7 +53,7 @@ public final class RestClientBuilder {
 
     static final String VERSION;
     static final String META_HEADER_NAME = "X-Elastic-Client-Meta";
-    private static final String META_HEADER_VALUE;
+    static final String META_HEADER_VALUE;
     private static final String USER_AGENT_HEADER_VALUE;
 
     private static final Header[] EMPTY_HEADERS = new Header[0];
@@ -286,7 +284,8 @@ public final class RestClientBuilder {
             failureListener,
             nodeSelector,
             strictDeprecationMode,
-            compressionEnabled
+            compressionEnabled,
+            metaHeaderEnabled
         );
         httpClient.start();
         return restClient;
@@ -314,14 +313,6 @@ public final class RestClientBuilder {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);
             }
 
-            // Always add metadata header last so that it's not overwritten
-            httpClientBuilder.addInterceptorLast((HttpRequest request, HttpContext context) -> {
-                if (metaHeaderEnabled) {
-                    request.setHeader(META_HEADER_NAME, META_HEADER_VALUE);
-                } else {
-                    request.removeHeaders(META_HEADER_NAME);
-                }
-            });
             final HttpAsyncClientBuilder finalBuilder = httpClientBuilder;
             return AccessController.doPrivileged((PrivilegedAction<CloseableHttpAsyncClient>) finalBuilder::build);
         } catch (NoSuchAlgorithmException e) {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
@@ -68,7 +68,7 @@ public class RestClientMultipleHostsTests extends RestClientTestCase {
         }
         nodes = Collections.unmodifiableList(nodes);
         failureListener = new HostsTrackingFailureListener();
-        return new RestClient(httpClient, new Header[0], nodes, null, failureListener, nodeSelector, false, false);
+        return new RestClient(httpClient, new Header[0], nodes, null, failureListener, nodeSelector, false, false, false);
     }
 
     /**

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -371,14 +371,13 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         header = esResponse.getHeader("User-Agent");
         assertTrue(header.matches("elasticsearch-java/[^ ]+ \\(Java/[^)].*\\)"));
 
-        // Meta header should not be overriden, test custom UA
+        // Test custom UA and meta header
         request.setOptions(
-            RequestOptions.DEFAULT.toBuilder().addHeader(RestClientBuilder.META_HEADER_NAME, "foobar").addHeader("User-Agent", "baz")
+            RequestOptions.DEFAULT.toBuilder().addHeader(RestClientBuilder.META_HEADER_NAME, "foo").addHeader("User-Agent", "bar")
         );
         esResponse = RestClientSingleHostTests.performRequestSyncOrAsync(restClient, request);
-        header = esResponse.getHeader(RestClientBuilder.META_HEADER_NAME);
-        assertTrue(header.matches("^es=[^,]*,jv=[^,]+,t=[^,]*,hc=.*"));
-        assertEquals("baz", esResponse.getHeader("User-Agent"));
+        assertEquals("foo", esResponse.getHeader(RestClientBuilder.META_HEADER_NAME));
+        assertEquals("bar", esResponse.getHeader("User-Agent"));
 
         // Create a new client and disable meta header
         RestClient newClient = createRestClient(true, true, false);
@@ -386,8 +385,8 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         esResponse = RestClientSingleHostTests.performRequestSyncOrAsync(newClient, request);
         assertNull(esResponse.getHeader(RestClientBuilder.META_HEADER_NAME));
 
-        // Should not be overriden
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(RestClientBuilder.META_HEADER_NAME, "foobar"));
+        // Meta header should not be present even if overriden
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(RestClientBuilder.META_HEADER_NAME, "foo"));
         esResponse = RestClientSingleHostTests.performRequestSyncOrAsync(newClient, request);
         assertNull(esResponse.getHeader(RestClientBuilder.META_HEADER_NAME));
 

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -126,6 +126,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
             failureListener,
             NodeSelector.ANY,
             strictDeprecationMode,
+            false,
             false
         );
     }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -60,7 +60,7 @@ public class RestClientTests extends RestClientTestCase {
     public void testCloseIsIdempotent() throws IOException {
         List<Node> nodes = singletonList(new Node(new HttpHost("localhost", 9200)));
         CloseableHttpAsyncClient closeableHttpAsyncClient = mock(CloseableHttpAsyncClient.class);
-        RestClient restClient = new RestClient(closeableHttpAsyncClient, new Header[0], nodes, null, null, null, false, false);
+        RestClient restClient = new RestClient(closeableHttpAsyncClient, new Header[0], nodes, null, null, null, false, false, false);
         restClient.close();
         verify(closeableHttpAsyncClient, times(1)).close();
         restClient.close();
@@ -360,7 +360,7 @@ public class RestClientTests extends RestClientTestCase {
 
     private static RestClient createRestClient() {
         List<Node> nodes = Collections.singletonList(new Node(new HttpHost("localhost", 9200)));
-        return new RestClient(mock(CloseableHttpAsyncClient.class), new Header[] {}, nodes, null, null, null, false, false);
+        return new RestClient(mock(CloseableHttpAsyncClient.class), new Header[] {}, nodes, null, null, null, false, false, false);
     }
 
     public void testRoundRobin() throws IOException {
@@ -395,7 +395,7 @@ public class RestClientTests extends RestClientTestCase {
     public void testIsRunning() {
         List<Node> nodes = Collections.singletonList(new Node(new HttpHost("localhost", 9200)));
         CloseableHttpAsyncClient client = mock(CloseableHttpAsyncClient.class);
-        RestClient restClient = new RestClient(client, new Header[] {}, nodes, null, null, null, false, false);
+        RestClient restClient = new RestClient(client, new Header[] {}, nodes, null, null, null, false, false, false);
 
         when(client.isRunning()).thenReturn(true);
         assertTrue(restClient.isRunning());


### PR DESCRIPTION
Backports the following commits to 8.0:
 - LLRC: expose http client and allow overriding meta header (#81955)