### PR TITLE
Introduce ClusterStateTaskListener#clusterStateUnchanged

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -33,11 +33,20 @@ public interface ClusterStateTaskListener {
 
     /**
      * Called when the result of the {@link ClusterStateTaskExecutor#execute(ClusterState, List)} have been processed
-     * properly by all listeners.
+     * properly by all listeners and a new cluster state was successfully published and applied.
+     *
+     * Also called by default by {@link #clusterStateUnchanged}, so that implementations can override this one method to handle both cases.
      *
      * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the master service at {@code ERROR}
      * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
      * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
     default void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
+
+    /**
+     * Called when the task was executed but the cluster state was unchanged.
+     */
+    default void clusterStateUnchanged(String source, ClusterState clusterState) {
+        clusterStateProcessed(source, clusterState, clusterState);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -108,13 +108,11 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         }
 
         @Override
-        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-            if (oldState == newState) {
-                // no state changed, check when we should remove the delay flag from the shards the next time.
-                // if cluster state changed, we can leave the scheduling of the next delay up to the clusterChangedEvent
-                // this should not be needed, but we want to be extra safe here
-                scheduleIfNeeded(currentNanoTime(), newState);
-            }
+        public void clusterStateUnchanged(String source, ClusterState clusterState) {
+            // no state changed, check when we should remove the delay flag from the shards the next time.
+            // if cluster state changed, we can leave the scheduling of the next delay up to the clusterChangedEvent
+            // this should not be needed, but we want to be extra safe here
+            scheduleIfNeeded(currentNanoTime(), clusterState);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -250,6 +250,11 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 }
 
                 @Override
+                public void clusterStateUnchanged(String source, ClusterState clusterState) {
+                    publicationStep.onResponse(false);
+                }
+
+                @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     if (changed) {
                         if (found) {
@@ -258,7 +263,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                             logger.info("put repository [{}]", request.name());
                         }
                     }
-                    publicationStep.onResponse(oldState != newState);
+                    publicationStep.onResponse(true);
                 }
             },
             ClusterStateTaskExecutor.unbatched()

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -497,6 +497,15 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
 
                 @Override
+                public void clusterStateUnchanged(String source, ClusterState clusterState) {
+                    if (executedTask) {
+                        updateTask.clusterStateUnchanged(source, clusterState);
+                    } else {
+                        executeConsistentStateUpdate(createUpdateTask, source, onFailure);
+                    }
+                }
+
+                @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     if (executedTask) {
                         updateTask.clusterStateProcessed(source, oldState, newState);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1456,6 +1456,14 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         }
 
                         @Override
+                        public void clusterStateUnchanged(String source, ClusterState clusterState) {
+                            ClusterState state = committedStatesByVersion.get(clusterState.version());
+                            assertNotNull("State not committed : " + clusterState, state);
+                            logger.trace("successfully processed noop: [{}]", clusterState);
+                            taskListener.clusterStateUnchanged(source, clusterState);
+                        }
+
+                        @Override
                         public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                             updateCommittedStates();
                             ClusterState state = committedStatesByVersion.get(newState.version());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -206,7 +206,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
     }
 
     @Override
-    public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(String source, ClusterState newState) {
         IndexMetadata indexMetadata = newState.metadata().index(index);
         if (indexMetadata != null) {
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -60,9 +60,10 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
 
     @Override
     public final void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        assert executed;
         listener.onResponse(null);
-        onClusterStateProcessed(source, newState);
+        if (executed) {
+            onClusterStateProcessed(source, newState);
+        } // else this update was a no-op but was batched with some other nontrivial updates
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -314,21 +314,22 @@ class IndexLifecycleRunner {
                     }
 
                     @Override
+                    public void clusterStateUnchanged(String source, ClusterState clusterState) {}
+
+                    @Override
                     public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        if (oldState.equals(newState) == false) {
-                            IndexMetadata newIndexMeta = newState.metadata().index(index);
-                            Step indexMetaCurrentStep = getCurrentStep(stepRegistry, policy, newIndexMeta);
-                            StepKey stepKey = indexMetaCurrentStep.getKey();
-                            if (stepKey != null && stepKey != TerminalPolicyStep.KEY && newIndexMeta != null) {
-                                logger.trace(
-                                    "policy [{}] for index [{}] was moved back on the failed step for as part of an automatic "
-                                        + "retry. Attempting to execute the failed step [{}] if it's an async action",
-                                    policy,
-                                    index,
-                                    stepKey
-                                );
-                                maybeRunAsyncAction(newState, newIndexMeta, policy, stepKey);
-                            }
+                        IndexMetadata newIndexMeta = newState.metadata().index(index);
+                        Step indexMetaCurrentStep = getCurrentStep(stepRegistry, policy, newIndexMeta);
+                        StepKey stepKey = indexMetaCurrentStep.getKey();
+                        if (stepKey != null && stepKey != TerminalPolicyStep.KEY && newIndexMeta != null) {
+                            logger.trace(
+                                "policy [{}] for index [{}] was moved back on the failed step for as part of an automatic "
+                                    + "retry. Attempting to execute the failed step [{}] if it's an async action",
+                                policy,
+                                index,
+                                stepKey
+                            );
+                            maybeRunAsyncAction(newState, newIndexMeta, policy, stepKey);
                         }
                     }
                 },

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
@@ -78,10 +78,11 @@ public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
+    public void clusterStateUnchanged(String source, ClusterState clusterState) {}
+
+    @Override
     public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        if (newState.equals(oldState) == false) {
-            stateChangeConsumer.accept(newState);
-        }
+        stateChangeConsumer.accept(newState);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -69,7 +69,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
     }
 
     @Override
-    public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(String source, ClusterState newState) {
         stateChangeConsumer.accept(newState);
     }
 


### PR DESCRIPTION
The `ClusterStateTaskListener#clusterStateProcessed` callback receives
the old and new cluster states. It's a bit odd to have the behaviour of
this method depend on the old cluster state, but on closer inspection
most `ClusterStateTaskListener` implementations only use it to determine
whether a cluster state was published or not. This commit introduces
`ClusterStateTaskListener#clusterStateUnchanged` to allow tasks to
distinguish these two cases without needing to compare the two cluster
states.