### PR TITLE
LocalClusterUpdateTask can't change cluster state

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -109,12 +109,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
     ) {
         assert request.waitForEvents() != null;
         if (request.local()) {
-            var updateTask = new LocalClusterUpdateTask(request.waitForEvents()) {
-                @Override
-                public ClusterTasksResult<LocalClusterUpdateTask> execute(ClusterState currentState) {
-                    return unchanged();
-                }
-
+            new LocalClusterUpdateTask(request.waitForEvents()) {
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     final long timeoutInMillis = Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis());
@@ -134,12 +129,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                     logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
                     listener.onFailure(e);
                 }
-            };
-            clusterService.submitStateUpdateTask(
-                "cluster_health (wait_for_events [" + request.waitForEvents() + "])",
-                updateTask,
-                updateTask
-            );
+            }.submit(clusterService.getMasterService(), "cluster_health (wait_for_events [" + request.waitForEvents() + "])");
         } else {
             final TimeValue taskTimeout = TimeValue.timeValueMillis(Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis()));
             clusterService.submitStateUpdateTask(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.cluster.LocalClusterUpdateTask;
+import org.elasticsearch.cluster.LocalMasterServiceTask;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -109,7 +109,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
     ) {
         assert request.waitForEvents() != null;
         if (request.local()) {
-            new LocalClusterUpdateTask(request.waitForEvents()) {
+            new LocalMasterServiceTask(request.waitForEvents()) {
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     final long timeoutInMillis = Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis());

--- a/server/src/main/java/org/elasticsearch/cluster/LocalClusterUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalClusterUpdateTask.java
@@ -41,7 +41,7 @@ public abstract class LocalClusterUpdateTask implements ClusterStateTaskListener
 
                 @Override
                 public String describeTasks(List<LocalClusterUpdateTask> tasks) {
-                    return "";
+                    return ""; // only one task in the batch so the source is enough
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
@@ -15,11 +15,11 @@ import java.util.List;
 /**
  * Used to execute things on the master service thread on nodes that are not necessarily master
  */
-public abstract class LocalClusterUpdateTask implements ClusterStateTaskListener {
+public abstract class LocalMasterServiceTask implements ClusterStateTaskListener {
 
     private final Priority priority;
 
-    public LocalClusterUpdateTask(Priority priority) {
+    public LocalMasterServiceTask(Priority priority) {
         this.priority = priority;
     }
 
@@ -40,17 +40,17 @@ public abstract class LocalClusterUpdateTask implements ClusterStateTaskListener
                 }
 
                 @Override
-                public String describeTasks(List<LocalClusterUpdateTask> tasks) {
+                public String describeTasks(List<LocalMasterServiceTask> tasks) {
                     return ""; // only one task in the batch so the source is enough
                 }
 
                 @Override
-                public ClusterTasksResult<LocalClusterUpdateTask> execute(ClusterState currentState, List<LocalClusterUpdateTask> tasks)
+                public ClusterTasksResult<LocalMasterServiceTask> execute(ClusterState currentState, List<LocalMasterServiceTask> tasks)
                     throws Exception {
-                    assert tasks.size() == 1 && tasks.get(0) == LocalClusterUpdateTask.this
+                    assert tasks.size() == 1 && tasks.get(0) == LocalMasterServiceTask.this
                         : "expected one-element task list containing current object but was " + tasks;
-                    LocalClusterUpdateTask.this.execute(currentState);
-                    return ClusterTasksResult.<LocalClusterUpdateTask>builder().successes(tasks).build(currentState);
+                    LocalMasterServiceTask.this.execute(currentState);
+                    return ClusterTasksResult.<LocalMasterServiceTask>builder().successes(tasks).build(currentState);
                 }
             },
             this

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.cluster.LocalClusterUpdateTask;
+import org.elasticsearch.cluster.LocalMasterServiceTask;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.ClusterFormationFailureHelper.ClusterFormationState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
@@ -800,7 +800,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     }
 
     private void cleanMasterService() {
-        new LocalClusterUpdateTask(Priority.NORMAL) {
+        new LocalMasterServiceTask(Priority.NORMAL) {
             @Override
             public void onFailure(String source, Exception e) {
                 // ignore

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -800,7 +800,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     }
 
     private void cleanMasterService() {
-        final LocalClusterUpdateTask update = new LocalClusterUpdateTask() {
+        new LocalClusterUpdateTask(Priority.NORMAL) {
             @Override
             public void onFailure(String source, Exception e) {
                 // ignore
@@ -808,15 +808,12 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             }
 
             @Override
-            public ClusterTasksResult<LocalClusterUpdateTask> execute(ClusterState currentState) {
+            public void execute(ClusterState currentState) {
                 if (currentState.nodes().isLocalNodeElectedMaster() == false) {
                     allocationService.cleanCaches();
                 }
-                return unchanged();
             }
-
-        };
-        masterService.submitStateUpdateTask("clean-up after stepping down as master", update, update);
+        }.submit(masterService, "clean-up after stepping down as master");
     }
 
     private PreVoteResponse getPreVoteResponse() {

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -22,7 +22,7 @@ import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.cluster.LocalClusterUpdateTask;
+import org.elasticsearch.cluster.LocalMasterServiceTask;
 import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.ClusterStatePublisher;
@@ -158,7 +158,7 @@ public class MasterServiceTests extends ESTestCase {
         assertTrue("cluster state update task was executed on a non-master", taskFailed[0]);
 
         final CountDownLatch latch2 = new CountDownLatch(1);
-        new LocalClusterUpdateTask(Priority.NORMAL) {
+        new LocalMasterServiceTask(Priority.NORMAL) {
             @Override
             public void execute(ClusterState currentState) {
                 taskFailed[0] = false;

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -158,12 +158,11 @@ public class MasterServiceTests extends ESTestCase {
         assertTrue("cluster state update task was executed on a non-master", taskFailed[0]);
 
         final CountDownLatch latch2 = new CountDownLatch(1);
-        final LocalClusterUpdateTask updateTask = new LocalClusterUpdateTask() {
+        new LocalClusterUpdateTask(Priority.NORMAL) {
             @Override
-            public ClusterTasksResult<LocalClusterUpdateTask> execute(ClusterState currentState) {
+            public void execute(ClusterState currentState) {
                 taskFailed[0] = false;
                 latch2.countDown();
-                return unchanged();
             }
 
             @Override
@@ -171,8 +170,7 @@ public class MasterServiceTests extends ESTestCase {
                 taskFailed[0] = true;
                 latch2.countDown();
             }
-        };
-        nonMaster.submitStateUpdateTask("test", updateTask, updateTask);
+        }.submit(nonMaster, "test");
         latch2.await();
         assertFalse("non-master cluster state update task was not executed", taskFailed[0]);
 


### PR DESCRIPTION
Today the `LocalClusterUpdateTask` runs an action on the master service
thread as if performing a cluster state update, but all implementations
leave the cluster state unchanged. It would be pretty bad to
unilaterally change the local cluster state like that anyway. This
commit fixes its API to clarify this, and gives it a dedicated
`ClusterStateTaskExecutor` implementation rather than having it execute
itself.

Small followup to #82524