### PR TITLE
Temporarily make package upgrade tests from unsupported versions a noop

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -132,7 +132,7 @@ public class DistroTestPlugin implements Plugin<Project> {
             lifecycleTasks.get(distribution.getType()).configure(t -> t.dependsOn(destructiveTask));
 
             if ((distribution.getType() == DEB || distribution.getType() == RPM) && distribution.getBundledJdk()) {
-                for (Version version : BuildParams.getBwcVersions().getWireCompatible()) {
+                for (Version version : BuildParams.getBwcVersions().getIndexCompatible()) {
                     final ElasticsearchDistribution bwcDistro;
                     if (version.equals(Version.fromString(distribution.getVersion()))) {
                         // this is the same as the distribution we are testing
@@ -248,7 +248,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     private static Map<String, TaskProvider<?>> versionTasks(Project project, String taskPrefix) {
         Map<String, TaskProvider<?>> versionTasks = new HashMap<>();
 
-        for (Version version : BuildParams.getBwcVersions().getWireCompatible()) {
+        for (Version version : BuildParams.getBwcVersions().getIndexCompatible()) {
             versionTasks.put(version.toString(), project.getTasks().register(taskPrefix + ".v" + version));
         }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -10,9 +10,11 @@ package org.elasticsearch.packaging.test;
 
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
+import org.elasticsearch.Version;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Packages;
 import org.elasticsearch.packaging.util.ServerUtils;
+import org.junit.BeforeClass;
 
 import java.nio.file.Paths;
 
@@ -20,6 +22,7 @@ import static org.elasticsearch.packaging.util.Packages.assertInstalled;
 import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assume.assumeTrue;
 
 public class PackageUpgradeTests extends PackagingTestCase {
 
@@ -27,6 +30,12 @@ public class PackageUpgradeTests extends PackagingTestCase {
     protected static final Distribution bwcDistribution;
     static {
         bwcDistribution = new Distribution(Paths.get(System.getProperty("tests.bwc-distribution")));
+    }
+
+    @BeforeClass
+    public static void filterVersions() {
+        // TODO: Explicitly add testing for these versions that validates that starting the node after upgrade fails
+        assumeTrue("only wire compatible versions", Version.fromString(bwcDistribution.baseVersion).isCompatible(Version.CURRENT));
     }
 
     public void test10InstallBwcVersion() throws Exception {


### PR DESCRIPTION
Follow up to #82445 to make these package upgrade tests no-ops instead. This fixes our issues in CI with missing tasks and leaves us a place to add proper testing for this scenario.