### PR TITLE
Simplify MappingMetadata Field in IndexMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -62,6 +62,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -451,7 +452,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private final Settings settings;
 
-    private final ImmutableOpenMap<String, MappingMetadata> mappings;
+    @Nullable
+    private final MappingMetadata mapping;
 
     private final ImmutableOpenMap<String, DiffableStringMap> customData;
 
@@ -493,7 +495,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final int numberOfShards,
         final int numberOfReplicas,
         final Settings settings,
-        final ImmutableOpenMap<String, MappingMetadata> mappings,
+        final MappingMetadata mapping,
         final ImmutableOpenMap<String, AliasMetadata> aliases,
         final ImmutableOpenMap<String, DiffableStringMap> customData,
         final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
@@ -531,7 +533,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.numberOfReplicas = numberOfReplicas;
         this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
         this.settings = settings;
-        this.mappings = mappings;
+        this.mapping = mapping;
         this.customData = customData;
         this.aliases = aliases;
         this.inSyncAllocationIds = inSyncAllocationIds;
@@ -561,9 +563,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (mapping() == mapping) {
             return this;
         }
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappingBuilder = ImmutableOpenMap.builder();
-        mappingBuilder.put(MapperService.SINGLE_MAPPING_NAME, mapping);
-
         return new IndexMetadata(
             this.index,
             this.version,
@@ -575,7 +574,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.numberOfShards,
             this.numberOfReplicas,
             this.settings,
-            mappingBuilder.build(),
+            mapping,
             this.aliases,
             this.customData,
             this.inSyncAllocationIds,
@@ -720,10 +719,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     @Nullable
     public MappingMetadata mapping() {
-        for (Map.Entry<String, MappingMetadata> cursor : mappings.entrySet()) {
-            return cursor.getValue();
-        }
-        return null;
+        return mapping;
     }
 
     public static final String INDEX_RESIZE_SOURCE_UUID_KEY = "index.resize.source.uuid";
@@ -816,7 +812,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (index.equals(that.index) == false) {
             return false;
         }
-        if (mappings.equals(that.mappings) == false) {
+        if (Objects.equals(mapping, that.mapping) == false) {
             return false;
         }
         if (settings.equals(that.settings) == false) {
@@ -856,7 +852,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         result = 31 * result + state.hashCode();
         result = 31 * result + aliases.hashCode();
         result = 31 * result + settings.hashCode();
-        result = 31 * result + mappings.hashCode();
+        result = 31 * result + Objects.hash(mapping);
         result = 31 * result + customData.hashCode();
         result = 31 * result + Long.hashCode(routingFactor);
         result = 31 * result + Long.hashCode(routingNumShards);
@@ -915,7 +911,16 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             state = after.state;
             settings = after.settings;
             primaryTerms = after.primaryTerms;
-            mappings = DiffableUtils.diff(before.mappings, after.mappings, DiffableUtils.getStringKeySerializer());
+            // TODO: find a nicer way to do BwC here and just work with Diff<MappingMetadata> here and in networking
+            mappings = DiffableUtils.diff(
+                before.mapping == null
+                    ? ImmutableOpenMap.of()
+                    : ImmutableOpenMap.<String, MappingMetadata>builder(1).fPut(MapperService.SINGLE_MAPPING_NAME, before.mapping).build(),
+                after.mapping == null
+                    ? ImmutableOpenMap.of()
+                    : ImmutableOpenMap.<String, MappingMetadata>builder(1).fPut(MapperService.SINGLE_MAPPING_NAME, after.mapping).build(),
+                DiffableUtils.getStringKeySerializer()
+            );
             aliases = DiffableUtils.diff(before.aliases, after.aliases, DiffableUtils.getStringKeySerializer());
             customData = DiffableUtils.diff(before.customData, after.customData, DiffableUtils.getStringKeySerializer());
             inSyncAllocationIds = DiffableUtils.diff(
@@ -1008,7 +1013,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.state(state);
             builder.settings(settings);
             builder.primaryTerms(primaryTerms);
-            builder.mappings.putAll(mappings.apply(part.mappings));
+            builder.mapping = mappings.apply(
+                ImmutableOpenMap.<String, MappingMetadata>builder(1).fPut(MapperService.SINGLE_MAPPING_NAME, part.mapping).build()
+            ).get(MapperService.SINGLE_MAPPING_NAME);
             builder.aliases.putAll(aliases.apply(part.aliases));
             builder.customMetadata.putAll(customData.apply(part.customData));
             builder.inSyncAllocationIds.putAll(inSyncAllocationIds.apply(part.inSyncAllocationIds));
@@ -1077,9 +1084,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
         out.writeVLongArray(primaryTerms);
-        out.writeVInt(mappings.size());
-        for (MappingMetadata mappingMetadata : mappings.values()) {
-            mappingMetadata.writeTo(out);
+        if (mapping == null) {
+            out.writeVInt(0);
+        } else {
+            out.writeVInt(1);
+            mapping.writeTo(out);
         }
         out.writeVInt(aliases.size());
         for (AliasMetadata aliasMetadata : aliases.values()) {
@@ -1135,7 +1144,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private long aliasesVersion = 1;
         private long[] primaryTerms = null;
         private Settings settings = Settings.EMPTY;
-        private final ImmutableOpenMap.Builder<String, MappingMetadata> mappings;
+        private MappingMetadata mapping;
         private final ImmutableOpenMap.Builder<String, AliasMetadata> aliases;
         private final ImmutableOpenMap.Builder<String, DiffableStringMap> customMetadata;
         private final ImmutableOpenIntMap.Builder<Set<String>> inSyncAllocationIds;
@@ -1146,7 +1155,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
         public Builder(String index) {
             this.index = index;
-            this.mappings = ImmutableOpenMap.builder();
             this.aliases = ImmutableOpenMap.builder();
             this.customMetadata = ImmutableOpenMap.builder();
             this.inSyncAllocationIds = ImmutableOpenIntMap.builder();
@@ -1163,7 +1171,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.aliasesVersion = indexMetadata.aliasesVersion;
             this.settings = indexMetadata.getSettings();
             this.primaryTerms = indexMetadata.primaryTerms.clone();
-            this.mappings = ImmutableOpenMap.builder(indexMetadata.mappings);
+            this.mapping = indexMetadata.mapping;
             this.aliases = ImmutableOpenMap.builder(indexMetadata.aliases);
             this.customMetadata = ImmutableOpenMap.builder(indexMetadata.customData);
             this.routingNumShards = indexMetadata.routingNumShards;
@@ -1237,7 +1245,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         public MappingMetadata mapping() {
-            return mappings.get(MapperService.SINGLE_MAPPING_NAME);
+            return mapping;
         }
 
         public Builder putMapping(String source) {
@@ -1251,10 +1259,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         public Builder putMapping(MappingMetadata mappingMd) {
-            mappings.clear();
-            if (mappingMd != null) {
-                mappings.put(MapperService.SINGLE_MAPPING_NAME, mappingMd);
-            }
+            mapping = mappingMd;
             return this;
         }
 
@@ -1516,7 +1521,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 numberOfShards,
                 numberOfReplicas,
                 settings,
-                mappings.build(),
+                mapping,
                 aliases.build(),
                 customMetadata.build(),
                 filledInSyncAllocationIds.build(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1084,6 +1084,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
         out.writeVLongArray(primaryTerms);
+        // TODO: adjust serialization format to using an optional writable
         if (mapping == null) {
             out.writeVInt(0);
         } else {


### PR DESCRIPTION
We only have a single entry in the map nowadays so the map is redundant
and has become a performance issue now that we do mapping deduplication
when building `Metadata`. Calls to this getter make up more 5%+ of the
master thread runtime in many shards benchmarking because of the expensive
iterator setup.
Unfortunately, it wasn't quite as easy to adjust the wire format here
since we need to still communicate with older version nodes that will
send a map diff so I left that as a TODO as it's low-impact/priority
and this change fixes the performance issue for now.

relates #77466 