### PR TITLE
[7.17] [ML] Skip time to next interval with data for datafeeds with aggs (#82488)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -98,7 +98,15 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             initAggregationProcessor(aggs);
         }
 
-        return Optional.of(processNextBatch());
+        outputStream.reset();
+        // We can cancel immediately as we process whole date_histogram buckets at a time
+        aggregationToJsonProcessor.writeAllDocsCancellable(_timestamp -> isCancelled, outputStream);
+        // We process the whole search. So, if we are chunking or not, we have nothing more to process given the current query
+        hasNext = false;
+
+        return aggregationToJsonProcessor.getKeyValueCount() > 0
+            ? Optional.of(new ByteArrayInputStream(outputStream.toByteArray()))
+            : Optional.empty();
     }
 
     private Aggregations search() {
@@ -161,16 +169,6 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
         }
 
         return aggs;
-    }
-
-    private InputStream processNextBatch() throws IOException {
-        outputStream.reset();
-
-        // We can cancel immediately as we process whole date_histogram buckets at a time
-        aggregationToJsonProcessor.writeAllDocsCancellable(_timestamp -> isCancelled, outputStream);
-        // We process the whole search. So, if we are chunking or not, we have nothing more to process given the current query
-        hasNext = false;
-        return new ByteArrayInputStream(outputStream.toByteArray());
     }
 
     public AggregationDataExtractorContext getContext() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -136,6 +136,7 @@ public class ChunkedDataExtractor implements DataExtractor {
         } else {
             // search is over
             currentEnd = context.end;
+            LOGGER.debug("[{}] Chunked search configured: no data found", context.jobId);
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
@@ -195,6 +195,18 @@ public class AggregationDataExtractorTests extends ESTestCase {
         assertThat(capturedSearchRequests.size(), equalTo(1));
     }
 
+    public void testExtractionGivenResponseHasEmptyHistogramAgg() throws IOException {
+        TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
+        SearchResponse response = createSearchResponse("time", Collections.emptyList());
+        extractor.setNextResponse(response);
+
+        assertThat(extractor.hasNext(), is(true));
+        assertThat(extractor.next().isPresent(), is(false));
+        assertThat(extractor.hasNext(), is(false));
+
+        assertThat(capturedSearchRequests.size(), equalTo(1));
+    }
+
     public void testExtractionGivenResponseHasMultipleTopLevelAggs() {
         TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [ML] Skip time to next interval with data for datafeeds with aggs (#82488)