### PR TITLE
stack monitoring: update logstash mappings

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -89,6 +89,35 @@
                             }
                           }
                         },
+                        "events": {
+                          "properties": {
+                            "duration_in_millis": {
+                              "type": "long"
+                            },
+                            "filtered": {
+                              "type": "long"
+                            },
+                            "in": {
+                              "type": "long"
+                            },
+                            "out": {
+                              "type": "long"
+                            },
+                            "queue_push_duration_in_millis": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "reloads": {
+                          "properties": {
+                            "failures": {
+                              "type": "long"
+                            },
+                            "successes": {
+                              "type": "long"
+                            }
+                          }
+                        },
                         "vertices": {
                           "type": "nested",
                           "properties": {
@@ -101,7 +130,7 @@
                               "ignore_above": 1024
                             },
                             "queue_push_duration_in_millis": {
-                              "type": "float"
+                              "type": "long"
                             },
                             "events_in": {
                               "type": "long"
@@ -111,6 +140,17 @@
                             },
                             "duration_in_millis": {
                               "type": "long"
+                            },
+                            "long_counters": {
+                              "type": "nested",
+                              "properties": {
+                                "name": {
+                                    "type": "keyword"
+                                },
+                                "value": {
+                                    "type": "long"
+                                }
+                              }
                             }
                           }
                         }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -59,7 +59,62 @@
                       }
                     },
                     "pipelines": {
-                      "type": "nested"
+                      "type": "nested",
+                      "properties": {
+                        "id": {
+                          "type": "keyword",
+                          "ignore_above": 1024
+                        },
+                        "ephemeral_id": {
+                          "type": "keyword"
+                        },
+                        "hash": {
+                          "type": "keyword",
+                          "ignore_above": 1024
+                        },
+                        "queue": {
+                          "properties": {
+                            "type": {
+                              "type": "keyword",
+                              "ignore_above": 1024
+                            },
+                            "events_count": {
+                              "type": "long"
+                            },
+                            "max_queue_size_in_bytes": {
+                              "type": "long"
+                            },
+                            "queue_size_in_bytes": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "vertices": {
+                          "type": "nested",
+                          "properties": {
+                            "id": {
+                              "type": "keyword",
+                              "ignore_above": 1024
+                            },
+                            "pipeline_ephemeral_id": {
+                              "type": "keyword",
+                              "ignore_above": 1024
+                            },
+                            "queue_push_duration_in_millis": {
+                              "type": "float"
+                            },
+                            "events_in": {
+                              "type": "long"
+                            },
+                            "events_out": {
+                              "type": "long"
+                            },
+                            "duration_in_millis": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
                     },
                     "os": {
                       "properties": {
@@ -198,6 +253,18 @@
                 "version": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                }
+              }
+            },
+            "elasticsearch": {
+              "properties": {
+                "cluster": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword",
+                      "ignore_above": 1024
+                    }
+                  }
                 }
               }
             }
@@ -353,6 +420,10 @@
                   "type": "alias"
                 }
               }
+            },
+            "timestamp": {
+              "type": "alias",
+              "path": "@timestamp"
             }
           }
         },
@@ -631,6 +702,10 @@
               "ignore_above": 1024
             }
           }
+        },
+        "cluster_uuid": {
+          "type": "alias",
+          "path": "logstash.elasticsearch.cluster.id"
         }
       }
     },


### PR DESCRIPTION
### Summary

Rel [elastic/kibana#121518](https://github.com/elastic/kibana/issues/121346)

New index templates were recently introduced for stack monitoring to support metricbeat version 8.
This change applies a couple of updates to logstash mappings.

### Testing

Applied the change to a running elasticsearch and verified the stack monitoring UI now successfully retrieves the aliased informations