### PR TITLE
[8.0] [DOCS] Note that `default_field` support wildcards (#81127)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -272,7 +272,7 @@ are ignored for this index.
     The maximum length of regex that can be used in Regexp Query.
     Defaults to `1000`.
 
-
+[[index-query-default-field]]
 `index.query.default_field`::
 +
 --

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -63,13 +63,14 @@ GET /_search
 `default_field`::
 +
 --
-(Optional, string) Default field you wish to search if no field is provided in
-the query string.
+(Optional, string) Default field to search if no field is provided in the query
+string. Supports wildcards (`*`).
 
-Defaults to the `index.query.default_field` index setting, which has a default
-value of `*`. The `*` value extracts all fields that are eligible for term
-queries and filters the metadata fields. All extracted fields are then
-combined to build a query if no `prefix` is specified.
+
+Defaults to the <<index-query-default-field,`index.query.default_field`>> index
+setting, which has a default value of `*`. The `*` value extracts all fields
+that are eligible for term queries and filters the metadata fields. All
+extracted fields are then combined to build a query if no `prefix` is specified.
 
 Searching across all eligible fields does not include <<nested,nested
 documents>>. Use a <<query-dsl-nested-query,`nested` query>> to search those
@@ -136,13 +137,11 @@ AND of AND Hungary`.
 from a `query_string` search. Defaults to `true`.
 
 `fields`::
+(Optional, array of strings) Array of fields to search. Supports wildcards
+(`*`).
 +
---
-(Optional, array of strings) Array of fields you wish to search.
-
 You can use this parameter query to search across multiple fields. See
 <<query-string-multi-field>>.
---
 
 `fuzziness`::
 (Optional, string) Maximum edit distance allowed for fuzzy matching. For fuzzy


### PR DESCRIPTION
This is an automatic backport of pull request #81127 to 8.0.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information