### PR TITLE
Reject zero-length vectors when using cosine similarity

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -144,7 +144,9 @@ Computes the cosine similarity. Note that the most efficient way to perform
 cosine similarity is to normalize all vectors to unit length, and instead use
 `dot_product`. You should only use `cosine` if you need to preserve the
 original vectors and cannot normalize them in advance. The document `_score`
-is computed as `(1 + cosine(query, vector)) / 2`.
+is computed as `(1 + cosine(query, vector)) / 2`. The `cosine` similarity does
+not allow vectors with zero magnitude, since cosine is not defined in this
+case.
 ====
 
 NOTE: Although they are conceptually related, the `similarity` parameter is

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -310,8 +310,8 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
                 );
             }
 
-            if (similarity == VectorSimilarity.dot_product) {
-                double squaredMagnitude = 0.0;
+            if (similarity == VectorSimilarity.dot_product || similarity == VectorSimilarity.cosine) {
+                float squaredMagnitude = 0.0f;
                 for (float e : queryVector) {
                     squaredMagnitude += e * e;
                 }
@@ -320,28 +320,32 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
             return new KnnVectorQuery(name(), queryVector, numCands);
         }
 
-        private void checkVectorMagnitude(float[] vector, double squaredMagnitude) {
-            if (Math.abs(squaredMagnitude - 1.0f) > 1e-4) {
-                // Include the first five elements of the invalid vector in the error message
-                StringBuilder sb = new StringBuilder(
-                    "The ["
-                        + VectorSimilarity.dot_product.name()
-                        + "] similarity can "
-                        + "only be used with unit-length vectors. Preview of invalid vector: "
+        private void checkVectorMagnitude(float[] vector, float squaredMagnitude) {
+            StringBuilder errorBuilder = null;
+            if (similarity == VectorSimilarity.dot_product && Math.abs(squaredMagnitude - 1.0f) > 1e-4f) {
+                errorBuilder = new StringBuilder(
+                    "The [" + VectorSimilarity.dot_product.name() + "] similarity can " + "only be used with unit-length vectors."
                 );
-                sb.append("[");
+            } else if (similarity == VectorSimilarity.cosine && Math.sqrt(squaredMagnitude) == 0.0f) {
+                errorBuilder = new StringBuilder(
+                    "The [" + VectorSimilarity.cosine.name() + "] similarity does not support vectors with zero magnitude."
+                );
+            }
+
+            if (errorBuilder != null) {
+                // Include the first five elements of the invalid vector in the error message
+                errorBuilder.append(" Preview of invalid vector: [");
                 for (int i = 0; i < Math.min(5, vector.length); i++) {
                     if (i > 0) {
-                        sb.append(", ");
+                        errorBuilder.append(", ");
                     }
-                    sb.append(vector[i]);
+                    errorBuilder.append(vector[i]);
                 }
                 if (vector.length >= 5) {
-                    sb.append(", ...");
+                    errorBuilder.append(", ...");
                 }
-                sb.append("]");
-
-                throw new IllegalArgumentException(sb.toString());
+                errorBuilder.append("]");
+                throw new IllegalArgumentException(errorBuilder.toString());
             }
         }
     }
@@ -399,7 +403,7 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
 
     private Field parseKnnVector(DocumentParserContext context) throws IOException {
         float[] vector = new float[dims];
-        double squaredMagnitude = 0.0;
+        float squaredMagnitude = 0.0f;
         int index = 0;
         for (Token token = context.parser().nextToken(); token != Token.END_ARRAY; token = context.parser().nextToken()) {
             checkDimensionExceeded(index, context);
@@ -410,9 +414,7 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
             squaredMagnitude += value * value;
         }
         checkDimensionMatches(index, context);
-        if (similarity == VectorSimilarity.dot_product) {
-            fieldType().checkVectorMagnitude(vector, squaredMagnitude);
-        }
+        fieldType().checkVectorMagnitude(vector, squaredMagnitude);
         return new KnnVectorField(fieldType().name(), vector, similarity.function);
     }
 

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
@@ -228,7 +228,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         assertThat(
             e.getCause().getMessage(),
             containsString(
-                "The [dot_product] similarity can only be used with unit-length vectors. " + "Preview of invalid vector: [-12.1, 2.7, -4.0]"
+                "The [dot_product] similarity can only be used with unit-length vectors. Preview of invalid vector: [-12.1, 2.7, -4.0]"
             )
         );
 
@@ -245,6 +245,23 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
             containsString(
                 "The [dot_product] similarity can only be used with unit-length vectors. "
                     + "Preview of invalid vector: [-12.1, 2.7, -4.0, 1.05, 10.0, ...]"
+            )
+        );
+    }
+
+    public void testCosineWithZeroVector() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                b -> b.field("type", "dense_vector").field("dims", 3).field("index", true).field("similarity", VectorSimilarity.cosine)
+            )
+        );
+        float[] vector = { -0.0f, 0.0f, 0.0f };
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.array("field", vector))));
+        assertNotNull(e.getCause());
+        assertThat(
+            e.getCause().getMessage(),
+            containsString(
+                "The [cosine] similarity does not support vectors with zero magnitude. Preview of invalid vector: [-0.0, 0.0, 0.0]"
             )
         );
     }

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldTypeTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldTypeTests.java
@@ -85,5 +85,16 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
         );
         e = expectThrows(IllegalArgumentException.class, () -> dotProductField.createKnnQuery(new float[] { 0.3f, 0.1f, 1.0f }, 10));
         assertThat(e.getMessage(), containsString("The [dot_product] similarity can only be used with unit-length vectors."));
+
+        DenseVectorFieldType cosineField = new DenseVectorFieldType(
+            "f",
+            Version.CURRENT,
+            3,
+            true,
+            VectorSimilarity.cosine,
+            Collections.emptyMap()
+        );
+        e = expectThrows(IllegalArgumentException.class, () -> cosineField.createKnnQuery(new float[] { 0.0f, 0.0f, 0.0f }, 10));
+        assertThat(e.getMessage(), containsString("The [cosine] similarity does not support vectors with zero magnitude."));
     }
 }


### PR DESCRIPTION
Cosine similarity is not defined when one of the vectors has zero magnitude.
Before, the kNN search endpoint threw a confusing exception related to top docs
collection. Now we reject vectors early with a clear error message, failing
indexing if the vector has zero magnitude.

Backport of #82241.