### PR TITLE
[8.0] [ML] Fix annotations index maintenance after reindexing (#82304)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -9,8 +9,11 @@ package org.elasticsearch.xpack.ml.integration;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -23,7 +26,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.SetResetModeActionRequest;
 import org.elasticsearch.xpack.core.ml.action.SetResetModeAction;
@@ -33,6 +35,7 @@ import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,21 +57,98 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
 
         // Ask a few times to increase the chance of failure if the .ml-annotations index is created when no other ML index exists
         for (int i = 0; i < 10; ++i) {
-            assertFalse(annotationsIndexExists());
+            assertFalse(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
             assertEquals(0, numberOfAnnotationsAliases());
         }
     }
 
     public void testCreatedWhenAfterOtherMlIndex() throws Exception {
-        AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
-        auditor.info("whatever", "blah");
-
         // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
+        createAnnotation();
 
         assertBusy(() -> {
-            assertTrue(annotationsIndexExists());
+            assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
             assertEquals(2, numberOfAnnotationsAliases());
+        });
+    }
+
+    public void testReindexing() throws Exception {
+        // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
+        // to be created, as it should get created as soon as any other ML index exists
+        createAnnotation();
+
+        assertBusy(() -> {
+            assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
+            assertEquals(2, numberOfAnnotationsAliases());
+        });
+
+        client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(true)).actionGet();
+
+        String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
+        createReindexedIndex(reindexedIndexName);
+
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
+            .indices()
+            .prepareAliases()
+            .addAliasAction(
+                IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.READ_ALIAS_NAME).isHidden(true)
+            )
+            .addAliasAction(
+                IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.WRITE_ALIAS_NAME).isHidden(true)
+            )
+            .addAliasAction(IndicesAliasesRequest.AliasActions.removeIndex().index(AnnotationIndex.LATEST_INDEX_NAME))
+            .addAliasAction(
+                IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
+            );
+
+        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+
+        client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
+
+        // Ask a few times to increase the chance of failure if the .ml-annotations index is created when no other ML index exists
+        for (int i = 0; i < 10; ++i) {
+            assertFalse(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
+            assertTrue(annotationsIndexExists(reindexedIndexName));
+            // Aliases should be read, write and original name
+            assertEquals(3, numberOfAnnotationsAliases());
+        }
+    }
+
+    public void testReindexingWithLostAliases() throws Exception {
+        // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
+        // to be created, as it should get created as soon as any other ML index exists
+        createAnnotation();
+
+        assertBusy(() -> {
+            assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
+            assertEquals(2, numberOfAnnotationsAliases());
+        });
+
+        client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(true)).actionGet();
+
+        String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
+        createReindexedIndex(reindexedIndexName);
+
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
+            .indices()
+            .prepareAliases()
+            // The difference compared to the standard reindexing test is that the read and write aliases are not correctly set up.
+            // The annotations index maintenance code should add them back.
+            .addAliasAction(IndicesAliasesRequest.AliasActions.removeIndex().index(AnnotationIndex.LATEST_INDEX_NAME))
+            .addAliasAction(
+                IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
+            );
+
+        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+
+        client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
+
+        assertBusy(() -> {
+            assertFalse(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
+            assertTrue(annotationsIndexExists(reindexedIndexName));
+            // Aliases should be read, write and original name
+            assertEquals(3, numberOfAnnotationsAliases());
         });
     }
 
@@ -91,7 +171,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         // When this happens the read alias should be changed to cover both indices, and the write alias should be
         // switched to only point at the new index.
         assertBusy(() -> {
-            assertTrue(annotationsIndexExists());
+            assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
             ImmutableOpenMap<String, List<AliasMetadata>> aliases = client().admin()
                 .indices()
                 .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME)
@@ -124,11 +204,9 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(true)).actionGet();
 
         try {
-            AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
-            auditor.info("whatever", "blah");
-
             // Creating a document in the .ml-notifications-000002 index would normally cause .ml-annotations
             // to be created, but in this case it shouldn't as we're doing an upgrade
+            createAnnotation();
 
             assertBusy(() -> {
                 try {
@@ -137,7 +215,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                 } catch (SearchPhaseExecutionException e) {
                     throw new AssertionError("Notifications index exists but shards not yet ready - continuing busy wait", e);
                 }
-                assertFalse(annotationsIndexExists());
+                assertFalse(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
                 assertEquals(0, numberOfAnnotationsAliases());
             });
         } finally {
@@ -162,7 +240,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
             assertBusy(() -> {
                 SearchResponse response = client().search(new SearchRequest(".ml-state")).actionGet();
                 assertEquals(1, response.getHits().getHits().length);
-                assertFalse(annotationsIndexExists());
+                assertFalse(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
                 assertEquals(0, numberOfAnnotationsAliases());
             });
         } finally {
@@ -170,15 +248,22 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         }
     }
 
-    private boolean annotationsIndexExists() {
-        return ESIntegTestCase.indexExists(AnnotationIndex.LATEST_INDEX_NAME, client());
+    private boolean annotationsIndexExists(String expectedName) {
+        GetIndexResponse getIndexResponse = client().admin()
+            .indices()
+            .prepareGetIndex()
+            .setIndices(AnnotationIndex.LATEST_INDEX_NAME)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .execute()
+            .actionGet();
+        return Arrays.asList(getIndexResponse.getIndices()).contains(expectedName);
     }
 
     private int numberOfAnnotationsAliases() {
         int count = 0;
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = client().admin()
             .indices()
-            .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME)
+            .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME, AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
             .get()
             .getAliases();
@@ -191,5 +276,25 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
             }
         }
         return count;
+    }
+
+    private void createReindexedIndex(String reindexedIndexName) {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest(reindexedIndexName).mapping(AnnotationIndex.annotationsMapping())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                    .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
+            );
+
+        client().admin().indices().create(createIndexRequest).actionGet();
+
+        // At this point the upgrade assistant would reindex the old index into the new index but there's
+        // no point in this test as there's nothing in the old index.
+    }
+
+    private void createAnnotation() {
+        AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
+        auditor.info("whatever", "blah");
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
@@ -96,7 +97,9 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
             IngestCommonPlugin.class,
             MockPainlessScriptEngine.TestPlugin.class,
             // ILM is required for .ml-state template index settings
-            IndexLifecycle.class
+            IndexLifecycle.class,
+            // Needed for scaled_float
+            MapperExtrasPlugin.class
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Fix annotations index maintenance after reindexing (#82304)