### PR TITLE
[8.0] Prevent upgrades to 8.0 from 7.non-last (#82321)

### DIFF
--- a/docs/changelog/82321.yaml
+++ b/docs/changelog/82321.yaml
@@ -1,0 +1,6 @@
+pr: 82321
+summary: Prevent upgrades to 8.0 from 7.non-last
+area: Infra/Core
+type: enhancement
+issues:
+ - 81865

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -136,7 +136,16 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         );
         assertThat(
             illegalStateException.getMessage(),
-            allOf(startsWith("cannot upgrade a node from version ["), endsWith("] directly to version [" + Version.CURRENT + "]"))
+            allOf(
+                startsWith("cannot upgrade a node from version ["),
+                endsWith(
+                    "] directly to version ["
+                        + Version.CURRENT
+                        + "], upgrade to version ["
+                        + Version.CURRENT.minimumCompatibilityVersion()
+                        + "] first."
+                )
+            )
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -92,14 +92,19 @@ public final class NodeMetadata {
     }
 
     public NodeMetadata upgradeToCurrentVersion() {
-        if (nodeVersion.equals(Version.V_EMPTY)) {
-            assert Version.CURRENT.major <= Version.V_7_0_0.major + 1 : "version is required in the node metadata from v9 onwards";
-            return new NodeMetadata(nodeId, Version.CURRENT, Version.V_EMPTY);
-        }
+        assert (nodeVersion.equals(Version.V_EMPTY) == false) || (Version.CURRENT.major <= Version.V_7_0_0.major + 1)
+            : "version is required in the node metadata from v9 onwards";
 
-        if (nodeVersion.before(Version.CURRENT.minimumIndexCompatibilityVersion())) {
+        if (nodeVersion.before(Version.CURRENT.minimumCompatibilityVersion())) {
             throw new IllegalStateException(
-                "cannot upgrade a node from version [" + nodeVersion + "] directly to version [" + Version.CURRENT + "]"
+                "cannot upgrade a node from version ["
+                    + nodeVersion
+                    + "] directly to version ["
+                    + Version.CURRENT
+                    + "], "
+                    + "upgrade to version ["
+                    + Version.CURRENT.minimumCompatibilityVersion()
+                    + "] first."
             );
         }
 

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -73,7 +73,7 @@ public class NodeMetadataTests extends ESTestCase {
         final NodeMetadata nodeMetadata = new NodeMetadata(
             nodeId,
             randomValueOtherThanMany(
-                v -> v.after(Version.CURRENT) || v.before(Version.CURRENT.minimumIndexCompatibilityVersion()),
+                v -> v.after(Version.CURRENT) || v.before(Version.CURRENT.minimumCompatibilityVersion()),
                 this::randomVersion
             )
         ).upgradeToCurrentVersion();
@@ -83,9 +83,15 @@ public class NodeMetadataTests extends ESTestCase {
 
     public void testUpgradesMissingVersion() {
         final String nodeId = randomAlphaOfLength(10);
-        final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, Version.V_EMPTY).upgradeToCurrentVersion();
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
-        assertThat(nodeMetadata.nodeId(), equalTo(nodeId));
+
+        final IllegalStateException illegalStateException = expectThrows(
+            IllegalStateException.class,
+            () -> new NodeMetadata(nodeId, Version.V_EMPTY).upgradeToCurrentVersion()
+        );
+        assertThat(
+            illegalStateException.getMessage(),
+            startsWith("cannot upgrade a node from version [" + Version.V_EMPTY + "] directly to version [" + Version.CURRENT + "]")
+        );
     }
 
     public void testDoesNotUpgradeFutureVersion() {
@@ -106,13 +112,23 @@ public class NodeMetadataTests extends ESTestCase {
         );
         assertThat(
             illegalStateException.getMessage(),
-            allOf(startsWith("cannot upgrade a node from version ["), endsWith("] directly to version [" + Version.CURRENT + "]"))
+            allOf(
+                startsWith("cannot upgrade a node from version ["),
+                endsWith(
+                    "] directly to version ["
+                        + Version.CURRENT
+                        + "], upgrade to version ["
+                        + Version.CURRENT.minimumCompatibilityVersion()
+                        + "] first."
+                )
+            )
         );
     }
 
     public void testUpgradeMarksPreviousVersion() {
         final String nodeId = randomAlphaOfLength(10);
-        final Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_3_0, Version.V_7_16_0);
+        final Version version = VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0);
+
         final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, version).upgradeToCurrentVersion();
         assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
         assertThat(nodeMetadata.previousNodeVersion(), equalTo(version));
@@ -123,6 +139,6 @@ public class NodeMetadataTests extends ESTestCase {
     }
 
     public static Version tooOldVersion() {
-        return Version.fromId(between(1, Version.CURRENT.minimumIndexCompatibilityVersion().id - 1));
+        return Version.fromId(between(1, Version.CURRENT.minimumCompatibilityVersion().id - 1));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
@@ -26,7 +26,10 @@ import static org.hamcrest.Matchers.is;
 public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testFailureUpgradeFrom7xWithImplicitSecuritySettings() throws Exception {
-        final Version previousVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_2_0, Version.V_7_16_0);
+        final Version previousVersion = randomValueOtherThan(
+            Version.V_8_0_0,
+            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion);
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata).check(
@@ -52,7 +55,10 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom7xWithImplicitSecuritySettingsOnGoldPlus() throws Exception {
-        final Version previousVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_2_0, Version.V_7_16_0);
+        final Version previousVersion = randomValueOtherThan(
+            Version.V_8_0_0,
+            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion);
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata).check(
@@ -62,7 +68,10 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom7xWithExplicitSecuritySettings() throws Exception {
-        final Version previousVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_2_0, Version.V_7_16_0);
+        final Version previousVersion = randomValueOtherThan(
+            Version.V_8_0_0,
+            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion);
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata).check(


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Prevent upgrades to 8.0 from 7.non-last (#82321)