### PR TITLE
Rolling restart instructions

### DIFF
--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -173,7 +173,18 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
-include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
+. *Stop non-essential indexing and perform a flush.* (Optional)
++
+--
+While you can continue indexing during the rolling restart, shard recovery
+is much faster if you temporarily stop non-essential indexing and perform a
+<<indices-flush, flush>>.
+
+[source,console]
+--------------------------------------------------
+POST /_flush
+--------------------------------------------------
+--
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_ml]
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -177,7 +177,7 @@ include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 +
 --
 While you can continue indexing during the rolling restart, shard recovery
-is much faster if you temporarily stop non-essential indexing and perform a
+can be faster if you temporarily stop non-essential indexing and perform a
 <<indices-flush, flush>>.
 
 [source,console]


### PR DESCRIPTION
In a rolling restart scenario, indexing do not need to be stopped. This step is optional. I have updated Rolling restart/ step 2.

Note: I am not sure how to check if the doc, once generated, will keep the numbering as section 1 and 3 are references to the full restart, can you check this detail?