### PR TITLE
Pluggable SortBuilder's

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/SortFromPluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/SortFromPluginIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.plugin.CustomSortBuilder;
+import org.elasticsearch.search.sort.plugin.CustomSortPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class SortFromPluginIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(CustomSortPlugin.class, InternalSettingsPlugin.class);
+    }
+
+    public void testPluginSort() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
+
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch("test").addSort(new CustomSortBuilder("field", SortOrder.ASC)).get();
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("3"));
+        assertThat(searchResponse.getHits().getAt(1).getId(), equalTo("2"));
+        assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("1"));
+
+        searchResponse = client().prepareSearch("test").addSort(new CustomSortBuilder("field", SortOrder.DESC)).get();
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(1).getId(), equalTo("2"));
+        assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("3"));
+    }
+
+    public void testPluginSortXContent() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
+
+        refresh();
+
+        // builder -> json -> builder
+        SearchResponse searchResponse = client().prepareSearch("test")
+            .setSource(
+                SearchSourceBuilder.fromXContent(
+                    createParser(
+                        JsonXContent.jsonXContent,
+                        new SearchSourceBuilder().sort(new CustomSortBuilder("field", SortOrder.ASC)).toString()
+                    )
+                )
+            )
+            .get();
+
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("3"));
+        assertThat(searchResponse.getHits().getAt(1).getId(), equalTo("2"));
+        assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("1"));
+
+        searchResponse = client().prepareSearch("test")
+            .setSource(
+                SearchSourceBuilder.fromXContent(
+                    createParser(
+                        JsonXContent.jsonXContent,
+                        new SearchSourceBuilder().sort(new CustomSortBuilder("field", SortOrder.DESC)).toString()
+                    )
+                )
+            )
+            .get();
+
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(1).getId(), equalTo("2"));
+        assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("3"));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.plugins;
 
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -36,6 +37,8 @@ import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.rescore.Rescorer;
 import org.elasticsearch.search.rescore.RescorerBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortParser;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
@@ -105,6 +108,13 @@ public interface SearchPlugin {
      * The new {@link Query}s defined by this plugin.
      */
     default List<QuerySpec<?>> getQueries() {
+        return emptyList();
+    }
+
+    /**
+     * The new {@link Sort}s defined by this plugin.
+     */
+    default List<SortSpec<?>> getSorts() {
         return emptyList();
     }
 
@@ -267,6 +277,38 @@ public interface SearchPlugin {
          * @param parser the parser the reads the query builder from xcontent
          */
         public QuerySpec(String name, Writeable.Reader<T> reader, QueryParser<T> parser) {
+            super(name, reader, parser);
+        }
+    }
+
+    /**
+     * Specification of custom {@link Sort}.
+     */
+    class SortSpec<T extends SortBuilder<T>> extends SearchExtensionSpec<T, SortParser<T>> {
+        /**
+         * Specification of custom {@link Sort}.
+         *
+         * @param name holds the names by which this sort might be parsed. The {@link ParseField#getPreferredName()} is special as it
+         *        is the name by under which the reader is registered. So it is the name that the sort should use as its
+         *        {@link NamedWriteable#getWriteableName()} too.
+         * @param reader the reader registered for this sort's builder. Typically a reference to a constructor that takes a
+         *        {@link StreamInput}
+         * @param parser the parser the reads the sort builder from xcontent
+         */
+        public SortSpec(ParseField name, Writeable.Reader<T> reader, SortParser<T> parser) {
+            super(name, reader, parser);
+        }
+
+        /**
+         * Specification of custom {@link Sort}.
+         *
+         * @param name the name by which this sort might be parsed or deserialized. Make sure that the query builder returns this name for
+         *        {@link NamedWriteable#getWriteableName()}.
+         * @param reader the reader registered for this sort's builder. Typically a reference to a constructor that takes a
+         *        {@link StreamInput}
+         * @param parser the parser the reads the sort builder from xcontent
+         */
+        public SortSpec(String name, Writeable.Reader<T> reader, SortParser<T> parser) {
             super(name, reader, parser);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -740,6 +740,27 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return PARSER.parse(parser, new FieldSortBuilder(fieldName), null);
     }
 
+    public static FieldSortBuilder fromXContentObject(XContentParser parser, String fieldName) throws IOException {
+        FieldSortBuilder builder = null;
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                builder = fromXContent(parser, currentFieldName);
+            } else {
+                throw new ParsingException(parser.getTokenLocation(), "[" + NAME + "] does not support [" + currentFieldName + "]");
+            }
+        }
+
+        if (builder == null) {
+            throw new ParsingException(parser.getTokenLocation(), "Invalid " + NAME);
+        }
+
+        return builder;
+    }
+
     private static final ObjectParser<FieldSortBuilder, Void> PARSER = new ObjectParser<>(NAME);
 
     static {

--- a/server/src/main/java/org/elasticsearch/search/sort/SortParser.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortParser.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+/**
+ * Defines a sort parser that is able to parse {@link SortBuilder}s from {@link org.elasticsearch.xcontent.XContent}.
+ */
+@FunctionalInterface
+public interface SortParser<SB extends SortBuilder<SB>> {
+    /**
+     * Creates a new {@link SortBuilder} from the sort held by the
+     * {@link XContentParser}. The state on the parser contained in this context
+     * will be changed as a side effect of this method call
+     */
+    SB fromXContent(XContentParser parser, String elementName) throws IOException;
+}

--- a/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -103,6 +103,7 @@ public class SortBuilderTests extends ESTestCase {
         result = parseSort(json);
         assertEquals(1, result.size());
         sortBuilder = result.get(0);
+        assertWarnings("Deprecated field [_geoDistance] used, expected [_geo_distance] instead");
         assertEquals(new GeoDistanceSortBuilder("pin.location", 40, -70), sortBuilder);
 
         json = """

--- a/server/src/test/java/org/elasticsearch/search/sort/plugin/CustomSortBuilder.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/plugin/CustomSortBuilder.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.sort.plugin;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortFieldAndFormat;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Custom sort builder that just rewrites to a basic field sort
+ */
+public class CustomSortBuilder extends SortBuilder<CustomSortBuilder> {
+    public static String NAME = "_custom";
+    public static ParseField SORT_FIELD = new ParseField("sort_field");
+
+    public final String field;
+    public final SortOrder order;
+
+    public CustomSortBuilder(String field, SortOrder order) {
+        this.field = field;
+        this.order = order;
+    }
+
+    public CustomSortBuilder(StreamInput in) throws IOException {
+        this.field = in.readString();
+        this.order = in.readOptionalWriteable(SortOrder::readFromStream);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeOptionalWriteable(order);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public SortBuilder<?> rewrite(final QueryRewriteContext ctx) throws IOException {
+        return SortBuilders.fieldSort(field).order(order);
+    }
+
+    @Override
+    protected SortFieldAndFormat build(final SearchExecutionContext context) throws IOException {
+        throw new IllegalStateException("rewrite");
+    }
+
+    @Override
+    public BucketedSort buildBucketedSort(
+        final SearchExecutionContext context,
+        final BigArrays bigArrays,
+        final int bucketSize,
+        final BucketedSort.ExtraData extra
+    ) throws IOException {
+        throw new IllegalStateException("rewrite");
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        CustomSortBuilder other = (CustomSortBuilder) object;
+        return Objects.equals(field, other.field) && Objects.equals(order, other.order);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, order);
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.field(SORT_FIELD.getPreferredName(), field);
+        builder.field(ORDER_FIELD.getPreferredName(), order);
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    public static CustomSortBuilder fromXContent(XContentParser parser, String elementName) {
+        return PARSER.apply(parser, null);
+    }
+
+    private static final ConstructingObjectParser<CustomSortBuilder, Void> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        a -> new CustomSortBuilder((String) a[0], (SortOrder) a[1])
+    );
+
+    static {
+        PARSER.declareField(constructorArg(), XContentParser::text, SORT_FIELD, ObjectParser.ValueType.STRING);
+        PARSER.declareField(constructorArg(), p -> SortOrder.fromString(p.text()), ORDER_FIELD, ObjectParser.ValueType.STRING);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/sort/plugin/CustomSortPlugin.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/plugin/CustomSortPlugin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.sort.plugin;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CustomSortPlugin extends Plugin implements SearchPlugin {
+    @Override
+    public List<SortSpec<?>> getSorts() {
+        return Collections.singletonList(new SortSpec<>(CustomSortBuilder.NAME, CustomSortBuilder::new, CustomSortBuilder::fromXContent));
+    }
+}


### PR DESCRIPTION
This pull request allows users to add custom SortBuilders via a SearchPlugin much like they can do for queries, aggregations, suggesters, etc.