### PR TITLE
[8.0] Add "maintenance" permission to the fleet-server service account (#82125)

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -93,7 +93,8 @@ GET /_security/service/elastic/fleet-server
             "write",
             "monitor",
             "create_index",
-            "auto_configure"
+            "auto_configure",
+            "maintenance"
           ],
           "allow_restricted_indices": true
         }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -110,7 +110,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "write",
                     "monitor",
                     "create_index",
-                    "auto_configure"
+                    "auto_configure",
+                    "maintenance"
                   ],
                   "allow_restricted_indices": true
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -41,7 +41,8 @@ final class ElasticServiceAccounts {
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-*")
-                    .privileges("read", "write", "monitor", "create_index", "auto_configure")
+                    // Fleet Server needs "maintenance" privilege to be able to perform operations with "refresh"
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
                     .allowRestrictedIndices(true)
                     .build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add "maintenance" permission to the fleet-server service account (#82125)