### PR TITLE
Search - reject arrays of values when passed to the Term query.  (#82194)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -120,6 +120,13 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
                         if (TERM_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                             value = maybeConvertToBytesRef(parser.objectBytes());
                         } else if (VALUE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
+                                throw new ParsingException(
+                                    parser.getTokenLocation(),
+                                    "[term] query does not support arrays for value - use a bool query with multiple term "
+                                        + "clauses in the should section or use a Terms query if scoring is not required"
+                                );
+                            }
                             value = maybeConvertToBytesRef(parser.objectBytes());
                         } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                             queryName = parser.text();

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -175,6 +175,23 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
         assertEquals("[term] query doesn't support multiple fields, found [message1] and [message2]", e.getMessage());
     }
 
+    public void testParseFailsWithMultipleValues() {
+        String json = """
+            {
+              "term" : {
+                "message1" : {
+                  "value" : ["this", "that"]
+                }
+              }
+            }""";
+        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
+        assertEquals(
+            "[term] query does not support arrays for value - use a bool query with multiple term clauses "
+                + "in the should section or use a Terms query if scoring is not required",
+            e.getMessage()
+        );
+    }
+
     public void testParseAndSerializeBigInteger() throws IOException {
         String json = """
             {


### PR DESCRIPTION
Bug fix to reject arrays of values when passed to the Term query. Use error message as an opportunity to advertise the `terms` query or use of a Bool query for scoring purposes.

Closes #82183