### PR TITLE
OsProbeTests: Allow free swap to be zero

### DIFF
--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -123,7 +123,7 @@ public class OsProbeTests extends ESTestCase {
         long total = stats.getSwap().getTotal().getBytes();
         if (total > 0) {
             assertThat(stats.getSwap().getTotal().getBytes(), greaterThan(0L));
-            assertThat(stats.getSwap().getFree().getBytes(), greaterThan(0L));
+            assertThat(stats.getSwap().getFree().getBytes(), greaterThanOrEqualTo(0L));
             assertThat(stats.getSwap().getUsed().getBytes(), greaterThanOrEqualTo(0L));
         } else {
             // On platforms with no swap


### PR DESCRIPTION
It's valid to zero free swap.

Fixes: #81393