### PR TITLE
[ML] Move datafeed stats action off of master node

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -52,6 +52,11 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
         super(NAME, Response::new);
     }
 
+    // This needs to be a MasterNodeReadRequest even though the corresponding transport
+    // action is a HandledTransportAction so that in mixed version clusters it can be
+    // serialized to older nodes where the transport action was a MasterNodeReadAction.
+    // TODO: Make this a simple request in a future version where there is no possibility
+    //       of this request being serialized to another node.
     public static class Request extends MasterNodeReadRequest<Request> {
 
         public static final String ALLOW_NO_MATCH = "allow_no_match";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -56,7 +56,7 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
     // action is a HandledTransportAction so that in mixed version clusters it can be
     // serialized to older nodes where the transport action was a MasterNodeReadAction.
     // TODO: Make this a simple request in a future version where there is no possibility
-    //       of this request being serialized to another node.
+    // of this request being serialized to another node.
     public static class Request extends MasterNodeReadRequest<Request> {
 
         public static final String ALLOW_NO_MATCH = "allow_no_match";


### PR DESCRIPTION
Previously the get datafeed stats action was handled on the
master node. This dated back to the time when datafeed configs
were stored in the cluster state. Now that the action consists
of running a series of searches it can be a handled transport
action.