### PR TITLE
Defer Reroute When Autocreating Datastream

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -169,7 +169,8 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                             request.index(),
                             dataStreamDescriptor,
                             request.masterNodeTimeout(),
-                            request.timeout()
+                            request.timeout(),
+                            false
                         );
                         ClusterState clusterState = metadataCreateDataStreamService.createDataStream(createRequest, currentState);
                         indexNameRef.set(clusterState.metadata().dataStreams().get(request.index()).getIndices().get(0).getName());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -97,21 +97,23 @@ public class MetadataCreateDataStreamService {
     public static final class CreateDataStreamClusterStateUpdateRequest extends ClusterStateUpdateRequest<
         CreateDataStreamClusterStateUpdateRequest> {
 
+        private final boolean performReroute;
         private final String name;
         private final long startTime;
         private final SystemDataStreamDescriptor descriptor;
 
         public CreateDataStreamClusterStateUpdateRequest(String name) {
-            this(name, System.currentTimeMillis(), null, TimeValue.ZERO, TimeValue.ZERO);
+            this(name, System.currentTimeMillis(), null, TimeValue.ZERO, TimeValue.ZERO, true);
         }
 
         public CreateDataStreamClusterStateUpdateRequest(
             String name,
             SystemDataStreamDescriptor systemDataStreamDescriptor,
             TimeValue masterNodeTimeout,
-            TimeValue timeout
+            TimeValue timeout,
+            boolean performReroute
         ) {
-            this(name, System.currentTimeMillis(), systemDataStreamDescriptor, masterNodeTimeout, timeout);
+            this(name, System.currentTimeMillis(), systemDataStreamDescriptor, masterNodeTimeout, timeout, performReroute);
         }
 
         public CreateDataStreamClusterStateUpdateRequest(
@@ -119,17 +121,23 @@ public class MetadataCreateDataStreamService {
             long startTime,
             SystemDataStreamDescriptor systemDataStreamDescriptor,
             TimeValue masterNodeTimeout,
-            TimeValue timeout
+            TimeValue timeout,
+            boolean performReroute
         ) {
             this.name = name;
             this.startTime = startTime;
             this.descriptor = systemDataStreamDescriptor;
+            this.performReroute = performReroute;
             masterNodeTimeout(masterNodeTimeout);
             ackTimeout(timeout);
         }
 
         public boolean isSystem() {
             return descriptor != null;
+        }
+
+        public boolean performReroute() {
+            return performReroute;
         }
 
         public SystemDataStreamDescriptor getSystemDataStreamDescriptor() {
@@ -201,7 +209,10 @@ public class MetadataCreateDataStreamService {
                 "initialize_data_stream",
                 firstBackingIndexName,
                 firstBackingIndexName
-            ).dataStreamName(dataStreamName).systemDataStreamDescriptor(systemDataStreamDescriptor).nameResolvedInstant(request.startTime);
+            ).dataStreamName(dataStreamName)
+                .systemDataStreamDescriptor(systemDataStreamDescriptor)
+                .nameResolvedInstant(request.startTime)
+                .performReroute(request.performReroute());
 
             if (isSystem) {
                 createIndexRequest.settings(SystemIndexDescriptor.DEFAULT_SETTINGS);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -199,7 +199,8 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
             dataStreamName,
             systemDataStreamDescriptor(),
             TimeValue.MAX_VALUE,
-            TimeValue.ZERO
+            TimeValue.ZERO,
+            true
         );
         ClusterState newState = MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
         assertThat(newState.metadata().dataStreams().size(), equalTo(1));

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/CreateDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/CreateDataStreamTransportAction.java
@@ -70,7 +70,8 @@ public class CreateDataStreamTransportAction extends AcknowledgedTransportMaster
                 request.getStartTime(),
                 systemDataStreamDescriptor,
                 request.masterNodeTimeout(),
-                request.timeout()
+                request.timeout(),
+                true
             );
         metadataCreateDataStreamService.createDataStream(updateRequest, listener);
     }


### PR DESCRIPTION
Defer reroute on autocreate DS. Follow-up to #82159.
