### PR TITLE
More Efficient Simple String List Setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1638,7 +1638,16 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<List<String>> stringListSetting(String key, Property... properties) {
-        return listSetting(key, List.of(), Function.identity(), v -> {}, properties);
+        return stringListSetting(key, List.of(), properties);
+    }
+
+    public static Setting<List<String>> stringListSetting(String key, List<String> defValue, Property... properties) {
+        return new ListSetting<>(key, null, s -> defValue, Setting::parseableStringToList, v -> {}, properties) {
+            @Override
+            public List<String> get(Settings settings) {
+                return settings.getAsList(getKey(), defValue);
+            }
+        };
     }
 
     public static Setting<List<String>> stringListSetting(String key, Validator<List<String>> validator, Property... properties) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -51,10 +51,9 @@ import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_F
  * be called for each settings update.
  */
 public final class IndexSettings {
-    public static final Setting<List<String>> DEFAULT_FIELD_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> DEFAULT_FIELD_SETTING = Setting.stringListSetting(
         "index.query.default_field",
         Collections.singletonList("*"),
-        Function.identity(),
         Property.IndexScope,
         Property.Dynamic
     );


### PR DESCRIPTION
For string lists there is no need to parse an existing list after serializing
it. Also, if there's no fallback settings and/or validation and just a constant
default, we can pass through that default outright instead of serializing and
deserializing it to make a copy.

This is motivated by finding lots of duplicate strings on heap for the default
query fields list on data nodes holding many indices with Beats mappings which
I tracked down to the fact that we are not passing through the list containing
deduplicated strings from the `Settings` instance.

relates #77466 