### PR TITLE
fix redundant upsert request versioning logic and rebuild upsert request

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -145,16 +145,17 @@ public class UpdateHelper {
             }
         }
 
-        indexRequest.index(request.index())
+        final IndexRequest finalIndexRequest = Requests.indexRequest(request.index())
             .id(request.id())
-            .setRefreshPolicy(request.getRefreshPolicy())
             .routing(request.routing())
+            .source(indexRequest.source())
+            .setRefreshPolicy(request.getRefreshPolicy())
             .timeout(request.timeout())
             .waitForActiveShards(request.waitForActiveShards())
             // it has to be a "create!"
             .create(true);
 
-        return new Result(indexRequest, DocWriteResponse.Result.CREATED, null, null);
+        return new Result(finalIndexRequest, DocWriteResponse.Result.CREATED, null, null);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -154,11 +154,6 @@ public class UpdateHelper {
             // it has to be a "create!"
             .create(true);
 
-        if (request.versionType() != VersionType.INTERNAL) {
-            // in all but the internal versioning mode, we want to create the new document using the given version.
-            indexRequest.version(request.version()).versionType(request.versionType());
-        }
-
         return new Result(indexRequest, DocWriteResponse.Result.CREATED, null, null);
     }
 


### PR DESCRIPTION
This PR contains two changes:
1. Since `UpdateRequest` does not support versioning and its `versionType` is always `INTERNAL`, the upsert request versioning logic can be removed;
2. Builds a new `IndexRequest` instead of using the one in the `UpdateRequest` for upsert.