### PR TITLE
skip restoring global state when one is absent in a snapshot

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -132,7 +132,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // snapshot by feature
         CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(REPO_NAME, "test-snap")
-            .setIncludeGlobalState(false)
+            .setIncludeGlobalState(true)
             .setWaitForCompletion(true)
             .setFeatureStates(SystemIndexTestPlugin.class.getSimpleName(), AnotherSystemIndexTestPlugin.class.getSimpleName())
             .get();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -302,7 +302,7 @@ public class RestoreService implements ClusterStateApplier {
         validateSnapshotRestorable(repository.getMetadata(), snapshotInfo);
 
         // Make sure that we can restore cluster state from this snapshot
-        validateGlobalStateRestorable(request, snapshot, snapshotInfo);
+        maybeFixRestoreGlobalStateFlag(request, snapshot, snapshotInfo);
 
         // Get the global state if necessary
         Metadata globalMetadata = null;
@@ -991,11 +991,12 @@ public class RestoreService implements ClusterStateApplier {
         }
     }
 
-    static void validateGlobalStateRestorable(RestoreSnapshotRequest request, Snapshot snapshot, SnapshotInfo snapshotInfo) {
+    static void maybeFixRestoreGlobalStateFlag(RestoreSnapshotRequest request, Snapshot snapshot, SnapshotInfo snapshotInfo) {
         if (request.includeGlobalState() && snapshotInfo.includeGlobalState() != Boolean.TRUE) {
             request.includeGlobalState(false);
             logger.warn(
-                "[{}] was created without global state but restore request [{}] asks for global state restore explicitly, "
+                "[{}] was created without global state "
+                    + "but restore request [{}] asks for global state restore explicitly, "
                     + "skipping global state restore",
                 snapshot,
                 request

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -994,7 +994,7 @@ public class RestoreService implements ClusterStateApplier {
     static void validateGlobalStateRestorable(RestoreSnapshotRequest request, Snapshot snapshot, SnapshotInfo snapshotInfo) {
         if (request.includeGlobalState() && snapshotInfo.includeGlobalState() != Boolean.TRUE) {
             request.includeGlobalState(false);
-            logger.warn("[{}] the snapshot was created without global state, skipping restoring global sate", snapshot);
+            logger.warn("[{}] was created without global state but restore request [{}] asks for global state restore explicitly, skipping global state restore", snapshot, request);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -301,6 +301,9 @@ public class RestoreService implements ClusterStateApplier {
         // Make sure that we can restore from this snapshot
         validateSnapshotRestorable(repository.getMetadata(), snapshotInfo);
 
+        // Make sure that we can restore cluster state from this snapshot
+        validateGlobalStateRestorable(request, snapshot, snapshotInfo);
+
         // Get the global state if necessary
         Metadata globalMetadata = null;
         final Metadata.Builder metadataBuilder;
@@ -985,6 +988,13 @@ public class RestoreService implements ClusterStateApplier {
                     + Version.CURRENT.minimumIndexCompatibilityVersion()
                     + "]"
             );
+        }
+    }
+
+    static void validateGlobalStateRestorable(RestoreSnapshotRequest request, Snapshot snapshot, SnapshotInfo snapshotInfo) {
+        if (request.includeGlobalState() && snapshotInfo.includeGlobalState() != Boolean.TRUE) {
+            request.includeGlobalState(false);
+            logger.warn("[{}] the snapshot was created without global state, skipping restoring global sate", snapshot);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -994,7 +994,12 @@ public class RestoreService implements ClusterStateApplier {
     static void validateGlobalStateRestorable(RestoreSnapshotRequest request, Snapshot snapshot, SnapshotInfo snapshotInfo) {
         if (request.includeGlobalState() && snapshotInfo.includeGlobalState() != Boolean.TRUE) {
             request.includeGlobalState(false);
-            logger.warn("[{}] was created without global state but restore request [{}] asks for global state restore explicitly, skipping global state restore", snapshot, request);
+            logger.warn(
+                "[{}] was created without global state but restore request [{}] asks for global state restore explicitly, "
+                    + "skipping global state restore",
+                snapshot,
+                request
+            );
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
@@ -184,12 +184,12 @@ public class RestoreServiceTests extends ESTestCase {
         finalAssertions.forEach(Runnable::run);
     }
 
-    public void testDisableRestoringGlobalStateIfSnapshotDoesNotHaveOne() {
+    public void testDisableRestoreGlobalStateIfSnapshotDoesNotHaveOne() {
         var request = spy(new RestoreSnapshotRequest().includeGlobalState(true));
         var snapshot = new Snapshot("repository", new SnapshotId("name", "uuid"));
         var snapshotInfo = createSnapshotInfo(snapshot, Boolean.FALSE);
 
-        RestoreService.validateGlobalStateRestorable(request, snapshot, snapshotInfo);
+        RestoreService.maybeFixRestoreGlobalStateFlag(request, snapshot, snapshotInfo);
 
         verify(request).includeGlobalState(false);
     }


### PR DESCRIPTION
Currently it is possible to restore with include_global_state: true from a snapshot that does not have a global state.
This behavior will nullify cluster state once #81373 is merged.
This pr adds skips global state restore and logs a warning when this happens.

related to #82019