### PR TITLE
Ownership check with security domains 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
@@ -53,7 +53,7 @@ public class DeleteAsyncResultsService {
      * delete async search submitted by another user.
      */
     private void hasCancelTaskPrivilegeAsync(Consumer<Boolean> consumer) {
-        final Authentication current = store.getAuthentication();
+        final Authentication current = store.getSecurityContext().getAuthentication();
         if (current != null) {
             HasPrivilegesRequest req = new HasPrivilegesRequest();
             req.username(current.getUser().principal());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -249,8 +249,7 @@ public class Authentication implements ToXContentObject {
         private final String nodeName;
         private final String name;
         private final String type;
-        private final @Nullable
-        String domain;
+        private final @Nullable String domain;
 
         public RealmRef(String name, String type, String nodeName) {
             this(name, type, nodeName, null);
@@ -295,8 +294,7 @@ public class Authentication implements ToXContentObject {
             return type;
         }
 
-        public @Nullable
-        String getDomain() {
+        public @Nullable String getDomain() {
             return domain;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
@@ -10,8 +10,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.support.DelegatedAuthorizationSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 
@@ -56,7 +59,11 @@ public abstract class Realm implements Comparable<Realm> {
         return config.order;
     }
 
-    public String domain() {
+    /**
+     * @return The domain of this realm, if set {@code null otherwise}. Identical usernames under different realms are considered to be the
+     * same end-user entity (person) if the realms are under the same domain.
+     */
+    public @Nullable String domain() {
         return config.domain();
     }
 
@@ -144,9 +151,18 @@ public abstract class Realm implements Comparable<Realm> {
         listener.onResponse(stats);
     }
 
+    public RealmRef getRealmRef() {
+        final String nodeName = Node.NODE_NAME_SETTING.get(config.settings());
+        return new RealmRef(name(), type(), nodeName, domain());
+    }
+
     @Override
     public String toString() {
-        return config.type() + "/" + config.name();
+        if (domain() != null) {
+            return type() + "/" + name();
+        } else {
+            return domain() + "/" + type() + "/" + name();
+        }
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
@@ -159,9 +159,9 @@ public abstract class Realm implements Comparable<Realm> {
     @Override
     public String toString() {
         if (domain() != null) {
-            return type() + "/" + name();
-        } else {
             return domain() + "/" + type() + "/" + name();
+        } else {
+            return type() + "/" + name();
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 // TODO: test CRUD operations
 public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
@@ -84,79 +85,112 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         }
     }
 
+    private Map<String, String> getAuthenticationAsHeaders(Authentication authentication) throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        authentication.writeToContext(threadContext);
+        return threadContext.getHeaders();
+    }
+
     public void testEnsuredAuthenticatedUserIsSame() throws IOException {
         Authentication original = new Authentication(new User("test", "role"), new Authentication.RealmRef("realm", "file", "node"), null);
         Authentication current = randomBoolean()
             ? original
             : new Authentication(new User("test", "role"), new Authentication.RealmRef("realm", "file", "node"), null);
-        assertTrue(original.canAccessResourcesOf(current));
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        original.writeToContext(threadContext);
-        assertTrue(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), current));
+        current.writeToContext(indexService.getSecurityContext().getThreadContext());
 
-        // original is not set
-        assertTrue(indexService.ensureAuthenticatedUserIsSame(Collections.emptyMap(), current));
-        // current is not set
-        assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), null));
+        assertTrue(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+
+        // original is not authenticated
+        assertTrue(indexService.getSecurityContext().canIAccessResourcesCreatedBy(Map.of()));
+        // current is not authenticated
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            assertFalse(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+            assertTrue(indexService.getSecurityContext().canIAccessResourcesCreatedBy(Map.of()));
+        }
 
         // original user being run as
         User user = new User(new User("test", "role"), new User("authenticated", "runas"));
-        current = new Authentication(
-            user,
-            new Authentication.RealmRef("realm", "file", "node"),
-            new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), "file", "node")
+        assertTrue(
+            indexService.getSecurityContext()
+                .canIAccessResourcesCreatedBy(
+                    getAuthenticationAsHeaders(
+                        new Authentication(
+                            user,
+                            new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), "file", "node"),
+                            new Authentication.RealmRef("realm", "file", "node")
+                        )
+                    )
+                )
         );
-        assertTrue(original.canAccessResourcesOf(current));
-        assertTrue(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), current));
 
-        // both user are run as
-        current = new Authentication(
-            user,
-            new Authentication.RealmRef("realm", "file", "node"),
-            new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), "file", "node")
-        );
-        Authentication runAs = current;
-        assertTrue(runAs.canAccessResourcesOf(current));
-        threadContext = new ThreadContext(Settings.EMPTY);
-        original.writeToContext(threadContext);
-        assertTrue(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), current));
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            // current user being run as
+            current = new Authentication(
+                user,
+                new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), "file", "node"),
+                new Authentication.RealmRef("realm", "file", "node")
+            );
+            current.writeToContext(indexService.getSecurityContext().getThreadContext());
+            assertTrue(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
 
-        // different authenticated by type
-        Authentication differentRealmType = new Authentication(
-            new User("test", "role"),
-            new Authentication.RealmRef("realm", randomAlphaOfLength(5), "node"),
-            null
-        );
-        threadContext = new ThreadContext(Settings.EMPTY);
-        original.writeToContext(threadContext);
-        assertFalse(original.canAccessResourcesOf(differentRealmType));
-        assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), differentRealmType));
+            // both users are run as
+            assertTrue(
+                indexService.getSecurityContext()
+                    .canIAccessResourcesCreatedBy(
+                        getAuthenticationAsHeaders(
+                            new Authentication(
+                                user,
+                                new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), "file", "node"),
+                                new Authentication.RealmRef("realm", "file", "node")
+                            )
+                        )
+                    )
+            );
+        }
 
-        // wrong user
-        Authentication differentUser = new Authentication(
-            new User("test2", "role"),
-            new Authentication.RealmRef("realm", "realm", "node"),
-            null
-        );
-        assertFalse(original.canAccessResourcesOf(differentUser));
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            // different authenticated by type
+            Authentication differentRealmType = new Authentication(
+                new User("test", "role"),
+                new Authentication.RealmRef("realm", randomAlphaOfLength(10), "node"),
+                null
+            );
+            differentRealmType.writeToContext(indexService.getSecurityContext().getThreadContext());
+            assertFalse(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+        }
+
+        // different user
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            Authentication differentUser = new Authentication(
+                new User("test2", "role"),
+                new Authentication.RealmRef("realm", "realm", "node"),
+                null
+            );
+            differentUser.writeToContext(indexService.getSecurityContext().getThreadContext());
+            assertFalse(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+        }
 
         // run as different user
-        Authentication diffRunAs = new Authentication(
-            new User(new User("test2", "role"), new User("authenticated", "runas")),
-            new Authentication.RealmRef("realm", "file", "node1"),
-            new Authentication.RealmRef("realm", "file", "node1")
-        );
-        assertFalse(original.canAccessResourcesOf(diffRunAs));
-        assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), diffRunAs));
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            Authentication differentRunAs = new Authentication(
+                new User(new User("test2", "role"), new User("authenticated", "runas")),
+                new Authentication.RealmRef("realm_runas", "file", "node1"),
+                new Authentication.RealmRef("realm", "file", "node1")
+            );
+            differentRunAs.writeToContext(indexService.getSecurityContext().getThreadContext());
+            assertFalse(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+        }
 
         // run as different looked up by type
-        Authentication runAsDiffType = new Authentication(
-            user,
-            new Authentication.RealmRef("realm", "file", "node"),
-            new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), randomAlphaOfLengthBetween(5, 12), "node")
-        );
-        assertFalse(original.canAccessResourcesOf(runAsDiffType));
-        assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), runAsDiffType));
+        try (ThreadContext.StoredContext ignore = indexService.getSecurityContext().getThreadContext().stashContext()) {
+            Authentication runAsDiffType = new Authentication(
+                user,
+                new Authentication.RealmRef("realm", "file", "node"),
+                new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), randomAlphaOfLengthBetween(5, 12), "node")
+            );
+            runAsDiffType.writeToContext(indexService.getSecurityContext().getThreadContext());
+            assertFalse(indexService.getSecurityContext().canIAccessResourcesCreatedBy(getAuthenticationAsHeaders(original)));
+        }
     }
 
     public void testAutoCreateIndex() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -111,7 +111,7 @@ public class AuthenticationService {
             new ServiceAccountAuthenticator(serviceAccountService, nodeName),
             new OAuth2TokenAuthenticator(tokenService),
             new ApiKeyAuthenticator(apiKeyService, nodeName),
-            new RealmsAuthenticator(nodeName, numInvalidation, lastSuccessfulAuthCache)
+            new RealmsAuthenticator(numInvalidation, lastSuccessfulAuthCache)
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
@@ -41,13 +41,11 @@ class RealmsAuthenticator implements Authenticator {
 
     private static final Logger logger = LogManager.getLogger(RealmsAuthenticator.class);
 
-    private final String nodeName;
     private final AtomicLong numInvalidation;
     private final Cache<String, Realm> lastSuccessfulAuthCache;
     private boolean authenticationTokenExtracted = false;
 
-    RealmsAuthenticator(String nodeName, AtomicLong numInvalidation, Cache<String, Realm> lastSuccessfulAuthCache) {
-        this.nodeName = nodeName;
+    RealmsAuthenticator(AtomicLong numInvalidation, Cache<String, Realm> lastSuccessfulAuthCache) {
         this.numInvalidation = numInvalidation;
         this.lastSuccessfulAuthCache = lastSuccessfulAuthCache;
     }
@@ -156,7 +154,7 @@ class RealmsAuthenticator implements Authenticator {
                     );
                     if (result.getStatus() == AuthenticationResult.Status.SUCCESS) {
                         // user was authenticated, populate the authenticated by information
-                        authenticatedByRef.set(new Authentication.RealmRef(realm.name(), realm.type(), nodeName));
+                        authenticatedByRef.set(realm.getRealmRef());
                         authenticationResultRef.set(result);
                         if (lastSuccessfulAuthCache != null && startInvalidation == numInvalidation.get()) {
                             lastSuccessfulAuthCache.put(authenticationToken.principal(), realm);
@@ -303,7 +301,7 @@ class RealmsAuthenticator implements Authenticator {
                     }
                     logger.trace("Using run-as user [{}] with authenticated user [{}]", foundUser, authentication.getUser().principal());
                     listener.onResponse(
-                        new Tuple<>(tuple.v1(), new Authentication.RealmRef(tuple.v2().name(), tuple.v2().type(), nodeName))
+                        new Tuple<>(tuple.v1(), tuple.v2().getRealmRef())
                     );
                 }
             }, e -> listener.onFailure(context.getRequest().exceptionProcessingRequest(e, context.getMostRecentAuthenticationToken()))));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
@@ -300,9 +300,7 @@ class RealmsAuthenticator implements Authenticator {
                         lastSuccessfulAuthCache.computeIfAbsent(runAsUsername, s -> realm);
                     }
                     logger.trace("Using run-as user [{}] with authenticated user [{}]", foundUser, authentication.getUser().principal());
-                    listener.onResponse(
-                        new Tuple<>(tuple.v1(), tuple.v2().getRealmRef())
-                    );
+                    listener.onResponse(new Tuple<>(tuple.v1(), tuple.v2().getRealmRef()));
                 }
             }, e -> listener.onFailure(context.getRequest().exceptionProcessingRequest(e, context.getMostRecentAuthenticationToken()))));
         } else if (runAsUsername == null) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
@@ -13,12 +13,10 @@ import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
-import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
@@ -68,19 +66,19 @@ public final class SecuritySearchOperationListener implements SearchOperationLis
     public void validateReaderContext(ReaderContext readerContext, TransportRequest request) {
         if (readerContext.scrollContext() != null) {
             final Authentication originalAuth = readerContext.getFromContext(AuthenticationField.AUTHENTICATION_KEY);
-            final Authentication current = securityContext.getAuthentication();
-            final ThreadContext threadContext = securityContext.getThreadContext();
-            final String action = threadContext.getTransient(ORIGINATING_ACTION_KEY);
-            ensureAuthenticatedUserIsSame(
-                originalAuth,
-                current,
-                auditTrailService,
-                readerContext.id(),
-                action,
-                request,
-                AuditUtil.extractRequestId(threadContext),
-                threadContext.getTransient(AUTHORIZATION_INFO_KEY)
-            );
+            if (false == securityContext.canIAccessResourcesCreatedBy(originalAuth)) {
+                final ThreadContext threadContext = securityContext.getThreadContext();
+                final String requestId = AuditUtil.extractRequestId(threadContext);
+                auditTrailService.get()
+                    .accessDenied(
+                        requestId,
+                        securityContext.getAuthentication(),
+                        threadContext.getTransient(ORIGINATING_ACTION_KEY),
+                        request,
+                        threadContext.getTransient(AUTHORIZATION_INFO_KEY)
+                    );
+                throw new SearchContextMissingException(readerContext.id());
+            }
             // piggyback on context validation to assert the DLS/FLS permissions on the thread context of the scroll search handler
             if (null == securityContext.getThreadContext().getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY)) {
                 // fill in the DLS and FLS permissions for the scroll search action from the scroll context
@@ -119,29 +117,6 @@ public final class SecuritySearchOperationListener implements SearchOperationLis
                         + "]"
                 );
             }
-        }
-    }
-
-    /**
-     * Compares the {@link Authentication} that was stored in the {@link ReaderContext} with the
-     * current authentication. We cannot guarantee that all of the details of the authentication will
-     * be the same. Some things that could differ include the roles, the name of the authenticating
-     * (or lookup) realm. To work around this we compare the username and the originating realm type.
-     */
-    static void ensureAuthenticatedUserIsSame(
-        Authentication original,
-        Authentication current,
-        AuditTrailService auditTrailService,
-        ShardSearchContextId id,
-        String action,
-        TransportRequest request,
-        String requestId,
-        AuthorizationInfo authorizationInfo
-    ) {
-        final boolean sameUser = original.canAccessResourcesOf(current);
-        if (sameUser == false) {
-            auditTrailService.get().accessDenied(requestId, current, action, request, authorizationInfo);
-            throw new SearchContextMissingException(id);
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -63,9 +63,7 @@ public class RealmsAuthenticatorTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     @Before
     public void init() throws Exception {
-        Settings settings = Settings.builder()
-            .put(Node.NODE_NAME_SETTING.getKey(), "test_node_name")
-            .build();
+        Settings settings = Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test_node_name").build();
         threadContext = new ThreadContext(settings);
         RealmConfig realmConfig = mock(RealmConfig.class);
         when(realmConfig.settings()).thenReturn(settings);
@@ -167,8 +165,10 @@ public class RealmsAuthenticatorTests extends ESTestCase {
         assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
         final Authentication authentication = result.getValue();
         assertThat(authentication.getUser(), is(user));
-        assertThat(authentication.getAuthenticatedBy(), equalTo(new Authentication.RealmRef(successfulRealm.name(),
-            successfulRealm.type(), "test_node_name", successfulRealm.domain())));
+        assertThat(
+            authentication.getAuthenticatedBy(),
+            equalTo(new Authentication.RealmRef(successfulRealm.name(), successfulRealm.type(), "test_node_name", successfulRealm.domain()))
+        );
     }
 
     public void testNullUser() throws IllegalAccessException {


### PR DESCRIPTION
EDIT 10.01.2022: The below is not currently an accurate description, see https://github.com/elastic/elasticsearch/pull/82335#issuecomment-1008903642 instead:

-----

This is under construction and will be split into components, but the general plan is:

Owned resources: Profiles, API Keys, Scroll Searches, Async Search Results, Refresh tokens

If the current username accessing some resource IS NOT under any domain (no domain configured for the realm that authenticated/looked-up the user), then this user can access the resources created under all/any domains, but only owned by the same username of the same realm name and type.

If the current username accessing some resource IS NOT under any domain (no domain configured for the realm that authenticated/looked-up the user), then this user can access the resources owned by the same username of the same realm name and type, even if these resources have been created while
the realm was assigned to a domain.

If the current username accessing the resource IS under some domain (the realm that authenticated/looked-up the user is assigned to a domain), then this user can access the resources of the same username created under the same domain (no matter the realms name and type), as well as the resources owned by the same username of the same realm name and type, created when the realm was domain-less.

The above implies that:
 * a user from a domain-less realm has access to its resources as long as the realm is not renamed; if the realm is renamed the user loses access to its resources created before the time of the rename
 * a user continues to have access to its resources after the realm is assigned to any domain(s), as long as the realm is not renamed
 * if the realm is renamed after it's being assigned to a domain, the user continues to have access to the resources created after the realm was assigned to the domain, but loses access to the resources created under the domain-less realm
 * if the domain is renamed, the user loses access to all the resources created while the realm was assigned to the old domain, but continues to have access to the resources created when the realm was domain-less (assuming the realm has not been renamed)
 * if the user is authenticated/looked-up by another realm, with the same username and under the same domain,
 it has access to the resources created under the other realm(s), but only to those created while the realm was under the same domain (excluding those created when the realm was domain-less, or under a different realm)
