### PR TITLE
Fix concurrent serialization test for StoredScript

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -43,12 +42,6 @@ import java.util.Objects;
  * saved in the {@link ClusterState}.
  */
 public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> implements Writeable, ToXContentObject {
-
-    /**
-     * Standard deprecation logger for used to deprecate allowance of empty templates.
-     */
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(StoredScriptSource.class);
-
     /**
      * Standard {@link ParseField} for outer level of stored script source.
      */


### PR DESCRIPTION
This fixes the concurrent toXContent tests for `StoredScript`. It turns
out that `StoredScript`'s tests are the only tests to encode a very long
string and `SMILE`'s xcontent serialization has unpredictable behavior
for long strings. It'll always produce a valid encoding, but sometimes
long strings will be output with the marker for utf-8 instead of ascii.
That causes the bytes comparison that the concurrent serialization
tests. So we never test with SMILE here. That's ok. The test is mostly
about concurrency, not xcontent type.

Also! The error message was quite difficult to debug here. So I improved
it while I was there.

Closes #82257
