### PR TITLE
Handle wrapped IO exceptions in test cluster distribution syncing

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1208,10 +1208,13 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                     syncMethod.accept(destination, source);
                 }
             });
-        } catch (NoSuchFileException e) {
-            // Ignore these files that are sometimes left behind by the JVM
-            if (e.getFile() == null || e.getFile().contains(".attach_pid") == false) {
-                throw new UncheckedIOException(e);
+        } catch (UncheckedIOException e) {
+            if (e.getCause() instanceof NoSuchFileException) {
+                NoSuchFileException cause = (NoSuchFileException) e.getCause();
+                // Ignore these files that are sometimes left behind by the JVM
+                if (cause.getFile() == null || cause.getFile().contains(".attach_pid") == false) {
+                    throw new UncheckedIOException(cause);
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Can't walk source " + sourceRoot, e);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1215,6 +1215,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 if (cause.getFile() == null || cause.getFile().contains(".attach_pid") == false) {
                     throw new UncheckedIOException(cause);
                 }
+            } else {
+                throw e;
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Can't walk source " + sourceRoot, e);


### PR DESCRIPTION
Third attempt at sorting out this problem after #82154 didn't do the trick. The issue is that `FileTreeIterator` wraps the root cause exception in an `UncheckedIOException` so to detect this scenario properly we actually have to inspect the cause.