### PR TITLE
[7.16] [DOC] Don't include searchable snapshot ILM action in both hot and cold phases (#82013)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -17,6 +17,10 @@ the frozen phase, the action mounts a <<partially-mounted,partially mounted
 index>> prefixed with `partial-` to the frozen tier. In other phases, the action mounts a
 <<fully-mounted,fully mounted index>> prefixed with `restored-` to the corresponding data tier.
 
+WARNING: Don't include the `searchable_snapshot` action in both the hot and cold
+phases. This can result in indices failing to automatically migrate to the cold
+tier during the cold phase.
+
 If the `searchable_snapshot` action is used in the hot phase the subsequent
 phases cannot include the `shrink`, `forcemerge`, or `freeze` actions.
 


### PR DESCRIPTION
This is an automatic backport of pull request #82013 to 7.16.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information