### PR TITLE
[ML] fixes categorize_text parameter validation to be parse order independent

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
@@ -153,6 +153,13 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
     }
 
     public CategorizeTextAggregationBuilder setCategorizationAnalyzerConfig(CategorizationAnalyzerConfig categorizationAnalyzerConfig) {
+        if (this.categorizationAnalyzerConfig != null) {
+            throw ExceptionsHelper.badRequestException(
+                "[{}] cannot be used with [{}] - instead specify them as pattern_replace char_filters in the analyzer",
+                CATEGORIZATION_FILTERS.getPreferredName(),
+                CATEGORIZATION_ANALYZER.getPreferredName()
+            );
+        }
         this.categorizationAnalyzerConfig = categorizationAnalyzerConfig;
         return this;
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
@@ -204,3 +204,21 @@ setup:
               }
             }
           }
+
+  - do:
+      catch: /\[categorization_filters\] cannot be used with \[categorization_analyzer\]/
+      search:
+        index: to_categorize
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "categories": {
+                "categorize_text": {
+                  "field": "text",
+                  "categorization_analyzer": "english",
+                  "categorization_filters": ["foo"]
+                }
+              }
+            }
+          }


### PR DESCRIPTION
Depending on how the input is parsed, we may not validate that the categorization_analyzer isn't set when the filters are present.

This commit addresses this bug.

closes https://github.com/elastic/elasticsearch/issues/82629