### PR TITLE
[DOCS] Adds page header to the Java REST Client book

### DIFF
--- a/docs/java-rest/page_header.html
+++ b/docs/java-rest/page_header.html
@@ -1,0 +1,7 @@
+<p>
+  <strong>WARNING</strong>: Deprecated in 7.15.0. 
+</p>  
+<p>
+  The Java REST Client is deprecated in favor of the 
+  <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html">Java API Client</a>.
+</p>


### PR DESCRIPTION
## Overview

This PR adds a page header to the Java REST Client book that informs the user that the Client is deprecated in favor of the Java API Client.

### Preview

[Java REST Client](https://elasticsearch_82351.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/current/index.html)

![Screenshot 2022-01-10 at 11 29 30](https://user-images.githubusercontent.com/22324794/148751414-be63edec-f27e-4241-afed-535424ab203f.png)

