### PR TITLE
[8.0] Fix concurrent serialization test for StoredScript (#82278)

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -43,12 +42,6 @@ import java.util.Objects;
  * saved in the {@link ClusterState}.
  */
 public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> implements Writeable, ToXContentObject {
-
-    /**
-     * Standard deprecation logger for used to deprecate allowance of empty templates.
-     */
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(StoredScriptSource.class);
-
     /**
      * Standard {@link ParseField} for outer level of stored script source.
      */


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix concurrent serialization test for StoredScript (#82278)