### PR TITLE
[8.0] Perform index checking in a caller thread (#82249)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -328,6 +328,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     public CheckIndex.Status checkIndex(PrintStream out) throws IOException {
         metadataLock.writeLock().lock();
         try (CheckIndex checkIndex = new CheckIndex(directory)) {
+            // Since 8.11 lucene performs index checking concurrently using disposable fixed thread pool executor by default.
+            // Setting thread count to 1 to keep prior behaviour (check is executed in single caller thread).
+            checkIndex.setThreadCount(1);
             checkIndex.setInfoStream(out);
             return checkIndex.checkIndex();
         } finally {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
@@ -300,12 +300,8 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
             // Cache prewarming also runs on a dedicated thread pool.
             || threadName.contains('[' + SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME + ']')
 
-            // Unit tests access the blob store on the main test thread, or via an asynchronous
-            // checkindex call;
-            // simplest just to permit this rather than have them override this
-            // method somehow.
+            // Unit tests access the blob store on the main test thread; simplest just to permit this rather than have them override this
             || threadName.startsWith("TEST-")
-            || threadName.startsWith("async-check-index")
             || threadName.startsWith("LuceneTestCase") : "current thread [" + Thread.currentThread() + "] may not read " + fileInfo;
         return true;
     }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Perform index checking in a caller thread (#82249)