### PR TITLE
Reintroduce full index compatible testing of full cluster restart

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -276,6 +276,10 @@ public class BwcVersions {
         return unmodifiableList(unreleasedWireCompatible);
     }
 
+    public Version getMinimumWireCompatibleVersion() {
+        return MINIMUM_WIRE_COMPATIBLE_VERSION;
+    }
+
     public static class UnreleasedVersionInfo {
         public final Version version;
         public final String branch;

--- a/plugins/examples/rescore/src/main/java/org/elasticsearch/example/rescore/ExampleRescoreBuilder.java
+++ b/plugins/examples/rescore/src/main/java/org/elasticsearch/example/rescore/ExampleRescoreBuilder.java
@@ -173,10 +173,10 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
                             endDoc = leaf.docBase + leaf.reader().maxDoc();
                         } while (topDocs.scoreDocs[i].doc >= endDoc);
                         LeafFieldData fd = context.factorField.load(leaf);
-                        if (false == (fd instanceof LeafNumericFieldData leafNumericFieldData)) {
+                        if (false == (fd instanceof LeafNumericFieldData)) {
                             throw new IllegalArgumentException("[" + context.factorField.getFieldName() + "] is not a number");
                         }
-                        data = leafNumericFieldData.getDoubleValues();
+                        data = ((LeafNumericFieldData) fd).getDoubleValues();
                     }
                     if (false == data.advanceExact(topDocs.scoreDocs[i].doc - leaf.docBase)) {
                         throw new IllegalArgumentException("document [" + topDocs.scoreDocs[i].doc

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -15,9 +15,14 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
-BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
+BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
-      versions =  [bwcVersion.toString(), project.version]
+      if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+        // When testing older versions we have to first upgrade to 7.last
+        versions = [bwcVersion.toString(), BuildParams.bwcVersions.minimumWireCompatibleVersion.toString(), project.version]
+      } else {
+        versions = [bwcVersion.toString(), project.version]
+      }
       numberOfNodes = 2
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '60m'
@@ -46,6 +51,10 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
         baseCluster.get().systemProperty 'es.index_mode_feature_flag_registered', 'true'
       }
       baseCluster.get().goToNextVersion()
+      if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+        // When doing a full cluster restart of older versions we actually have to upgrade twice. First to 7.last, then to the current version.
+        baseCluster.get().goToNextVersion()
+      }
     }
     systemProperty 'tests.is_old_cluster', 'false'
   }

--- a/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
@@ -29,10 +29,15 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
+BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
         testDistribution = "DEFAULT"
-        versions = [bwcVersion.toString(), project.version]
+        if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+          // When testing older versions we have to first upgrade to 7.last
+          versions = [bwcVersion.toString(), BuildParams.bwcVersions.minimumWireCompatibleVersion.toString(), project.version]
+        } else {
+          versions = [bwcVersion.toString(), project.version]
+        }
         numberOfNodes = 2
         setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
         user username: "test_user", password: "x-pack-test-password"
@@ -78,7 +83,11 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
             if (BuildParams.isSnapshotBuild() == false) {
                 systemProperty 'es.index_mode_feature_flag_registered', 'true'
             }
-            testClusters.named(baseName).get().goToNextVersion()
+            baseCluster.get().goToNextVersion()
+            if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+              // When doing a full cluster restart of older versions we actually have to upgrade twice. First to 7.last, then to the current version.
+              baseCluster.get().goToNextVersion()
+            }
         }
         systemProperty 'tests.is_old_cluster', 'false'
     }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -71,33 +71,31 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
-      // Compatibility testing for JDBC driver started with version 7.9.0
-      if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
-        UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
-        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
-          // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433
-          transitive = false
-        }
-        Object driverDependency = null
+    // Compatibility testing for JDBC driver started with version 7.9.0
+    BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }) { bwcVersion, baseName ->
+      UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
+      Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
+        // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433
+        transitive = false
+      }
+      Object driverDependency = null
 
-        if (unreleasedVersion) {
-          // For unreleased snapshot versions, build them from source
-          driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
-        } else {
-          // For released versions, download it
-          driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
-        }
+      if (unreleasedVersion) {
+        // For unreleased snapshot versions, build them from source
+        driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
+      } else {
+        // For released versions, download it
+        driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
+      }
 
-        dependencies {
-          "jdbcDriver${baseName}"(driverDependency)
-        }
+      dependencies {
+        "jdbcDriver${baseName}"(driverDependency)
+      }
 
-        final String bwcVersionString = bwcVersion.toString()
-        tasks.register(bwcTaskName(bwcVersion), RestIntegTestTask) {
-            classpath += driverConfiguration
-            systemProperty 'jdbc.driver.version', bwcVersionString
-        }
+      final String bwcVersionString = bwcVersion.toString()
+      tasks.register(bwcTaskName(bwcVersion), RestIntegTestTask) {
+          classpath += driverConfiguration
+          systemProperty 'jdbc.driver.version', bwcVersionString
       }
     }
   }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -29,10 +29,15 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
   into outputDir
 }
 
-BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
+BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
         testDistribution = "DEFAULT"
-        versions = [bwcVersion.toString(), project.version]
+        if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+          // When testing older versions we have to first upgrade to 7.last
+          versions = [bwcVersion.toString(), BuildParams.bwcVersions.minimumWireCompatibleVersion.toString(), project.version]
+        } else {
+          versions = [bwcVersion.toString(), project.version]
+        }
         numberOfNodes = 2
         setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
         user username: "test_user", password: "x-pack-test-password"
@@ -81,7 +86,11 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
             if (BuildParams.isSnapshotBuild() == false) {
                 systemProperty 'es.index_mode_feature_flag_registered', 'true'
             }
-            testClusters.named(baseName).get().goToNextVersion()
+            baseCluster.get().goToNextVersion()
+            if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+              // When doing a full cluster restart of older versions we actually have to upgrade twice. First to 7.last, then to the current version.
+              baseCluster.get().goToNextVersion()
+            }
         }
         systemProperty 'tests.is_old_cluster', 'false'
         exclude 'org/elasticsearch/upgrades/FullClusterRestartIT.class'


### PR DESCRIPTION
As a follow up to #82445 we are now adding back full cluster restart testing across all index-compatible versions of Elasticsearch but in a way compatible with https://github.com/elastic/elasticsearch/pull/82321. This means as part of doing a full cluster restart upgrade to 8.0 you must first upgrade to 7.last. All full cluster restart test scenarios have been updated to do exactly this.