### PR TITLE
Rollback switch expressions in the SQL plugin

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
@@ -260,24 +260,32 @@ final class TypeConverter {
 
     private static Double doubleValue(Object v) {
         if (v instanceof String) {
-            return switch ((String) v) {
-                case "NaN" -> Double.NaN;
-                case "Infinity" -> Double.POSITIVE_INFINITY;
-                case "-Infinity" -> Double.NEGATIVE_INFINITY;
-                default -> Double.parseDouble((String) v);
-            };
+            switch ((String) v) {
+                case "NaN":
+                    return Double.NaN;
+                case "Infinity":
+                    return Double.POSITIVE_INFINITY;
+                case "-Infinity":
+                    return Double.NEGATIVE_INFINITY;
+                default:
+                    return Double.parseDouble((String) v);
+            }
         }
         return ((Number) v).doubleValue();
     }
 
     private static Float floatValue(Object v) {
         if (v instanceof String) {
-            return switch ((String) v) {
-                case "NaN" -> Float.NaN;
-                case "Infinity" -> Float.POSITIVE_INFINITY;
-                case "-Infinity" -> Float.NEGATIVE_INFINITY;
-                default -> Float.parseFloat((String) v);
-            };
+            switch ((String) v) {
+                case "NaN":
+                    return Float.NaN;
+                case "Infinity":
+                    return Float.POSITIVE_INFINITY;
+                case "-Infinity":
+                    return Float.NEGATIVE_INFINITY;
+                default:
+                    return Float.parseFloat((String) v);
+            }
         }
         return ((Number) v).floatValue();
     }
@@ -297,13 +305,23 @@ final class TypeConverter {
     }
 
     private static Boolean asBoolean(Object val, EsType columnType, String typeString) throws SQLException {
-        return switch (columnType) {
-            case BOOLEAN, BYTE, SHORT, INTEGER, LONG, FLOAT, HALF_FLOAT, SCALED_FLOAT, DOUBLE -> Boolean.valueOf(
-                Integer.signum(((Number) val).intValue()) != 0
-            );
-            case KEYWORD, TEXT -> Boolean.valueOf((String) val);
-            default -> failConversion(val, columnType, typeString, Boolean.class);
-        };
+        switch (columnType) {
+            case BOOLEAN:
+            case BYTE:
+            case SHORT:
+            case INTEGER:
+            case LONG:
+            case FLOAT:
+            case HALF_FLOAT:
+            case SCALED_FLOAT:
+            case DOUBLE:
+                return Boolean.valueOf(Integer.signum(((Number) val).intValue()) != 0);
+            case KEYWORD:
+            case TEXT:
+                return Boolean.valueOf((String) val);
+            default:
+                return failConversion(val, columnType, typeString, Boolean.class);
+        }
     }
 
     private static Byte asByte(Object val, EsType columnType, String typeString) throws SQLException {

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
@@ -325,14 +325,23 @@ public class JreHttpUrlConnection implements Closeable {
         NOT_SUPPORTED(SQLFeatureNotSupportedException::new);
 
         public static SqlExceptionType fromRemoteFailureType(String type) {
-            return switch (type) {
-                case "analysis_exception", "resource_not_found_exception", "verification_exception" -> DATA;
-                case "planning_exception", "mapping_exception" -> NOT_SUPPORTED;
-                case "parsing_exception" -> SYNTAX;
-                case "security_exception" -> SECURITY;
-                case "timeout_exception" -> TIMEOUT;
-                default -> null;
-            };
+            switch (type) {
+                case "analysis_exception":
+                case "resource_not_found_exception":
+                case "verification_exception":
+                    return DATA;
+                case "planning_exception":
+                case "mapping_exception":
+                    return NOT_SUPPORTED;
+                case "parsing_exception":
+                    return SYNTAX;
+                case "security_exception":
+                    return SECURITY;
+                case "timeout_exception":
+                    return TIMEOUT;
+                default:
+                    return null;
+            }
         }
 
         private final Function<String, SQLException> toException;

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/RemoteFailure.java
@@ -145,7 +145,7 @@ public class RemoteFailure {
         RemoteFailure exception = null;
 
         /* It'd be lovely to use the high level constructs that we have in core like ObjectParser
-        * but, alas, we aren't going to modularize those out any time soon. */
+         * but, alas, we aren't going to modularize those out any time soon. */
         JsonToken token = parser.nextToken();
         if (token != JsonToken.START_OBJECT) {
             throw new IllegalArgumentException(
@@ -158,7 +158,7 @@ public class RemoteFailure {
                 fieldName = parser.getCurrentName();
             } else {
                 switch (fieldName) {
-                    case "error" -> {
+                    case "error":
                         if (token != JsonToken.START_OBJECT && token != JsonToken.VALUE_STRING) {
                             throw new IOException(
                                 "Expected [error] to be an object or string but was [" + token + "][" + parser.getText() + "]"
@@ -170,17 +170,14 @@ public class RemoteFailure {
                             exception = parseFailure(parser);
                         }
                         continue;
-                    }
-                    case "status" -> {
+                    case "status":
                         if (token != JsonToken.VALUE_NUMBER_INT) {
                             throw new IOException("Expected [status] to be a string but was [" + token + "][" + parser.getText() + "]");
                         }
                         // Intentionally ignored
                         continue;
-                    }
-                    default -> throw new IOException(
-                        "Expected one of [error, status] but got [" + fieldName + "][" + parser.getText() + "]"
-                    );
+                    default:
+                        throw new IOException("Expected one of [error, status] but got [" + fieldName + "][" + parser.getText() + "]");
                 }
             }
         }

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
@@ -279,11 +279,14 @@ public abstract class StringUtils {
     }
 
     public static boolean parseBoolean(String input) {
-        return switch (input) {
-            case "true" -> true;
-            case "false" -> false;
-            default -> throw new IllegalArgumentException("must be [true] or [false]");
-        };
+        switch (input) {
+            case "true":
+                return true;
+            case "false":
+                return false;
+            default:
+                throw new IllegalArgumentException("must be [true] or [false]");
+        }
     }
 
     public static String asHexString(byte[] content, int offset, int length) {

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/core/TimeValue.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/core/TimeValue.java
@@ -64,14 +64,23 @@ public class TimeValue {
         if (duration < 0) {
             return Long.toString(duration);
         }
-        return switch (timeUnit) {
-            case NANOSECONDS -> duration + "nanos";
-            case MICROSECONDS -> duration + "micros";
-            case MILLISECONDS -> duration + "ms";
-            case SECONDS -> duration + "s";
-            case MINUTES -> duration + "m";
-            case HOURS -> duration + "h";
-            case DAYS -> duration + "d";
-        };
+        switch (timeUnit) {
+            case NANOSECONDS:
+                return duration + "nanos";
+            case MICROSECONDS:
+                return duration + "micros";
+            case MILLISECONDS:
+                return duration + "ms";
+            case SECONDS:
+                return duration + "s";
+            case MINUTES:
+                return duration + "m";
+            case HOURS:
+                return duration + "h";
+            case DAYS:
+                return duration + "d";
+            default:
+                throw new IllegalArgumentException("unknown time unit: " + timeUnit.name());
+        }
     }
 }


### PR DESCRIPTION
The plugin's source compatibility was updated to Java 8 in #82274, so switch expressions are not supported anymore.

See #82178
