### PR TITLE
ILM step retry safe refresh of the cached phase

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -250,26 +250,19 @@ public final class IndexLifecycleTransition {
 
             Map<String, Phase> policyPhases = policyMetadata.getPolicy().getPhases();
             final LifecycleExecutionState nextStepState;
-            if (policyPhases.get(nextStepKey.getPhase()) == null
-                || policyPhases.get(nextStepKey.getPhase()).getActions().get(nextStepKey.getAction()) == null) {
-                // the failed step's phase or action doesn't exist in the "real" policy anymore so don't refresh the cached phase as that
-                // would block due to not recognizing the new step as part of the policy. we'll honour the cached phase in this case.
-                nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
-                    policyMetadata,
-                    lifecycleState,
-                    nextStepKey,
-                    nowSupplier,
-                    false
-                );
-            } else {
-                nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
-                    policyMetadata,
-                    lifecycleState,
-                    nextStepKey,
-                    nowSupplier,
-                    true
-                );
-            }
+
+            // the failed step's phase or action doesn't exist in the "real" policy anymore so don't refresh the cached phase as that
+            // would block due to not recognizing the new step as part of the policy. we'll honour the cached phase in this case.
+            boolean forcePhaseDefinitionRefresh = policyPhases.get(nextStepKey.getPhase()) != null
+                && policyPhases.get(nextStepKey.getPhase()).getActions().get(nextStepKey.getAction()) != null;
+
+            nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
+                policyMetadata,
+                lifecycleState,
+                nextStepKey,
+                nowSupplier,
+                forcePhaseDefinitionRefresh
+            );
 
             LifecycleExecutionState.Builder retryStepState = LifecycleExecutionState.builder(nextStepState);
             retryStepState.setIsAutoRetryableError(lifecycleState.isAutoRetryableError());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -249,14 +249,14 @@ public final class IndexLifecycleTransition {
                 .get(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings()));
 
             Map<String, Phase> policyPhases = policyMetadata.getPolicy().getPhases();
-            final LifecycleExecutionState nextStepState;
 
-            // the failed step's phase or action doesn't exist in the "real" policy anymore so don't refresh the cached phase as that
-            // would block due to not recognizing the new step as part of the policy. we'll honour the cached phase in this case.
+            // we only refresh the cached phase if the failed step's action is still present in the underlying policy
+            // as otherwise ILM would block due to not recognizing the next step as part of the policy.
+            // if the policy was updated to not contain the action or even phase, we honour the cached phase as it is and do not refresh it
             boolean forcePhaseDefinitionRefresh = policyPhases.get(nextStepKey.getPhase()) != null
                 && policyPhases.get(nextStepKey.getPhase()).getActions().get(nextStepKey.getAction()) != null;
 
-            nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
+            final LifecycleExecutionState nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
                 policyMetadata,
                 lifecycleState,
                 nextStepKey,

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -812,6 +812,74 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertThat(executionState.getFailedStepRetryCount(), is(1));
     }
 
+    public void testMoveToFailedStepDoesntRefreshCachedPhaseWhenUnsafe() {
+        String initialPhaseDefinition = """
+            {
+                    "policy" : "my-policy",
+                    "phase_definition" : {
+                      "min_age" : "20m",
+                      "actions" : {
+                        "rollover" : {
+                          "max_age" : "5s"
+                        },
+                        "set_priority" : {
+                          "priority" : 150
+                        }
+                      }
+                    },
+                    "version" : 1,
+                    "modified_date_in_millis" : 1578521007076
+                  }""";
+        String failedStep = "check-rollover-ready";
+        LifecycleExecutionState.Builder currentExecutionState = LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep(ErrorStep.NAME)
+            .setFailedStep(failedStep)
+            // the phase definition contains the rollover action, but the actual policy does not contain rollover anymore
+            .setPhaseDefinition(initialPhaseDefinition);
+
+        IndexMetadata meta = buildIndexMetadata("my-policy", currentExecutionState);
+        String indexName = meta.getIndex().getName();
+
+        Map<String, LifecycleAction> actions = new HashMap<>();
+        actions.put("set_priority", new SetPriorityAction(100));
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
+        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
+        LifecyclePolicy currentPolicy = new LifecyclePolicy("my-policy", phases);
+
+        List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
+        policyMetadatas.add(
+            new LifecyclePolicyMetadata(currentPolicy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong())
+        );
+
+        Step.StepKey errorStepKey = new Step.StepKey("hot", RolloverAction.NAME, ErrorStep.NAME);
+        PolicyStepsRegistry stepsRegistry = createOneStepPolicyStepRegistry("my-policy", new ErrorStep(errorStepKey));
+
+        ClusterState clusterState = buildClusterState(
+            indexName,
+            Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, "my-policy"),
+            currentExecutionState.build(),
+            policyMetadatas
+        );
+        ClusterState newState = IndexLifecycleTransition.moveClusterStateToPreviouslyFailedStep(
+            clusterState,
+            indexName,
+            ESTestCase::randomNonNegativeLong,
+            stepsRegistry,
+            false
+        );
+
+        IndexMetadata indexMetadata = newState.metadata().index(indexName);
+        LifecycleExecutionState nextLifecycleExecutionState = LifecycleExecutionState.fromIndexMetadata(indexMetadata);
+        assertThat(
+            "we musn't refresh the cache definition if the failed step is not part of the real policy anymore",
+            nextLifecycleExecutionState.getPhaseDefinition(),
+            is(initialPhaseDefinition)
+        );
+        assertThat(nextLifecycleExecutionState.getStep(), is(failedStep));
+    }
+
     public void testRefreshPhaseJson() throws IOException {
         LifecycleExecutionState.Builder exState = LifecycleExecutionState.builder()
             .setPhase("hot")


### PR DESCRIPTION
When ILM retries a step (moving from the ERROR step back to the
failed_step) we always refreshed the ILM cached phase (the use case here
was that the policy might've been changed for an index due to
accidentally configuring the wrong policy).

In the case when the `failed_step` doesn't exit in the policy though,
refreshing the cached phase would block ILM as the retried step (the
`failed_step`) would not be recognized anymore.

This commit changes retrying an ILM step to only refresh the cached
phase if the failed_step's action and phase are still present in the
policy. If the action or even phase were removed, ILM will honour the
cached phase.

Fixes #81921 
