### PR TITLE
[7.17] Revert "Mute watcher rolling upgrade yaml tests (#81935) (#81974)"

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -11,6 +11,8 @@ import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -22,6 +24,12 @@ import org.junit.Before;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @TimeoutSuite(millis = 5 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
@@ -47,8 +55,7 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
         }
     }
 
-    /*@Before
-    // AwaitFix=https://github.com/elastic/elasticsearch/issues/81110
+    @Before
     public void waitForWatcher() throws Exception {
         // Wait for watcher to be in started state in order to avoid errors due
         // to manually executing watches prior for watcher to be ready:
@@ -66,7 +73,7 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
         } catch (AssertionError e) {
             throw new AssertionError("Failure in test setup: Failed to initialize at least 3 watcher nodes", e);
         }
-    }*/
+    }
 
     @Override
     protected boolean preserveIndicesUponCompletion() {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
@@ -1,8 +1,5 @@
 ---
 "CRUD watch APIs":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/81110"
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
@@ -75,8 +72,3 @@
       watcher.stats: {}
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
-
----
-"Test do something":
-  - do: { ping: { } }
-  - is_true: ''

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
@@ -1,8 +1,5 @@
 ---
 "CRUD watch APIs":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/81110"
   - do:
       watcher.put_watch:
         id: "my_watch"
@@ -104,8 +101,3 @@
       watcher.stats: {}
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
-
----
-"Test do something":
-  - do: { ping: { } }
-  - is_true: ''

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
@@ -1,8 +1,5 @@
 ---
 "CRUD watch APIs":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/81110"
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
@@ -76,8 +73,3 @@
       watcher.stats: {}
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
-
----
-"Test do something":
-  - do: { ping: { } }
-  - is_true: ''


### PR DESCRIPTION
This reverts commit bdada637cf77d35e26890776e3640dcebc1edb67.

Backport of #82425
