### PR TITLE
Don't Parse Monitoring Templates on Every CS Update

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -253,18 +253,16 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
+    private static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
+        BEATS_STACK_INDEX_TEMPLATE,
+        ES_STACK_INDEX_TEMPLATE,
+        KIBANA_STACK_INDEX_TEMPLATE,
+        LOGSTASH_STACK_INDEX_TEMPLATE
+    );
+
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        if (monitoringTemplatesEnabled) {
-            return parseComposableTemplates(
-                BEATS_STACK_INDEX_TEMPLATE,
-                ES_STACK_INDEX_TEMPLATE,
-                KIBANA_STACK_INDEX_TEMPLATE,
-                LOGSTASH_STACK_INDEX_TEMPLATE
-            );
-        } else {
-            return Collections.emptyMap();
-        }
+        return monitoringTemplatesEnabled ? COMPOSABLE_INDEX_TEMPLATE_CONFIGS : Map.of();
     }
 
     @Override


### PR DESCRIPTION
Same as #80086 fixing the monitoring templates which that original
PR forgot (after fixing a bunch of other things recently this is 5% of the applier runtime when creating indices in a hot loop at the moment).

Relates #77466

