### PR TITLE
Fix spotlessJavaCheck violation

### DIFF
--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -110,7 +110,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "            \"monitor\",\n"
         + "            \"create_index\",\n"
         + "            \"auto_configure\",\n"
-        + "            \"maintenance\"\n"        
+        + "            \"maintenance\"\n"
         + "          ],\n"
         + "          \"allow_restricted_indices\": false\n"
         + "        }\n"


### PR DESCRIPTION
Fixed error in https://gradle-enterprise.elastic.co/s/7quke3kmm3uuu/failure#1

The following files had format violations:
```
    src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
        @@ -110,7 +110,7 @@
         ········+·"············\"monitor\",\n"
         ········+·"············\"create_index\",\n"
         ········+·"············\"auto_configure\",\n"
        -········+·"············\"maintenance\"\n"········
        +········+·"············\"maintenance\"\n"
         ········+·"··········],\n"
         ········+·"··········\"allow_restricted_indices\":·false\n"
         ········+·"········}\n"
Run './gradlew :x-pack:plugin:security:qa:service-account:spotlessApply' to fix these violations.

```