### PR TITLE
[8.0] [ML] Fix typo (#82313)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -65,7 +65,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
     public void testCreatedWhenAfterOtherMlIndex() throws Exception {
         // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
-        createAnnotation();
+        createNotification();
 
         assertBusy(() -> {
             assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
@@ -76,7 +76,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
     public void testReindexing() throws Exception {
         // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
-        createAnnotation();
+        createNotification();
 
         assertBusy(() -> {
             assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
@@ -118,7 +118,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
     public void testReindexingWithLostAliases() throws Exception {
         // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
-        createAnnotation();
+        createNotification();
 
         assertBusy(() -> {
             assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
@@ -206,7 +206,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         try {
             // Creating a document in the .ml-notifications-000002 index would normally cause .ml-annotations
             // to be created, but in this case it shouldn't as we're doing an upgrade
-            createAnnotation();
+            createNotification();
 
             assertBusy(() -> {
                 try {
@@ -293,7 +293,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         // no point in this test as there's nothing in the old index.
     }
 
-    private void createAnnotation() {
+    private void createNotification() {
         AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
         auditor.info("whatever", "blah");
     }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] Fix typo (#82313)