### PR TITLE
Fix internal cluster test randomness.

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -584,7 +584,7 @@ public final class InternalTestCluster extends TestCluster {
         if (random.nextInt(10) == 0) {
             builder.put(
                 PersistedClusterStateService.DOCUMENT_PAGE_SIZE.getKey(),
-                new ByteSizeValue(RandomNumbers.randomIntBetween(random, rarely() ? 10 : 100, randomFrom(1000, 10000, 100000, 1000000)))
+                new ByteSizeValue(RandomNumbers.randomIntBetween(random, rarely(random) ? 10 : 100, randomFrom(random,1000, 10000, 100000, 1000000)))
             );
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -584,7 +584,9 @@ public final class InternalTestCluster extends TestCluster {
         if (random.nextInt(10) == 0) {
             builder.put(
                 PersistedClusterStateService.DOCUMENT_PAGE_SIZE.getKey(),
-                new ByteSizeValue(RandomNumbers.randomIntBetween(random, rarely(random) ? 10 : 100, randomFrom(random,1000, 10000, 100000, 1000000)))
+                new ByteSizeValue(
+                    RandomNumbers.randomIntBetween(random, rarely(random) ? 10 : 100, randomFrom(random, 1000, 10000, 100000, 1000000))
+                )
             );
         }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -152,7 +152,6 @@ public class InternalTestClusterTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82212")
     public void testBeforeTest() throws Exception {
         final boolean autoManageMinMasterNodes = randomBoolean();
         long clusterSeed = randomLong();


### PR DESCRIPTION
The InternalClusterTestTests code was relying on random numbers produced by the same random seed number generator.
However the InternalClusterTest code in `getRandomNodeSettings()` that sets DOCUMENT_PAGE_SIZE was not using the supplied random number generator and it created a new one.

The test fails intermittently because the problem code is only triggered randomly once out of 10.

Closes #82212