### PR TITLE
[7.16] Allow clearing blocks on managed system indices (#82507)

### DIFF
--- a/docs/changelog/82507.yaml
+++ b/docs/changelog/82507.yaml
@@ -1,0 +1,6 @@
+pr: 82507
+summary: Allow clearing blocks on managed system indices
+area: Infra/Core
+type: bug
+issues:
+  - 80814

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
@@ -13,6 +13,8 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
@@ -36,6 +38,7 @@ import static org.elasticsearch.indices.TestSystemIndexDescriptor.PRIMARY_INDEX_
 import static org.elasticsearch.test.XContentTestUtils.convertToXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SystemIndexManagerIT extends ESIntegTestCase {
@@ -94,6 +97,30 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
 
         // Mappings should be unchanged.
         assertBusy(() -> assertMappingsAndSettings(TestSystemIndexDescriptor.getNewMappings()));
+    }
+
+    /**
+     * Ensures that we can clear any blocks that get set on managed system indices.
+     *
+     * See https://github.com/elastic/elasticsearch/issues/80814
+     */
+    public void testBlocksCanBeClearedFromManagedSystemIndices() throws Exception {
+        internalCluster().startNodes(1);
+
+        // Trigger the creation of the system index
+        assertAcked(prepareCreate(INDEX_NAME));
+        ensureGreen(INDEX_NAME);
+
+        for (IndexMetadata.APIBlock blockType : IndexMetadata.APIBlock.values()) {
+            enableIndexBlock(INDEX_NAME, blockType.settingName());
+
+            AcknowledgedResponse removeBlockResp = client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put(blockType.settingName(), false))
+                .get();
+            assertThat(removeBlockResp.isAcknowledged(), is(true));
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.indices.SystemIndexManager.MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST;
+
 public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNodeAction<UpdateSettingsRequest> {
 
     private static final Logger logger = LogManager.getLogger(TransportUpdateSettingsAction.class);
@@ -157,6 +159,10 @@ public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNo
                 final Settings descriptorSettings = descriptor.getSettings();
                 List<String> failedKeys = new ArrayList<>();
                 for (String key : requestSettings.keySet()) {
+                    if (MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST.contains(key)) {
+                        // Don't check the setting if it's on the allowlist.
+                        continue;
+                    }
                     final String expectedValue = descriptorSettings.get(key);
                     final String actualValue = requestSettings.get(key);
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -32,8 +32,11 @@ import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.xcontent.XContentType;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -47,6 +50,16 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_FORMAT_SETT
  */
 public class SystemIndexManager implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(SystemIndexManager.class);
+
+    public static final Set<String> MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST;
+    static {
+        Set<String> allowlist = new HashSet<>();
+        // Add all the blocks, we need to be able to clear those
+        for (IndexMetadata.APIBlock blockType : IndexMetadata.APIBlock.values()) {
+            allowlist.add(blockType.settingName());
+        }
+        MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST = Collections.unmodifiableSet(allowlist);
+    }
 
     private final SystemIndices systemIndices;
     private final Client client;


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Allow clearing blocks on managed system indices (#82507)