### PR TITLE
Nest the mappings of user profile document

### DIFF
--- a/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
+++ b/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
@@ -27,30 +27,32 @@ public class ProfileIT extends ESRestTestCase {
 
     public static final String SAMPLE_PROFILE_DOCUMENT_TEMPLATE = """
         {
-          "uid": "%s",
-          "enabled": true,
-          "user": {
-            "username": "foo",
-            "realm": {
-              "name": "realm_name",
-              "type": "realm_type",
-              "node_name": "node1"
+          "user_profile": {
+            "uid": "%s",
+            "enabled": true,
+            "user": {
+              "username": "foo",
+              "realm": {
+                "name": "realm_name",
+                "type": "realm_type",
+                "node_name": "node1"
+              },
+              "email": "foo@example.com",
+              "full_name": "User Foo",
+              "display_name": "Curious Foo"
             },
-            "email": "foo@example.com",
-            "full_name": "User Foo",
-            "display_name": "Curious Foo"
-          },
-          "last_synchronized": %s,
-          "access": {
-            "roles": [
-              "role1",
-              "role2"
-            ],
-            "applications": {}
-          },
-          "application_data": {
-            "app1": { "name": "app1" },
-            "app2": { "name": "app2" }
+            "last_synchronized": %s,
+            "access": {
+              "roles": [
+                "role1",
+                "role2"
+              ],
+              "applications": {}
+            },
+            "application_data": {
+              "app1": { "name": "app1" },
+              "app2": { "name": "app2" }
+            }
           }
         }
         """;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +30,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -56,7 +56,7 @@ public class ProfileSingleNodeTests extends SecuritySingleNodeTestCase {
 
     public void testProfileIndexAutoCreation() {
         var indexResponse = client().prepareIndex(randomFrom(INTERNAL_SECURITY_PROFILE_INDEX_8, SECURITY_PROFILE_ALIAS))
-            .setSource(Map.of("uid", randomAlphaOfLength(22)))
+            .setSource(Map.of("user_profile", Map.of("uid", randomAlphaOfLength(22))))
             .get();
 
         assertThat(indexResponse.status().getStatus(), equalTo(201));
@@ -80,8 +80,15 @@ public class ProfileSingleNodeTests extends SecuritySingleNodeTestCase {
         final Map<String, Object> mappings = getIndexResponse.getMappings().get(INTERNAL_SECURITY_PROFILE_INDEX_8).getSourceAsMap();
 
         @SuppressWarnings("unchecked")
-        final Set<String> topLevelFields = ((Map<String, Object>) mappings.get("properties")).keySet();
-        assertThat(topLevelFields, hasItems("uid", "enabled", "last_synchronized", "user", "access", "application_data"));
+        final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+        assertThat(properties, hasKey("user_profile"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> userProfileProperties = (Map<String, Object>) ((Map<String, Object>) properties.get("user_profile")).get(
+            "properties"
+        );
+
+        assertThat(userProfileProperties.keySet(), hasItems("uid", "enabled", "last_synchronized", "user", "access", "application_data"));
     }
 
     public void testGetProfileByAuthentication() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
@@ -48,7 +48,7 @@ public record ProfileDocument(
     }
 
     static final ConstructingObjectParser<ProfileDocumentUser, Void> PROFILE_USER_PARSER = new ConstructingObjectParser<>(
-        "profile_document_user",
+        "user_profile_document_user",
         false,
         (args, v) -> new ProfileDocumentUser(
             (String) args[0],
@@ -61,13 +61,13 @@ public record ProfileDocument(
 
     @SuppressWarnings("unchecked")
     static final ConstructingObjectParser<Access, Void> ACCESS_PARSER = new ConstructingObjectParser<>(
-        "profile_access",
+        "user_profile_access",
         false,
         (args, v) -> new Access((List<String>) args[0], (Map<String, Object>) args[1])
     );
 
-    static final ConstructingObjectParser<ProfileDocument, Void> PARSER = new ConstructingObjectParser<>(
-        "profile_document",
+    static final ConstructingObjectParser<ProfileDocument, Void> PROFILE_PARSER = new ConstructingObjectParser<>(
+        "user_profile_document",
         false,
         (args, v) -> new ProfileDocument(
             (String) args[0],
@@ -77,6 +77,12 @@ public record ProfileDocument(
             (Access) args[4],
             (BytesReference) args[5]
         )
+    );
+
+    static final ConstructingObjectParser<ProfileDocument, Void> PARSER = new ConstructingObjectParser<>(
+        "user_profile_document_container",
+        true,
+        (args, v) -> (ProfileDocument) args[0]
     );
 
     static {
@@ -92,12 +98,14 @@ public record ProfileDocument(
         ACCESS_PARSER.declareStringArray(constructorArg(), new ParseField("roles"));
         ACCESS_PARSER.declareObject(constructorArg(), (p, c) -> p.map(), new ParseField("applications"));
 
-        PARSER.declareString(constructorArg(), new ParseField("uid"));
-        PARSER.declareBoolean(constructorArg(), new ParseField("enabled"));
-        PARSER.declareLong(constructorArg(), new ParseField("last_synchronized"));
-        PARSER.declareObject(constructorArg(), (p, c) -> PROFILE_USER_PARSER.parse(p, null), new ParseField("user"));
-        PARSER.declareObject(constructorArg(), (p, c) -> ACCESS_PARSER.parse(p, null), new ParseField("access"));
+        PROFILE_PARSER.declareString(constructorArg(), new ParseField("uid"));
+        PROFILE_PARSER.declareBoolean(constructorArg(), new ParseField("enabled"));
+        PROFILE_PARSER.declareLong(constructorArg(), new ParseField("last_synchronized"));
+        PROFILE_PARSER.declareObject(constructorArg(), (p, c) -> PROFILE_USER_PARSER.parse(p, null), new ParseField("user"));
+        PROFILE_PARSER.declareObject(constructorArg(), (p, c) -> ACCESS_PARSER.parse(p, null), new ParseField("access"));
         ObjectParserHelper<ProfileDocument, Void> parserHelper = new ObjectParserHelper<>();
-        parserHelper.declareRawObject(PARSER, constructorArg(), new ParseField("application_data"));
+        parserHelper.declareRawObject(PROFILE_PARSER, constructorArg(), new ParseField("application_data"));
+
+        PARSER.declareObject(constructorArg(), (p, c) -> PROFILE_PARSER.parse(p, null), new ParseField("user_profile"));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
@@ -61,7 +61,7 @@ public record ProfileDocument(
 
     @SuppressWarnings("unchecked")
     static final ConstructingObjectParser<Access, Void> ACCESS_PARSER = new ConstructingObjectParser<>(
-        "user_profile_access",
+        "user_profile_document_access",
         false,
         (args, v) -> new Access((List<String>) args[0], (Map<String, Object>) args[1])
     );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -98,9 +98,9 @@ public class ProfileService {
             final SearchRequest searchRequest = client.prepareSearch(SECURITY_PROFILE_ALIAS)
                 .setQuery(
                     QueryBuilders.boolQuery()
-                        .must(QueryBuilders.termQuery("user.username", authentication.getUser().principal()))
+                        .must(QueryBuilders.termQuery("user_profile.user.username", authentication.getUser().principal()))
                         // TODO: this will be replaced by domain lookup and reverse lookup
-                        .must(QueryBuilders.termQuery("user.realm.name", authentication.getSourceRealm().getName()))
+                        .must(QueryBuilders.termQuery("user_profile.user.realm.name", authentication.getSourceRealm().getName()))
                 )
                 .request();
             frozenProfileIndex.checkIndexVersionThenExecute(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -739,89 +739,98 @@ public class SecuritySystemIndices {
                 builder.field("dynamic", "strict");
                 builder.startObject("properties");
                 {
-                    builder.startObject("uid");
-                    builder.field("type", "keyword");
-                    builder.endObject();
-
-                    builder.startObject("enabled");
-                    builder.field("type", "boolean");
-                    builder.endObject();
-
-                    builder.startObject("user");
+                    builder.startObject("user_profile");
                     {
                         builder.field("type", "object");
                         builder.startObject("properties");
                         {
-                            builder.startObject("username");
-                            builder.field("type", "search_as_you_type");
+                            builder.startObject("uid");
+                            builder.field("type", "keyword");
                             builder.endObject();
 
-                            builder.startObject("realm");
+                            builder.startObject("enabled");
+                            builder.field("type", "boolean");
+                            builder.endObject();
+
+                            builder.startObject("user");
                             {
                                 builder.field("type", "object");
                                 builder.startObject("properties");
                                 {
-                                    builder.startObject("name");
-                                    builder.field("type", "keyword");
+                                    builder.startObject("username");
+                                    builder.field("type", "search_as_you_type");
                                     builder.endObject();
 
-                                    builder.startObject("type");
-                                    builder.field("type", "keyword");
+                                    builder.startObject("realm");
+                                    {
+                                        builder.field("type", "object");
+                                        builder.startObject("properties");
+                                        {
+                                            builder.startObject("name");
+                                            builder.field("type", "keyword");
+                                            builder.endObject();
+
+                                            builder.startObject("type");
+                                            builder.field("type", "keyword");
+                                            builder.endObject();
+
+                                            builder.startObject("node_name");
+                                            builder.field("type", "keyword");
+                                            builder.endObject();
+                                        }
+                                        builder.endObject();
+                                    }
                                     builder.endObject();
 
-                                    builder.startObject("node_name");
-                                    builder.field("type", "keyword");
+                                    builder.startObject("email");
+                                    builder.field("type", "text");
+                                    builder.field("analyzer", "email");
+                                    builder.endObject();
+
+                                    builder.startObject("full_name");
+                                    builder.field("type", "search_as_you_type");
+                                    builder.endObject();
+
+                                    builder.startObject("display_name");
+                                    builder.field("type", "search_as_you_type");
                                     builder.endObject();
                                 }
                                 builder.endObject();
                             }
                             builder.endObject();
 
-                            builder.startObject("email");
-                            builder.field("type", "text");
-                            builder.field("analyzer", "email");
+                            builder.startObject("last_synchronized");
+                            builder.field("type", "date");
+                            builder.field("format", "epoch_millis");
                             builder.endObject();
 
-                            builder.startObject("full_name");
-                            builder.field("type", "search_as_you_type");
+                            builder.startObject("access");
+                            {
+                                builder.field("type", "object");
+                                builder.startObject("properties");
+                                {
+                                    builder.startObject("roles");
+                                    builder.field("type", "keyword");
+                                    builder.endObject();
+
+                                    // Application specific access data, e.g. kibana spaces
+                                    builder.startObject("applications");
+                                    builder.field("type", "flattened");
+                                    builder.endObject();
+                                }
+                                builder.endObject();
+                            }
                             builder.endObject();
 
-                            builder.startObject("display_name");
-                            builder.field("type", "search_as_you_type");
-                            builder.endObject();
-                        }
-                        builder.endObject();
-                    }
-                    builder.endObject();
-
-                    builder.startObject("last_synchronized");
-                    builder.field("type", "date");
-                    builder.field("format", "epoch_millis");
-                    builder.endObject();
-
-                    builder.startObject("access");
-                    {
-                        builder.field("type", "object");
-                        builder.startObject("properties");
-                        {
-                            builder.startObject("roles");
-                            builder.field("type", "keyword");
-                            builder.endObject();
-
-                            // Application specific access data, e.g. kibana spaces
-                            builder.startObject("applications");
-                            builder.field("type", "flattened");
+                            // Application data, retrievable but not searchable
+                            builder.startObject("application_data");
+                            {
+                                builder.field("type", "object");
+                                builder.field("enabled", false);
+                            }
                             builder.endObject();
                         }
                         builder.endObject();
-                    }
-                    builder.endObject();
-
-                    // Application data, retrievable but not searchable
-                    builder.startObject("application_data");
-                    {
-                        builder.field("type", "object");
-                        builder.field("enabled", false);
                     }
                     builder.endObject();
                 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -47,30 +47,32 @@ public class ProfileServiceTests extends ESTestCase {
 
     public static final String SAMPLE_PROFILE_DOCUMENT_TEMPLATE = """
         {
-          "uid": "%s",
-          "enabled": true,
-          "user": {
-            "username": "foo",
-            "realm": {
-              "name": "realm_name",
-              "type": "realm_type",
-              "node_name": "node1"
+          "user_profile":  {
+            "uid": "%s",
+            "enabled": true,
+            "user": {
+              "username": "foo",
+              "realm": {
+                "name": "realm_name",
+                "type": "realm_type",
+                "node_name": "node1"
+              },
+              "email": "foo@example.com",
+              "full_name": "User Foo",
+              "display_name": "Curious Foo"
             },
-            "email": "foo@example.com",
-            "full_name": "User Foo",
-            "display_name": "Curious Foo"
-          },
-          "last_synchronized": %s,
-          "access": {
-            "roles": [
-              "role1",
-              "role2"
-            ],
-            "applications": {}
-          },
-          "application_data": {
-            "app1": { "name": "app1" },
-            "app2": { "name": "app2" }
+            "last_synchronized": %s,
+            "access": {
+              "roles": [
+                "role1",
+                "role2"
+              ],
+              "applications": {}
+            },
+            "application_data": {
+              "app1": { "name": "app1" },
+              "app2": { "name": "app2" }
+            }
           }
         }
         """;


### PR DESCRIPTION
This PR moves the user profile document definition nested under a
"user_profile" field of the root object. This adds more flexibility in
case we need store different type of documents in the same index. Even
if we don't, the nesting does not cause obvious overhead. So we favour
flexibility in this case.
