### PR TITLE
[ML] optimize the job stats call to do fewer searches

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
@@ -254,7 +254,7 @@ public class DataCounts implements ToXContentObject, Writeable {
         logTime = in.readOptionalInstant();
     }
 
-    public String getJobid() {
+    public String getJobId() {
         return jobId;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCountsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCountsTests.java
@@ -208,7 +208,7 @@ public class DataCountsTests extends AbstractSerializingTestCase<DataCounts> {
 
     public void testDocumentId() {
         DataCounts dataCounts = createTestInstance();
-        String jobId = dataCounts.getJobid();
+        String jobId = dataCounts.getJobId();
         assertEquals(jobId + "_data_counts", DataCounts.documentId(jobId));
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -416,7 +416,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         job.setAnalysisConfig(createAnalysisConfig("by_field_1", Collections.emptyList()));
         job.setDataDescription(new DataDescription.Builder());
 
-        // Put fist job. This should create the results index as it's the first job.
+        // Put first job. This should create the results index as it's the first job.
         client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
         AtomicReference<DataCounts> dataCountsAtomicReference = new AtomicReference<>();
         AtomicReference<ModelSizeStats> modelSizeStatsAtomicReference = new AtomicReference<>();
@@ -445,7 +445,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         job.setAnalysisConfig(createAnalysisConfig("by_field_1", Collections.emptyList()));
         job.setDataDescription(new DataDescription.Builder());
 
-        // Put fist job. This should create the results index as it's the first job.
+        // Put first job. This should create the results index as it's the first job.
         client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
         AtomicReference<DataCounts> dataCountsAtomicReference = new AtomicReference<>();
         AtomicReference<ModelSizeStats> modelSizeStatsAtomicReference = new AtomicReference<>();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -62,6 +63,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCountsTe
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
@@ -88,6 +90,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary;
@@ -106,6 +109,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
 
     private JobResultsProvider jobProvider;
     private ResultsPersisterService resultsPersisterService;
+    private JobResultsPersister jobResultsPersister;
     private AnomalyDetectionAuditor auditor;
 
     @Before
@@ -131,6 +135,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
 
         OriginSettingClient originSettingClient = new OriginSettingClient(client(), ClientHelper.ML_ORIGIN);
         resultsPersisterService = new ResultsPersisterService(tp, originSettingClient, clusterService, builder.build());
+        jobResultsPersister = new JobResultsPersister(originSettingClient, resultsPersisterService);
         auditor = new AnomalyDetectionAuditor(client(), clusterService);
         waitForMlTemplates();
     }
@@ -406,6 +411,96 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         }
     }
 
+    public void testGetDataCountsModelSizeAndTimingStatsWithNoDocs() throws Exception {
+        Job.Builder job = new Job.Builder("first_job");
+        job.setAnalysisConfig(createAnalysisConfig("by_field_1", Collections.emptyList()));
+        job.setDataDescription(new DataDescription.Builder());
+
+        // Put fist job. This should create the results index as it's the first job.
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+        AtomicReference<DataCounts> dataCountsAtomicReference = new AtomicReference<>();
+        AtomicReference<ModelSizeStats> modelSizeStatsAtomicReference = new AtomicReference<>();
+        AtomicReference<TimingStats> timingStatsAtomicReference = new AtomicReference<>();
+        AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
+
+        getDataCountsModelSizeAndTimingStats(
+            job.getId(),
+            dataCountsAtomicReference::set,
+            modelSizeStatsAtomicReference::set,
+            timingStatsAtomicReference::set,
+            exceptionAtomicReference::set
+        );
+
+        if (exceptionAtomicReference.get() != null) {
+            throw exceptionAtomicReference.get();
+        }
+
+        assertThat(dataCountsAtomicReference.get().getJobId(), equalTo(job.getId()));
+        assertThat(modelSizeStatsAtomicReference.get().getJobId(), equalTo(job.getId()));
+        assertThat(timingStatsAtomicReference.get().getJobId(), equalTo(job.getId()));
+    }
+
+    public void testGetDataCountsModelSizeAndTimingStatsWithSomeDocs() throws Exception {
+        Job.Builder job = new Job.Builder("first_job");
+        job.setAnalysisConfig(createAnalysisConfig("by_field_1", Collections.emptyList()));
+        job.setDataDescription(new DataDescription.Builder());
+
+        // Put fist job. This should create the results index as it's the first job.
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+        AtomicReference<DataCounts> dataCountsAtomicReference = new AtomicReference<>();
+        AtomicReference<ModelSizeStats> modelSizeStatsAtomicReference = new AtomicReference<>();
+        AtomicReference<TimingStats> timingStatsAtomicReference = new AtomicReference<>();
+        AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
+
+        CheckedSupplier<Void, Exception> setOrThrow = () -> {
+            getDataCountsModelSizeAndTimingStats(
+                job.getId(),
+                dataCountsAtomicReference::set,
+                modelSizeStatsAtomicReference::set,
+                timingStatsAtomicReference::set,
+                exceptionAtomicReference::set
+            );
+
+            if (exceptionAtomicReference.get() != null) {
+                throw exceptionAtomicReference.get();
+            }
+            return null;
+        };
+
+        ModelSizeStats storedModelSizeStats = new ModelSizeStats.Builder(job.getId()).setModelBytes(10L).build();
+        jobResultsPersister.persistModelSizeStats(storedModelSizeStats, () -> false);
+        jobResultsPersister.commitResultWrites(job.getId());
+
+        setOrThrow.get();
+        assertThat(dataCountsAtomicReference.get().getJobId(), equalTo(job.getId()));
+        assertThat(modelSizeStatsAtomicReference.get(), equalTo(storedModelSizeStats));
+        assertThat(timingStatsAtomicReference.get().getJobId(), equalTo(job.getId()));
+
+        TimingStats storedTimingStats = new TimingStats(job.getId());
+        storedTimingStats.updateStats(10);
+
+        jobResultsPersister.bulkPersisterBuilder(job.getId()).persistTimingStats(storedTimingStats).executeRequest();
+        jobResultsPersister.commitResultWrites(job.getId());
+
+        setOrThrow.get();
+
+        assertThat(dataCountsAtomicReference.get().getJobId(), equalTo(job.getId()));
+        assertThat(modelSizeStatsAtomicReference.get(), equalTo(storedModelSizeStats));
+        assertThat(timingStatsAtomicReference.get(), equalTo(storedTimingStats));
+
+        DataCounts storedDataCounts = new DataCounts(job.getId());
+        storedDataCounts.incrementInputBytes(1L);
+        storedDataCounts.incrementMissingFieldCount(1L);
+        JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client(), resultsPersisterService, auditor);
+        jobDataCountsPersister.persistDataCounts(job.getId(), storedDataCounts);
+        jobResultsPersister.commitResultWrites(job.getId());
+
+        setOrThrow.get();
+        assertThat(dataCountsAtomicReference.get(), equalTo(storedDataCounts));
+        assertThat(modelSizeStatsAtomicReference.get(), equalTo(storedModelSizeStats));
+        assertThat(timingStatsAtomicReference.get(), equalTo(storedTimingStats));
+    }
+
     private Map<String, Object> getIndexMappingProperties(String index) {
         GetMappingsRequest request = new GetMappingsRequest().indices(index);
         GetMappingsResponse response = client().execute(GetMappingsAction.INSTANCE, request).actionGet();
@@ -496,6 +591,26 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         }
 
         return calendarHolder.get();
+    }
+
+    private void getDataCountsModelSizeAndTimingStats(
+        String jobId,
+        Consumer<DataCounts> dataCountsConsumer,
+        Consumer<ModelSizeStats> modelSizeStatsConsumer,
+        Consumer<TimingStats> timingStatsConsumer,
+        Consumer<Exception> exceptionConsumer
+    ) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        jobProvider.getDataCountsModelSizeAndTimingStats(jobId, (dataCounts, modelSizeStats, timingStats) -> {
+            dataCountsConsumer.accept(dataCounts);
+            modelSizeStatsConsumer.accept(modelSizeStats);
+            timingStatsConsumer.accept(timingStats);
+            latch.countDown();
+        }, e -> {
+            exceptionConsumer.accept(e);
+            latch.countDown();
+        });
+        latch.await();
     }
 
     public void testScheduledEventsForJobs() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -46,6 +46,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
@@ -68,9 +69,12 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.filter.Filters;
+import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.Stats;
+import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -489,6 +493,77 @@ public class JobResultsProvider {
         );
     }
 
+    public void getDataCountsModelSizeAndTimingStats(
+        String jobId,
+        TriConsumer<DataCounts, ModelSizeStats, TimingStats> handler,
+        Consumer<Exception> errorHandler
+    ) {
+        final String results = "results";
+        final String timingStats = "timing_stats";
+        final String dataCounts = "data_counts";
+        final String modelSizeStats = "model_size_stats";
+        final String topHits = "hits";
+        SearchRequest request = client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId))
+            .setSize(0)
+            .setTrackTotalHits(false)
+            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .addAggregation(
+                AggregationBuilders.filters(
+                    results,
+                    new FiltersAggregator.KeyedFilter(
+                        dataCounts,
+                        QueryBuilders.idsQuery().addIds(DataCounts.documentId(jobId), DataCounts.v54DocumentId(jobId))
+                    ),
+                    new FiltersAggregator.KeyedFilter(timingStats, QueryBuilders.idsQuery().addIds(TimingStats.documentId(jobId))),
+                    new FiltersAggregator.KeyedFilter(
+                        modelSizeStats,
+                        QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), ModelSizeStats.RESULT_TYPE_VALUE)
+                    )
+                )
+                    .subAggregation(
+                        AggregationBuilders.topHits(topHits)
+                            .size(1)
+                            .sorts(
+                                List.of(
+                                    SortBuilders.fieldSort(DataCounts.LOG_TIME.getPreferredName())
+                                        .order(SortOrder.DESC)
+                                        .unmappedType(NumberFieldMapper.NumberType.LONG.typeName())
+                                        .missing(0L),
+                                    SortBuilders.fieldSort(TimingStats.BUCKET_COUNT.getPreferredName())
+                                        .order(SortOrder.DESC)
+                                        .unmappedType(NumberFieldMapper.NumberType.LONG.typeName())
+                                        .missing(0L)
+                                )
+                            )
+                    )
+            )
+            .request();
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, request, ActionListener.<SearchResponse>wrap(response -> {
+            Aggregations aggs = response.getAggregations();
+            if (aggs == null) {
+                handler.apply(new DataCounts(jobId), new ModelSizeStats.Builder(jobId).build(), new TimingStats(jobId));
+                return;
+            }
+            Filters filters = aggs.get(results);
+            TopHits dataCountHit = filters.getBucketByKey(dataCounts).getAggregations().get(topHits);
+            DataCounts dataCountsResult = dataCountHit.getHits().getHits().length == 0
+                ? new DataCounts(jobId)
+                : MlParserUtils.parse(dataCountHit.getHits().getHits()[0], DataCounts.PARSER);
+
+            TopHits timingStatsHits = filters.getBucketByKey(timingStats).getAggregations().get(topHits);
+            TimingStats timingStatsResult = timingStatsHits.getHits().getHits().length == 0
+                ? new TimingStats(jobId)
+                : MlParserUtils.parse(timingStatsHits.getHits().getHits()[0], TimingStats.PARSER);
+
+            TopHits modelSizeHits = filters.getBucketByKey(timingStats).getAggregations().get(topHits);
+            ModelSizeStats modelSizeStatsResult = modelSizeHits.getHits().getHits().length == 0
+                ? new ModelSizeStats.Builder(jobId).build()
+                : MlParserUtils.parse(modelSizeHits.getHits().getHits()[0], ModelSizeStats.LENIENT_PARSER).build();
+
+            handler.apply(dataCountsResult, modelSizeStatsResult, timingStatsResult);
+        }, errorHandler), client::search);
+    }
+
     private SearchRequestBuilder createLatestDataCountsSearch(String indexName, String jobId) {
         return client.prepareSearch(indexName)
             .setSize(1)
@@ -505,24 +580,6 @@ public class JobResultsProvider {
                     .missing(0L)
             )
             .addSort(SortBuilders.fieldSort(DataCounts.LATEST_RECORD_TIME.getPreferredName()).order(SortOrder.DESC));
-    }
-
-    /**
-     * Get the job's timing stats
-     *
-     * @param jobId The job id
-     */
-    public void timingStats(String jobId, Consumer<TimingStats> handler, Consumer<Exception> errorHandler) {
-        String indexName = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
-        searchSingleResult(
-            jobId,
-            TimingStats.TYPE.getPreferredName(),
-            createLatestTimingStatsSearch(indexName, jobId),
-            TimingStats.PARSER,
-            result -> handler.accept(result.result),
-            errorHandler,
-            () -> new TimingStats(jobId)
-        );
     }
 
     private SearchRequestBuilder createLatestTimingStatsSearch(String indexName, String jobId) {
@@ -1698,7 +1755,7 @@ public class JobResultsProvider {
             AggregationBuilders.terms(ForecastStats.Fields.STATUSES).field(ForecastRequestStats.STATUS.getPreferredName())
         );
         sourceBuilder.size(0);
-        sourceBuilder.trackTotalHits(true);
+        sourceBuilder.trackTotalHits(false);
 
         searchRequest.source(sourceBuilder);
 
@@ -1707,9 +1764,8 @@ public class JobResultsProvider {
             ML_ORIGIN,
             searchRequest,
             ActionListener.<SearchResponse>wrap(searchResponse -> {
-                long totalHits = searchResponse.getHits().getTotalHits().value;
                 Aggregations aggregations = searchResponse.getAggregations();
-                if (totalHits == 0 || aggregations == null) {
+                if (aggregations == null) {
                     handler.accept(new ForecastStats());
                     return;
                 }
@@ -1717,9 +1773,10 @@ public class JobResultsProvider {
                 StatsAccumulator memoryStats = StatsAccumulator.fromStatsAggregation(
                     (Stats) aggregationsAsMap.get(ForecastStats.Fields.MEMORY)
                 );
-                StatsAccumulator recordStats = StatsAccumulator.fromStatsAggregation(
-                    (Stats) aggregationsAsMap.get(ForecastStats.Fields.RECORDS)
-                );
+                Stats aggRecordsStats = (Stats) aggregationsAsMap.get(ForecastStats.Fields.RECORDS);
+                // Stats already gives us all the counts and every doc as a "records" field.
+                long totalHits = aggRecordsStats.getCount();
+                StatsAccumulator recordStats = StatsAccumulator.fromStatsAggregation(aggRecordsStats);
                 StatsAccumulator runtimeStats = StatsAccumulator.fromStatsAggregation(
                     (Stats) aggregationsAsMap.get(ForecastStats.Fields.RUNTIME)
                 );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -555,7 +555,7 @@ public class JobResultsProvider {
                 ? new TimingStats(jobId)
                 : MlParserUtils.parse(timingStatsHits.getHits().getHits()[0], TimingStats.PARSER);
 
-            TopHits modelSizeHits = filters.getBucketByKey(timingStats).getAggregations().get(topHits);
+            TopHits modelSizeHits = filters.getBucketByKey(modelSizeStats).getAggregations().get(topHits);
             ModelSizeStats modelSizeStatsResult = modelSizeHits.getHits().getHits().length == 0
                 ? new ModelSizeStats.Builder(jobId).build()
                 : MlParserUtils.parse(modelSizeHits.getHits().getHits()[0], ModelSizeStats.LENIENT_PARSER).build();


### PR DESCRIPTION
This reduces the number of searches required for a closed job stats from 4 to 2.

This commit merges the searches for model_size_stats, timing_stats, and data_counts. 

Relates to: https://github.com/elastic/elasticsearch/issues/82255