### PR TITLE
Add jira in the list of supported actions

### DIFF
--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -26,6 +26,7 @@ serve as a model for a templated email body.
 * <<actions-logging,`logging`>>
 * <<actions-slack,`slack`>>
 * <<actions-pagerduty,`pagerduty`>>
+* <<actions-jira,`jira`>>
 
 [discrete]
 [[actions-ack-throttle]]


### PR DESCRIPTION
The page https://www.elastic.co/guide/en/elasticsearch/reference/master/actions.html is missing Jira in the list of supported actions
