### PR TITLE
[7.17] [docs] clarify purged http stats (#82123)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1908,6 +1908,8 @@ Total number of HTTP connections opened for the node.
 `clients`::
 (array of objects)
 Information on current and recently-closed HTTP client connections.
+Clients that have been closed longer than the <<http-settings,http.client_stats.closed_channels.max_age>>
+setting will not be represented here.
 +
 .Properties of `clients`
 [%collapsible%open]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [docs] clarify purged http stats (#82123)