### PR TITLE
[8.0] Make TaskBatcher Less Lock-Heavy (#82227)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/service/TaskBatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TaskBatcherTests.java
@@ -118,9 +118,7 @@ public class TaskBatcherTests extends TaskExecutorTests {
     @Override
     public void testTimedOutTaskCleanedUp() throws Exception {
         super.testTimedOutTaskCleanedUp();
-        synchronized (taskBatcher.tasksPerBatchingKey) {
-            assertTrue("expected empty map but was " + taskBatcher.tasksPerBatchingKey, taskBatcher.tasksPerBatchingKey.isEmpty());
-        }
+        assertTrue("expected empty map but was " + taskBatcher.tasksPerBatchingKey, taskBatcher.tasksPerBatchingKey.isEmpty());
     }
 
     public void testOneExecutorDoesntStarveAnother() throws InterruptedException {
@@ -309,8 +307,8 @@ public class TaskBatcherTests extends TaskExecutorTests {
 
             submitTask("first time", task, ClusterStateTaskConfig.build(Priority.NORMAL), executor, listener);
 
-            final IllegalStateException e = expectThrows(
-                IllegalStateException.class,
+            final AssertionError e = expectThrows(
+                AssertionError.class,
                 () -> submitTask("second time", task, ClusterStateTaskConfig.build(Priority.NORMAL), executor, listener)
             );
             assertThat(e, hasToString(containsString("task [1] with source [second time] is already queued")));


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Make TaskBatcher Less Lock-Heavy (#82227)