### PR TITLE
Ignoring certain system templates with custom types

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -600,6 +601,8 @@ public class ClusterDeprecationChecks {
     static DeprecationIssue checkTemplatesWithCustomAndMultipleTypes(ClusterState state) {
         Set<String> templatesWithMultipleTypes = new TreeSet<>();
         Set<String> templatesWithCustomTypes = new TreeSet<>();
+        // See https://github.com/elastic/elasticsearch/issues/82109#issuecomment-1006143687 for details:
+        Set<String> systemTemplatesWithCustomTypes = Sets.newHashSet(".triggered_watches", ".watch-history-9", ".watches");
         state.getMetadata().getTemplates().forEach((templateCursor) -> {
             String templateName = templateCursor.key;
             ImmutableOpenMap<String, CompressedXContent> mappings = templateCursor.value.mappings();
@@ -612,7 +615,9 @@ public class ClusterDeprecationChecks {
                     return MapperService.SINGLE_MAPPING_NAME.equals(typeName) == false;
                 });
                 if (hasCustomType) {
-                    templatesWithCustomTypes.add(templateName);
+                    if (systemTemplatesWithCustomTypes.contains(templateName) == false) {
+                        templatesWithCustomTypes.add(templateName);
+                    }
                 }
             }
         });

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -389,10 +389,26 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             .patterns(Collections.singletonList("foo"))
             .putMapping("_doc", "{\"_doc\":{}}")
             .build();
+        // The following 3 have a custom type, but they should be ignored:
+        IndexTemplateMetadata triggeredWatches = IndexTemplateMetadata.builder(".triggered_watches")
+            .patterns(Collections.singletonList("foo"))
+            .putMapping("someType", "{\"type2\":{}}")
+            .build();
+        IndexTemplateMetadata watchHistory9 = IndexTemplateMetadata.builder(".watch-history-9")
+            .patterns(Collections.singletonList("foo"))
+            .putMapping("someType", "{\"type2\":{}}")
+            .build();
+        IndexTemplateMetadata watches = IndexTemplateMetadata.builder(".watches")
+            .patterns(Collections.singletonList("foo"))
+            .putMapping("someType", "{\"type2\":{}}")
+            .build();
         ImmutableOpenMap<String, IndexTemplateMetadata> templates = ImmutableOpenMap.<String, IndexTemplateMetadata>builder()
             .fPut("template1", template1)
             .fPut("template2", template2)
             .fPut("template3", template3)
+            .fPut(".triggered_watches", triggeredWatches)
+            .fPut(".watch-history-9", watchHistory9)
+            .fPut(".watches", watches)
             .build();
         Metadata badMetadata = Metadata.builder().templates(templates).build();
         ClusterState badState = ClusterState.builder(new ClusterName("test")).metadata(badMetadata).build();


### PR DESCRIPTION
As documented in https://github.com/elastic/elasticsearch/issues/82109#issuecomment-1006143687, we need to
ignore the `.triggered_watches`, `.watch-history-9`, and `.watches templates` templates in the deprecation
info API check for templates with custom types.