### PR TITLE
Fix PendingReplicationActions Submitting lots of NOOP Tasks to GENERIC

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/PendingReplicationActions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/PendingReplicationActions.java
@@ -18,6 +18,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -83,12 +84,12 @@ public class PendingReplicationActions implements Consumer<ReplicationGroup>, Re
     // Visible for testing
     synchronized void acceptNewTrackedAllocationIds(Set<String> trackedAllocationIds) {
         for (String targetAllocationId : trackedAllocationIds) {
-            onGoingReplicationActions.putIfAbsent(targetAllocationId, ConcurrentCollections.newConcurrentSet());
+            onGoingReplicationActions.computeIfAbsent(targetAllocationId, k -> ConcurrentCollections.newConcurrentSet());
         }
-        ArrayList<Set<RetryableAction<?>>> toCancel = new ArrayList<>();
+        ArrayList<RetryableAction<?>> toCancel = new ArrayList<>();
         for (String allocationId : onGoingReplicationActions.keySet()) {
             if (trackedAllocationIds.contains(allocationId) == false) {
-                toCancel.add(onGoingReplicationActions.remove(allocationId));
+                toCancel.addAll(onGoingReplicationActions.remove(allocationId));
             }
         }
 
@@ -97,18 +98,16 @@ public class PendingReplicationActions implements Consumer<ReplicationGroup>, Re
 
     @Override
     public synchronized void close() {
-        ArrayList<Set<RetryableAction<?>>> toCancel = new ArrayList<>(onGoingReplicationActions.values());
+        final List<RetryableAction<?>> toCancel = onGoingReplicationActions.values().stream().flatMap(Collection::stream).toList();
         onGoingReplicationActions.clear();
 
         cancelActions(toCancel, "Primary closed.");
     }
 
-    private void cancelActions(ArrayList<Set<RetryableAction<?>>> toCancel, String message) {
-        threadPool.executor(ThreadPool.Names.GENERIC)
-            .execute(
-                () -> toCancel.stream()
-                    .flatMap(Collection::stream)
-                    .forEach(action -> action.cancel(new IndexShardClosedException(shardId, message)))
-            );
+    private void cancelActions(List<RetryableAction<?>> toCancel, String message) {
+        if (toCancel.isEmpty() == false) {
+            threadPool.executor(ThreadPool.Names.GENERIC)
+                .execute(() -> toCancel.forEach(action -> action.cancel(new IndexShardClosedException(shardId, message))));
+        }
     }
 }


### PR DESCRIPTION
At times sending empty lists to generic here did get quite hot in many shards benchmarks.

extracted from #79837
relates #77466 