### PR TITLE
Fix Failing TranslogTests.testRecoveryFromFailureOnTrimming

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -478,11 +478,11 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                         try {
                             // Write ops will release operations.
                             writeAndReleaseOps(toWrite);
+                            assert channel.position() == checkpointToSync.offset;
                         } catch (final Exception ex) {
                             closeWithTragicEvent(ex);
                             throw ex;
                         }
-                        assert channel.position() == checkpointToSync.offset;
                     }
                     // now do the actual fsync outside of the synchronized block such that
                     // we can continue writing to the buffer etc.


### PR DESCRIPTION
In #77674 the assertion that is moved here was added.
The problem with it is that when running tests that do
random IO exceptions on the `channel.position()` call,
the assertion actual has a side effect.
If the exception it triggers as a side effect is not caught and
the translog failed as a result, tests around the safety of handling
IOExceptions in this code fail. Unfortunately, the assertion still
has a side effect after this change but its side effect is handled
like an expected IOException.

The obvious alternative to having this kind of messy assertion would be to just remove it ... but it's actually quite nice to have so I went with this approach.