### PR TITLE
[ML] Simplify the way ML legacy templates are removed

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.elasticsearch.xpack.ml.MlInitializationService;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 
 import java.io.IOException;
@@ -61,7 +60,6 @@ import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
@@ -217,14 +215,6 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
             internalCluster().startNode();
         }
         ensureStableCluster(3);
-
-        // By now the ML initialization service should have realised that there are no
-        // legacy ML templates in the cluster and it doesn't need to keep checking
-        MlInitializationService mlInitializationService = internalCluster().getInstance(
-            MlInitializationService.class,
-            internalCluster().getMasterName()
-        );
-        assertBusy(() -> assertThat(mlInitializationService.checkForLegacyMlTemplates(), is(false)));
 
         String jobId = "dedicated-ml-node-job";
         Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -426,6 +427,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -1599,6 +1601,25 @@ public class MachineLearning extends Plugin
 
     public static String[] getMlHiddenIndexPatterns() {
         return ASSOCIATED_INDEX_DESCRIPTORS.stream().map(AssociatedIndexDescriptor::getIndexPattern).toArray(String[]::new);
+    }
+
+    @Override
+    public UnaryOperator<Map<String, IndexTemplateMetadata>> getIndexTemplateMetadataUpgrader() {
+        return templates -> {
+            // These are all legacy templates that were created in old versions. None are needed now. The
+            // indices they were associated with either became system indices or now use composable templates.
+            templates.remove(".ml-anomalies-");
+            templates.remove(".ml-config");
+            templates.remove(".ml-inference-000001");
+            templates.remove(".ml-inference-000002");
+            templates.remove(".ml-inference-000003");
+            templates.remove(".ml-meta");
+            templates.remove(".ml-notifications");
+            templates.remove(".ml-notifications-000001");
+            templates.remove(".ml-state");
+            templates.remove(".ml-stats");
+            return templates;
+        };
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -10,7 +10,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -21,19 +20,14 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayService;
@@ -56,26 +50,10 @@ public class MlInitializationService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(MlInitializationService.class);
 
-    public static final List<String> LEGACY_ML_INDEX_TEMPLATES = List.of(
-        ".ml-anomalies-",
-        ".ml-config",
-        ".ml-inference-000001",
-        ".ml-inference-000002",
-        ".ml-inference-000003",
-        ".ml-meta",
-        ".ml-notifications",
-        ".ml-notifications-000001",
-        ".ml-notifications-000002",
-        ".ml-state",
-        ".ml-stats"
-    );
-
     private final Client client;
     private final ThreadPool threadPool;
     private final AtomicBoolean isIndexCreationInProgress = new AtomicBoolean(false);
     private final AtomicBoolean mlInternalIndicesHidden = new AtomicBoolean(false);
-    private final AtomicBoolean mlLegacyTemplateDeletionInProgress = new AtomicBoolean(false);
-    private final AtomicBoolean checkForLegacyMlTemplates = new AtomicBoolean(true);
     private volatile String previousException;
 
     private final MlDailyMaintenanceService mlDailyMaintenanceService;
@@ -176,56 +154,6 @@ public class MlInitializationService implements ClusterStateListener {
                 })
             );
         }
-
-        // The atomic flag shortcircuits the check after no legacy templates have been found to exist.
-        if (this.isMaster && checkForLegacyMlTemplates.get()) {
-            if (deleteOneMlLegacyTemplateIfNecessary(event.state()) == false) {
-                checkForLegacyMlTemplates.set(false);
-            }
-        }
-    }
-
-    /**
-     * @return <code>true</code> if further calls to this method are worthwhile.
-     *         <code>false</code> if this method never needs to be called again.
-     */
-    private boolean deleteOneMlLegacyTemplateIfNecessary(ClusterState state) {
-
-        String templateToDelete = nextTemplateToDelete(state.getMetadata().getTemplates());
-        if (templateToDelete != null) {
-            // This atomic flag prevents multiple simultaneous attempts to delete a legacy index
-            // template if there is a flurry of cluster state updates in quick succession.
-            if (mlLegacyTemplateDeletionInProgress.compareAndSet(false, true) == false) {
-                return true;
-            }
-            executeAsyncWithOrigin(
-                client,
-                ML_ORIGIN,
-                DeleteIndexTemplateAction.INSTANCE,
-                new DeleteIndexTemplateRequest(templateToDelete),
-                ActionListener.wrap(r -> {
-                    mlLegacyTemplateDeletionInProgress.set(false);
-                    logger.debug("Deleted legacy ML index template [{}]", templateToDelete);
-                }, e -> {
-                    mlLegacyTemplateDeletionInProgress.set(false);
-                    logger.debug(new ParameterizedMessage("Error deleting legacy ML index template [{}]", templateToDelete), e);
-                })
-            );
-
-            return true;
-        }
-
-        // We should never need to check again
-        return false;
-    }
-
-    private String nextTemplateToDelete(ImmutableOpenMap<String, IndexTemplateMetadata> legacyTemplates) {
-        for (String mlLegacyTemplate : LEGACY_ML_INDEX_TEMPLATES) {
-            if (legacyTemplates.containsKey(mlLegacyTemplate)) {
-                return mlLegacyTemplate;
-            }
-        }
-        return null;
     }
 
     /** For testing */
@@ -236,11 +164,6 @@ public class MlInitializationService implements ClusterStateListener {
     /** For testing */
     public boolean areMlInternalIndicesHidden() {
         return mlInternalIndicesHidden.get();
-    }
-
-    /** For testing */
-    public boolean checkForLegacyMlTemplates() {
-        return checkForLegacyMlTemplates.get();
     }
 
     private void makeMlInternalIndicesHidden() {


### PR DESCRIPTION
In #80874 ML legacy templates were removed by continuously
monitoring the cluster state and removing the templates once
all nodes were on version 7.14 or higher.

For 8.x this is unnecessarily complex. We know the oldest
possible node in the cluster will be 7.17, so can just remove
all ML legacy templates from the cluster state unconditionally
on startup.