### PR TITLE
Faster Mapping Parsing on Master and Datanode

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
@@ -21,7 +21,7 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
     private final CompressedXContent source;
 
     public PutMappingClusterStateUpdateRequest(String source) throws IOException {
-        this.source = new CompressedXContent(source);
+        this.source = CompressedXContent.fromJSON(source);
     }
 
     public CompressedXContent source() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -253,8 +253,8 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         Map<String, AliasMetadata> aliasesByName = aliases.stream().collect(Collectors.toMap(AliasMetadata::getAlias, Function.identity()));
 
         // empty request mapping as the user can't specify any explicit mappings via the simulate api
-        List<Map<String, Object>> mappings = MetadataCreateIndexService.collectV2Mappings(
-            "{}",
+        List<CompressedXContent> mappings = MetadataCreateIndexService.collectV2Mappings(
+            null,
             simulatedState,
             matchingTemplate,
             xContentRegistry,
@@ -265,10 +265,8 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
             indexMetadata,
             tempIndexService -> {
                 MapperService mapperService = tempIndexService.mapperService();
-                for (Map<String, Object> mapping : mappings) {
-                    if (mapping.isEmpty() == false) {
-                        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
-                    }
+                for (CompressedXContent mapping : mappings) {
+                    mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
                 }
 
                 DocumentMapper documentMapper = mapperService.documentMapper();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -425,7 +425,7 @@ public class MetadataCreateIndexService {
         final boolean silent,
         final IndexMetadata sourceMetadata,
         final IndexMetadata temporaryIndexMeta,
-        final List<Map<String, Object>> mappings,
+        final List<CompressedXContent> mappings,
         final Function<IndexService, List<AliasMetadata>> aliasSupplier,
         final List<String> templatesApplied,
         final BiConsumer<Metadata.Builder, IndexMetadata> metadataTransformer
@@ -518,13 +518,18 @@ public class MetadataCreateIndexService {
             templates.stream().map(IndexTemplateMetadata::name).collect(Collectors.toList())
         );
 
-        final Map<String, Object> mappings = Collections.unmodifiableMap(
-            parseV1Mappings(
-                request.mappings(),
-                templates.stream().map(IndexTemplateMetadata::getMappings).collect(toList()),
-                xContentRegistry
-            )
+        final Map<String, Object> mappingsMap = parseV1Mappings(
+            request.mappings(),
+            templates.stream().map(IndexTemplateMetadata::getMappings).collect(toList()),
+            xContentRegistry
         );
+
+        final CompressedXContent mappings;
+        if (mappingsMap.isEmpty()) {
+            mappings = null;
+        } else {
+            mappings = new CompressedXContent((builder, params) -> builder.mapContents(mappingsMap));
+        }
 
         final Settings aggregatedIndexSettings = aggregateIndexSettings(
             currentState,
@@ -545,7 +550,7 @@ public class MetadataCreateIndexService {
             silent,
             null,
             tmpImd,
-            List.of(mappings),
+            mappings == null ? List.of() : List.of(mappings),
             indexService -> resolveAndValidateAliases(
                 request.index(),
                 request.aliases(),
@@ -586,7 +591,7 @@ public class MetadataCreateIndexService {
             );
         }
 
-        final List<Map<String, Object>> mappings = collectV2Mappings(
+        final List<CompressedXContent> mappings = collectV2Mappings(
             request.mappings(),
             currentState,
             templateName,
@@ -648,7 +653,7 @@ public class MetadataCreateIndexService {
         }
 
         final Map<String, ComponentTemplate> componentTemplates = request.systemDataStreamDescriptor().getComponentTemplates();
-        final List<Map<String, Object>> mappings = collectSystemV2Mappings(template, componentTemplates, xContentRegistry, request.index());
+        final List<CompressedXContent> mappings = collectSystemV2Mappings(template, componentTemplates, xContentRegistry, request.index());
 
         final Settings aggregatedIndexSettings = aggregateIndexSettings(
             currentState,
@@ -688,7 +693,7 @@ public class MetadataCreateIndexService {
         );
     }
 
-    private static List<Map<String, Object>> collectSystemV2Mappings(
+    private static List<CompressedXContent> collectSystemV2Mappings(
         final ComposableIndexTemplate composableIndexTemplate,
         final Map<String, ComponentTemplate> componentTemplates,
         final NamedXContentRegistry xContentRegistry,
@@ -699,11 +704,11 @@ public class MetadataCreateIndexService {
             componentTemplates,
             indexName
         );
-        return collectV2Mappings("{}", templateMappings, xContentRegistry);
+        return collectV2Mappings(null, templateMappings, xContentRegistry);
     }
 
-    public static List<Map<String, Object>> collectV2Mappings(
-        final String requestMappings,
+    public static List<CompressedXContent> collectV2Mappings(
+        @Nullable final String requestMappings,
         final ClusterState currentState,
         final String templateName,
         final NamedXContentRegistry xContentRegistry,
@@ -713,20 +718,19 @@ public class MetadataCreateIndexService {
         return collectV2Mappings(requestMappings, templateMappings, xContentRegistry);
     }
 
-    public static List<Map<String, Object>> collectV2Mappings(
-        final String requestMappings,
+    private static List<CompressedXContent> collectV2Mappings(
+        @Nullable final String requestMappings,
         final List<CompressedXContent> templateMappings,
         final NamedXContentRegistry xContentRegistry
     ) throws Exception {
-        List<Map<String, Object>> result = new ArrayList<>();
-
-        for (CompressedXContent templateMapping : templateMappings) {
-            Map<String, Object> parsedTemplateMapping = MapperService.parseMapping(xContentRegistry, templateMapping);
-            result.add(parsedTemplateMapping);
+        List<CompressedXContent> result = new ArrayList<>(templateMappings.size() + 1);
+        result.addAll(templateMappings);
+        if (requestMappings != null) {
+            Map<String, Object> parsedRequestMappings = MapperService.parseMapping(xContentRegistry, requestMappings);
+            if (parsedRequestMappings.isEmpty() == false) {
+                result.add(new CompressedXContent((builder, params) -> builder.mapContents(parsedRequestMappings)));
+            }
         }
-
-        Map<String, Object> parsedRequestMappings = MapperService.parseMapping(xContentRegistry, requestMappings);
-        result.add(parsedRequestMappings);
         return result;
     }
 
@@ -765,7 +769,7 @@ public class MetadataCreateIndexService {
             silent,
             sourceMetadata,
             tmpImd,
-            List.of(mappings),
+            List.of(),
             indexService -> resolveAndValidateAliases(
                 request.index(),
                 request.aliases(),
@@ -797,7 +801,7 @@ public class MetadataCreateIndexService {
         String mappingsJson,
         List<CompressedXContent> templateMappings,
         NamedXContentRegistry xContentRegistry
-    ) throws Exception {
+    ) throws IOException {
         Map<String, Object> mappings = MapperService.parseMapping(xContentRegistry, mappingsJson);
         // apply templates, merging the mappings into the request mapping if exists
         for (CompressedXContent mapping : templateMappings) {
@@ -1211,18 +1215,17 @@ public class MetadataCreateIndexService {
     private void updateIndexMappingsAndBuildSortOrder(
         IndexService indexService,
         CreateIndexClusterStateUpdateRequest request,
-        List<Map<String, Object>> mappings,
+        List<CompressedXContent> mappings,
         @Nullable IndexMetadata sourceMetadata
     ) throws IOException {
         MapperService mapperService = indexService.mapperService();
         IndexMode indexMode = indexService.getIndexSettings() != null ? indexService.getIndexSettings().getMode() : IndexMode.STANDARD;
-        List<Map<String, Object>> mergedMappings = new ArrayList<>(1 + mappings.size());
-        mergedMappings.add(indexMode.getDefaultMapping());
-        mergedMappings.addAll(mappings);
-        for (Map<String, Object> mapping : mergedMappings) {
-            if (mapping.isEmpty() == false) {
-                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
-            }
+        final CompressedXContent defaultMapping = indexMode.getDefaultMapping();
+        if (defaultMapping != null) {
+            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, defaultMapping, MergeReason.INDEX_TEMPLATE);
+        }
+        for (CompressedXContent mapping : mappings) {
+            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
         }
         indexMode.validateTimestampFieldMapping(request.dataStreamName() != null, mapperService.mappingLookup());
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -282,7 +282,7 @@ public class MetadataIndexTemplateService {
             return currentState;
         }
 
-        validateTemplate(finalSettings, wrappedMappings, indicesService, xContentRegistry);
+        validateTemplate(finalSettings, wrappedMappings, indicesService);
         validate(name, finalComponentTemplate);
 
         // Validate all composable index templates that use this component template
@@ -959,7 +959,7 @@ public class MetadataIndexTemplateService {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    validateTemplate(request.settings, request.mappings, indicesService, xContentRegistry);
+                    validateTemplate(request.settings, request.mappings, indicesService);
                     return innerPutTemplate(currentState, request, templateBuilder);
                 }
 
@@ -1429,12 +1429,8 @@ public class MetadataIndexTemplateService {
         });
     }
 
-    private static void validateTemplate(
-        Settings validateSettings,
-        CompressedXContent mappings,
-        IndicesService indicesService,
-        NamedXContentRegistry xContentRegistry
-    ) throws Exception {
+    private static void validateTemplate(Settings validateSettings, CompressedXContent mappings, IndicesService indicesService)
+        throws Exception {
         // Hard to validate settings if they're non-existent, so used empty ones if none were provided
         Settings settings = validateSettings;
         if (settings == null) {
@@ -1466,12 +1462,7 @@ public class MetadataIndexTemplateService {
             createdIndex = dummyIndexService.index();
 
             if (mappings != null) {
-                dummyIndexService.mapperService()
-                    .merge(
-                        MapperService.SINGLE_MAPPING_NAME,
-                        MapperService.parseMapping(xContentRegistry, mappings),
-                        MergeReason.MAPPING_UPDATE
-                    );
+                dummyIndexService.mapperService().merge(MapperService.SINGLE_MAPPING_NAME, mappings, MergeReason.MAPPING_UPDATE);
             }
 
         } finally {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -162,7 +162,7 @@ public class MetadataMappingService {
                 // update mapping metadata on all types
                 DocumentMapper mapper = mapperService.documentMapper();
                 if (mapper != null) {
-                    indexMetadataBuilder.putMapping(new MappingMetadata(mapper.mappingSource()));
+                    indexMetadataBuilder.putMapping(new MappingMetadata(mapper));
                 }
                 if (updatedMapping) {
                     indexMetadataBuilder.mappingVersion(1 + indexMetadataBuilder.mappingVersion());

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -137,6 +137,13 @@ public final class CompressedXContent {
         this(new BytesArray(data));
     }
 
+    /**
+     * Parses the given JSON string and then serializes it back in compressed form without any whitespaces. This is used to normalize
+     * mapping json strings for deduplication.
+     *
+     * @param json string containing valid JSON
+     * @return compressed x-content normalized to not contain any whitespaces
+     */
     public static CompressedXContent fromJSON(String json) throws IOException {
         return new CompressedXContent(new ToXContent() {
             @Override

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -21,6 +21,8 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -133,6 +135,20 @@ public final class CompressedXContent {
 
     public CompressedXContent(byte[] data) throws IOException {
         this(new BytesArray(data));
+    }
+
+    public static CompressedXContent fromJSON(String json) throws IOException {
+        return new CompressedXContent(new ToXContent() {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                return builder.copyCurrentStructure(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json));
+            }
+
+            @Override
+            public boolean isFragment() {
+                return false;
+            }
+        });
     }
 
     public CompressedXContent(String str) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -22,7 +23,6 @@ import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -66,8 +66,8 @@ public enum IndexMode {
         }
 
         @Override
-        public Map<String, Object> getDefaultMapping() {
-            return Collections.emptyMap();
+        public CompressedXContent getDefaultMapping() {
+            return null;
         }
 
         @Override
@@ -122,7 +122,7 @@ public enum IndexMode {
         }
 
         @Override
-        public Map<String, Object> getDefaultMapping() {
+        public CompressedXContent getDefaultMapping() {
             return DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
         }
 
@@ -140,15 +140,26 @@ public enum IndexMode {
         }
     };
 
-    public static final Map<String, Object> DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING = Map.of(
-        MapperService.SINGLE_MAPPING_NAME,
-        Map.of(
-            DataStreamTimestampFieldMapper.NAME,
-            Map.of("enabled", true),
-            "properties",
-            Map.of(DataStreamTimestampFieldMapper.DEFAULT_PATH, Map.of("type", DateFieldMapper.CONTENT_TYPE))
-        )
-    );
+    public static final CompressedXContent DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
+
+    static {
+        try {
+            DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING = new CompressedXContent(
+                ((builder, params) -> builder.startObject(MapperService.SINGLE_MAPPING_NAME)
+                    .startObject(DataStreamTimestampFieldMapper.NAME)
+                    .field("enabled", true)
+                    .endObject()
+                    .startObject("properties")
+                    .startObject(DataStreamTimestampFieldMapper.DEFAULT_PATH)
+                    .field("type", DateFieldMapper.CONTENT_TYPE)
+                    .endObject()
+                    .endObject()
+                    .endObject())
+            );
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
 
     private static final List<Setting<?>> TIME_SERIES_UNSUPPORTED = List.of(
         IndexSortConfig.INDEX_SORT_FIELD_SETTING,
@@ -187,10 +198,10 @@ public enum IndexMode {
     public abstract void validateTimestampFieldMapping(boolean isDataStream, MappingLookup mappingLookup) throws IOException;
 
     /**
-     * get default mapping for this index.
-     * @return
+     * Get default mapping for this index or {@code null} if there is none.
      */
-    public abstract Map<String, Object> getDefaultMapping();
+    @Nullable
+    public abstract CompressedXContent getDefaultMapping();
 
     /**
      * Return an instance of the {@link TimeSeriesIdFieldMapper} that generates

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -29,14 +29,16 @@ public class DocumentMapper {
         RootObjectMapper root = new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME).build(MapperBuilderContext.ROOT);
         MetadataFieldMapper[] metadata = mapperService.getMetadataMappers().values().toArray(new MetadataFieldMapper[0]);
         Mapping mapping = new Mapping(root, metadata, null);
-        return new DocumentMapper(mapperService.documentParser(), mapping);
+        return new DocumentMapper(mapperService.documentParser(), mapping, mapping.toCompressedXContent());
     }
 
-    DocumentMapper(DocumentParser documentParser, Mapping mapping) {
+    DocumentMapper(DocumentParser documentParser, Mapping mapping, CompressedXContent source) {
         this.documentParser = documentParser;
         this.type = mapping.getRoot().name();
         this.mappingLookup = MappingLookup.fromMapping(mapping);
-        this.mappingSource = mapping.toCompressedXContent();
+        this.mappingSource = source;
+        assert mapping.toCompressedXContent().equals(source)
+            : "provided source [" + source + "] differs from mapping [" + mapping.toCompressedXContent() + "]";
     }
 
     public Mapping mapping() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.settings.Setting;
@@ -34,7 +33,6 @@ import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -224,6 +222,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      * Parses the mappings (formatted as JSON) into a map
      */
     public static Map<String, Object> parseMapping(NamedXContentRegistry xContentRegistry, String mappingSource) throws IOException {
+        if ("{}".equals(mappingSource)) {
+            // empty JSON is a common default value so it makes sense to optimize for it a little
+            return Map.of();
+        }
         try (
             XContentParser parser = XContentType.JSON.xContent()
                 .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, mappingSource)
@@ -271,7 +273,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             synchronized (this) {
                 previousMapper = this.mapper;
                 assert assertRefreshIsNotNeeded(previousMapper, type, incomingMapping);
-                this.mapper = newDocumentMapper(incomingMapping, MergeReason.MAPPING_RECOVERY);
+                this.mapper = newDocumentMapper(incomingMapping, MergeReason.MAPPING_RECOVERY, incomingMappingSource);
             }
             String op = previousMapper != null ? "updated" : "added";
             if (logger.isDebugEnabled() && incomingMappingSource.compressed().length < 512) {
@@ -333,32 +335,25 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return true;
     }
 
-    public void merge(String type, Map<String, Object> mappings, MergeReason reason) throws IOException {
-        CompressedXContent content = new CompressedXContent(Strings.toString(XContentFactory.jsonBuilder().map(mappings)));
-        mergeAndApplyMappings(type, content, reason);
-    }
-
     public void merge(IndexMetadata indexMetadata, MergeReason reason) {
         assert reason != MergeReason.MAPPING_UPDATE_PREFLIGHT;
         MappingMetadata mappingMetadata = indexMetadata.mapping();
         if (mappingMetadata != null) {
-            mergeAndApplyMappings(mappingMetadata.type(), mappingMetadata.source(), reason);
+            merge(mappingMetadata.type(), mappingMetadata.source(), reason);
         }
     }
 
     public DocumentMapper merge(String type, CompressedXContent mappingSource, MergeReason reason) {
-        return mergeAndApplyMappings(type, mappingSource, reason);
-    }
-
-    private DocumentMapper mergeAndApplyMappings(String mappingType, CompressedXContent mappingSource, MergeReason reason) {
         final DocumentMapper currentMapper = this.mapper;
         if (currentMapper != null && currentMapper.mappingSource().equals(mappingSource)) {
             return currentMapper;
         }
         synchronized (this) {
-            Mapping incomingMapping = parseMapping(mappingType, mappingSource);
+            Mapping incomingMapping = parseMapping(type, mappingSource);
             Mapping mapping = mergeMappings(this.mapper, incomingMapping, reason);
-            DocumentMapper newMapper = newDocumentMapper(mapping, reason);
+            // TODO: In many cases the source here is equal to mappingSource so we need not serialize again.
+            // We should identify these cases reliably and save expensive serialization here
+            DocumentMapper newMapper = newDocumentMapper(mapping, reason, mapping.toCompressedXContent());
             if (reason == MergeReason.MAPPING_UPDATE_PREFLIGHT) {
                 return newMapper;
             }
@@ -368,8 +363,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         }
     }
 
-    private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason) {
-        DocumentMapper newMapper = new DocumentMapper(documentParser, mapping);
+    private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason, CompressedXContent mappingSource) {
+        DocumentMapper newMapper = new DocumentMapper(documentParser, mapping, mappingSource);
         newMapper.mapping().getRoot().fixRedundantIncludes();
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
@@ -398,7 +393,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         final CompressedXContent mappingSource = mapper.mappingSource();
         Mapping newMapping = parseMapping(mapper.type(), mappingSource);
         if (newMapping.toCompressedXContent().equals(mappingSource) == false) {
-            throw new IllegalStateException(
+            throw new AssertionError(
                 "Mapping serialization result is different from source. \n--> Source ["
                     + mappingSource
                     + "]\n--> Result ["

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -62,7 +62,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties" { "field": { "type": "text" }}}""");
+            { "properties": { "field": { "type": "text" }}}""");
         ClusterState result = mappingService.putMappingExecutor.execute(
             clusterService.state(),
             Collections.singletonList(request)

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -64,7 +64,7 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         assertThat(stage1.mappers().getMapper("obj1.prop1"), nullValue());
         // but merged should
         DocumentParser documentParser = new DocumentParser(null, null, null, null);
-        DocumentMapper mergedMapper = new DocumentMapper(documentParser, merged);
+        DocumentMapper mergedMapper = new DocumentMapper(documentParser, merged, merged.toCompressedXContent());
         assertThat(mergedMapper.mappers().getMapper("age"), notNullValue());
         assertThat(mergedMapper.mappers().getMapper("obj1.prop1"), notNullValue());
     }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1916,7 +1916,7 @@ public class DataStreamIT extends ESIntegTestCase {
         request.indexTemplate(
             new ComposableIndexTemplate(
                 patterns,
-                new Template(settings, mappings == null ? null : new CompressedXContent(mappings), aliases),
+                new Template(settings, mappings == null ? null : CompressedXContent.fromJSON(mappings), aliases),
                 null,
                 null,
                 null,


### PR DESCRIPTION
A couple of straightforward mapper parsing improvements.
Save round-trips to `String` in many spots.
Don't serialize the mapping again in the document mapper constructor
when the mapping is known to be correct (free of redundant white-paces etc.)
because we received it from the master/CS. This also saves a bit of memory
from not having duplicate `CompressedXContent` on heap on data nodes (because we
use the instances straight from the cluster state and those are deduplicated).

relates #77466 