### PR TITLE
Try next replica shard when slow shard found in search action

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
@@ -101,6 +101,14 @@ public final class SearchShardIterator implements Comparable<SearchShardIterator
         return null;
     }
 
+    SearchShardTarget peekNextOrNull() {
+        final String nodeId = targetNodesIterator.peekNextOrNull();
+        if (nodeId != null) {
+            return new SearchShardTarget(nodeId, shardId, clusterAlias);
+        }
+        return null;
+    }
+
     int remaining() {
         return targetNodesIterator.remaining();
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.Nullable;
@@ -713,6 +714,7 @@ public class SearchTransportService {
         }
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     class LongTailReaper implements Runnable {
         @Override
         public void run() {
@@ -732,7 +734,9 @@ public class SearchTransportService {
         }
     }
 
-    public void registerClusterSettingsListeners (ClusterSettings clusterSettings) {
+    public void registerClusterSettingsListeners (Settings settings, ClusterSettings clusterSettings) {
+        searchLongTailTryNextEnable = SEARCH_LONG_TAIL_TRY_NEXT_ENABLE.get(settings);
+        searchLongTailMaxRetryQps = SEARCH_LONG_TAIL_MAX_RETRY_QPS.get(settings);
         clusterSettings.addSettingsUpdateConsumer(SEARCH_LONG_TAIL_TRY_NEXT_ENABLE, this::setSearchLongTailTryNextEnable);
         clusterSettings.addSettingsUpdateConsumer(SEARCH_LONG_TAIL_MAX_RETRY_QPS, this::setSearchLongTailMaxRetryQps);
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1227,6 +1227,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     clusters
                 );
             };
+            task.setSearchAsyncAction(searchAsyncAction);
             return searchAsyncAction;
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.settings;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
+import org.elasticsearch.action.search.SearchTransportService;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.DestructiveOperations;
@@ -295,6 +296,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
         MasterService.MASTER_SERVICE_STARVATION_LOGGING_THRESHOLD_SETTING,
         SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
         SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
+        SearchTransportService.SEARCH_LONG_TAIL_TRY_NEXT_ENABLE,
+        SearchTransportService.SEARCH_LONG_TAIL_MAX_RETRY_QPS,
         TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
         TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,
         RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
@@ -41,6 +41,14 @@ public class PlainIterator<T> implements Iterable<T>, Countable {
         }
     }
 
+    public T peekNextOrNull() {
+        if (index == elements.size()) {
+            return null;
+        } else {
+            return elements.get(index);
+        }
+    }
+
     @Override
     public int size() {
         return elements.size();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -749,6 +749,7 @@ public class Node implements Closeable {
                 client,
                 SearchExecutionStatsCollector.makeWrapper(responseCollectorService)
             );
+            searchTransportService.registerClusterSettingsListeners(settings, settingsModule.getClusterSettings());
             final HttpServerTransport httpServerTransport = newHttpTransport(networkModule);
             final IndexingPressure indexingLimits = new IndexingPressure(settings);
 

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -175,6 +175,7 @@ public class NodeService implements Closeable {
     @Override
     public void close() throws IOException {
         IOUtils.close(indicesService);
+        searchTransportService.close();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -75,6 +75,7 @@ public class Task {
      */
     private final long startTimeNanos;
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private AbstractSearchAsyncAction searchAsyncAction = null;
 
     public Task(long id, String type, String action, String description, TaskId parentTask, Map<String, String> headers) {
@@ -236,10 +237,12 @@ public class Task {
         }
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void setSearchAsyncAction(AbstractSearchAsyncAction searchAsyncAction){
         this.searchAsyncAction = searchAsyncAction;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public AbstractSearchAsyncAction getSearchAsyncAction(){
         return searchAsyncAction;
     }

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.tasks;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.AbstractSearchAsyncAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.xcontent.ToXContent;
@@ -73,6 +74,8 @@ public class Task {
      * The task's start time as a relative time ({@link System#nanoTime()} style).
      */
     private final long startTimeNanos;
+
+    private AbstractSearchAsyncAction searchAsyncAction = null;
 
     public Task(long id, String type, String action, String description, TaskId parentTask, Map<String, String> headers) {
         this(id, type, action, description, parentTask, System.currentTimeMillis(), System.nanoTime(), headers);
@@ -231,5 +234,13 @@ public class Task {
         } else {
             throw new IllegalStateException("response has to implement ToXContent to be able to store the results");
         }
+    }
+
+    public void setSearchAsyncAction(AbstractSearchAsyncAction searchAsyncAction){
+        this.searchAsyncAction = searchAsyncAction;
+    }
+
+    public AbstractSearchAsyncAction getSearchAsyncAction(){
+        return searchAsyncAction;
     }
 }


### PR DESCRIPTION
As described in #82164 , this change will try next shard in search action , when slow shard is detected .The conditions for slow shards are:

* 80% of shards have received a response, and get the  `MAX_LATENCY`
* running time is greater than 1 second , and greater than  `3 * MAX_LATENCY`

then, this change will try next replica only once

i apply this change on one node of my cluster, the following is latency statistics form coordinate only nodes
![image](https://user-images.githubusercontent.com/23521001/148896855-3780be71-9b58-458e-8ff3-03d964791522.png)

each coordination node processes roughly the same number of requests
![image](https://user-images.githubusercontent.com/23521001/148898641-56fd56c2-0305-4b09-bffb-418e4b387054.png)


my cluster:
version: 7.6.2
RAM: 265GB
JVM: 31G
CPU: Intel(R) Xeon(R) Gold 5118 CPU @ 2.30GHz
Store: 1TB SSD x 2
NetWork:  25G
