### PR TITLE
Allow doc-values only search on date types

### DIFF
--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -17,7 +17,8 @@ makes this data access pattern possible. They store the same values as the
 sorting and aggregations. Doc values are supported on almost all field types,
 with the __notable exception of `text` and `annotated_text` fields__.
 
-<<number,Numeric types>>, such as `long` and `double`, can also be queried
+<<number,Numeric types>>, such as `long` and `double`, and <<date,Date types>>
+can also be queried
 when they are not <<mapping-index,indexed>> but only have doc values enabled.
 Query performance on doc values is much slower than on index structures, but
 offers an interesting tradeoff between disk usage and query performance for

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -137,7 +137,9 @@ The following parameters are accepted by `date` fields:
 
 <<mapping-index,`index`>>::
 
-    Should the field be searchable? Accepts `true` (default) and `false`.
+    Should the field be quickly searchable? Accepts `true` (default) and
+    `false`. Date fields that only have <<doc-values,`doc_values`>>
+    enabled can also be queried, albeit slower.
 
 <<null-value,`null_value`>>::
 

--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -33,7 +33,8 @@ the stability of the cluster. Those queries can be categorised as follows:
 
 * Queries that need to do linear scans to identify matches:
 ** <<query-dsl-script-query,`script` queries>>
-** queries on <<number,numeric fields>> that are not indexed but have <<doc-values,doc values>> enabled
+** queries on <<number,numeric>> and <<date,date>> fields that are not indexed
+   but have <<doc-values,doc values>> enabled
 
 * Queries that have a high up-front cost:
 ** <<query-dsl-fuzzy-query,`fuzzy` queries>> (except on

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -223,7 +223,7 @@ setup:
         index: 'test1,test2,test3'
         fields: non_indexed_date
 
-  - match: {fields.non_indexed_date.searchable:                       true}
+  - match: {fields.non_indexed_date.date.searchable:                       true}
 
 ---
 "Get object and nested field caps":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -83,6 +83,9 @@ setup:
                     type:     long
                   date:
                     type:     date
+                  non_indexed_date:
+                    type:     date
+                    index:    false
                   geo:
                     type:     keyword
                   object:
@@ -209,6 +212,18 @@ setup:
         fields: object*
 
   - match: {fields.object\.nested1.long.searchable:                       true}
+
+---
+"Field caps for date field with only doc values":
+  - skip:
+      version: " - 8.0.99"
+      reason: "doc values search was added in 8.1.0"
+  - do:
+      field_caps:
+        index: 'test1,test2,test3'
+        fields: non_indexed_date
+
+  - match: {fields.non_indexed_date.searchable:                       true}
 
 ---
 "Get object and nested field caps":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -10,6 +10,10 @@ setup:
                 created_at:
                    type: date
                    format: "yyyy-MM-dd"
+                created_at_not_indexed:
+                   type: date
+                   index: false
+                   format: "yyyy-MM-dd"
   - do:
       indices.create:
           index: index_2
@@ -21,6 +25,10 @@ setup:
                 created_at:
                    type: date_nanos
                    format: "yyyy-MM-dd"
+                created_at_not_indexed:
+                   type: date
+                   index: false
+                   format: "yyyy-MM-dd"
   - do:
       indices.create:
           index: index_3
@@ -31,6 +39,10 @@ setup:
               properties:
                 created_at:
                    type: date
+                   format: "yyyy-MM-dd"
+                created_at_not_indexed:
+                   type: date
+                   index: false
                    format: "yyyy-MM-dd"
 
 
@@ -222,3 +234,53 @@ setup:
   - length: { hits.hits: 1 }
   - match: {hits.hits.0._id: "3" }
   - length: { aggregations.idx_terms.buckets: 3 }
+
+---
+"prefilter on non-indexed date fields":
+  - skip:
+      version: "- 8.0.99"
+      reason: "doc values search was added in 8.1.0"
+
+  - do:
+      index:
+        index: index_1
+        id: 1
+        body: { "created_at_not_indexed": "2016-01-01"}
+  - do:
+      index:
+        index: index_2
+        id: 2
+        body: { "created_at_not_indexed": "2017-01-01" }
+
+  - do:
+      index:
+        index: index_3
+        id: 3
+        body: { "created_at_not_indexed": "2018-01-01" }
+  - do:
+      indices.refresh: {}
+
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "query" : { "range" : { "created_at_not_indexed" : { "gte" : "2016-02-01", "lt": "2018-02-01"} } } }
+
+  - match: { _shards.total: 3 }
+  - match: { _shards.successful: 3 }
+  - match: { _shards.skipped: 0 }
+  - match: { _shards.failed: 0 }
+  - match: { hits.total: 2 }
+
+  # this is a case where we would normally skip due to rewrite but we can't because we only have doc values
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        pre_filter_shard_size: 1
+        body: { "size" : 0, "query" : { "range" : { "created_at_not_indexed" : { "gte" : "2016-02-01", "lt": "2018-02-01"} } } }
+
+  - match: { _shards.total: 3 }
+  - match: { _shards.successful: 3 }
+  - match: { _shards.skipped : 0 }
+  - match: { _shards.failed: 0 }
+  - match: { hits.total: 2 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
@@ -32,6 +32,10 @@ setup:
               short:
                 type: short
                 index: false
+              date:
+                type: date
+                format: yyyy/MM/dd
+                index: false
 
   - do:
       index:
@@ -45,6 +49,7 @@ setup:
           integer: 1
           long: 1
           short: 1
+          date: "2017/01/01"
 
   - do:
       index:
@@ -58,6 +63,7 @@ setup:
           integer: 2
           long: 2
           short: 2
+          date: "2017/01/02"
 
   - do:
       indices.refresh: {}
@@ -195,4 +201,22 @@ setup:
       search:
         index: test
         body: { query: { range: { short: { gte: 0 } } } }
+  - length:   { hits.hits: 2  }
+
+---
+"Test match query on date field where only doc values are enabled":
+
+  - do:
+      search:
+        index: test
+        body: { query: { match: { date: { query: "2017/01/01" } } } }
+  - length:   { hits.hits: 1  }
+
+---
+"Test range query on date field where only doc values are enabled":
+
+  - do:
+      search:
+        index: test
+        body: { query: { range: { date: { gte: "2017/01/01" } } } }
   - length:   { hits.hits: 2  }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2025,6 +2025,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (mappedFieldType instanceof DateFieldMapper.DateFieldType == false) {
             return ShardLongFieldRange.UNKNOWN; // field missing or not a date
         }
+        if (mappedFieldType.isIndexed() == false) {
+            return ShardLongFieldRange.UNKNOWN; // range information missing
+        }
 
         final ShardLongFieldRange rawTimestampFieldRange;
         try {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -63,8 +63,19 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
+    public void testIsFieldWithinRangeOnlyDocValues() throws IOException {
+        QueryRewriteContext context = new QueryRewriteContext(parserConfig(), writableRegistry(), null, () -> nowInMillis);
+        IndexReader reader = new MultiReader();
+        DateFieldType ft = new DateFieldType("my_date", false);
+        // in case of only doc-values, we can't establish disjointness
+        assertEquals(
+            Relation.INTERSECTS,
+            ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03", randomBoolean(), randomBoolean(), null, null, context)
+        );
+    }
+
     public void testIsFieldWithinQueryDateMillis() throws IOException {
-        DateFieldType ft = new DateFieldType("my_date", Resolution.MILLISECONDS);
+        DateFieldType ft = new DateFieldType("my_date");
         isFieldWithinRangeTestCase(ft);
     }
 
@@ -192,11 +203,15 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
         assertEquals(expected, ft.termQuery(date, context));
 
+        ft = new DateFieldType("field", false);
+        expected = SortedNumericDocValuesField.newSlowRangeQuery("field", instant, instant + 999);
+        assertEquals(expected, ft.termQuery(date, context));
+
         MappedFieldType unsearchable = new DateFieldType(
             "field",
             false,
             false,
-            true,
+            false,
             DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
             Resolution.MILLISECONDS,
             null,
@@ -204,7 +219,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             Collections.emptyMap()
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery(date, context));
-        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+        assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
     }
 
     public void testRangeQuery() throws IOException {
@@ -245,6 +260,10 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
         assertEquals(expected, ft.rangeQuery(date1, date2, true, true, null, null, null, context).rewrite(new MultiReader()));
 
+        MappedFieldType ft2 = new DateFieldType("field", false);
+        Query expected2 = SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2);
+        assertEquals(expected2, ft2.rangeQuery(date1, date2, true, true, null, null, null, context).rewrite(new MultiReader()));
+
         instant1 = nowInMillis;
         instant2 = instant1 + 100;
         expected = new DateRangeIncludingNowQuery(
@@ -255,11 +274,14 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
         assertEquals(expected, ft.rangeQuery("now", instant2, true, true, null, null, null, context));
 
+        expected2 = new DateRangeIncludingNowQuery(SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2));
+        assertEquals(expected2, ft2.rangeQuery("now", instant2, true, true, null, null, null, context));
+
         MappedFieldType unsearchable = new DateFieldType(
             "field",
             false,
             false,
-            true,
+            false,
             DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
             Resolution.MILLISECONDS,
             null,
@@ -270,7 +292,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             IllegalArgumentException.class,
             () -> unsearchable.rangeQuery(date1, date2, true, true, null, null, null, context)
         );
-        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+        assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
     }
 
     public void testRangeQueryWithIndexSort() {
@@ -320,6 +342,10 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             instant2,
             new IndexOrDocValuesQuery(pointQuery, dvQuery)
         );
+        assertEquals(expected, ft.rangeQuery(date1, date2, true, true, null, null, null, context));
+
+        ft = new DateFieldType("field", false);
+        expected = new IndexSortSortedNumericDocValuesRangeQuery("field", instant1, instant2, dvQuery);
         assertEquals(expected, ft.rangeQuery(date1, date2, true, true, null, null, null, context));
     }
 


### PR DESCRIPTION
Similar to #82409, but for date fields.

Allows searching on date field types (date, date_nanos) when those fields are not indexed (index: false) but just doc values are enabled.

This enables searches on archive data, which has access to doc values but not index structures. When combined with searchable snapshots, it allows downloading only data for a given (doc value) field to quickly filter down to a select set of documents.

Relates #81210 and #52728