### PR TITLE
Search as you type field to support subfields

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -255,7 +255,16 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
             }
             ft.setPrefixField(prefixFieldType);
             ft.setShingleFields(shingleFieldTypes);
-            return new SearchAsYouTypeFieldMapper(name, ft, copyTo.build(), indexAnalyzers, prefixFieldMapper, shingleFieldMappers, this);
+            return new SearchAsYouTypeFieldMapper(
+                name,
+                ft,
+                copyTo.build(),
+                indexAnalyzers,
+                prefixFieldMapper,
+                shingleFieldMappers,
+                multiFieldsBuilder.build(this, context),
+                this
+            );
         }
     }
 
@@ -644,9 +653,10 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         Map<String, NamedAnalyzer> indexAnalyzers,
         PrefixFieldMapper prefixField,
         ShingleFieldMapper[] shingleFields,
+        MultiFields multiFields,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, indexAnalyzers, MultiFields.empty(), copyTo, false, null);
+        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo, false, null);
         this.prefixField = prefixField;
         this.shingleFields = shingleFields;
         this.maxShingleSize = builder.maxShingleSize.getValue();


### PR DESCRIPTION
It has been reported that the search as you type field accepts sub-fields as part of its mapping definition, but those are being silently ignored. With this commit we add support for multi-fields to the search as you type field.

Closes #56326