### PR TITLE
Reenable bwc tests and adjust serialisation version checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,9 +125,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/82472"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
@@ -63,7 +63,7 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         migratedPolicies = in.readStringList();
         migratedIndices = in.readStringList();
         dryRun = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
             migratedLegacyTemplates = in.readStringList();
             migratedComposableTemplates = in.readStringList();
             migratedComponentTemplates = in.readStringList();
@@ -154,7 +154,7 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         out.writeStringCollection(migratedPolicies);
         out.writeStringCollection(migratedIndices);
         out.writeBoolean(dryRun);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
             out.writeStringCollection(migratedLegacyTemplates);
             out.writeStringCollection(migratedComposableTemplates);
             out.writeStringCollection(migratedComponentTemplates);


### PR DESCRIPTION
Reenable bwc and adjust serialisation version checks after https://github.com/elastic/elasticsearch/pull/82522 was merged