### PR TITLE
Fixing the following vulnerabilities: CVE-2020-28491, CVE-2020-25649

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -9,7 +9,7 @@ checkstyle = 8.45.1
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0
-jackson           = 2.10.4
+jackson           = 2.11.4
 snakeyaml         = 1.26
 icu4j             = 68.2
 supercsv          = 2.4.0


### PR DESCRIPTION
Changing jackson version to 2.11.4.

Below can be found the table with more description of these security vulnerabilities:

|CVE | Package | Version | Severity | Status|
|-- | -- | -- | -- | --|
|CVE-2020-28491 | com.fasterxml.jackson.dataformat_jackson-dataformat-cbor | 2.10.4 | high | fixed in 2.11.4, 2.12.1|
|CVE-2020-25649 | com.fasterxml.jackson.core_jackson-databind | 2.10.4 | high | fixed in 2.10.5.1, 2.9.10.7, 2|
