### PR TITLE
[DOCS] Clarify document updates don't apply ingest pipelines

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -316,7 +316,9 @@ Defaults to `*`, which matches all fields eligible for
     Default <<ingest,ingest pipeline>> for the index. Index requests will fail
     if the default pipeline is set and the pipeline does not exist. The default may be
     overridden using the `pipeline` parameter. The special pipeline name `_none` indicates
-    no ingest pipeline should be run.
+    no ingest pipeline should be run. This pipeline doesn't apply to document
+    updates made using the <<docs-update,update API>> or the <<docs-bulk,bulk
+    API>>'s `update` action.
 
 [[index-final-pipeline]]
 `index.final_pipeline`::
@@ -324,7 +326,9 @@ Final <<ingest,ingest pipeline>> for the index. Indexing requests
 will fail if the final pipeline is set and the pipeline does not exist.
 The final pipeline always runs after the request pipeline (if specified) and
 the default pipeline (if it exists). The special pipeline name `_none`
-indicates no ingest pipeline will run.
+indicates no ingest pipeline will run. This pipeline doesn't apply to document
+updates made using the <<docs-update,update API>> or the <<docs-bulk,bulk
+API>>'s `update` action.
 +
 NOTE: You can't use a final pipeline to change the `_index` field. If the
 pipeline attempts to change the `_index` field, the indexing request will fail.

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -316,9 +316,7 @@ Defaults to `*`, which matches all fields eligible for
     Default <<ingest,ingest pipeline>> for the index. Index requests will fail
     if the default pipeline is set and the pipeline does not exist. The default may be
     overridden using the `pipeline` parameter. The special pipeline name `_none` indicates
-    no ingest pipeline should be run. This pipeline doesn't apply to document
-    updates made using the <<docs-update,update API>> or the <<docs-bulk,bulk
-    API>>'s `update` action.
+    no ingest pipeline should be run.
 
 [[index-final-pipeline]]
 `index.final_pipeline`::
@@ -326,9 +324,7 @@ Final <<ingest,ingest pipeline>> for the index. Indexing requests
 will fail if the final pipeline is set and the pipeline does not exist.
 The final pipeline always runs after the request pipeline (if specified) and
 the default pipeline (if it exists). The special pipeline name `_none`
-indicates no ingest pipeline will run. This pipeline doesn't apply to document
-updates made using the <<docs-update,update API>> or the <<docs-bulk,bulk
-API>>'s `update` action.
+indicates no ingest pipeline will run.
 +
 NOTE: You can't use a final pipeline to change the `_index` field. If the
 pipeline attempts to change the `_index` field, the indexing request will fail.

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -264,8 +264,8 @@ POST _reindex
 === Set a default pipeline
 
 Use the <<index-default-pipeline,`index.default_pipeline`>> index setting to set
-a default pipeline. {es} applies this pipeline to <<docs-index_, index requests>> if no `pipeline` parameter
-is specified.
+a default pipeline. {es} applies this pipeline to indexing requests if no
+`pipeline` parameter is specified.
 
 [discrete]
 [[set-final-pipeline]]

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -217,7 +217,7 @@ The API returns transformed documents:
 [[add-pipeline-to-indexing-request]]
 === Add a pipeline to an indexing request
 
-Use the `pipeline` parameter to apply a pipeline to documents in
+Use the `pipeline` query parameter to apply a pipeline to documents in
 <<docs-index_,individual>> or <<docs-bulk,bulk>> indexing requests.
 
 [source,console]
@@ -231,7 +231,7 @@ POST my-data-stream/_doc?pipeline=my-pipeline
 PUT my-data-stream/_bulk?pipeline=my-pipeline
 { "create":{ } }
 { "@timestamp": "2099-03-07T11:04:06.000Z", "my-keyword-field": "foo" }
-{ "create":{ "pipeline": "my-other-pipeline" } }
+{ "create":{ } }
 { "@timestamp": "2099-03-07T11:04:07.000Z", "my-keyword-field": "bar" }
 ----
 // TEST[setup:my_data_stream]
@@ -259,15 +259,12 @@ POST _reindex
 // TEST[setup:my_data_stream]
 // TEST[teardown:data_stream_cleanup]
 
-{es} doesn't apply pipelines to other document updates, such as those made using
-the <<docs-update,update API>> or the <<docs-bulk,bulk API>>'s `update` action.
-
 [discrete]
 [[set-default-pipeline]]
 === Set a default pipeline
 
 Use the <<index-default-pipeline,`index.default_pipeline`>> index setting to set
-a default pipeline. {es} applies this pipeline if no `pipeline` parameter
+a default pipeline. {es} applies this pipeline to <<docs-index_, index requests>> if no `pipeline` parameter
 is specified.
 
 [discrete]

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -264,7 +264,7 @@ POST _reindex
 === Set a default pipeline
 
 Use the <<index-default-pipeline,`index.default_pipeline`>> index setting to set
-a default pipeline. {es} applies this pipeline if no `pipeline` parameter
+a default pipeline. {es} applies this pipeline to <<docs-index_, index requests>> if no `pipeline` parameter
 is specified.
 
 [discrete]

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -217,7 +217,7 @@ The API returns transformed documents:
 [[add-pipeline-to-indexing-request]]
 === Add a pipeline to an indexing request
 
-Use the `pipeline` query parameter to apply a pipeline to documents in
+Use the `pipeline` parameter to apply a pipeline to documents in
 <<docs-index_,individual>> or <<docs-bulk,bulk>> indexing requests.
 
 [source,console]
@@ -231,7 +231,7 @@ POST my-data-stream/_doc?pipeline=my-pipeline
 PUT my-data-stream/_bulk?pipeline=my-pipeline
 { "create":{ } }
 { "@timestamp": "2099-03-07T11:04:06.000Z", "my-keyword-field": "foo" }
-{ "create":{ } }
+{ "create":{ "pipeline": "my-other-pipeline" } }
 { "@timestamp": "2099-03-07T11:04:07.000Z", "my-keyword-field": "bar" }
 ----
 // TEST[setup:my_data_stream]
@@ -259,12 +259,15 @@ POST _reindex
 // TEST[setup:my_data_stream]
 // TEST[teardown:data_stream_cleanup]
 
+{es} doesn't apply pipelines to other document updates, such as those made using
+the <<docs-update,update API>> or the <<docs-bulk,bulk API>>'s `update` action.
+
 [discrete]
 [[set-default-pipeline]]
 === Set a default pipeline
 
 Use the <<index-default-pipeline,`index.default_pipeline`>> index setting to set
-a default pipeline. {es} applies this pipeline to <<docs-index_, index requests>> if no `pipeline` parameter
+a default pipeline. {es} applies this pipeline if no `pipeline` parameter
 is specified.
 
 [discrete]


### PR DESCRIPTION
Adding text to clarify that the default pipeline only applies to index requests vs updates