### PR TITLE
[8.0] Correctly synchronize RecoveryState#Translog internal state (#81528)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -486,10 +486,12 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeVInt(recovered);
-            out.writeVInt(total);
-            out.writeVInt(totalOnStart);
-            out.writeVInt(totalLocal);
+            synchronized (this) {
+                out.writeVInt(recovered);
+                out.writeVInt(total);
+                out.writeVInt(totalOnStart);
+                out.writeVInt(totalLocal);
+            }
         }
 
         public synchronized void reset() {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Correctly synchronize RecoveryState#Translog internal state (#81528)