### PR TITLE
[7.16] Do not remove legacy watcher templates in 7.x (#82167)

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -720,11 +720,6 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     public UnaryOperator<Map<String, IndexTemplateMetadata>> getIndexTemplateMetadataUpgrader() {
         return map -> {
             map.keySet().removeIf(name -> name.startsWith("watch_history_"));
-            // watcher migrated to using system indices so these legacy templates are not needed anymore
-            map.remove(".watches");
-            map.remove(".triggered_watches");
-            // post 7.x we moved to typeless watch-history-10
-            map.remove(".watch-history-9");
             return map;
         };
     }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -21,12 +20,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class WatcherRestartIT extends AbstractUpgradeTestCase {
@@ -133,31 +130,6 @@ public class WatcherRestartIT extends AbstractUpgradeTestCase {
             templateNames,
             hasItem(expectedTemplate)
         );
-    }
-
-    public void testEnsureWatcherDeletesLegacyTemplates() throws Exception {
-        if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
-            // legacy index template created in previous releases should not be present anymore
-            assertBusy(() -> {
-                Request request = new Request("GET", "/_template/*watch*");
-                try {
-                    Response response = client().performRequest(request);
-                    Map<String, Object> responseLevel = entityAsMap(response);
-                    assertNotNull(responseLevel);
-
-                    assertThat(responseLevel.containsKey(".watches"), is(false));
-                    assertThat(responseLevel.containsKey(".triggered_watches"), is(false));
-                    assertThat(responseLevel.containsKey(".watch-history-9"), is(false));
-                } catch (ResponseException e) {
-                    // Not found is fine
-                    assertThat(
-                        "Unexpected failure getting templates: " + e.getResponse().getStatusLine(),
-                        e.getResponse().getStatusLine().getStatusCode(),
-                        is(404)
-                    );
-                }
-            }, 30, TimeUnit.SECONDS);
-        }
     }
 
     private void ensureWatcherStopped() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Do not remove legacy watcher templates in 7.x (#82167)