### PR TITLE
Using startsWith rather than exact matches for watcher history template names (#82396)

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -82,14 +82,13 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
     }
 
     public static boolean validate(ClusterState state) {
-        return state.getMetadata().templatesV2().containsKey(WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME)
-            || state.getMetadata().templatesV2().containsKey(WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME_NO_ILM)
-            ||
-            // Template versions 12 or 13 are also ok to have (no breaking changes). At some point these will be upgraded to version 14.
-            state.getMetadata().templatesV2().containsKey(".watch-history-12")
-            || state.getMetadata().templatesV2().containsKey(".watch-history-no-ilm-12")
-            || state.getMetadata().templatesV2().containsKey(".watch-history-13")
-            || state.getMetadata().templatesV2().containsKey(".watch-history-no-ilm-13");
+        return state.getMetadata()
+            .templatesV2()
+            .keySet()
+            .stream()
+            .filter(s -> s.startsWith(".watch-history-"))
+            .map(s -> Integer.valueOf(s.substring(s.lastIndexOf('-') + 1)))
+            .anyMatch(version -> version >= 12);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -260,6 +260,23 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             existingTemplates.put(".watches", INDEX_TEMPLATE_VERSION);
             assertThat(WatcherIndexTemplateRegistry.validate(createClusterState(existingTemplates)), is(true));
         }
+
+        {
+            Map<String, Integer> existingTemplates = new HashMap<>();
+            existingTemplates.put(".watch-history-11", 11);
+            existingTemplates.put(".triggered_watches", 11);
+            existingTemplates.put(".watches", 11);
+            assertThat(WatcherIndexTemplateRegistry.validate(createClusterState(existingTemplates)), is(false));
+        }
+
+        {
+            Map<String, Integer> existingTemplates = new HashMap<>();
+            existingTemplates.put(".watch-history-15", 15);
+            existingTemplates.put(".triggered_watches", 15);
+            existingTemplates.put(".watches", 15);
+            assertThat(WatcherIndexTemplateRegistry.validate(createClusterState(existingTemplates)), is(true));
+        }
+
         {
             Map<String, Integer> existingTemplates = new HashMap<>();
             existingTemplates.put(WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME, INDEX_TEMPLATE_VERSION);


### PR DESCRIPTION
This commit makes the check for watcher history template names a little more flexible, by checking for
any with version greater than or equal to 12, rather than listing out versions.