### PR TITLE
[7.16] [DOCS] Update snapshot vers compat table to use minor versions (#81885)

### DIFF
--- a/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
+++ b/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
@@ -1,0 +1,11 @@
+
+[cols="^,^,^,^"]
+|====
+| 3+^h| Cluster version
+h| Index creation version   | 6.8        | 7.0–7.1    | 7.2–{minor-version}
+| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}
+| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}
+| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}
+| 7.0–7.1                   | {no-icon}  | {yes-icon} | {yes-icon}
+| 7.2–{minor-version}       | {no-icon}  | {no-icon}  | {yes-icon}
+|====

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -110,16 +110,7 @@ any restored indices must be compatible.
 [[snapshot-cluster-compatibility]]
 === Snapshot version compatibility
 
-[cols="6"]
-|===
-| 5+^h| Cluster version
-^h| Snapshot version ^| 2.x ^| 5.x ^| 6.x ^| 7.x ^| 8.x
-^| *1.x* -> ^|{yes-icon} ^|{no-icon}  ^|{no-icon}  ^|{no-icon}  ^|{no-icon}
-^| *2.x* -> ^|{yes-icon} ^|{yes-icon} ^|{no-icon}  ^|{no-icon}  ^|{no-icon}
-^| *5.x* -> ^|{no-icon}  ^|{yes-icon} ^|{yes-icon} ^|{no-icon}  ^|{no-icon}
-^| *6.x* -> ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon} ^|{no-icon}
-^| *7.x* -> ^|{no-icon}  ^|{no-icon}  ^|{no-icon}  ^|{yes-icon} ^|{yes-icon}
-|===
+include::snapshot-vers-compat.asciidoc[]
 
 You can't restore a snapshot to an earlier version of {es}. For example, you
 can't restore a snapshot taken in 7.6.0 to a cluster running 7.5.0.
@@ -145,22 +136,26 @@ endif::[]
 [[snapshot-index-compatibility]]
 === Index compatibility
 
-A cluster is only compatible with indices created in the previous major version
-of {es}. Any data stream or index you restore from a snapshot must be compatible
-with the current cluster's version. If you try to restore an index created in an
-incompatible version, the restore attempt will fail.
+Any index you restore from a snapshot must also be compatible with the current
+cluster's version. If you try to restore an index created in an incompatible
+version, the restore attempt will fail.
 
-A snapshot can contain indices created in a previous major version. For example,
-a snapshot of a 6.x cluster can contain an index created in 5.x. If you try to
-restore the 5.x index to a 7.x cluster, the restore attempt will fail. Keep this
-in mind if you take a snapshot before upgrading a cluster.
+include::cluster-index-compat.asciidoc[]
 
-As a workaround, you can first restore the data stream or index to another
-cluster running the latest version of {es} that's compatible with both the index
-and your current cluster. You can then use
-<<reindex-from-remote,reindex-from-remote>> to rebuild the data stream or index
-on your current cluster. Reindex from remote is only possible if the index's
-<<mapping-source-field,`_source`>> is enabled.
+You can't restore an index to an earlier version of {es}. For example, you can't
+restore an index created in 7.6.0 to a cluster running 7.5.0.
+
+A compatible snapshot can contain indices created in an incompatible version.
+For example, a snapshot of a 6.8 cluster can contain an index created in 5.6. If
+you try to restore the 5.6 index to a {minor-version} cluster, the restore
+attempt will fail. Keep this in mind if you take a snapshot before upgrading a
+cluster.
+
+As a workaround, you can first restore the index to another cluster running the
+latest version of {es} that's compatible with both the index and your current
+cluster. You can then use <<reindex-from-remote,reindex-from-remote>> to rebuild
+the index on your current cluster. Reindex from remote is only possible if the
+index's <<mapping-source-field,`_source`>> is enabled.
 
 Reindexing from remote can take significantly longer than restoring a snapshot.
 Before you start, test the reindex from remote process with a subset of the data
@@ -168,7 +163,7 @@ to estimate your time requirements.
 
 [discrete]
 [[snapshot-restore-warnings]]
-=== Warnings
+== Warnings
 
 [discrete]
 [[other-backup-methods]]

--- a/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
+++ b/docs/reference/snapshot-restore/snapshot-vers-compat.asciidoc
@@ -1,0 +1,11 @@
+
+[cols="^,^,^,^"]
+|====
+| 3+^h| Cluster version
+h| Snapshot version         | 6.8        | 7.0–7.1    | 7.2–{minor-version}
+| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}
+| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}
+| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}
+| 7.0–7.1                   | {no-icon}  | {yes-icon} | {yes-icon}
+| 7.2–{minor-version}       | {no-icon}  | {no-icon}  | {yes-icon}
+|====


### PR DESCRIPTION
This is an automatic backport of pull request #81885 to 7.16.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information