### PR TITLE
Upgrade documentation for xpack.monitoring.history.duration

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -94,7 +94,7 @@ The `elasticsearch-setup-passwords` tool is deprecated in 8.0. To
 manually reset the password for built-in users (including the `elastic` user), use
 the {ref}/reset-password.html[`elasticsearch-reset-password`] tool, the {es}
 {ref}/security-api-change-password.html[change passwords API], or the
-User Management features in {kib}. 
+User Management features in {kib}.
 `elasticsearch-setup-passwords` will be removed in a future release.
 
 *Impact* +

--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -917,15 +917,17 @@ Any node that did not have an explicitly configured password hashing algorithm i
 Prior to 8.0, Elasticsearch would internally handle removal of all monitoring indices according to the
 `xpack.monitoring.history.duration` setting.
 
-When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy.
+When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy. The policy will be created using the `xpack.monitoring.history.duration` as an initial retention period.
 
-If you need to customize retention settings for monitoring data, please update the ILM policy directly.
+If you need to customize retention settings for monitoring data collected with metricbeat, please update the `.monitoring-8-ilm-policy` ILM policy directly.
 
 The `xpack.monitoring.history.duration` setting will only apply to monitoring indices written using (legacy) internal
 collection, not indices created by metricbeat or agent.
 
 *Impact* +
-After upgrading, insure that the monitoring ILM policy aligns with your desired retention settings. If you only use
+After upgrading, ensure that the `.monitoring-8-ilm-policy` ILM policy aligns with your desired retention settings.
+
+If you only use
 metricbeat or agent to collect monitoring data, you can also remove any custom `xpack.monitoring.history.duration`
 settings.
 

--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -907,3 +907,27 @@ will continue to use that configured value.
 Any node that did not have an explicitly configured password hashing algorithm in
 {es} 6.x or {es} 7.x would have failed to start.
 ====
+
+//tag::notable-breaking-changes[]
+.The `xpack.monitoring.history.duration` will not delete indices created by metricbeat or elastic agent
+[%collapsible]
+====
+*Details* +
+
+Prior to 8.0, Elasticsearch would internally handle removal of all monitoring indices according to the
+`xpack.monitoring.history.duration` setting.
+
+When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy.
+
+If you need to customize retention settings for monitoring data, please update the ILM policy directly.
+
+The `xpack.monitoring.history.duration` setting will only apply to monitoring indices written using (legacy) internal
+collection, not indices created by metricbeat or agent.
+
+*Impact* +
+After upgrading, insure that the monitoring ILM policy aligns with your desired retention settings. If you only use
+metricbeat or agent to collect monitoring data, you can also remove any custom `xpack.monitoring.history.duration`
+settings.
+
+====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -925,7 +925,7 @@ The `xpack.monitoring.history.duration` setting will only apply to monitoring in
 collection, not indices created by metricbeat or agent.
 
 *Impact* +
-After upgrading, ensure that the `.monitoring-8-ilm-policy` ILM policy aligns with your desired retention settings.
+After upgrading, insure that the `.monitoring-8-ilm-policy` ILM policy aligns with your desired retention settings.
 
 If you only use
 metricbeat or agent to collect monitoring data, you can also remove any custom `xpack.monitoring.history.duration`

--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -917,7 +917,7 @@ Any node that did not have an explicitly configured password hashing algorithm i
 Prior to 8.0, Elasticsearch would internally handle removal of all monitoring indices according to the
 `xpack.monitoring.history.duration` setting.
 
-When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy. The policy will be created using the `xpack.monitoring.history.duration` as an initial retention period.
+When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy. If the setting is present, the policy will be created using the `xpack.monitoring.history.duration` as an initial retention period.
 
 If you need to customize retention settings for monitoring data collected with metricbeat, please update the `.monitoring-8-ilm-policy` ILM policy directly.
 


### PR DESCRIPTION
Rel: https://github.com/elastic/elasticsearch/issues/81839

As part of the upgrade from 7 to 8, anyone using metricbeat to monitor elastic stack will likely need to adjust ILM policies to reflect retention settings.

This is a mostly-complete draft of the upgrade note.

We'll probably want to update it once we know exactly what the ILM policy will be named.