### PR TITLE
[7.17] Migrate to data tiers API dry run on any ILM status (#82226)

### DIFF
--- a/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
+++ b/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
@@ -51,6 +51,8 @@ not perform the migration. This provides a way to retrieve the indices and ILM p
 migrated.
 Defaults to `false`.
 
+NOTE: When simulating a migration (ie. `dry_run` is `true`) {ilm-init} doesn't need to be stopped.
+
 [[ilm-migrate-to-data-tiers-example]]
 ==== {api-examples-title}
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
@@ -285,13 +285,6 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
             TimeUnit.SECONDS
         );
 
-        // let's stop ILM so we can simulate the migration
-        client().performRequest(new Request("POST", "_ilm/stop"));
-        assertBusy(() -> {
-            Response response = client().performRequest(new Request("GET", "_ilm/status"));
-            assertThat(EntityUtils.toString(response.getEntity()), containsString(OperationMode.STOPPED.toString()));
-        });
-
         String indexWithDataWarmRouting = "indexwithdatawarmrouting";
         Settings.Builder settings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -134,13 +134,16 @@ public final class MetadataMigrateToDataTiersRoutingService {
         @Nullable String indexTemplateToDelete,
         NamedXContentRegistry xContentRegistry,
         Client client,
-        XPackLicenseState licenseState
+        XPackLicenseState licenseState,
+        boolean dryRun
     ) {
-        IndexLifecycleMetadata currentMetadata = currentState.metadata().custom(IndexLifecycleMetadata.TYPE);
-        if (currentMetadata != null && currentMetadata.getOperationMode() != STOPPED) {
-            throw new IllegalStateException(
-                "stop ILM before migrating to data tiers, current state is [" + currentMetadata.getOperationMode() + "]"
-            );
+        if (dryRun == false) {
+            IndexLifecycleMetadata currentMetadata = currentState.metadata().custom(IndexLifecycleMetadata.TYPE);
+            if (currentMetadata != null && currentMetadata.getOperationMode() != STOPPED) {
+                throw new IllegalStateException(
+                    "stop ILM before migrating to data tiers, current state is [" + currentMetadata.getOperationMode() + "]"
+                );
+            }
         }
 
         Metadata.Builder mb = Metadata.builder(currentState.metadata());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
@@ -73,16 +73,6 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
         ClusterState state,
         ActionListener<MigrateToDataTiersResponse> listener
     ) throws Exception {
-        IndexLifecycleMetadata currentMetadata = state.metadata().custom(IndexLifecycleMetadata.TYPE);
-        if (currentMetadata != null && currentMetadata.getOperationMode() != STOPPED) {
-            listener.onFailure(
-                new IllegalStateException(
-                    "stop ILM before migrating to data tiers, current state is [" + currentMetadata.getOperationMode() + "]"
-                )
-            );
-            return;
-        }
-
         if (request.isDryRun()) {
             MigratedEntities entities = migrateToDataTiersRouting(
                 state,
@@ -90,10 +80,21 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
                 request.getLegacyTemplateToDelete(),
                 xContentRegistry,
                 client,
-                licenseState
+                licenseState,
+                request.isDryRun()
             ).v2();
             listener.onResponse(
                 new MigrateToDataTiersResponse(entities.removedIndexTemplateName, entities.migratedPolicies, entities.migratedIndices, true)
+            );
+            return;
+        }
+
+        IndexLifecycleMetadata currentMetadata = state.metadata().custom(IndexLifecycleMetadata.TYPE);
+        if (currentMetadata != null && currentMetadata.getOperationMode() != STOPPED) {
+            listener.onFailure(
+                new IllegalStateException(
+                    "stop ILM before migrating to data tiers, current state is [" + currentMetadata.getOperationMode() + "]"
+                )
             );
             return;
         }
@@ -108,7 +109,8 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
                     request.getLegacyTemplateToDelete(),
                     xContentRegistry,
                     client,
-                    licenseState
+                    licenseState,
+                    request.isDryRun()
                 );
 
                 migratedEntities.set(migratedEntitiesTuple.v2());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -992,7 +992,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 "catch-all",
                 REGISTRY,
                 client,
-                null
+                null,
+                false
             );
 
             MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
@@ -1016,7 +1017,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 null,
                 REGISTRY,
                 client,
-                null
+                null,
+                false
             );
 
             MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
@@ -1040,7 +1042,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 null,
                 REGISTRY,
                 client,
-                null
+                null,
+                false
             );
 
             MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
@@ -1070,7 +1073,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 .build();
             IllegalStateException illegalStateException = expectThrows(
                 IllegalStateException.class,
-                () -> migrateToDataTiersRouting(ilmRunningState, "data", "catch-all", REGISTRY, client, null)
+                () -> migrateToDataTiersRouting(ilmRunningState, "data", "catch-all", REGISTRY, client, null, false)
             );
             assertThat(illegalStateException.getMessage(), is("stop ILM before migrating to data tiers, current state is [RUNNING]"));
         }
@@ -1087,7 +1090,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 .build();
             IllegalStateException illegalStateException = expectThrows(
                 IllegalStateException.class,
-                () -> migrateToDataTiersRouting(ilmStoppingState, "data", "catch-all", REGISTRY, client, null)
+                () -> migrateToDataTiersRouting(ilmStoppingState, "data", "catch-all", REGISTRY, client, null, false)
             );
             assertThat(illegalStateException.getMessage(), is("stop ILM before migrating to data tiers, current state is [STOPPING]"));
         }
@@ -1108,11 +1111,34 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 "catch-all",
                 REGISTRY,
                 client,
-                null
+                null,
+                false
             );
             assertThat(migratedState.v2().migratedIndices, empty());
             assertThat(migratedState.v2().migratedPolicies, empty());
             assertThat(migratedState.v2().removedIndexTemplateName, nullValue());
+        }
+    }
+
+    public void testDryRunDoesntRequireILMStopped() {
+        {
+            ClusterState ilmRunningState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(
+                    Metadata.builder().putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(Map.of(), OperationMode.RUNNING))
+                )
+                .build();
+            migrateToDataTiersRouting(ilmRunningState, "data", "catch-all", REGISTRY, client, null, true);
+            // no exceptions
+        }
+
+        {
+            ClusterState ilmStoppingState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(
+                    Metadata.builder().putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(Map.of(), OperationMode.STOPPING))
+                )
+                .build();
+            migrateToDataTiersRouting(ilmStoppingState, "data", "catch-all", REGISTRY, client, null, true);
+            // no exceptions
         }
     }
 
@@ -1131,7 +1157,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             composableTemplateName,
             REGISTRY,
             client,
-            null
+            null,
+            false
         );
         assertThat(migratedEntitiesTuple.v2().removedIndexTemplateName, nullValue());
         assertThat(migratedEntitiesTuple.v1().metadata().templatesV2().get(composableTemplateName), is(composableIndexTemplate));
@@ -1144,7 +1171,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
 
         // if the cluster state doesn't mention the setting, it ends up true
         clusterState = ClusterState.builder(ClusterName.DEFAULT).build();
-        migratedEntitiesTuple = migrateToDataTiersRouting(clusterState, null, null, REGISTRY, client, null);
+        migratedEntitiesTuple = migrateToDataTiersRouting(clusterState, null, null, REGISTRY, client, null, false);
         assertTrue(DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE_SETTING.get(migratedEntitiesTuple.v1().metadata().persistentSettings()));
         assertFalse(migratedEntitiesTuple.v1().metadata().transientSettings().keySet().contains(DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE));
 
@@ -1154,7 +1181,7 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
         metadata.persistentSettings(Settings.builder().put(ENFORCE_DEFAULT_TIER_PREFERENCE, randomBoolean()).build());
         metadata.transientSettings(Settings.builder().put(ENFORCE_DEFAULT_TIER_PREFERENCE, randomBoolean()).build());
         clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
-        migratedEntitiesTuple = migrateToDataTiersRouting(clusterState, null, null, REGISTRY, client, null);
+        migratedEntitiesTuple = migrateToDataTiersRouting(clusterState, null, null, REGISTRY, client, null, false);
         assertTrue(DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE_SETTING.get(migratedEntitiesTuple.v1().metadata().persistentSettings()));
         assertFalse(migratedEntitiesTuple.v1().metadata().transientSettings().keySet().contains(DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE));
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -1124,7 +1124,11 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
         {
             ClusterState ilmRunningState = ClusterState.builder(ClusterName.DEFAULT)
                 .metadata(
-                    Metadata.builder().putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(Map.of(), OperationMode.RUNNING))
+                    Metadata.builder()
+                        .putCustom(
+                            IndexLifecycleMetadata.TYPE,
+                            new IndexLifecycleMetadata(org.elasticsearch.core.Map.of(), OperationMode.RUNNING)
+                        )
                 )
                 .build();
             migrateToDataTiersRouting(ilmRunningState, "data", "catch-all", REGISTRY, client, null, true);
@@ -1134,7 +1138,11 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
         {
             ClusterState ilmStoppingState = ClusterState.builder(ClusterName.DEFAULT)
                 .metadata(
-                    Metadata.builder().putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(Map.of(), OperationMode.STOPPING))
+                    Metadata.builder()
+                        .putCustom(
+                            IndexLifecycleMetadata.TYPE,
+                            new IndexLifecycleMetadata(org.elasticsearch.core.Map.of(), OperationMode.STOPPING)
+                        )
                 )
                 .build();
             migrateToDataTiersRouting(ilmStoppingState, "data", "catch-all", REGISTRY, client, null, true);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Migrate to data tiers API dry run on any ILM status (#82226)