### PR TITLE
Wait for maintenance task to complete before restarting node

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -27,7 +27,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -153,7 +152,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
 
         // Temporarily stop garbage collection, making sure to wait for any in-flight tasks to complete
         stopMaintenanceService();
-        assertBusy(MockSearchService::assertNoInFlightContext);
+        ensureAllSearchContextsReleased();
 
         internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {
         });


### PR DESCRIPTION
In AsyncSearchActionIT#testRestartAfterCompletion, we make sure to stop the
maintenance task while the node is restarting. This ensures that we don't send
delete-by-query requests while the node is restarting, which can cause failures.

There is still an edge case where a delete-by-query request could be sent off
right before we tell the task to "stop" and restart the node. In this case, the
request can leave behind a search context, which causes test failures. This
commit adds an explicit wait for no search contexts before restarting the
node.

Closes #81941.