### PR TITLE
whitelist async-check-index threads

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -81,7 +81,6 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSnapshotsIntegTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81949")
     public void testCreateAndRestorePartialSearchableSnapshot() throws Exception {
         final String fsRepoName = randomAlphaOfLength(10);
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
@@ -300,9 +300,12 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
             // Cache prewarming also runs on a dedicated thread pool.
             || threadName.contains('[' + SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME + ']')
 
-            // Unit tests access the blob store on the main test thread; simplest just to permit this rather than have them override this
+            // Unit tests access the blob store on the main test thread, or via an asynchronous
+            // checkindex call;
+            // simplest just to permit this rather than have them override this
             // method somehow.
             || threadName.startsWith("TEST-")
+            || threadName.startsWith("async-check-index")
             || threadName.startsWith("LuceneTestCase") : "current thread [" + Thread.currentThread() + "] may not read " + fileInfo;
         return true;
     }


### PR DESCRIPTION
Lucene 8.11.x has a new feature (https://github.com/apache/lucene/pull/128)
to check segments concurrently. Since this is executed in a threadpool,
new thread name needs to be whitelisted.

Similar change has been implemented in 8.x when upgrading to lucene 9: https://github.com/elastic/elasticsearch/commit/524d1ea757938cc4a05eb596dc0e93f888933d50

Closes: #81949 

