### PR TITLE
Use a stricter semver format

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -183,7 +183,7 @@ can't shadow metrics:
 # Test that _tsid field is not added if an index is not a time-series index
 no _tsid in standard indices:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -17,7 +17,7 @@ teardown:
 ---
 "Create a snapshot and then restore it":
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
       features: ["allowed_warnings"]
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/40_search.yml
@@ -96,7 +96,7 @@ query a metric:
 ---
 "query tsid fails":
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -170,7 +170,7 @@ fetch a tag:
 ---
 "fetch the tsid":
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -265,7 +265,7 @@ aggregate a tag:
 ---
 "aggregate the tsid":
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -289,7 +289,7 @@ aggregate a tag:
 ---
 "aggregate filter the tsid fails":
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -307,7 +307,7 @@ aggregate a tag:
 ---
 field capabilities:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/50_alias.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/50_alias.yml
@@ -63,7 +63,7 @@ setup:
 ---
 search an alias:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -92,7 +92,7 @@ search an alias:
 ---
 index into alias:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/60_add_dimensions.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/60_add_dimensions.yml
@@ -1,7 +1,7 @@
 ---
 add dimensions with put_mapping:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -54,7 +54,7 @@ add dimensions with put_mapping:
 ---
 add dimensions to no dims with dynamic_template over index:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -102,7 +102,7 @@ add dimensions to no dims with dynamic_template over index:
 ---
 add dimensions to no dims with dynamic_template over bulk:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -150,7 +150,7 @@ add dimensions to no dims with dynamic_template over bulk:
 ---
 add dimensions to some dims with dynamic_template over index:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -202,7 +202,7 @@ add dimensions to some dims with dynamic_template over index:
 ---
 add dimensions to some dims with dynamic_template over bulk:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/70_dimension_types.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/70_dimension_types.yml
@@ -1,7 +1,7 @@
 keyword dimension:
   - skip:
       features: close_to
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -74,7 +74,7 @@ keyword dimension:
 long dimension:
   - skip:
       features: close_to
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -149,7 +149,7 @@ long dimension:
 ip dimension:
   - skip:
       features: close_to
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/80_index_resize.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/80_index_resize.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: introduced in 8.1.0
       features: "arbitrary_key"
 
@@ -85,7 +85,7 @@ setup:
 ---
 split:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: index-split check introduced in 8.1.0
 
   - do:
@@ -101,7 +101,7 @@ split:
 ---
 shrink:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -128,7 +128,7 @@ shrink:
 ---
 clone:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -152,7 +152,7 @@ clone:
 ---
 clone no source index:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: introduced in 8.1.0
 
   - do:

--- a/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/70_time_series.yml
+++ b/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/70_time_series.yml
@@ -50,7 +50,7 @@ setup:
 ---
 fetch the _tsid:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -74,7 +74,7 @@ fetch the _tsid:
 # TODO: Sort order is wrong here. Probably this is caused by the encoding of unsigned_long
 aggregate the _tsid:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:
@@ -104,7 +104,7 @@ aggregate the _tsid:
 # TODO: Sort order is wrong here. Probably this is caused by the encoding of unsigned_long
 default sort:
   - skip:
-      version: " - 8.00.99"
+      version: " - 8.0.99"
       reason: _tsid support introduced in 8.1.0
 
   - do:


### PR DESCRIPTION
Some semver parsers do not accept `00` as a valid value. This pr updates every occurrence.