### PR TITLE
[DOCS] Update ES quick start for Cloud UI

### DIFF
--- a/docs/reference/tab-widgets/api-call.asciidoc
+++ b/docs/reference/tab-widgets/api-call.asciidoc
@@ -1,23 +1,5 @@
 // tag::cloud[]
-**Use curl**
-
-. To communicate with {es} using curl or another client, you need your
-cluster's endpoint. Go to the **Elasticsearch** page and click **Copy
-endpoint**.
-
-. To submit an example API request, run the following curl command in a new
-terminal session. Replace `<password>` with the password for the `elastic` user.
-Replace `<elasticsearch_endpoint>` with your endpoint.
-+
-[source,sh]
-----
-curl -u elastic:<password> <elasticsearch_endpoint>/
-----
-// NOTCONSOLE
-
 **Use {kib}**
-
-. Go to the *{kib}* page and click **Launch**.
 
 //tag::kibana-api-ex[]
 . Open {kib}'s main menu and go to **Dev Tools > Console**.
@@ -33,9 +15,34 @@ GET /
 ----
 
 //end::kibana-api-ex[]
+
+**Use curl**
+
+To communicate with {es} using curl or another client, you need your cluster's
+endpoint.
+
+. Open {kib}'s main menu and click **Manage this deployment**.
+
+. From your deployment menu, go to the **Elasticsearch** page. Click **Copy
+endpoint**.
+
+. To submit an example API request, run the following curl command in a new
+terminal session. Replace `<password>` with the password for the `elastic` user.
+Replace `<elasticsearch_endpoint>` with your endpoint.
++
+[source,sh]
+----
+curl -u elastic:<password> <elasticsearch_endpoint>/
+----
+// NOTCONSOLE
+
 // end::cloud[]
 
 // tag::self-managed[]
+**Use {kib}**
+
+include::api-call.asciidoc[tag=kibana-api-ex]
+
 **Use curl**
 
 To submit an example API request, run the following curl command in a new
@@ -47,7 +54,4 @@ curl -X GET http://localhost:9200/
 ----
 // NOTCONSOLE
 
-**Use {kib}**
-
-include::api-call.asciidoc[tag=kibana-api-ex]
 // end::self-managed[]

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -1,6 +1,10 @@
 
 // tag::cloud[]
 include::{docs-root}/shared/cloud/ess-getting-started.asciidoc[tag=generic]
+
+. Click **Continue** to open {kib}.
+
+. Click **Explore on my own**.
 // end::cloud[]
 
 // tag::self-managed[]
@@ -23,7 +27,6 @@ docker network create elastic
 docker pull {docker-repo}:{version}
 docker run --name es-node01 --net elastic -p 9200:9200 -p 9300:9300 -it {docker-image}
 ----
-endif::[]
 +
 When you start {es} for the first time, the following security configuration 
 occurs automatically:
@@ -52,6 +55,7 @@ To generate new enrollment tokens for {kib} or {es} nodes, run the
 <<create-enrollment-token,`elasticsearch-create-enrollment-token`>> tool.
 These tools are available in the {es} `bin` directory.
 ====
+endif::[]
 
 **Install and run {kib}**
 
@@ -61,6 +65,7 @@ To analyze, visualize, and manage {es} data using an intuitive UI, install
 ifeval::["{release-state}"=="unreleased"]
 NOTE: No Docker image is currently available for {kib} {version}.
 endif::[]
+
 ifeval::["{release-state}"!="unreleased"]
 
 . In a new terminal session, run:


### PR DESCRIPTION
Changes:

* Updates the Cloud setup instructions to note that you open Kibana by default.
* Reorders the API call section to highlight Kibana.
* Fixes the Docker ifeval to hide some text on unreleased branches.

### Preview
https://elasticsearch_82499.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/getting-started.html