### PR TITLE
Missing request element under transform search

### DIFF
--- a/x-pack/docs/en/watcher/transform.asciidoc
+++ b/x-pack/docs/en/watcher/transform.asciidoc
@@ -42,7 +42,9 @@ and one as part of the definition of the `my_webhook` action.
   "condition" : { ... },
   "transform" : { <1>
     "search" : {
-      "body" : { "query" : { "match_all" : {} } }
+      "request": {
+        "body" : { "query" : { "match_all" : {} } }
+      }
     }
   },
   "actions" : {


### PR DESCRIPTION
The example at https://www.elastic.co/guide/en/elasticsearch/reference/7.16/transform.html is missing the request element under transform-search.