### PR TITLE
Fix enrich cache corruption bug

### DIFF
--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.enrich;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.ingest.SimulateDocumentBaseResult;
+import org.elasticsearch.action.ingest.SimulatePipelineRequest;
+import org.elasticsearch.action.ingest.SimulatePipelineResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
+import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class EnrichProcessorIT extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(LocalStateEnrich.class, ReindexPlugin.class, IngestCommonPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            // TODO Change this to run with security enabled
+            // https://github.com/elastic/elasticsearch/issues/75940
+            .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .build();
+    }
+
+    public void testEnrichCacheValuesCannotBeCorrupted() {
+        // Ensure enrich cache is empty
+        EnrichStatsAction.Request statsRequest = new EnrichStatsAction.Request();
+        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
+        assertThat(statsResponse.getCacheStats().size(), equalTo(1));
+        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(0L));
+
+        String policyName = "device-enrich-policy";
+        String sourceIndexName = "devices-idx";
+
+        EnrichPolicy enrichPolicy = new EnrichPolicy(
+            EnrichPolicy.MATCH_TYPE,
+            null,
+            Collections.singletonList(sourceIndexName),
+            "host.ip",
+            Arrays.asList("device.name", "host.ip")
+        );
+
+        // Create source index and add a single document:
+        createSourceIndices(client(), enrichPolicy);
+        IndexRequest indexRequest = new IndexRequest(sourceIndexName);
+        indexRequest.create(true);
+        indexRequest.source("{\"host\": {\"ip\": \"10.151.80.8\"},\"device\": {\"name\": \"bla\"}}", XContentType.JSON);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().index(indexRequest).actionGet();
+
+        // Store policy and execute it:
+        PutEnrichPolicyAction.Request putPolicyRequest = new PutEnrichPolicyAction.Request(policyName, enrichPolicy);
+        client().execute(PutEnrichPolicyAction.INSTANCE, putPolicyRequest).actionGet();
+        ExecuteEnrichPolicyAction.Request executePolicyRequest = new ExecuteEnrichPolicyAction.Request(policyName);
+        client().execute(ExecuteEnrichPolicyAction.INSTANCE, executePolicyRequest).actionGet();
+
+        SimulatePipelineRequest simulatePipelineRequest = new SimulatePipelineRequest(
+            new BytesArray(
+                "{\n"
+                    + "              \"pipeline\": {\n"
+                    + "                \"processors\": [\n"
+                    + "                  {\n"
+                    + "                    \"enrich\": {\n"
+                    + "                      \"policy_name\": \"device-enrich-policy\",\n"
+                    + "                      \"field\": \"host.ip\",\n"
+                    + "                      \"target_field\": \"_tmp.device\"\n"
+                    + "                    }\n"
+                    + "                  },\n"
+                    + "                  {\n"
+                    + "                    \"rename\" : {\n"
+                    + "                      \"field\" : \"_tmp.device.device.name\",\n"
+                    + "                      \"target_field\" : \"device.name\"\n"
+                    + "                    }\n"
+                    + "                  }\n"
+                    + "                ]\n"
+                    + "              },\n"
+                    + "              \"docs\": [\n"
+                    + "                {\n"
+                    + "                  \"_source\": {\n"
+                    + "                    \"host\": {\n"
+                    + "                      \"ip\": \"10.151.80.8\"\n"
+                    + "                    }\n"
+                    + "                  }\n"
+                    + "                }\n"
+                    + "              ]\n"
+                    + "            }"
+            ),
+            XContentType.JSON
+        );
+        SimulatePipelineResponse response = client().admin().cluster().simulatePipeline(simulatePipelineRequest).actionGet();
+        SimulateDocumentBaseResult result = (SimulateDocumentBaseResult) response.getResults().get(0);
+        assertThat(result.getFailure(), nullValue());
+        assertThat(result.getIngestDocument().getFieldValue("device.name", String.class), equalTo("bla"));
+
+        // Verify that there was a cache miss and a new entry was added to enrich cache.
+        statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
+        assertThat(statsResponse.getCacheStats().size(), equalTo(1));
+        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(0L));
+
+        simulatePipelineRequest = new SimulatePipelineRequest(
+            new BytesArray(
+                "{\n"
+                    + "              \"pipeline\": {\n"
+                    + "                \"processors\": [\n"
+                    + "                  {\n"
+                    + "                    \"enrich\": {\n"
+                    + "                      \"policy_name\": \"device-enrich-policy\",\n"
+                    + "                      \"field\": \"host.ip\",\n"
+                    + "                      \"target_field\": \"_tmp\"\n"
+                    + "                    }\n"
+                    + "                  }\n"
+                    + "                ]\n"
+                    + "              },\n"
+                    + "              \"docs\": [\n"
+                    + "                {\n"
+                    + "                  \"_source\": {\n"
+                    + "                    \"host\": {\n"
+                    + "                      \"ip\": \"10.151.80.8\"\n"
+                    + "                    }\n"
+                    + "                  }\n"
+                    + "                }\n"
+                    + "              ]\n"
+                    + "            }"
+            ),
+            XContentType.JSON
+        );
+        response = client().admin().cluster().simulatePipeline(simulatePipelineRequest).actionGet();
+        result = (SimulateDocumentBaseResult) response.getResults().get(0);
+        assertThat(result.getFailure(), nullValue());
+        assertThat(result.getIngestDocument().getFieldValue("_tmp.device.name", String.class), equalTo("bla"));
+
+        // Verify that enrich lookup was served from cache:
+        statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
+        assertThat(statsResponse.getCacheStats().size(), equalTo(1));
+        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(1L));
+    }
+
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
@@ -7,14 +7,12 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.routing.Preference;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.script.TemplateScript;
-import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 
@@ -27,7 +25,7 @@ import java.util.function.BiConsumer;
 public abstract class AbstractEnrichProcessor extends AbstractProcessor {
 
     private final String policyName;
-    private final BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner;
+    private final BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> searchRunner;
     private final TemplateScript.Factory field;
     private final TemplateScript.Factory targetField;
     private final boolean ignoreMissing;
@@ -38,7 +36,7 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
     protected AbstractEnrichProcessor(
         String tag,
         String description,
-        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner,
+        BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> searchRunner,
         String policyName,
         TemplateScript.Factory field,
         TemplateScript.Factory targetField,
@@ -84,7 +82,7 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
             req.preference(Preference.LOCAL.type());
             req.source(searchBuilder);
 
-            searchRunner.accept(req, (searchResponse, e) -> {
+            searchRunner.accept(req, (searchHits, e) -> {
                 if (e != null) {
                     handler.accept(null, e);
                     return;
@@ -93,8 +91,7 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
                 // If the index is empty, return the unchanged document
                 // If the enrich key does not exist in the index, throw an error
                 // If no documents match the key, return the unchanged document
-                SearchHit[] searchHits = searchResponse.getHits().getHits();
-                if (searchHits.length < 1) {
+                if (searchHits.size() < 1) {
                     handler.accept(ingestDocument, null);
                     return;
                 }
@@ -102,14 +99,11 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
                 String renderedTargetField = ingestDocument.renderTemplate(this.targetField);
                 if (overrideEnabled || ingestDocument.hasField(renderedTargetField) == false) {
                     if (maxMatches == 1) {
-                        Map<String, Object> firstDocument = searchHits[0].getSourceAsMap();
+                        Map<?, ?> firstDocument = searchHits.get(0);
                         ingestDocument.setFieldValue(renderedTargetField, firstDocument);
                     } else {
-                        List<Map<String, Object>> enrichDocuments = new ArrayList<>(searchHits.length);
-                        for (SearchHit searchHit : searchHits) {
-                            Map<String, Object> enrichDocument = searchHit.getSourceAsMap();
-                            enrichDocuments.add(enrichDocument);
-                        }
+                        List<Map<?, ?>> enrichDocuments = new ArrayList<>(searchHits.size());
+                        enrichDocuments.addAll(searchHits);
                         ingestDocument.setFieldValue(renderedTargetField, enrichDocuments);
                     }
                 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -14,8 +14,15 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -43,11 +50,11 @@ import static org.elasticsearch.action.ActionListener.wrap;
  */
 public class EnrichCache {
 
-    protected final Cache<CacheKey, CompletableFuture<SearchResponse>> cache;
+    protected final Cache<CacheKey, CompletableFuture<List<Map<?, ?>>>> cache;
     private volatile Metadata metadata;
 
     EnrichCache(long maxSize) {
-        this.cache = CacheBuilder.<CacheKey, CompletableFuture<SearchResponse>>builder().setMaximumWeight(maxSize).build();
+        this.cache = CacheBuilder.<CacheKey, CompletableFuture<List<Map<?, ?>>>>builder().setMaximumWeight(maxSize).build();
     }
 
     /**
@@ -56,7 +63,7 @@ public class EnrichCache {
      * @param searchRequest the key
      * @return the cached value or null
      */
-    CompletableFuture<SearchResponse> get(SearchRequest searchRequest) {
+    CompletableFuture<List<Map<?, ?>>> get(SearchRequest searchRequest) {
         CacheKey cacheKey = toKey(searchRequest);
         return cache.get(cacheKey);
     }
@@ -89,13 +96,16 @@ public class EnrichCache {
     public void resolveOrDispatchSearch(
         SearchRequest searchRequest,
         BiConsumer<SearchRequest, ActionListener<SearchResponse>> searchDispatcher,
-        BiConsumer<SearchResponse, Exception> callBack
+        BiConsumer<List<Map<?, ?>>, Exception> callBack
     ) {
         CacheKey cacheKey = toKey(searchRequest);
         try {
-            CompletableFuture<SearchResponse> cacheEntry = cache.computeIfAbsent(cacheKey, request -> {
-                CompletableFuture<SearchResponse> completableFuture = new CompletableFuture<>();
-                searchDispatcher.accept(searchRequest, wrap(completableFuture::complete, completableFuture::completeExceptionally));
+            CompletableFuture<List<Map<?, ?>>> cacheEntry = cache.computeIfAbsent(cacheKey, request -> {
+                CompletableFuture<List<Map<?, ?>>> completableFuture = new CompletableFuture<>();
+                searchDispatcher.accept(
+                    searchRequest,
+                    wrap(response -> completableFuture.complete(toCacheValue(response)), completableFuture::completeExceptionally)
+                );
                 return completableFuture;
             });
             cacheEntry.whenComplete((response, throwable) -> {
@@ -103,13 +113,13 @@ public class EnrichCache {
                     // Don't cache failures
                     cache.invalidate(cacheKey, cacheEntry);
                     if (throwable instanceof Exception) {
-                        callBack.accept(response, (Exception) throwable);
+                        callBack.accept(null, (Exception) throwable);
                         return;
                     }
                     // Let ElasticsearchUncaughtExceptionHandler handle this, which should halt Elasticsearch
                     throw (Error) throwable;
                 }
-                callBack.accept(response, null);
+                callBack.accept(deepCopy(response, false), null);
             });
         } catch (ExecutionException e) {
             callBack.accept(null, e);
@@ -125,6 +135,44 @@ public class EnrichCache {
         String alias = searchRequest.indices()[0];
         IndexAbstraction ia = metadata.getIndicesLookup().get(alias);
         return ia.getIndices().get(0).getName();
+    }
+
+    private List<Map<?, ?>> toCacheValue(SearchResponse response) {
+        List<Map<?, ?>> result = new ArrayList<>(response.getHits().getHits().length);
+        for (SearchHit hit : response.getHits()) {
+            result.add(deepCopy(hit.getSourceAsMap(), true));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T deepCopy(T value, boolean unmodifiable) {
+        return (T) innerDeepCopy(value, unmodifiable);
+    }
+
+    private static Object innerDeepCopy(Object value, boolean unmodifiable) {
+        if (value instanceof Map<?, ?>) {
+            Map<?, ?> mapValue = (Map<?, ?>) value;
+            Map<Object, Object> copy = new HashMap<>(mapValue.size());
+            for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
+                copy.put(entry.getKey(), innerDeepCopy(entry.getValue(), unmodifiable));
+            }
+            return unmodifiable ? Collections.unmodifiableMap(copy) : copy;
+        } else if (value instanceof List<?>) {
+            List<?> listValue = (List<?>) value;
+            List<Object> copy = new ArrayList<>(listValue.size());
+            for (Object itemValue : listValue) {
+                copy.add(innerDeepCopy(itemValue, unmodifiable));
+            }
+            return unmodifiable ? Collections.unmodifiableList(copy) : copy;
+        } else if (value instanceof byte[]) {
+            byte[] bytes = (byte[]) value;
+            return Arrays.copyOf(bytes, bytes.length);
+        } else if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean) {
+            return value;
+        } else {
+            throw new IllegalArgumentException("unexpected value type [" + value.getClass() + "]");
+        }
     }
 
     private static class CacheKey {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
@@ -24,6 +23,7 @@ import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -77,7 +77,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         if (maxMatches < 1 || maxMatches > 128) {
             throw ConfigurationUtils.newConfigurationException(TYPE, tag, "max_matches", "should be between 1 and 128");
         }
-        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner = createSearchRunner(client, enrichCache);
+        BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> searchRunner = createSearchRunner(client, enrichCache);
         switch (policyType) {
             case EnrichPolicy.MATCH_TYPE:
             case EnrichPolicy.RANGE_TYPE:
@@ -123,7 +123,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         enrichCache.setMetadata(metadata);
     }
 
-    private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(
+    private static BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> createSearchRunner(
         Client client,
         EnrichCache enrichCache
     ) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -16,6 +15,8 @@ import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.TemplateScript;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 public final class GeoMatchProcessor extends AbstractEnrichProcessor {
@@ -26,7 +27,7 @@ public final class GeoMatchProcessor extends AbstractEnrichProcessor {
     GeoMatchProcessor(
         String tag,
         String description,
-        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner,
+        BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> searchRunner,
         String policyName,
         TemplateScript.Factory field,
         TemplateScript.Factory targetField,

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
@@ -7,13 +7,13 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.script.TemplateScript;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 public final class MatchProcessor extends AbstractEnrichProcessor {
@@ -21,7 +21,7 @@ public final class MatchProcessor extends AbstractEnrichProcessor {
     MatchProcessor(
         String tag,
         String description,
-        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner,
+        BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> searchRunner,
         String policyName,
         TemplateScript.Factory field,
         TemplateScript.Factory targetField,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
@@ -6,27 +6,22 @@
  */
 package org.elasticsearch.xpack.enrich;
 
-import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.profile.SearchProfileResults;
-import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -34,9 +29,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.elasticsearch.xpack.enrich.MatchProcessorTests.mapOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class EnrichCacheTests extends ESTestCase {
 
@@ -75,24 +73,7 @@ public class EnrichCacheTests extends ESTestCase {
             new SearchSourceBuilder().query(new MatchQueryBuilder("match_field", "2"))
         );
         // Emulated search response (content doesn't matter, since it isn't used, it just a cache entry)
-        SearchResponse searchResponse = new SearchResponse(
-            new InternalSearchResponse(
-                new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 0.0f),
-                InternalAggregations.EMPTY,
-                new Suggest(Collections.emptyList()),
-                new SearchProfileResults(Collections.emptyMap()),
-                false,
-                false,
-                1
-            ),
-            "",
-            1,
-            1,
-            0,
-            0,
-            ShardSearchFailure.EMPTY_ARRAY,
-            SearchResponse.Clusters.EMPTY
-        );
+        List<Map<?, ?>> searchResponse = Collections.singletonList(mapOf("test", "entry"));
 
         TestEnrichCache enrichCache = new TestEnrichCache(3);
         enrichCache.setMetadata(metadata);
@@ -199,13 +180,60 @@ public class EnrichCacheTests extends ESTestCase {
         executor.shutdownNow();
     }
 
+    public void testDeepCopy() {
+        Map<String, Object> original = new HashMap<>();
+        {
+            original.put("foo", "bar");
+            original.put("int", 123);
+            original.put("double", 123.0D);
+            Map<String, Object> innerObject = new HashMap<>();
+            innerObject.put("buzz", "hello world");
+            innerObject.put("foo_null", null);
+            innerObject.put("1", "bar");
+            innerObject.put("long", 123L);
+            List<String> innerInnerList = new ArrayList<>();
+            innerInnerList.add("item1");
+            List<Object> innerList = new ArrayList<>();
+            innerList.add(innerInnerList);
+            innerObject.put("list", innerList);
+            original.put("fizz", innerObject);
+            List<Map<String, Object>> list = new ArrayList<>();
+            Map<String, Object> value = new HashMap<>();
+            value.put("field", "value");
+            list.add(value);
+            list.add(null);
+            original.put("list", list);
+            List<String> list2 = new ArrayList<>();
+            list2.add("foo");
+            list2.add("bar");
+            list2.add("baz");
+            original.put("list2", list2);
+        }
+
+        Map<?, ?> result = EnrichCache.deepCopy(original, false);
+        assertThat(result, equalTo(original));
+        assertThat(result, not(sameInstance(original)));
+
+        result = EnrichCache.deepCopy(original, true);
+        assertThat(result, equalTo(original));
+        assertThat(result, not(sameInstance(original)));
+        Map<?, ?> innerMap = (Map<?, ?>) result.get("fizz");
+        expectThrows(UnsupportedOperationException.class, () -> innerMap.remove("x"));
+        List<?> innerList = (List<?>) result.get("list");
+        expectThrows(UnsupportedOperationException.class, () -> innerList.remove(0));
+
+        original.put("embedded_object", new byte[] { 1, 2, 3 });
+        result = EnrichCache.deepCopy(original, false);
+        assertArrayEquals(new byte[] { 1, 2, 3 }, (byte[]) result.get("embedded_object"));
+    }
+
     static class TestEnrichCache extends EnrichCache {
 
         TestEnrichCache(long maxSize) {
             super(maxSize);
         }
 
-        void warmCache(SearchRequest searchRequest, SearchResponse entry) {
+        void warmCache(SearchRequest searchRequest, List<Map<?, ?>> entry) {
             this.cache.put(toKey(searchRequest), CompletableFuture.completedFuture(entry));
         }
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/GeoMatchProcessorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/GeoMatchProcessorTests.java
@@ -6,17 +6,11 @@
  */
 package org.elasticsearch.xpack.enrich;
 
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchResponseSections;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.routing.Preference;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.text.Text;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
 import org.elasticsearch.geometry.Line;
@@ -24,21 +18,11 @@ import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentType;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -103,7 +87,7 @@ public class GeoMatchProcessorTests extends ESTestCase {
 
     private void testBasicsForFieldValue(Object fieldValue, Geometry expectedGeometry) {
         int maxMatches = randomIntBetween(1, 8);
-        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("key", mapOf("shape", "object", "zipcode", 94040)));
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("shape", "object", "zipcode", 94040));
         GeoMatchProcessor processor = new GeoMatchProcessor(
             "_tag",
             null,
@@ -165,13 +149,13 @@ public class GeoMatchProcessorTests extends ESTestCase {
 
     }
 
-    private static final class MockSearchFunction implements BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> {
-        private final SearchResponse mockResponse;
+    private static final class MockSearchFunction implements BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> {
+        private final List<Map<?, ?>> mockResponse;
         private final SetOnce<SearchRequest> capturedRequest;
         private final Exception exception;
 
-        MockSearchFunction(SearchResponse mockResponse) {
-            this.mockResponse = mockResponse;
+        MockSearchFunction(Map<?, ?> mockResponse) {
+            this.mockResponse = Collections.singletonList(mockResponse);
             this.exception = null;
             this.capturedRequest = new SetOnce<>();
         }
@@ -183,7 +167,7 @@ public class GeoMatchProcessorTests extends ESTestCase {
         }
 
         @Override
-        public void accept(SearchRequest request, BiConsumer<SearchResponse, Exception> handler) {
+        public void accept(SearchRequest request, BiConsumer<List<Map<?, ?>>, Exception> handler) {
             capturedRequest.set(request);
             if (exception != null) {
                 handler.accept(null, exception);
@@ -198,53 +182,14 @@ public class GeoMatchProcessorTests extends ESTestCase {
     }
 
     public MockSearchFunction mockedSearchFunction() {
-        return new MockSearchFunction(mockResponse(Collections.emptyMap()));
+        return new MockSearchFunction(Collections.emptyMap());
     }
 
     public MockSearchFunction mockedSearchFunction(Exception exception) {
         return new MockSearchFunction(exception);
     }
 
-    public MockSearchFunction mockedSearchFunction(Map<String, Map<String, ?>> documents) {
-        return new MockSearchFunction(mockResponse(documents));
-    }
-
-    public SearchResponse mockResponse(Map<String, Map<String, ?>> documents) {
-        SearchHit[] searchHits = documents.entrySet().stream().map(e -> {
-            SearchHit searchHit = new SearchHit(
-                randomInt(100),
-                e.getKey(),
-                new Text(MapperService.SINGLE_MAPPING_NAME),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            );
-            try (XContentBuilder builder = XContentBuilder.builder(XContentType.SMILE.xContent())) {
-                builder.map(e.getValue());
-                builder.flush();
-                ByteArrayOutputStream outputStream = (ByteArrayOutputStream) builder.getOutputStream();
-                searchHit.sourceRef(new BytesArray(outputStream.toByteArray()));
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-            return searchHit;
-        }).toArray(SearchHit[]::new);
-        return new SearchResponse(
-            new SearchResponseSections(
-                new SearchHits(searchHits, new TotalHits(documents.size(), TotalHits.Relation.EQUAL_TO), 1.0f),
-                new Aggregations(Collections.emptyList()),
-                new Suggest(Collections.emptyList()),
-                false,
-                false,
-                null,
-                1
-            ),
-            null,
-            1,
-            1,
-            0,
-            1,
-            ShardSearchFailure.EMPTY_ARRAY,
-            new SearchResponse.Clusters(1, 1, 0)
-        );
+    public MockSearchFunction mockedSearchFunction(Map<?, ?> documents) {
+        return new MockSearchFunction(documents);
     }
 }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/MatchProcessorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/MatchProcessorTests.java
@@ -6,35 +6,19 @@
  */
 package org.elasticsearch.xpack.enrich;
 
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchResponseSections;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.routing.Preference;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.script.TemplateScript;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentType;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,7 +36,7 @@ public class MatchProcessorTests extends ESTestCase {
 
     public void testBasics() throws Exception {
         int maxMatches = randomIntBetween(1, 8);
-        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("elastic.co", mapOf("globalRank", 451, "tldRank", 23, "tld", "co")));
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("globalRank", 451, "tldRank", 23, "tld", "co"));
         MatchProcessor processor = new MatchProcessor(
             "_tag",
             null,
@@ -256,7 +240,7 @@ public class MatchProcessorTests extends ESTestCase {
     }
 
     public void testExistingFieldWithOverrideDisabled() throws Exception {
-        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("elastic.co", mapOf("globalRank", 451, "tldRank", 23, "tld", "co")));
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("globalRank", 451, "tldRank", 23, "tld", "co"));
         MatchProcessor processor = new MatchProcessor(
             "_tag",
             null,
@@ -283,7 +267,7 @@ public class MatchProcessorTests extends ESTestCase {
     }
 
     public void testExistingNullFieldWithOverrideDisabled() throws Exception {
-        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("elastic.co", mapOf("globalRank", 451, "tldRank", 23, "tld", "co")));
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("globalRank", 451, "tldRank", 23, "tld", "co"));
         MatchProcessor processor = new MatchProcessor(
             "_tag",
             null,
@@ -313,7 +297,7 @@ public class MatchProcessorTests extends ESTestCase {
     }
 
     public void testNumericValue() {
-        MockSearchFunction mockSearch = mockedSearchFunction(mapOf(2, mapOf("globalRank", 451, "tldRank", 23, "tld", "co")));
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("globalRank", 451, "tldRank", 23, "tld", "co"));
         MatchProcessor processor = new MatchProcessor(
             "_tag",
             null,
@@ -358,9 +342,7 @@ public class MatchProcessorTests extends ESTestCase {
     }
 
     public void testArray() {
-        MockSearchFunction mockSearch = mockedSearchFunction(
-            mapOf(Arrays.asList("1", "2"), mapOf("globalRank", 451, "tldRank", 23, "tld", "co"))
-        );
+        MockSearchFunction mockSearch = mockedSearchFunction(mapOf("globalRank", 451, "tldRank", 23, "tld", "co"));
         MatchProcessor processor = new MatchProcessor(
             "_tag",
             null,
@@ -406,13 +388,13 @@ public class MatchProcessorTests extends ESTestCase {
         assertThat(entry.get("tld"), equalTo("co"));
     }
 
-    private static final class MockSearchFunction implements BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> {
-        private final SearchResponse mockResponse;
+    private static final class MockSearchFunction implements BiConsumer<SearchRequest, BiConsumer<List<Map<?, ?>>, Exception>> {
+        private final List<Map<?, ?>> mockResponse;
         private final SetOnce<SearchRequest> capturedRequest;
         private final Exception exception;
 
-        MockSearchFunction(SearchResponse mockResponse) {
-            this.mockResponse = mockResponse;
+        MockSearchFunction(Map<?, ?> mockResponse) {
+            this.mockResponse = mockResponse.isEmpty() ? Collections.emptyList() : Collections.singletonList(mockResponse);
             this.exception = null;
             this.capturedRequest = new SetOnce<>();
         }
@@ -424,7 +406,7 @@ public class MatchProcessorTests extends ESTestCase {
         }
 
         @Override
-        public void accept(SearchRequest request, BiConsumer<SearchResponse, Exception> handler) {
+        public void accept(SearchRequest request, BiConsumer<List<Map<?, ?>>, Exception> handler) {
             capturedRequest.set(request);
             if (exception != null) {
                 handler.accept(null, exception);
@@ -439,54 +421,15 @@ public class MatchProcessorTests extends ESTestCase {
     }
 
     public MockSearchFunction mockedSearchFunction() {
-        return new MockSearchFunction(mockResponse(Collections.emptyMap()));
+        return new MockSearchFunction(Collections.emptyMap());
     }
 
     public MockSearchFunction mockedSearchFunction(Exception exception) {
         return new MockSearchFunction(exception);
     }
 
-    public MockSearchFunction mockedSearchFunction(Map<?, Map<String, ?>> documents) {
-        return new MockSearchFunction(mockResponse(documents));
-    }
-
-    public SearchResponse mockResponse(Map<?, Map<String, ?>> documents) {
-        SearchHit[] searchHits = documents.entrySet().stream().map(e -> {
-            SearchHit searchHit = new SearchHit(
-                randomInt(100),
-                e.getKey().toString(),
-                new Text(MapperService.SINGLE_MAPPING_NAME),
-                Collections.emptyMap(),
-                Collections.emptyMap()
-            );
-            try (XContentBuilder builder = XContentBuilder.builder(XContentType.SMILE.xContent())) {
-                builder.map(e.getValue());
-                builder.flush();
-                ByteArrayOutputStream outputStream = (ByteArrayOutputStream) builder.getOutputStream();
-                searchHit.sourceRef(new BytesArray(outputStream.toByteArray()));
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-            return searchHit;
-        }).toArray(SearchHit[]::new);
-        return new SearchResponse(
-            new SearchResponseSections(
-                new SearchHits(searchHits, new TotalHits(documents.size(), TotalHits.Relation.EQUAL_TO), 1.0f),
-                new Aggregations(Collections.emptyList()),
-                new Suggest(Collections.emptyList()),
-                false,
-                false,
-                null,
-                1
-            ),
-            null,
-            1,
-            1,
-            0,
-            1,
-            ShardSearchFailure.EMPTY_ARRAY,
-            new SearchResponse.Clusters(1, 1, 0)
-        );
+    public MockSearchFunction mockedSearchFunction(Map<?, ?> document) {
+        return new MockSearchFunction(document);
     }
 
     static TemplateScript.Factory str(String stringLiteral) {


### PR DESCRIPTION
Backport #82441 to 7.17 branch.

The enrich cache currently uses `SearchResponse` as cache value,
which contains the hits used by the enrich processor for enrichment.
What is actually used is by the enrich processor is `SearchHit.getSourceAsMap()`,
which is a map of maps representation of a search hit.

The problem is that this map is mutable and the map of maps is directly
passed into `IngestDocument` and at the same time this is cached by the
enrich cache via `SearchResponse` cache value. Any processor that modifies
the content added by the enrich processor, also changes the map of maps
representation of a search hit in the cache. This corrupts the cache,
because if this the enrich cache serves a cache entry for the same key,
a different snippet added to the document being enriched.

The following changes have been made to fix this bug:
* Use `List<Map<?, ?>>` as cache value for the enrich cache.
* Upon caching lookup / search, make an immutable deep copy of `SearchHit.getSourceAsMap()`.
* Upon serving an entry from the cache, make a normal deep copy,
  so the enrichent can be safely modified by subsequent processors.

Closes #82340