### PR TITLE
Add "maintenance" permission to the fleet-server service account

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -93,7 +93,8 @@ GET /_security/service/elastic/fleet-server
             "write",
             "monitor",
             "create_index",
-            "auto_configure"
+            "auto_configure",
+            "maintenance"
           ],
           "allow_restricted_indices": true
         }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -110,7 +110,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "write",
                     "monitor",
                     "create_index",
-                    "auto_configure"
+                    "auto_configure",
+                    "maintenance"
                   ],
                   "allow_restricted_indices": true
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -41,7 +41,8 @@ final class ElasticServiceAccounts {
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-*")
-                    .privileges("read", "write", "monitor", "create_index", "auto_configure")
+                    // Fleet Server needs "maintenance" privilege to be able to perform operations with "refresh"
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
                     .allowRestrictedIndices(true)
                     .build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {


### PR DESCRIPTION
## What is the problem this PR solves?

Elimination of the username/password authentication from the fleet server and replacement with the fleet service account token exposed an issue that the code that relies on performing queries with ```refresh``` is no longer works. 

Surprisingly enough the ```_bulk``` API calls with refresh still succeed, which could be a possible issue that allows to circumvent the ```refresh``` permissions with _bulk requests.

Fleet server need to be able to perform some API calls with ```refresh``` flag enabled.

This would be a prerequisite for PR https://github.com/elastic/fleet-server/pull/1039

## How does this PR solve the problem?

Adds "maintenance" permission to the fleet-server service account in order to allow the fleet service perm operations with refresh. 

## Related issues

- Related to https://github.com/elastic/fleet-server/pull/1039
