### PR TITLE
Watcher fix testTriggeredWatchLoading

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -259,6 +259,7 @@ public class BootStrapTests extends AbstractWatcherIntegrationTestCase {
     }
 
     public void testTriggeredWatchLoading() throws Exception {
+        cluster().wipeIndices(TriggeredWatchStoreField.INDEX_NAME);
         createIndex("output");
         client().prepareIndex()
             .setIndex("my-index")


### PR DESCRIPTION
In all reported cases it appears that the found count is > expected count. 
It is suspected that there are some Watches from previous tests
still pending in the .triggered_watches index causing extra Watches to be executed.

The change here is to ensure that .triggered_watches is removed prior to the 
test run ensuing a clean slate. 

closes #67729
