### PR TITLE
[7.17] Make the rollover API respect the request's master_timeout (#82326)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -177,7 +177,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     // block in that it is single-threaded on the master node
                     clusterService.submitStateUpdateTask(
                         "rollover_index source [" + trialRolloverIndexName + "] to target [" + trialRolloverIndexName + "]",
-                        new ClusterStateUpdateTask() {
+                        new ClusterStateUpdateTask(rolloverRequest.masterNodeTimeout()) {
                             @Override
                             public ClusterState execute(ClusterState currentState) throws Exception {
                                 // Regenerate the rollover names, as a rollover could have happened


### PR DESCRIPTION
Backport of #82326 to 7.17. Related to #81762.

/cc @martijnvg 