### PR TITLE
Update superuser built-in role description

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -169,7 +169,7 @@ to change index settings or to read or update data stream or index data.
 
 [[built-in-roles-superuser]] `superuser`::
 Grants full access to cluster management and data indices. This role also grants
-direct read access to restricted indices like `.security`. A user with the
+direct read-only access to restricted indices like `.security`. A user with the
 `superuser` role can <<run-as-privilege, impersonate>> any other user in the system. 
 +
 NOTE: This role can manage security and create roles with unlimited privileges.

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -168,10 +168,12 @@ to remove or add repositories or to restore snapshots. It also does not enable
 to change index settings or to read or update data stream or index data.
 
 [[built-in-roles-superuser]] `superuser`::
-Grants full access to the cluster, including all indices and data. A user with
-the `superuser` role can also manage users and roles and
-<<run-as-privilege, impersonate>> any other user in the system. Due to the
-permissive nature of this role, take extra care when assigning it to a user.
+Grants full access to cluster management and data indices. This role also grants
+direct read access to restricted indices like `.security`. A user with the
+`superuser` role can <<run-as-privilege, impersonate>> any other user in the system. 
++
+NOTE: This role can manage security and create roles with unlimited privileges.
+Take extra care when assigning it to a user.
 
 [[built-in-roles-transform-admin]] `transform_admin`::
 Grants `manage_transform` cluster privileges, which enable you to manage

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -65,13 +65,13 @@ The following describes the structure of an indices permissions entry:
     access to. A document within the associated data streams and indices must match this query
     in order for it to be accessible by the owners of the role.
 <5> Restricted indices are a special category of indices that are used
-    internally to store configuration data. Only internal system
-    roles should normally grant privileges over the restricted indices.
-    **Toggling this flag is most discouraged because it could effectively grant
-    superuser privileges.** If however, for administrative purposes, you need to
-    create a role with privileges covering restricted indices, you must set
-    this field to `true` (default is `false`), and then the `names` field will
-    cover the restricted indices as well.
+    internally to store configuration data and should not be directly accessed.
+    Only internal system roles should normally grant privileges over the restricted indices.
+    **Toggling this flag is very discouraged because it could effectively grant unrestricted
+    operations on critical data, making the entire system unstable or leaking sensitive information.**
+    If however, for administrative purposes, you need to create a role with privileges covering
+    restricted indices, you must set this field to `true` (default is `false`), and then the
+    `names` field will cover the restricted indices as well.
 
 [TIP]
 ==============================================================================

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -67,7 +67,7 @@ The following describes the structure of an indices permissions entry:
 <5> Restricted indices are a special category of indices that are used
     internally to store configuration data and should not be directly accessed.
     Only internal system roles should normally grant privileges over the restricted indices.
-    **Toggling this flag is very discouraged because it could effectively grant unrestricted
+    **Toggling this flag is very strongly discouraged because it could effectively grant unrestricted
     operations on critical data, making the entire system unstable or leaking sensitive information.**
     If however, for administrative purposes, you need to create a role with privileges covering
     restricted indices, you must set this field to `true` (default is `false`), and then the


### PR DESCRIPTION
Update the `superuser` built-in role description to reflect new privileges.
Unlike the previous version, the new role definition doesn't allow write access to restricted indices by default.