### PR TITLE
[8.0] [DOCS] Adds ML release notes (#82388)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,12 +6,14 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.0.0-rc1>>
 * <<release-notes-8.0.0-beta1>>
 * <<release-notes-8.0.0-alpha2>>
 * <<release-notes-8.0.0-alpha1>>
 
 --
 
+include::release-notes/8.0.0-rc1.asciidoc[]
 include::release-notes/8.0.0-beta1.asciidoc[]
 include::release-notes/8.0.0-alpha2.asciidoc[]
 include::release-notes/8.0.0-alpha1.asciidoc[]

--- a/docs/reference/release-notes/8.0.0-rc1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc1.asciidoc
@@ -1,0 +1,16 @@
+:es-issue: https://github.com/elastic/elasticsearch/issues/
+:es-pull:  https://github.com/elastic/elasticsearch/pull/
+
+[[release-notes-8.0.0-rc1]]
+== {es} version 8.0.0-rc1
+
+coming::[8.0.0-rc1]
+
+Also see <<breaking-changes-8.0,Breaking changes in 8.0>>.
+
+[[bug-8.0.0-rc1]]
+[float]
+=== Bug fixes
+
+Machine Learning::
+* Set model state compatibility version to 8.0.0 {ml-pull}2139[#2139]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Adds ML release notes (#82388)