### PR TITLE
[DOCS] Changes setting name to lower-case in release notes

### DIFF
--- a/docs/reference/release-notes/8.0.0-rc1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc1.asciidoc
@@ -72,7 +72,7 @@ Ingest::
 
 Machine Learning::
 * Add `deployment_stats` to trained model stats {es-pull}80531[#80531]
-* Use_auto_machine_memory_percent now defaults `max_model_memory_limit` {es-pull}80532[#80532] (issue: {es-issue}80415[#80415])
+* The setting `use_auto_machine_memory_percent` now defaults `max_model_memory_limit` {es-pull}80532[#80532] (issue: {es-issue}80415[#80415])
 
 Monitoring::
 * Adding default templates for Metricbeat ECS data {es-pull}81744[#81744]


### PR DESCRIPTION
## Overview

This PR rephrases one of the release notes so it doesn't start with a setting name that needs to be lower-case.

### Preview

[Elasticsearch version 8.0.0-rc1]() --available soon