### PR TITLE
Missing request element under input search

### DIFF
--- a/x-pack/docs/en/watcher/condition/script.asciidoc
+++ b/x-pack/docs/en/watcher/condition/script.asciidoc
@@ -113,10 +113,12 @@ number of hits is above a specified threshold:
 {
   "input" : {
     "search" : {
-      "indices" : "log-events",
-      "body" : {
-        "size" : 0,
-        "query" : { "match" : { "status" : "error" } }
+      "request": {
+        "indices" : "log-events",
+        "body" : {
+          "size" : 0,
+          "query" : { "match" : { "status" : "error" } }
+        }
       }
     }
   },


### PR DESCRIPTION
The example at https://www.elastic.co/guide/en/elasticsearch/reference/7.16/condition-script.html#accessing-watch-payload is missing the `request` element under input-search.
