### PR TITLE
Fix Noisy Warnings in SecurityIntegTestCase

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
@@ -13,16 +13,12 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.SecuritySingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,13 +52,6 @@ public class ProfileSingleNodeTests extends SecuritySingleNodeTestCase {
     @Override
     protected String configUsersRoles() {
         return super.configUsersRoles() + "rac_role:" + RAC_USER_NAME + "\n";
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        final ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
-        plugins.add(MapperExtrasPlugin.class);
-        return plugins;
     }
 
     public void testProfileIndexAutoCreation() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -9,7 +9,6 @@ package org.elasticsearch.test;
 import io.netty.util.ThreadDeathWatcher;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
@@ -22,7 +21,6 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -33,8 +31,6 @@ import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
@@ -56,11 +52,9 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
 
 /**
  * Base class to run tests against a cluster with X-Pack installed and security enabled.
@@ -368,12 +362,6 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
         }
     }
 
-    protected static void assertGreenClusterState(Client client) {
-        ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth().get();
-        assertNoTimeout(clusterHealthResponse);
-        assertThat(clusterHealthResponse.getStatus(), is(ClusterHealthStatus.GREEN));
-    }
-
     /**
      * Creates the indices provided as argument, randomly associating them with aliases, indexes one dummy document per index
      * and refreshes the new indices
@@ -430,7 +418,6 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
             assertBusy(() -> {
                 ClusterState clusterState = client.admin().cluster().prepareState().setLocal(true).get().getState();
                 assertFalse(clusterState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
-                XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint().startObject();
                 Index securityIndex = resolveSecurityIndex(clusterState.metadata());
                 if (securityIndex != null) {
                     IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(securityIndex);
@@ -469,10 +456,6 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
             return indexAbstraction.getIndices().get(0);
         }
         return null;
-    }
-
-    protected boolean isTransportSSLEnabled() {
-        return customSecuritySettingsSource.isSslEnabled();
     }
 
     public static Hasher getFastStoredHashAlgoForTests() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -178,12 +179,6 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         return nodePath(nodeOrdinal).resolve("config");
     }
 
-    protected void addDefaultSecurityTransportType(Settings.Builder builder, Settings settings) {
-        if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings) == false) {
-            builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), SecurityField.NAME4);
-        }
-    }
-
     @Override
     public Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(
@@ -191,7 +186,8 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
             Netty4Plugin.class,
             ReindexPlugin.class,
             CommonAnalysisPlugin.class,
-            InternalSettingsPlugin.class
+            InternalSettingsPlugin.class,
+            MapperExtrasPlugin.class
         );
     }
 
@@ -260,43 +256,6 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         } else if (randomBoolean()) {
             builder.put(XPackSettings.TRANSPORT_SSL_ENABLED.getKey(), false);
         }
-    }
-
-    public void addClientSSLSettings(Settings.Builder builder, String prefix) {
-        builder.put("xpack.security.transport.ssl.enabled", sslEnabled);
-        if (usePEM) {
-            addSSLSettingsForPEMFiles(
-                builder,
-                prefix,
-                "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.pem",
-                "testclient",
-                "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt",
-                Arrays.asList(
-                    "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt",
-                    "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt",
-                    "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt"
-                ),
-                hostnameVerificationEnabled
-            );
-        } else {
-            addSSLSettingsForStore(
-                builder,
-                prefix,
-                "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.jks",
-                "testclient",
-                hostnameVerificationEnabled
-            );
-        }
-    }
-
-    /**
-     * Returns the configuration settings given the location of a certificate and its password
-     *
-     * @param resourcePathToStore the location of the keystore or truststore
-     * @param password the password
-     */
-    public static void addSSLSettingsForStore(Settings.Builder builder, String resourcePathToStore, String password, String prefix) {
-        addSSLSettingsForStore(builder, prefix, resourcePathToStore, password, true);
     }
 
     private static void addSSLSettingsForStore(


### PR DESCRIPTION
Adding the mapper extras plugin to avoid endless warnings about a
missing scaled_float mapper in these tests.
Also, removed some unrelated dead code that wasn't really worth a separate PR.
