### PR TITLE
Factor in typless templates for cluster deprecation checks

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -53,6 +53,7 @@ public class ClusterDeprecationChecks {
     private static final Logger logger = LogManager.getLogger(ClusterDeprecationChecks.class);
 
     private static final String SPARSE_VECTOR = "sparse_vector";
+    public static final String TYPELESS = "properties";
 
     @SuppressWarnings("unchecked")
     static DeprecationIssue checkUserAgentPipelines(ClusterState state) {
@@ -609,7 +610,7 @@ public class ClusterDeprecationChecks {
                 }
                 boolean hasCustomType = mappings.stream().anyMatch(mapping -> {
                     String typeName = mapping.getKey();
-                    return MapperService.SINGLE_MAPPING_NAME.equals(typeName) == false;
+                    return TYPELESS.equals(typeName) == false && MapperService.SINGLE_MAPPING_NAME.equals(typeName) == false;
                 });
                 if (hasCustomType) {
                     templatesWithCustomTypes.add(templateName);

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -53,7 +53,7 @@ public class ClusterDeprecationChecks {
     private static final Logger logger = LogManager.getLogger(ClusterDeprecationChecks.class);
 
     private static final String SPARSE_VECTOR = "sparse_vector";
-    public static final String TYPELESS = "properties";
+    public static final String TYPELESS_MAPPING = "properties";
 
     @SuppressWarnings("unchecked")
     static DeprecationIssue checkUserAgentPipelines(ClusterState state) {
@@ -610,7 +610,7 @@ public class ClusterDeprecationChecks {
                 }
                 boolean hasCustomType = mappings.stream().anyMatch(mapping -> {
                     String typeName = mapping.getKey();
-                    return TYPELESS.equals(typeName) == false && MapperService.SINGLE_MAPPING_NAME.equals(typeName) == false;
+                    return TYPELESS_MAPPING.equals(typeName) == false && MapperService.SINGLE_MAPPING_NAME.equals(typeName) == false;
                 });
                 if (hasCustomType) {
                     templatesWithCustomTypes.add(templateName);

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -350,9 +350,14 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             .patterns(Collections.singletonList("foo"))
             .putMapping("_doc", "{\"type1\":{}}")
             .build();
+        IndexTemplateMetadata noType = IndexTemplateMetadata.builder("no-type")
+            .patterns(Collections.singletonList("foo"))
+            .putMapping("properties", "{ \"foo\": {\n" + "\"type\": \"keyword\"\n} }")
+            .build();
         ImmutableOpenMap<String, IndexTemplateMetadata> templates = ImmutableOpenMap.<String, IndexTemplateMetadata>builder()
             .fPut("multiple-types", multipleTypes)
             .fPut("single-type", singleType)
+            .fPut("no-type", noType)
             .build();
         Metadata badMetadata = Metadata.builder().templates(templates).build();
         ClusterState badState = ClusterState.builder(new ClusterName("test")).metadata(badMetadata).build();


### PR DESCRIPTION
The deprecation checks are looking for legacy templates that specify
multiple types or a single type that's different than `_doc`.

The checks must not raise a deprecation warning for templates that are
typeless. (ie. mappings are included directly under the `properties` key)