### PR TITLE
[8.0] Use Java 8 for JDBC driver target compatibility version (#82274)

### DIFF
--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -16,6 +16,11 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
+tasks.named("compileJava").configure {
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
 
 tasks.named("shadowJar").configure {
   relocate 'com.fasterxml', 'shadow.fasterxml'

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfiguration.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfiguration.java
@@ -12,7 +12,6 @@ import org.elasticsearch.xpack.sql.client.StringUtils;
 
 import java.net.URI;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.DriverPropertyInfo;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -148,8 +147,8 @@ public class JdbcConfiguration extends ConnectionConfiguration {
                     if (args.size() != 2) {
                         throw new JdbcSQLException("Invalid parameter [" + param + "], format needs to be key=value");
                     }
-                    final String key = URLDecoder.decode(args.get(0), StandardCharsets.UTF_8).trim();
-                    final String val = URLDecoder.decode(args.get(1), StandardCharsets.UTF_8);
+                    final String key = URLDecoder.decode(args.get(0), "UTF-8").trim();
+                    final String val = URLDecoder.decode(args.get(1), "UTF-8");
                     // further validation happens in the constructor (since extra properties might be specified either way)
                     props.setProperty(key, val);
                 }

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -12,6 +12,11 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
+tasks.named("compileJava").configure {
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks.named('forbiddenApisMain').configure {
   // does not depend on core, so only jdk and http signatures should be checked
   replaceSignatureFiles 'jdk-signatures'

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
@@ -301,4 +301,14 @@ public abstract class StringUtils {
         return buf.toString();
     }
 
+    public static String repeatString(String in, int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("negative count: " + count);
+        }
+        StringBuffer sb = new StringBuffer(in.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(in);
+        }
+        return sb.toString();
+    }
 }

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/UriUtils.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/UriUtils.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.sql.client.StringUtils.repeatString;
+
 public final class UriUtils {
     private UriUtils() {
 
@@ -109,7 +111,7 @@ public final class UriUtils {
             int attrIdx = string.toLowerCase(Locale.ROOT).indexOf(needle); // note: won't catch "valid" `=password[%20]+=` cases
             if (attrIdx >= 0) { // ex: `...=[value]password=foo...`
                 int attrEndIdx = attrIdx + needle.length();
-                return string.substring(0, attrEndIdx) + String.valueOf(replacement).repeat(string.length() - attrEndIdx);
+                return string.substring(0, attrEndIdx) + repeatString(String.valueOf(replacement), string.length() - attrEndIdx);
             }
             return string;
         }
@@ -124,7 +126,7 @@ public final class UriUtils {
             for (String k : similar) {
                 for (Map.Entry<String, String> e : attrs) {
                     if (e.getKey().equals(k)) {
-                        e.setValue(String.valueOf(replacement).repeat(e.getValue().length()));
+                        e.setValue(repeatString(String.valueOf(replacement), e.getValue().length()));
                     }
                 }
             }
@@ -178,7 +180,7 @@ public final class UriUtils {
                 sb.append("://");
             }
             if (uri.getRawUserInfo() != null) {
-                sb.append("\0".repeat(uri.getRawUserInfo().length()));
+                sb.append(repeatString("\0", uri.getRawUserInfo().length()));
                 if (uri.getHost() != null) {
                     sb.append('@');
                 }

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -16,6 +16,11 @@ dependencies {
   }
 }
 
+tasks.named("compileJava").configure {
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks.named('forbiddenApisMain').configure {
   //sql does not depend on server, so only jdk signatures should be checked
   replaceSignatureFiles 'jdk-signatures'

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/xcontent/ErrorOnUnknown.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/xcontent/ErrorOnUnknown.java
@@ -33,7 +33,7 @@ public interface ErrorOnUnknown {
      */
     int priority();
 
-    private static ErrorOnUnknown findImplementation() {
+    static ErrorOnUnknown findImplementation() {
         ErrorOnUnknown best = new ErrorOnUnknown() {
             @Override
             public String errorMessage(String parserName, String unknownField, Iterable<String> candidates) {

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/xcontent/ParsedMediaType.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/xcontent/ParsedMediaType.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.sql.proto.xcontent;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class ParsedMediaType {
         this.originalHeaderValue = originalHeaderValue;
         this.type = type;
         this.subType = subType;
-        this.parameters = Map.copyOf(parameters);
+        this.parameters = Collections.unmodifiableMap(parameters);
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Use Java 8 for JDBC driver target compatibility version (#82274)