### PR TITLE
Rename setBlockAndOnWriteShardLevelSnapFiles to setBlockOnShardLevelSnapFiles

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -228,7 +228,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     }
 
     public static void blockMasterOnShardLevelSnapshotFile(final String repositoryName, String indexId) {
-        AbstractSnapshotIntegTestCase.<MockRepository>getRepositoryOnMaster(repositoryName).setBlockAndOnWriteShardLevelSnapFiles(indexId);
+        AbstractSnapshotIntegTestCase.<MockRepository>getRepositoryOnMaster(repositoryName).setBlockOnShardLevelSnapFiles(indexId);
     }
 
     @SuppressWarnings("unchecked")

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -269,7 +269,7 @@ public class MockRepository extends FsRepository {
         blockAndFailOnWriteSnapFile = true;
     }
 
-    public void setBlockAndOnWriteShardLevelSnapFiles(String indexId) {
+    public void setBlockOnShardLevelSnapFiles(String indexId) {
         blockedIndexId = indexId;
     }
 


### PR DESCRIPTION
The name of this method is confusing and suggests that it has something to do with writing shard level snapshot files, whereas it has effect with read/write/delete.