### PR TITLE
Fix Watcher testWatcherWithApiKey

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -244,7 +244,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 final Map<String, Object> getWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
                 final Map<String, Object> status = (Map<String, Object>) getWatchStatusResponse.get("status");
                 assertEquals("executed", status.get("execution_state"));
-            });
+            }, 30, TimeUnit.SECONDS);
 
         } else {
             logger.info("testing against {}", getOldClusterVersion());
@@ -280,7 +280,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                         versionIncreased.get() && executed.get(),
                         is(true)
                     );
-                });
+                }, 30, TimeUnit.SECONDS);
             } finally {
                 stopWatcher();
             }


### PR DESCRIPTION
Bump the timeout allowed for a Watch to execute. 

closes #77026

--- 
Note - when back porting to 7.16 and 7.17 the test needs to be un-muted. 