### PR TITLE
Fix Watcher test 'testVars'

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/ExecutionVarsIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/ExecutionVarsIntegrationTests.java
@@ -32,6 +32,7 @@ import static org.elasticsearch.xpack.watcher.input.InputBuilders.simpleInput;
 import static org.elasticsearch.xpack.watcher.transform.TransformBuilders.scriptTransform;
 import static org.elasticsearch.xpack.watcher.trigger.TriggerBuilders.schedule;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.cron;
+import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -109,11 +110,10 @@ public class ExecutionVarsIntegrationTests extends AbstractWatcherIntegrationTes
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67908")
     public void testVars() throws Exception {
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client()).setId(watchId)
             .setSource(
-                watchBuilder().trigger(schedule(cron("0/1 * * * * ?")))
+                watchBuilder().trigger(schedule(interval("1h")))
                     .input(simpleInput("value", 5))
                     .condition(
                         new ScriptCondition(


### PR DESCRIPTION
The error that caused his test be muted is 
`java.lang.AssertionError: Count is 2 hits but 1 was expected.`
from:      `assertHitCount(searchResponse, 1L);`
when searching for watch records. 

It is believed this is due to the cron scheduler executing a
second watch. The change here is to use a long interval 
schedule instead of the cron scheduler. 

Fixes #67908