### PR TITLE
[8.0] Allow read template with cluster monitor privilege (#82046)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -15,6 +15,9 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAct
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetComponentTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
 import org.elasticsearch.action.ingest.GetPipelineAction;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.common.Strings;
@@ -64,7 +67,12 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> MANAGE_API_KEY_PATTERN = Set.of("cluster:admin/xpack/security/api_key/*");
     private static final Set<String> MANAGE_SERVICE_ACCOUNT_PATTERN = Set.of("cluster:admin/xpack/security/service_account/*");
     private static final Set<String> GRANT_API_KEY_PATTERN = Set.of(GrantApiKeyAction.NAME + "*");
-    private static final Set<String> MONITOR_PATTERN = Set.of("cluster:monitor/*");
+    private static final Set<String> MONITOR_PATTERN = Set.of(
+        "cluster:monitor/*",
+        GetIndexTemplatesAction.NAME,
+        GetComponentTemplateAction.NAME,
+        GetComposableIndexTemplateAction.NAME
+    );
     private static final Set<String> MONITOR_ML_PATTERN = Set.of("cluster:monitor/xpack/ml/*");
     private static final Set<String> MONITOR_TEXT_STRUCTURE_PATTERN = Set.of("cluster:monitor/text_structure/*");
     private static final Set<String> MONITOR_TRANSFORM_PATTERN = Set.of("cluster:monitor/data_frame/*", "cluster:monitor/transform/*");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeTests.java
@@ -8,14 +8,29 @@
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.indices.template.get.GetComponentTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 import org.elasticsearch.xpack.core.security.authz.permission.ClusterPermission;
+
+import java.util.List;
 
 public class ClusterPrivilegeTests extends ESTestCase {
 
     public void testMonitorPrivilegeWillGrantActions() {
         assertGranted(ClusterPrivilegeResolver.MONITOR, EnrichStatsAction.INSTANCE);
+    }
+
+    public void testMonitorPrivilegeGrantsGetTemplateActions() {
+        for (var action : List.of(
+            GetComponentTemplateAction.INSTANCE,
+            GetComposableIndexTemplateAction.INSTANCE,
+            GetIndexTemplatesAction.INSTANCE
+        )) {
+            assertGranted(ClusterPrivilegeResolver.MONITOR, action);
+        }
     }
 
     public static void assertGranted(ClusterPrivilege clusterPrivilege, ActionType<?> actionType) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1220,7 +1220,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(remoteMonitoringCollectorRole.cluster().check(ClusterHealthAction.NAME, request, authentication), is(true));
         assertThat(remoteMonitoringCollectorRole.cluster().check(ClusterStateAction.NAME, request, authentication), is(true));
         assertThat(remoteMonitoringCollectorRole.cluster().check(ClusterStatsAction.NAME, request, authentication), is(true));
-        assertThat(remoteMonitoringCollectorRole.cluster().check(GetIndexTemplatesAction.NAME, request, authentication), is(false));
+        assertThat(remoteMonitoringCollectorRole.cluster().check(GetIndexTemplatesAction.NAME, request, authentication), is(true));
         assertThat(remoteMonitoringCollectorRole.cluster().check(PutIndexTemplateAction.NAME, request, authentication), is(false));
         assertThat(remoteMonitoringCollectorRole.cluster().check(DeleteIndexTemplateAction.NAME, request, authentication), is(false));
         assertThat(remoteMonitoringCollectorRole.cluster().check(ClusterRerouteAction.NAME, request, authentication), is(false));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
@@ -127,9 +127,17 @@ public class ClusterPrivilegeIntegrationTests extends AbstractPrivilegeTestCase 
         assertAccessIsAllowed("user_b", "GET", "/_nodes/stats");
         assertAccessIsAllowed("user_b", "GET", "/_nodes/hot_threads");
         assertAccessIsAllowed("user_b", "GET", "/_nodes/infos");
+        // monitoring allows template retrieval (because it's implied by having read access to cluster state
+        assertAccessIsAllowed("user_b", "GET", "/_cat/templates/" + (randomBoolean() ? "" : randomAlphaOfLengthBetween(2, 8)));
+        assertAccessIsAllowed("user_b", "GET", "/_template/");
+        assertAccessIsAllowed("user_b", "GET", "/_index_template/");
+        assertAccessIsAllowed("user_b", "GET", "/_component_template/");
         // but no admin stuff
         assertAccessIsDenied("user_b", "POST", "/_cluster/reroute");
         assertAccessIsDenied("user_b", "PUT", "/_cluster/settings", "{ \"transient\" : { \"search.default_search_timeout\": \"1m\" } }");
+        assertAccessIsDenied("user_b", "DELETE", "/_template/" + randomAlphaOfLengthBetween(2, 8));
+        assertAccessIsDenied("user_b", "DELETE", "/_index_template/" + randomAlphaOfLengthBetween(2, 8));
+        assertAccessIsDenied("user_b", "DELETE", "/_component_template/" + randomAlphaOfLengthBetween(2, 8));
 
         // sorry user_c, you are not allowed anything
         assertAccessIsDenied("user_c", "GET", "/_cluster/state");


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Allow read template with cluster monitor privilege (#82046)