### PR TITLE
Fixing security vulnerabilities: CVE-2021-37137, CVE-2021-37136, CVE-2020-28491, CVE-2020-25649, CVE-2021-43797, CVE-2018-10237, CVE-2020-13956

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 7.16.3
+elasticsearch     = 7.16.4
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
@@ -9,7 +9,7 @@ checkstyle = 8.39
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0
-jackson           = 2.10.4
+jackson           = 2.11.4
 snakeyaml         = 1.26
 icu4j             = 62.1
 supercsv          = 2.4.0
@@ -19,7 +19,7 @@ slf4j             = 1.6.2
 
 jna               = 5.10.0
 
-netty             = 4.1.66.Final
+netty             = 4.1.71.Final
 joda              = 2.10.10
 
 commons_lang3                   = 3.9
@@ -33,7 +33,7 @@ bouncycastle=1.64
 randomizedrunner  = 2.7.1
 junit             = 4.12
 junit5            = 5.7.1
-httpclient        = 4.5.10
+httpclient        = 4.5.13
 httpcore          = 4.4.12
 httpasyncclient   = 4.1.4
 commonslogging    = 1.1.3

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 7.16.3
+elasticsearch     = 7.16.4
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 7.16.4
+elasticsearch     = 7.16.3
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
-  runtimeOnly 'com.google.guava:guava:19.0'
+  runtimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
   testImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -63,7 +63,7 @@ dependencies {
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
-  runtimeOnly 'com.google.guava:guava:19.0'
+  runtimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 
   // Dependencies for oidc
   api "com.nimbusds:oauth2-oidc-sdk:9.3.1"


### PR DESCRIPTION
Below can be found the table with more description of these security vulnerabilities:


|CVE | Package | Version | Severity | Status|
|-- | -- | -- | -- | --|
|CVE-2021-37137 | io.netty_netty-codec | 4.1.66.Final | high | fixed in 4.1.68|
|CVE-2021-37136 | io.netty_netty-codec | 4.1.66.Final | high | fixed in 4.1.68|
|CVE-2020-28491 | com.fasterxml.jackson.dataformat_jackson-dataformat-cbor | 2.10.4 | high | fixed in 2.11.4, 2.12.1|
|CVE-2020-25649 | com.fasterxml.jackson.core_jackson-databind | 2.10.4 | high | fixed in 2.10.5.1, 2.9.10.7, 2|
|CVE-2021-43797 | io.netty_netty-codec | 4.1.66.Final | medium | fixed in 4.1.71|
|CVE-2018-10237 | com.google.guava_guava | 19 | medium | fixed in 24.1.1|
|CVE-2020-13956 | org.apache.httpcomponents_httpclient | 4.5.10 | medium | fixed in 5.0.3, 4.5.13|



</body>

</html>
