### PR TITLE
Make FieldNamesFieldMapper a Singleton in most Cases

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -390,7 +390,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     @Override
     public final FieldMapper merge(Mapper mergeWith) {
-
+        if (mergeWith == this) {
+            return this;
+        }
         if (mergeWith instanceof FieldMapper == false) {
             throw new IllegalArgumentException(
                 "mapper ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -37,7 +37,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(indexVersionCreated).init(this);
+        return new Builder(createdOnOrAfterV8).init(this);
     }
 
     public static class Defaults {
@@ -71,11 +71,15 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             Defaults.ENABLED.value()
         );
 
-        private final Version indexVersionCreated;
+        private final boolean createdOnOrAfterV8;
 
         Builder(Version indexVersionCreated) {
+            this(indexVersionCreated.onOrAfter(Version.V_8_0_0));
+        }
+
+        Builder(boolean createdOnOrAfterV8) {
             super(Defaults.NAME);
-            this.indexVersionCreated = indexVersionCreated;
+            this.createdOnOrAfterV8 = createdOnOrAfterV8;
         }
 
         @Override
@@ -86,7 +90,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         @Override
         public FieldNamesFieldMapper build() {
             if (enabled.getValue().explicit()) {
-                if (indexVersionCreated.onOrAfter(Version.V_8_0_0)) {
+                if (createdOnOrAfterV8) {
                     throw new MapperParsingException(
                         "The `enabled` setting for the `_field_names` field has been deprecated and "
                             + "removed. Please remove it from your mappings and templates."
@@ -95,12 +99,19 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
                     deprecationLogger.warn(DeprecationCategory.TEMPLATES, "field_names_enabled_parameter", ENABLED_DEPRECATION_MESSAGE);
                 }
             }
-            return new FieldNamesFieldMapper(enabled.getValue(), indexVersionCreated);
+            if (Defaults.ENABLED.equals(enabled.getValue())) {
+                return createdOnOrAfterV8 ? DEFAULT : DEFAULT_OLD;
+            }
+            return new FieldNamesFieldMapper(enabled.getValue(), createdOnOrAfterV8);
         }
     }
 
+    private static final FieldNamesFieldMapper DEFAULT = new FieldNamesFieldMapper(Defaults.ENABLED, true);
+
+    private static final FieldNamesFieldMapper DEFAULT_OLD = new FieldNamesFieldMapper(Defaults.ENABLED, false);
+
     public static final TypeParser PARSER = new ConfigurableTypeParser(
-        c -> new FieldNamesFieldMapper(Defaults.ENABLED, c.indexVersionCreated()),
+        c -> c.indexVersionCreated().onOrAfter(Version.V_8_0_0) ? DEFAULT : DEFAULT_OLD,
         c -> new Builder(c.indexVersionCreated())
     );
 
@@ -155,12 +166,12 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
     }
 
     private final Explicit<Boolean> enabled;
-    private final Version indexVersionCreated;
+    private final boolean createdOnOrAfterV8;
 
-    private FieldNamesFieldMapper(Explicit<Boolean> enabled, Version indexVersionCreated) {
+    private FieldNamesFieldMapper(Explicit<Boolean> enabled, boolean createdOnOrAfterV8) {
         super(FieldNamesFieldType.get(enabled.value()));
         this.enabled = enabled;
-        this.indexVersionCreated = indexVersionCreated;
+        this.createdOnOrAfterV8 = createdOnOrAfterV8;
     }
 
     @Override


### PR DESCRIPTION
This is mostly the same instance => just removing a little noise from
data node heap dumps, not much memory savings here obviously but we made the
data stream timestamp parser etc. singletons so why not this one.

Also short-circuited an obvious noop when merging mappings.