### PR TITLE
Limit full cluster restart upgrade tests to wire compatible versions

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -236,11 +236,11 @@ public class BwcVersions {
         );
     }
 
-    public void withIndexCompatiple(BiConsumer<Version, String> versionAction) {
+    public void withIndexCompatible(BiConsumer<Version, String> versionAction) {
         getIndexCompatible().forEach(v -> versionAction.accept(v, "v" + v.toString()));
     }
 
-    public void withIndexCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+    public void withIndexCompatible(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
         getIndexCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v" + v.toString()));
     }
 
@@ -250,11 +250,11 @@ public class BwcVersions {
         );
     }
 
-    public void withWireCompatiple(BiConsumer<Version, String> versionAction) {
+    public void withWireCompatible(BiConsumer<Version, String> versionAction) {
         getWireCompatible().forEach(v -> versionAction.accept(v, "v" + v.toString()));
     }
 
-    public void withWireCompatiple(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
+    public void withWireCompatible(Predicate<Version> filter, BiConsumer<Version, String> versionAction) {
         getWireCompatible().stream().filter(filter).forEach(v -> versionAction.accept(v, "v" + v.toString()));
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -132,7 +132,7 @@ public class DistroTestPlugin implements Plugin<Project> {
             lifecycleTasks.get(distribution.getType()).configure(t -> t.dependsOn(destructiveTask));
 
             if ((distribution.getType() == DEB || distribution.getType() == RPM) && distribution.getBundledJdk()) {
-                for (Version version : BuildParams.getBwcVersions().getIndexCompatible()) {
+                for (Version version : BuildParams.getBwcVersions().getWireCompatible()) {
                     final ElasticsearchDistribution bwcDistro;
                     if (version.equals(Version.fromString(distribution.getVersion()))) {
                         // this is the same as the distribution we are testing
@@ -248,7 +248,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     private static Map<String, TaskProvider<?>> versionTasks(Project project, String taskPrefix) {
         Map<String, TaskProvider<?>> versionTasks = new HashMap<>();
 
-        for (Version version : BuildParams.getBwcVersions().getIndexCompatible()) {
+        for (Version version : BuildParams.getBwcVersions().getWireCompatible()) {
             versionTasks.put(version.toString(), project.getTasks().register(taskPrefix + ".v" + version));
         }
 

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   /**
    * We execute tests 3 times.

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
-BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
       versions =  [bwcVersion.toString(), project.version]
       numberOfNodes = 2

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -21,7 +21,7 @@ restResources {
   }
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
     /* This project runs the core REST tests against a 4 node cluster where two of

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   String oldClusterName = "${baseName}-old"
   String newClusterName = "${baseName}-new"
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   /*
    * The goal here is to:
    * <ul>

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
       version = bwcVersion.toString()
       setting 'xpack.security.enabled', 'true'

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
 tasks.named("integTest").configure { enabled = false }
 
-BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.0") &&
+BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.0") &&
         v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
     def cluster = testClusters.register(baseName) {
         versions = [bwcVersion.toString(), project.version]

--- a/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
@@ -29,7 +29,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
         testDistribution = "DEFAULT"
         versions = [bwcVersion.toString(), project.version]

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -37,7 +37,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -71,7 +71,7 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+    BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       // Compatibility testing for JDBC driver started with version 7.9.0
       if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
         UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -21,7 +21,7 @@ testClusters.configureEach {
 tasks.named("integTest").configure{ enabled = false}
 
 // A bug (https://github.com/elastic/elasticsearch/issues/68439) limits us to perform tests with versions from 7.10.3 onwards
-BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.10.3") &&
+BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.3") &&
         v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -29,7 +29,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withIndexCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
         testDistribution = "DEFAULT"
         versions = [bwcVersion.toString(), project.version]

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 // Only run tests for 7.9+, since the node.roles setting was introduced in 7.9.0
-BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.9.0") &&
+BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
         v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
     versions = [bwcVersion.toString(), project.version]

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   def baseLeaderCluster = testClusters.register("${baseName}-leader") {
       numberOfNodes = 3

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -30,7 +30,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests


### PR DESCRIPTION
This is the first in a serious of changes related to https://github.com/elastic/elasticsearch/pull/82321. In order to unblock that pull request we first must remove testing for full cluster restart upgrades from versions prior to 7.last since we are now explicitly disallowing such an upgrade path.