### PR TITLE
Deprecate Unbatched Cluster State Updates

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -18,7 +18,11 @@ import org.elasticsearch.core.TimeValue;
 /**
  * An extension interface to {@link ClusterStateUpdateTask} that allows to be notified when
  * all the nodes have acknowledged a cluster state update request
+ * @deprecated unbatched cluster state updates are deprecated.
+ *             See {@link org.elasticsearch.cluster.service.ClusterService#submitStateUpdateTask(String, ClusterStateTaskConfig)}
+ *             for details.
  */
+@Deprecated
 public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask implements AckedClusterStateTaskListener {
 
     private final ActionListener<AcknowledgedResponse> listener;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -16,7 +16,11 @@ import java.util.List;
 
 /**
  * A task that can update the cluster state.
+ * @deprecated unbatched cluster state updates are deprecated.
+ *             See {@link org.elasticsearch.cluster.service.ClusterService#submitStateUpdateTask(String, ClusterStateTaskConfig)}
+ *             for details.
  */
+@Deprecated
 public abstract class ClusterStateUpdateTask
     implements
         ClusterStateTaskConfig,

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
-import java.util.Map;
 
 public class ClusterService extends AbstractLifecycleComponent {
     private final MasterService masterService;
@@ -227,11 +226,14 @@ public class ClusterService extends AbstractLifecycleComponent {
      * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, Object, ClusterStateTaskConfig,
      * ClusterStateTaskExecutor, ClusterStateTaskListener)}, submitted updates will not be batched.
      *
+     * @deprecated Unbatched cluster state update tasks are deprecated as they may cause scalability issues if submitted at high rates.
+     *             Use batched state updates via {@link #submitStateUpdateTask(String, Object, ClusterStateTaskConfig,
+     *             ClusterStateTaskExecutor, ClusterStateTaskListener)} instead.
      * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
      *                   task
-     *
      */
+    @Deprecated
     public <T extends ClusterStateTaskConfig & ClusterStateTaskExecutor<T> & ClusterStateTaskListener> void submitStateUpdateTask(
         String source,
         T updateTask
@@ -265,28 +267,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         ClusterStateTaskExecutor<T> executor,
         ClusterStateTaskListener listener
     ) {
-        submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
+        masterService.submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
     }
 
-    /**
-     * Submits a batch of cluster state update tasks; submitted updates are guaranteed to be processed together,
-     * potentially with more tasks of the same executor.
-     *
-     * @param source   the source of the cluster state update task
-     * @param tasks    a map of update tasks and their corresponding listeners
-     * @param config   the cluster state update task configuration
-     * @param executor the cluster state update task executor; tasks
-     *                 that share the same executor will be executed
-     *                 batches on this executor
-     * @param <T>      the type of the cluster state update task state
-     *
-     */
-    public <T> void submitStateUpdateTasks(
-        final String source,
-        final Map<T, ClusterStateTaskListener> tasks,
-        final ClusterStateTaskConfig config,
-        final ClusterStateTaskExecutor<T> executor
-    ) {
-        masterService.submitStateUpdateTasks(source, tasks, config, executor);
-    }
 }


### PR DESCRIPTION
Deprecate unbatched cluster state updates because as they tend to cause
scalability issues when task submit rates become high. Implementing a
batched update instead of only slightly more effort and avoids many of
the scalability pitfalls encountered in ILM etc. recently out of the box
in most cases.
Moving all unbatched tasks to batched will take a lot of work but by
deprecating the API now we at least prevent the list of unbatched
updates from growing.

This came out of the last many shards sync and I think it's the way to go.
Adding team discuss, but we might be able to come to a conclusion on this async in this PR IMO.

relates #77466 