### PR TITLE
[7.17] Correctly synchronize RecoveryState#Translog internal state (#81528)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -492,11 +492,13 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeVInt(recovered);
-            out.writeVInt(total);
-            out.writeVInt(totalOnStart);
-            if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
-                out.writeVInt(totalLocal);
+            synchronized (this) {
+                out.writeVInt(recovered);
+                out.writeVInt(total);
+                out.writeVInt(totalOnStart);
+                if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
+                    out.writeVInt(totalLocal);
+                }
             }
         }
 


### PR DESCRIPTION
Backports #81528 to 7.17

* Correctly synchronize RecoveryState#Translog internal state

We must synchronize all access to the internal state, otherwise
there's no read/write memory barriers when deserializing/serialize
the state from the wire.

* Remove synchronization from the constructor
