### PR TITLE
[ML] Support updates to MPNet tokenizer

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdateTests.java
@@ -60,7 +60,19 @@ public class NlpConfigUpdateTests extends ESTestCase {
             ElasticsearchStatusException.class,
             () -> NlpConfigUpdate.tokenizationFromMap(finalConfig)
         );
-        assertThat(e.getMessage(), containsString("unknown tokenization type expecting one of [bert] got [not_bert]"));
+        assertThat(e.getMessage(), containsString("unknown tokenization type expecting one of [bert, mpnet] got [not_bert]"));
+    }
 
+    public void testTokenizationFromMap_MpNet() {
+        Map<String, Object> config = new HashMap<>() {
+            {
+                Map<String, Object> truncate = new HashMap<>();
+                truncate.put("truncate", "first");
+                Map<String, Object> tokenizer = new HashMap<>();
+                tokenizer.put("mpnet", truncate);
+                put("tokenization", tokenizer);
+            }
+        };
+        assertThat(NlpConfigUpdate.tokenizationFromMap(config), equalTo(new MPNetTokenizationUpdate(Tokenization.Truncate.FIRST)));
     }
 }


### PR DESCRIPTION
A tokenizer's truncate setting can be updated at inference, this PR enables that update for MPNet tokenisers.

```
"tokenization": {
  "mpnet": {
    "truncate":"first"
  }
}
```

Follow up to #82234