### PR TITLE
Drop source from CSTaskListener failure handlers

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
@@ -52,8 +52,8 @@ public class ClusterStateRestCancellationIT extends HttpSmokeTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
-                throw new AssertionError(source, e);
+            public void onFailure(Exception e) {
+                throw new AssertionError("update state", e);
             }
 
             @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -293,9 +293,9 @@ public class ClusterHealthIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 completionFuture.onFailure(e);
-                throw new AssertionError(source, e);
+                throw new AssertionError("looping task", e);
             }
 
             @Override
@@ -384,9 +384,9 @@ public class ClusterHealthIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 completionFuture.onFailure(e);
-                throw new AssertionError(source, e);
+                throw new AssertionError("looping task", e);
             }
 
             @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -351,7 +351,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 failure.set(e);
                 latch.countDown();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -464,7 +464,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
                                 }
 
                                 @Override
-                                public void onFailure(String source, Exception e) {
+                                public void onFailure(Exception e) {
                                     throw new AssertionError(e);
                                 }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -108,7 +108,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {}
+            public void onFailure(Exception e) {}
         }, ClusterStateTaskExecutor.unbatched());
         ensureGreen(index);
         // remove the extra node
@@ -123,7 +123,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {}
+            public void onFailure(Exception e) {}
         }, ClusterStateTaskExecutor.unbatched());
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.cluster.service;
 
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
@@ -80,8 +79,8 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
-                    logger.error(() -> new ParameterizedMessage("failed to execute callback in test {}", source), e);
+                public void onFailure(Exception e) {
+                    logger.error("failed to execute callback in test", e);
                     onFailure.set(true);
                     latch.countDown();
                 }
@@ -137,8 +136,8 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
-                    logger.error(() -> new ParameterizedMessage("failed to execute callback in test {}", source), e);
+                public void onFailure(Exception e) {
+                    logger.error("failed to execute callback in test", e);
                     onFailure.set(true);
                     latch.countDown();
                 }
@@ -197,8 +196,8 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
-                    logger.error(() -> new ParameterizedMessage("failed to execute callback in test {}", source), e);
+                public void onFailure(Exception e) {
+                    logger.error("failed to execute callback in test", e);
                     onFailure.set(true);
                     latch.countDown();
                 }
@@ -257,8 +256,8 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
-                    logger.error(() -> new ParameterizedMessage("failed to execute callback in test {}", source), e);
+                public void onFailure(Exception e) {
+                    logger.error("failed to execute callback in test", e);
                     onFailure.set(true);
                     latch.countDown();
                 }
@@ -297,7 +296,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 invoked1.countDown();
                 fail();
             }
@@ -312,7 +311,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
 
@@ -367,7 +366,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 invoked3.countDown();
                 fail();
             }
@@ -382,7 +381,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.discovery;
 
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -242,8 +241,8 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
-                    logger.warn(() -> new ParameterizedMessage("failure [{}]", source), e);
+                public void onFailure(Exception e) {
+                    logger.warn("failure [sneaky-update]", e);
                 }
             }, ClusterStateTaskExecutor.unbatched());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -156,7 +156,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     throw new AssertionError("unexpected", e);
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -193,7 +193,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     throw new AssertionError("unexpected", e);
                 }
             }, ClusterStateTaskExecutor.unbatched());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -118,7 +118,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -145,7 +145,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -108,6 +108,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         final long endTimeRelativeMillis
     ) {
         assert request.waitForEvents() != null;
+        final String source = "cluster_health (wait_for_events [" + request.waitForEvents() + "])";
         if (request.local()) {
             new LocalMasterServiceTask(request.waitForEvents()) {
                 @Override
@@ -125,63 +126,55 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
                     listener.onFailure(e);
                 }
-            }.submit(clusterService.getMasterService(), "cluster_health (wait_for_events [" + request.waitForEvents() + "])");
+            }.submit(clusterService.getMasterService(), source);
         } else {
             final TimeValue taskTimeout = TimeValue.timeValueMillis(Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis()));
-            clusterService.submitStateUpdateTask(
-                "cluster_health (wait_for_events [" + request.waitForEvents() + "])",
-                new ClusterStateUpdateTask(request.waitForEvents(), taskTimeout) {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        return currentState;
-                    }
+            clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(request.waitForEvents(), taskTimeout) {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    return currentState;
+                }
 
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        final long timeoutInMillis = Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis());
-                        final TimeValue newTimeout = TimeValue.timeValueMillis(timeoutInMillis);
-                        request.timeout(newTimeout);
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    final long timeoutInMillis = Math.max(0, endTimeRelativeMillis - threadPool.relativeTimeInMillis());
+                    final TimeValue newTimeout = TimeValue.timeValueMillis(timeoutInMillis);
+                    request.timeout(newTimeout);
 
-                        // we must use the state from the applier service, because if the state-not-recovered block is in place then the
-                        // applier service has a different view of the cluster state from the one supplied here
-                        final ClusterState appliedState = clusterService.state();
-                        assert newState.stateUUID().equals(appliedState.stateUUID())
-                            : newState.stateUUID() + " vs " + appliedState.stateUUID();
-                        executeHealth(
-                            request,
-                            appliedState,
-                            listener,
-                            waitCount,
-                            observedState -> waitForEventsAndExecuteHealth(request, listener, waitCount, endTimeRelativeMillis)
-                        );
-                    }
+                    // we must use the state from the applier service, because if the state-not-recovered block is in place then the
+                    // applier service has a different view of the cluster state from the one supplied here
+                    final ClusterState appliedState = clusterService.state();
+                    assert newState.stateUUID().equals(appliedState.stateUUID()) : newState.stateUUID() + " vs " + appliedState.stateUUID();
+                    executeHealth(
+                        request,
+                        appliedState,
+                        listener,
+                        waitCount,
+                        observedState -> waitForEventsAndExecuteHealth(request, listener, waitCount, endTimeRelativeMillis)
+                    );
+                }
 
-                    @Override
-                    public void onNoLongerMaster(String source) {
-                        logger.trace(
-                            "stopped being master while waiting for events with priority [{}]. retrying.",
-                            request.waitForEvents()
-                        );
-                        // TransportMasterNodeAction implements the retry logic, which is triggered by passing a NotMasterException
-                        listener.onFailure(new NotMasterException("no longer master. source: [" + source + "]"));
-                    }
+                @Override
+                public void onNoLongerMaster() {
+                    logger.trace("stopped being master while waiting for events with priority [{}]. retrying.", request.waitForEvents());
+                    // TransportMasterNodeAction implements the retry logic, which is triggered by passing a NotMasterException
+                    listener.onFailure(new NotMasterException("no longer master. source: [" + source + "]"));
+                }
 
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        if (e instanceof ProcessClusterEventTimeoutException) {
-                            listener.onResponse(getResponse(request, clusterService.state(), waitCount, TimeoutState.TIMED_OUT));
-                        } else {
-                            logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
-                            listener.onFailure(e);
-                        }
+                @Override
+                public void onFailure(Exception e) {
+                    if (e instanceof ProcessClusterEventTimeoutException) {
+                        listener.onResponse(getResponse(request, clusterService.state(), waitCount, TimeoutState.TIMED_OUT));
+                    } else {
+                        logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+                        listener.onFailure(e);
                     }
-                },
-                ClusterStateTaskExecutor.unbatched()
-            );
+                }
+            }, ClusterStateTaskExecutor.unbatched());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -118,7 +118,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                         }
 
                         @Override
-                        public void onFailure(String source, Exception e) {
+                        public void onFailure(Exception e) {
                             logger.warn("Failed to remove repository cleanup task [{}] from cluster state", repositoryCleanupInProgress);
                         }
                     },
@@ -219,7 +219,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         after(e, null);
                     }
 
@@ -268,7 +268,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                                 }
 
                                 @Override
-                                public void onFailure(String source, Exception e) {
+                                public void onFailure(Exception e) {
                                     if (failure != null) {
                                         e.addSuppressed(failure);
                                     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.admin.cluster.reroute;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -208,7 +207,7 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
 
         @Override
         public void onFailure(Exception e) {
-            logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", TASK_SOURCE), e);
+            logger.debug("failed to perform [" + TASK_SOURCE + "]", e);
             super.onFailure(e);
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -159,9 +159,11 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
         );
     }
 
+    private static final String TASK_SOURCE = "cluster_reroute (api)";
+
     private void submitStateUpdate(final ClusterRerouteRequest request, final ActionListener<ClusterRerouteResponse> listener) {
         clusterService.submitStateUpdateTask(
-            "cluster_reroute (api)",
+            TASK_SOURCE,
             new ClusterRerouteResponseAckedClusterStateUpdateTask(logger, allocationService, request, listener.map(response -> {
                 if (request.dryRun() == false) {
                     response.getExplanations().getYesDecisionMessages().forEach(logger::info);
@@ -205,9 +207,9 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
-            logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", source), e);
-            super.onFailure(source, e);
+        public void onFailure(Exception e) {
+            logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", TASK_SOURCE), e);
+            super.onFailure(e);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -130,6 +130,9 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         return true;
     }
 
+    private static final String UPDATE_TASK_SOURCE = "cluster_update_settings";
+    private static final String REROUTE_TASK_SOURCE = "reroute_after_cluster_update_settings";
+
     @Override
     protected void masterOperation(
         Task task,
@@ -138,127 +141,119 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         final ActionListener<ClusterUpdateSettingsResponse> listener
     ) {
         final SettingsUpdater updater = new SettingsUpdater(clusterSettings);
-        clusterService.submitStateUpdateTask(
-            "cluster_update_settings",
-            new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
+        clusterService.submitStateUpdateTask(UPDATE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
 
-                private volatile boolean changed = false;
+            private volatile boolean changed = false;
 
-                @Override
-                protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
-                    return new ClusterUpdateSettingsResponse(acknowledged, updater.getTransientUpdates(), updater.getPersistentUpdate());
+            @Override
+            protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
+                return new ClusterUpdateSettingsResponse(acknowledged, updater.getTransientUpdates(), updater.getPersistentUpdate());
+            }
+
+            @Override
+            public void onAllNodesAcked(@Nullable Exception e) {
+                if (changed) {
+                    reroute(true);
+                } else {
+                    super.onAllNodesAcked(e);
+                }
+            }
+
+            @Override
+            public void onAckTimeout() {
+                if (changed) {
+                    reroute(false);
+                } else {
+                    super.onAckTimeout();
+                }
+            }
+
+            private void reroute(final boolean updateSettingsAcked) {
+                // We're about to send a second update task, so we need to check if we're still the elected master
+                // For example the minimum_master_node could have been breached and we're no longer elected master,
+                // so we should *not* execute the reroute.
+                if (clusterService.state().nodes().isLocalNodeElectedMaster() == false) {
+                    logger.debug("Skipping reroute after cluster update settings, because node is no longer master");
+                    listener.onResponse(
+                        new ClusterUpdateSettingsResponse(updateSettingsAcked, updater.getTransientUpdates(), updater.getPersistentUpdate())
+                    );
+                    return;
                 }
 
-                @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
-                    if (changed) {
-                        reroute(true);
-                    } else {
-                        super.onAllNodesAcked(e);
-                    }
-                }
+                // The reason the reroute needs to be send as separate update task, is that all the *cluster* settings are encapsulate
+                // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
+                // to the components until the ClusterStateListener instances have been invoked, but are visible after
+                // the first update task has been completed.
+                clusterService.submitStateUpdateTask(
+                    REROUTE_TASK_SOURCE,
+                    new AckedClusterStateUpdateTask(Priority.URGENT, request, listener) {
 
-                @Override
-                public void onAckTimeout() {
-                    if (changed) {
-                        reroute(false);
-                    } else {
-                        super.onAckTimeout();
-                    }
-                }
+                        @Override
+                        public boolean mustAck(DiscoveryNode discoveryNode) {
+                            // we wait for the reroute ack only if the update settings was acknowledged
+                            return updateSettingsAcked;
+                        }
 
-                private void reroute(final boolean updateSettingsAcked) {
-                    // We're about to send a second update task, so we need to check if we're still the elected master
-                    // For example the minimum_master_node could have been breached and we're no longer elected master,
-                    // so we should *not* execute the reroute.
-                    if (clusterService.state().nodes().isLocalNodeElectedMaster() == false) {
-                        logger.debug("Skipping reroute after cluster update settings, because node is no longer master");
-                        listener.onResponse(
-                            new ClusterUpdateSettingsResponse(
-                                updateSettingsAcked,
+                        @Override
+                        // we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the
+                        // update settings was acknowledged
+                        protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
+                            return new ClusterUpdateSettingsResponse(
+                                updateSettingsAcked && acknowledged,
                                 updater.getTransientUpdates(),
                                 updater.getPersistentUpdate()
-                            )
-                        );
-                        return;
-                    }
+                            );
+                        }
 
-                    // The reason the reroute needs to be send as separate update task, is that all the *cluster* settings are encapsulate
-                    // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
-                    // to the components until the ClusterStateListener instances have been invoked, but are visible after
-                    // the first update task has been completed.
-                    clusterService.submitStateUpdateTask(
-                        "reroute_after_cluster_update_settings",
-                        new AckedClusterStateUpdateTask(Priority.URGENT, request, listener) {
-
-                            @Override
-                            public boolean mustAck(DiscoveryNode discoveryNode) {
-                                // we wait for the reroute ack only if the update settings was acknowledged
-                                return updateSettingsAcked;
-                            }
-
-                            @Override
-                            // we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the
-                            // update settings was acknowledged
-                            protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
-                                return new ClusterUpdateSettingsResponse(
-                                    updateSettingsAcked && acknowledged,
+                        @Override
+                        public void onNoLongerMaster() {
+                            logger.debug(
+                                "failed to preform reroute after cluster settings were updated - current node is no longer a master"
+                            );
+                            listener.onResponse(
+                                new ClusterUpdateSettingsResponse(
+                                    updateSettingsAcked,
                                     updater.getTransientUpdates(),
                                     updater.getPersistentUpdate()
-                                );
-                            }
+                                )
+                            );
+                        }
 
-                            @Override
-                            public void onNoLongerMaster(String source) {
-                                logger.debug(
-                                    "failed to preform reroute after cluster settings were updated - current node is no longer a master"
-                                );
-                                listener.onResponse(
-                                    new ClusterUpdateSettingsResponse(
-                                        updateSettingsAcked,
-                                        updater.getTransientUpdates(),
-                                        updater.getPersistentUpdate()
-                                    )
-                                );
-                            }
+                        @Override
+                        public void onFailure(Exception e) {
+                            // if the reroute fails we only log
+                            logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
+                            listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
+                        }
 
-                            @Override
-                            public void onFailure(String source, Exception e) {
-                                // if the reroute fails we only log
-                                logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", source), e);
-                                listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
-                            }
+                        @Override
+                        public ClusterState execute(final ClusterState currentState) {
+                            // now, reroute in case things that require it changed (e.g. number of replicas)
+                            return allocationService.reroute(currentState, "reroute after cluster update settings");
+                        }
+                    },
+                    ClusterStateTaskExecutor.unbatched()
+                );
+            }
 
-                            @Override
-                            public ClusterState execute(final ClusterState currentState) {
-                                // now, reroute in case things that require it changed (e.g. number of replicas)
-                                return allocationService.reroute(currentState, "reroute after cluster update settings");
-                            }
-                        },
-                        ClusterStateTaskExecutor.unbatched()
-                    );
-                }
+            @Override
+            public void onFailure(Exception e) {
+                logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", UPDATE_TASK_SOURCE), e);
+                super.onFailure(e);
+            }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", source), e);
-                    super.onFailure(source, e);
-                }
-
-                @Override
-                public ClusterState execute(final ClusterState currentState) {
-                    final ClusterState clusterState = updater.updateSettings(
-                        currentState,
-                        clusterSettings.upgradeSettings(request.transientSettings()),
-                        clusterSettings.upgradeSettings(request.persistentSettings()),
-                        logger
-                    );
-                    changed = clusterState != currentState;
-                    return clusterState;
-                }
-            },
-            ClusterStateTaskExecutor.unbatched()
-        );
+            @Override
+            public ClusterState execute(final ClusterState currentState) {
+                final ClusterState clusterState = updater.updateSettings(
+                    currentState,
+                    clusterSettings.upgradeSettings(request.transientSettings()),
+                    clusterSettings.upgradeSettings(request.persistentSettings()),
+                    logger
+                );
+                changed = clusterState != currentState;
+                return clusterState;
+            }
+        }, ClusterStateTaskExecutor.unbatched());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -316,7 +316,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             listener.onFailure(e);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -72,7 +72,7 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
+    public void onFailure(Exception e) {
         listener.onFailure(e);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskConfig.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskConfig.java
@@ -17,7 +17,7 @@ import org.elasticsearch.core.TimeValue;
 public interface ClusterStateTaskConfig {
     /**
      * The timeout for this cluster state update task configuration. If the cluster state update task isn't processed within this timeout,
-     * the associated {@link ClusterStateTaskListener#onFailure(String, Exception)} is invoked. Tasks arising from client requests should
+     * the associated {@link ClusterStateTaskListener#onFailure(Exception)} is invoked. Tasks arising from client requests should
      * have a timeout which clients can adjust via the {@code ?master_timeout} query parameter, and typically defaults to {@code 30s}. In
      * contrast, internal tasks can reasonably have an infinite timeout, especially if a timeout would simply trigger a retry.
      *

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -18,7 +18,7 @@ public interface ClusterStateTaskListener {
      * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
      * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
-    void onFailure(String source, Exception e);
+    void onFailure(Exception e);
 
     /**
      * A callback for when the task was rejected because the processing node is no longer the elected master.
@@ -27,8 +27,8 @@ public interface ClusterStateTaskListener {
      * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
      * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
-    default void onNoLongerMaster(String source) {
-        onFailure(source, new NotMasterException("no longer master. source: [" + source + "]"));
+    default void onNoLongerMaster() {
+        onFailure(new NotMasterException("no longer master"));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -53,11 +53,11 @@ public abstract class ClusterStateUpdateTask implements ClusterStateTaskConfig, 
      * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
      * using a more specific logger and at a less dramatic log level.
      */
-    public abstract void onFailure(String source, Exception e);
+    public abstract void onFailure(Exception e);
 
     /**
      * If the cluster state update task wasn't processed by the provided timeout, call
-     * {@link ClusterStateTaskListener#onFailure(String, Exception)}. May return null to indicate no timeout is needed (default).
+     * {@link ClusterStateTaskListener#onFailure(Exception)}. May return null to indicate no timeout is needed (default).
      */
     @Nullable
     public final TimeValue timeout() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -307,13 +307,13 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     nodeRemovalExecutor,
                     new ClusterStateTaskListener() {
                         @Override
-                        public void onFailure(final String source, final Exception e) {
-                            logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+                        public void onFailure(final Exception e) {
+                            logger.error("unexpected failure during [node-left]", e);
                         }
 
                         @Override
-                        public void onNoLongerMaster(String source) {
-                            logger.debug("no longer master while processing node removal [{}]", source);
+                        public void onNoLongerMaster() {
+                            logger.debug("no longer master while processing node removal [node-left]");
                         }
 
                         @Override
@@ -802,7 +802,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     private void cleanMasterService() {
         new LocalMasterServiceTask(Priority.NORMAL) {
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 // ignore
                 logger.trace("failed to clean-up after stepping down as master", e);
             }
@@ -1174,7 +1174,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     reconfigurationTaskScheduled.set(false);
                     logger.debug("reconfiguration failed", e);
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -372,7 +372,7 @@ public class JoinHelper {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             joinListener.onFailure(e);
         }
 
@@ -468,8 +468,8 @@ public class JoinHelper {
 
                 final String stateUpdateSource = "elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
 
-                pendingAsTasks.put(JoinTaskExecutor.newBecomeMasterTask(), (source, e) -> {});
-                pendingAsTasks.put(JoinTaskExecutor.newFinishElectionTask(), (source, e) -> {});
+                pendingAsTasks.put(JoinTaskExecutor.newBecomeMasterTask(), (e) -> {});
+                pendingAsTasks.put(JoinTaskExecutor.newFinishElectionTask(), (e) -> {});
                 joinTaskExecutor = joinTaskExecutorGenerator.get();
                 masterService.submitStateUpdateTasks(
                     stateUpdateSource,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -304,13 +304,13 @@ public class MetadataCreateIndexService {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     if (e instanceof ResourceAlreadyExistsException) {
                         logger.trace(() -> new ParameterizedMessage("[{}] failed to create", request.index()), e);
                     } else {
                         logger.debug(() -> new ParameterizedMessage("[{}] failed to create", request.index()), e);
                     }
-                    super.onFailure(source, e);
+                    super.onFailure(e);
                 }
             },
             ClusterStateTaskExecutor.unbatched()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -192,7 +192,7 @@ public class MetadataIndexStateService {
                                                 }
 
                                                 @Override
-                                                public void onFailure(final String source, final Exception e) {
+                                                public void onFailure(final Exception e) {
                                                     listener.onFailure(e);
                                                 }
 
@@ -250,7 +250,7 @@ public class MetadataIndexStateService {
                 }
 
                 @Override
-                public void onFailure(final String source, final Exception e) {
+                public void onFailure(final Exception e) {
                     listener.onFailure(e);
                 }
             },
@@ -500,7 +500,7 @@ public class MetadataIndexStateService {
                                                 }
 
                                                 @Override
-                                                public void onFailure(final String source, final Exception e) {
+                                                public void onFailure(final Exception e) {
                                                     listener.onFailure(e);
                                                 }
 
@@ -525,7 +525,7 @@ public class MetadataIndexStateService {
                 }
 
                 @Override
-                public void onFailure(final String source, final Exception e) {
+                public void onFailure(final Exception e) {
                     listener.onFailure(e);
                 }
             },

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -147,7 +147,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, request.masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 
@@ -202,7 +202,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 
@@ -374,7 +374,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 
@@ -491,7 +491,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 
@@ -831,7 +831,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 
@@ -959,7 +959,7 @@ public class MetadataIndexTemplateService {
             new ClusterStateUpdateTask(Priority.URGENT, request.masterTimeout) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -219,7 +219,7 @@ public class MetadataMappingService {
             new AckedClusterStateTaskListener() {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -130,7 +130,7 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             updateTaskPending = false;
             logger.error("failed to update system index metadata", e);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
@@ -91,7 +91,8 @@ public class BatchedRerouteService implements RerouteService {
             }
         }
         try {
-            clusterService.submitStateUpdateTask(CLUSTER_UPDATE_TASK_SOURCE + "(" + reason + ")", new ClusterStateUpdateTask(priority) {
+            final String source = CLUSTER_UPDATE_TASK_SOURCE + "(" + reason + ")";
+            clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(priority) {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -114,7 +115,7 @@ public class BatchedRerouteService implements RerouteService {
                 }
 
                 @Override
-                public void onNoLongerMaster(String source) {
+                public void onNoLongerMaster() {
                     synchronized (mutex) {
                         if (pendingRerouteListeners == currentListeners) {
                             pendingRerouteListeners = null;
@@ -125,7 +126,7 @@ public class BatchedRerouteService implements RerouteService {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     synchronized (mutex) {
                         if (pendingRerouteListeners == currentListeners) {
                             pendingRerouteListeners = null;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -118,7 +118,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             removeIfSameTask(this);
             logger.warn("failed to schedule/execute reroute post unassigned shard", e);
         }

--- a/server/src/main/java/org/elasticsearch/common/settings/ConsistentSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ConsistentSettingsService.java
@@ -251,7 +251,7 @@ public final class ConsistentSettingsService {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.error("unable to publish secure settings hashes", e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -209,6 +209,8 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
         scheduledRecovery.set(false);
     }
 
+    private static final String TASK_SOURCE = "local-gateway-elected-state";
+
     class RecoverStateUpdateTask extends ClusterStateUpdateTask {
 
         @Override
@@ -235,14 +237,14 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
         }
 
         @Override
-        public void onNoLongerMaster(String source) {
-            logger.debug("stepped down as master before recovering state [{}]", source);
+        public void onNoLongerMaster() {
+            logger.debug("stepped down as master before recovering state [{}]", TASK_SOURCE);
             resetRecoveredFlags();
         }
 
         @Override
-        public void onFailure(final String source, final Exception e) {
-            logger.info(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+        public void onFailure(final Exception e) {
+            logger.info(() -> new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE), e);
             resetRecoveredFlags();
         }
     }
@@ -253,10 +255,6 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
     }
 
     private void runRecovery() {
-        clusterService.submitStateUpdateTask(
-            "local-gateway-elected-state",
-            new RecoverStateUpdateTask(),
-            ClusterStateTaskExecutor.unbatched()
-        );
+        clusterService.submitStateUpdateTask(TASK_SOURCE, new RecoverStateUpdateTask(), ClusterStateTaskExecutor.unbatched());
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -104,7 +104,8 @@ public class LocalAllocateDangledIndices {
             for (int i = 0; i < request.indices.length; i++) {
                 indexNames[i] = request.indices[i].getIndex().getName();
             }
-            clusterService.submitStateUpdateTask("allocation dangled indices " + Arrays.toString(indexNames), new ClusterStateUpdateTask() {
+            final String source = "allocation dangled indices " + Arrays.toString(indexNames);
+            clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     if (currentState.blocks().disableStatePersistence()) {
@@ -217,7 +218,7 @@ public class LocalAllocateDangledIndices {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
                     try {
                         channel.sendResponse(e);

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -126,7 +126,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -185,7 +185,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -216,7 +216,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -259,7 +259,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -300,7 +300,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -394,7 +394,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 reassigningTasks.set(false);
                 logger.warn("failed to reassign persistent tasks", e);
                 if (e instanceof NotMasterException == false) {

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -237,10 +237,10 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.warn(() -> new ParameterizedMessage("failed to create repository [{}]", request.name()), e);
                     publicationStep.onFailure(e);
-                    super.onFailure(source, e);
+                    super.onFailure(e);
                 }
 
                 @Override
@@ -314,7 +314,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -488,9 +488,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     if (executedTask) {
-                        updateTask.onFailure(source, e);
+                        updateTask.onFailure(e);
                     } else {
                         onFailure.accept(e);
                     }
@@ -1818,7 +1818,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                         }
 
                                         @Override
-                                        public void onFailure(String source, Exception e) {
+                                        public void onFailure(Exception e) {
                                             onFailure.accept(e);
                                         }
 
@@ -2069,7 +2069,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(
                         new RepositoryException(
                             metadata.name(),
@@ -2167,75 +2167,76 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         // Step 1: Set repository generation state to the next possible pending generation
         final StepListener<Long> setPendingStep = new StepListener<>();
-        clusterService.submitStateUpdateTask(
-            "set pending repository generation [" + metadata.name() + "][" + expectedGen + "]",
-            new ClusterStateUpdateTask() {
+        final String setPendingGenerationSource = "set pending repository generation [" + metadata.name() + "][" + expectedGen + "]";
+        clusterService.submitStateUpdateTask(setPendingGenerationSource, new ClusterStateUpdateTask() {
 
-                private long newGen;
+            private long newGen;
 
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    final RepositoryMetadata meta = getRepoMetadata(currentState);
-                    final String repoName = metadata.name();
-                    final long genInState = meta.generation();
-                    final boolean uninitializedMeta = meta.generation() == RepositoryData.UNKNOWN_REPO_GEN || bestEffortConsistency;
-                    if (uninitializedMeta == false && meta.pendingGeneration() != genInState) {
-                        logger.info(
-                            "Trying to write new repository data over unfinished write, repo [{}] is at "
-                                + "safe generation [{}] and pending generation [{}]",
-                            meta.name(),
-                            genInState,
-                            meta.pendingGeneration()
-                        );
-                    }
-                    assert expectedGen == RepositoryData.EMPTY_REPO_GEN || uninitializedMeta || expectedGen == meta.generation()
-                        : "Expected non-empty generation [" + expectedGen + "] does not match generation tracked in [" + meta + "]";
-                    // If we run into the empty repo generation for the expected gen, the repo is assumed to have been cleared of
-                    // all contents by an external process so we reset the safe generation to the empty generation.
-                    final long safeGeneration = expectedGen == RepositoryData.EMPTY_REPO_GEN
-                        ? RepositoryData.EMPTY_REPO_GEN
-                        : (uninitializedMeta ? expectedGen : genInState);
-                    // Regardless of whether or not the safe generation has been reset, the pending generation always increments so that
-                    // even if a repository has been manually cleared of all contents we will never reuse the same repository generation.
-                    // This is motivated by the consistency behavior the S3 based blob repository implementation has to support which does
-                    // not offer any consistency guarantees when it comes to overwriting the same blob name with different content.
-                    final long nextPendingGen = metadata.pendingGeneration() + 1;
-                    newGen = uninitializedMeta ? Math.max(expectedGen + 1, nextPendingGen) : nextPendingGen;
-                    assert newGen > latestKnownRepoGen.get()
-                        : "Attempted new generation ["
-                            + newGen
-                            + "] must be larger than latest known generation ["
-                            + latestKnownRepoGen.get()
-                            + "]";
-                    return ClusterState.builder(currentState)
-                        .metadata(
-                            Metadata.builder(currentState.getMetadata())
-                                .putCustom(
-                                    RepositoriesMetadata.TYPE,
-                                    currentState.metadata()
-                                        .<RepositoriesMetadata>custom(RepositoriesMetadata.TYPE)
-                                        .withUpdatedGeneration(repoName, safeGeneration, newGen)
-                                )
-                                .build()
-                        )
-                        .build();
-                }
-
-                @Override
-                public void onFailure(String source, Exception e) {
-                    listener.onFailure(
-                        new RepositoryException(metadata.name(), "Failed to execute cluster state update [" + source + "]", e)
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                final RepositoryMetadata meta = getRepoMetadata(currentState);
+                final String repoName = metadata.name();
+                final long genInState = meta.generation();
+                final boolean uninitializedMeta = meta.generation() == RepositoryData.UNKNOWN_REPO_GEN || bestEffortConsistency;
+                if (uninitializedMeta == false && meta.pendingGeneration() != genInState) {
+                    logger.info(
+                        "Trying to write new repository data over unfinished write, repo [{}] is at "
+                            + "safe generation [{}] and pending generation [{}]",
+                        meta.name(),
+                        genInState,
+                        meta.pendingGeneration()
                     );
                 }
+                assert expectedGen == RepositoryData.EMPTY_REPO_GEN || uninitializedMeta || expectedGen == meta.generation()
+                    : "Expected non-empty generation [" + expectedGen + "] does not match generation tracked in [" + meta + "]";
+                // If we run into the empty repo generation for the expected gen, the repo is assumed to have been cleared of
+                // all contents by an external process so we reset the safe generation to the empty generation.
+                final long safeGeneration = expectedGen == RepositoryData.EMPTY_REPO_GEN
+                    ? RepositoryData.EMPTY_REPO_GEN
+                    : (uninitializedMeta ? expectedGen : genInState);
+                // Regardless of whether or not the safe generation has been reset, the pending generation always increments so that
+                // even if a repository has been manually cleared of all contents we will never reuse the same repository generation.
+                // This is motivated by the consistency behavior the S3 based blob repository implementation has to support which does
+                // not offer any consistency guarantees when it comes to overwriting the same blob name with different content.
+                final long nextPendingGen = metadata.pendingGeneration() + 1;
+                newGen = uninitializedMeta ? Math.max(expectedGen + 1, nextPendingGen) : nextPendingGen;
+                assert newGen > latestKnownRepoGen.get()
+                    : "Attempted new generation ["
+                        + newGen
+                        + "] must be larger than latest known generation ["
+                        + latestKnownRepoGen.get()
+                        + "]";
+                return ClusterState.builder(currentState)
+                    .metadata(
+                        Metadata.builder(currentState.getMetadata())
+                            .putCustom(
+                                RepositoriesMetadata.TYPE,
+                                currentState.metadata()
+                                    .<RepositoriesMetadata>custom(RepositoriesMetadata.TYPE)
+                                    .withUpdatedGeneration(repoName, safeGeneration, newGen)
+                            )
+                            .build()
+                    )
+                    .build();
+            }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    logger.trace("[{}] successfully set pending repository generation to [{}]", metadata.name(), newGen);
-                    setPendingStep.onResponse(newGen);
-                }
-            },
-            ClusterStateTaskExecutor.unbatched()
-        );
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(
+                    new RepositoryException(
+                        metadata.name(),
+                        "Failed to execute cluster state update [" + setPendingGenerationSource + "]",
+                        e
+                    )
+                );
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                logger.trace("[{}] successfully set pending repository generation to [{}]", metadata.name(), newGen);
+                setPendingStep.onResponse(newGen);
+            }
+        }, ClusterStateTaskExecutor.unbatched());
 
         final StepListener<RepositoryData> filterRepositoryDataStep = new StepListener<>();
 
@@ -2309,74 +2310,72 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             maybeWriteIndexLatest(newGen);
 
             // Step 3: Update CS to reflect new repository generation.
-            clusterService.submitStateUpdateTask(
-                "set safe repository generation [" + metadata.name() + "][" + newGen + "]",
-                new ClusterStateUpdateTask() {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        final RepositoryMetadata meta = getRepoMetadata(currentState);
-                        if (meta.generation() != expectedGen) {
-                            throw new IllegalStateException(
-                                "Tried to update repo generation to [" + newGen + "] but saw unexpected generation in state [" + meta + "]"
-                            );
-                        }
-                        if (meta.pendingGeneration() != newGen) {
-                            throw new IllegalStateException(
-                                "Tried to update from unexpected pending repo generation ["
-                                    + meta.pendingGeneration()
-                                    + "] after write to generation ["
-                                    + newGen
-                                    + "]"
-                            );
-                        }
-                        final RepositoriesMetadata currentMetadata = currentState.metadata().custom(RepositoriesMetadata.TYPE);
-                        final RepositoriesMetadata withGenerations = currentMetadata.withUpdatedGeneration(metadata.name(), newGen, newGen);
-                        final RepositoriesMetadata withUuid = meta.uuid().equals(newRepositoryData.getUuid())
-                            ? withGenerations
-                            : withGenerations.withUuid(metadata.name(), newRepositoryData.getUuid());
-                        final ClusterState newClusterState = stateFilter.apply(
-                            ClusterState.builder(currentState)
-                                .metadata(Metadata.builder(currentState.getMetadata()).putCustom(RepositoriesMetadata.TYPE, withUuid))
-                                .build()
-                        );
-                        return updateRepositoryGenerationsIfNecessary(newClusterState, expectedGen, newGen);
-                    }
-
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        listener.onFailure(
-                            new RepositoryException(metadata.name(), "Failed to execute cluster state update [" + source + "]", e)
+            final String setSafeGenerationSource = "set safe repository generation [" + metadata.name() + "][" + newGen + "]";
+            clusterService.submitStateUpdateTask(setSafeGenerationSource, new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    final RepositoryMetadata meta = getRepoMetadata(currentState);
+                    if (meta.generation() != expectedGen) {
+                        throw new IllegalStateException(
+                            "Tried to update repo generation to [" + newGen + "] but saw unexpected generation in state [" + meta + "]"
                         );
                     }
-
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        logger.trace("[{}] successfully set safe repository generation to [{}]", metadata.name(), newGen);
-                        cacheRepositoryData(newRepositoryData, version);
-                        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
-                            // Delete all now outdated index files up to 1000 blobs back from the new generation.
-                            // If there are more than 1000 dangling index-N cleanup functionality on repo delete will take care of them.
-                            // Deleting one older than the current expectedGen is done for BwC reasons as older versions used to keep
-                            // two index-N blobs around.
-                            try {
-                                deleteFromContainer(
-                                    blobContainer(),
-                                    LongStream.range(Math.max(Math.max(expectedGen - 1, 0), newGen - 1000), newGen)
-                                        .mapToObj(gen -> INDEX_FILE_PREFIX + gen)
-                                        .iterator()
-                                );
-                            } catch (IOException e) {
-                                logger.warn(
-                                    () -> new ParameterizedMessage("Failed to clean up old index blobs from before [{}]", newGen),
-                                    e
-                                );
-                            }
-                            return newRepositoryData;
-                        }));
+                    if (meta.pendingGeneration() != newGen) {
+                        throw new IllegalStateException(
+                            "Tried to update from unexpected pending repo generation ["
+                                + meta.pendingGeneration()
+                                + "] after write to generation ["
+                                + newGen
+                                + "]"
+                        );
                     }
-                },
-                ClusterStateTaskExecutor.unbatched()
-            );
+                    final RepositoriesMetadata currentMetadata = currentState.metadata().custom(RepositoriesMetadata.TYPE);
+                    final RepositoriesMetadata withGenerations = currentMetadata.withUpdatedGeneration(metadata.name(), newGen, newGen);
+                    final RepositoriesMetadata withUuid = meta.uuid().equals(newRepositoryData.getUuid())
+                        ? withGenerations
+                        : withGenerations.withUuid(metadata.name(), newRepositoryData.getUuid());
+                    final ClusterState newClusterState = stateFilter.apply(
+                        ClusterState.builder(currentState)
+                            .metadata(Metadata.builder(currentState.getMetadata()).putCustom(RepositoriesMetadata.TYPE, withUuid))
+                            .build()
+                    );
+                    return updateRepositoryGenerationsIfNecessary(newClusterState, expectedGen, newGen);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(
+                        new RepositoryException(
+                            metadata.name(),
+                            "Failed to execute cluster state update [" + setSafeGenerationSource + "]",
+                            e
+                        )
+                    );
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    logger.trace("[{}] successfully set safe repository generation to [{}]", metadata.name(), newGen);
+                    cacheRepositoryData(newRepositoryData, version);
+                    threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
+                        // Delete all now outdated index files up to 1000 blobs back from the new generation.
+                        // If there are more than 1000 dangling index-N cleanup functionality on repo delete will take care of them.
+                        // Deleting one older than the current expectedGen is done for BwC reasons as older versions used to keep
+                        // two index-N blobs around.
+                        try {
+                            deleteFromContainer(
+                                blobContainer(),
+                                LongStream.range(Math.max(Math.max(expectedGen - 1, 0), newGen - 1000), newGen)
+                                    .mapToObj(gen -> INDEX_FILE_PREFIX + gen)
+                                    .iterator()
+                            );
+                        } catch (IOException e) {
+                            logger.warn(() -> new ParameterizedMessage("Failed to clean up old index blobs from before [{}]", newGen), e);
+                        }
+                        return newRepositoryData;
+                    }));
+                }
+            }, ClusterStateTaskExecutor.unbatched());
         }, listener::onFailure);
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1066,13 +1066,13 @@ public class RestoreService implements ClusterStateApplier {
             }
 
             @Override
-            public void onFailure(final String source, final Exception e) {
+            public void onFailure(final Exception e) {
                 cleanupInProgress = false;
                 logger.warn(() -> new ParameterizedMessage("failed to remove completed restores from cluster state"), e);
             }
 
             @Override
-            public void onNoLongerMaster(String source) {
+            public void onNoLongerMaster() {
                 cleanupInProgress = false;
                 logger.debug("no longer master while removing completed restores from cluster state");
             }
@@ -1565,7 +1565,7 @@ public class RestoreService implements ClusterStateApplier {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             logger.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", snapshot), e);
             listener.onFailure(e);
         }

--- a/server/src/main/java/org/elasticsearch/upgrades/MigrationResultsUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/MigrationResultsUpdateTask.java
@@ -78,7 +78,7 @@ public class MigrationResultsUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, Exception clusterStateUpdateException) {
+    public void onFailure(Exception clusterStateUpdateException) {
         if (status.succeeded()) {
             logger.warn(
                 new ParameterizedMessage("failed to update cluster state after successful migration of feature [{}]", featureName),

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -603,7 +603,7 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error("failed to clear migration results when starting new migration", e);
                 listener.onFailure(e);
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -545,7 +545,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     throw new AssertionError("unexpected failure", e);
                 }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -87,8 +87,8 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
-                throw new AssertionError(source, e);
+            public void onFailure(Exception e) {
+                throw new AssertionError("block master service", e);
             }
         }, ClusterStateTaskExecutor.unbatched());
 
@@ -114,7 +114,6 @@ public class BatchedRerouteServiceTests extends ESTestCase {
         };
         actions.add(rerouteFromPriority.apply(Priority.URGENT)); // ensure at least one URGENT priority reroute
         for (int i = 1; i < iterations; i++) {
-            final int iteration = i;
             if (randomBoolean()) {
                 actions.add(rerouteFromPriority.apply(randomFrom(Priority.LOW, Priority.NORMAL, Priority.HIGH, Priority.URGENT)));
             } else {
@@ -123,45 +122,42 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                 if (submittedConcurrentlyWithReroute == false) {
                     tasksSubmittedCountDown.countDown(); // this task might be submitted later
                 }
+                final String source = "other task " + i + " at " + priority;
                 actions.add(() -> {
-                    clusterService.submitStateUpdateTask(
-                        "other task " + iteration + " at " + priority,
-                        new ClusterStateUpdateTask(priority) {
+                    clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(priority) {
 
-                            @Override
-                            public ClusterState execute(ClusterState currentState) {
-                                switch (priority) {
-                                    case IMMEDIATE:
-                                        if (submittedConcurrentlyWithReroute) {
-                                            assertFalse("should have rerouted after " + priority + " priority task", rerouteExecuted.get());
-                                        } // else this task might be submitted too late to precede the reroute
-                                        break;
-                                    case URGENT:
-                                        // may run either before or after reroute
-                                        break;
-                                    case HIGH:
-                                    case NORMAL:
-                                        assertTrue("should have rerouted before " + priority + " priority task", rerouteExecuted.get());
-                                        break;
-                                    default:
-                                        fail("unexpected priority: " + priority);
-                                        break;
-                                }
-                                return currentState;
+                        @Override
+                        public ClusterState execute(ClusterState currentState) {
+                            switch (priority) {
+                                case IMMEDIATE:
+                                    if (submittedConcurrentlyWithReroute) {
+                                        assertFalse("should have rerouted after " + priority + " priority task", rerouteExecuted.get());
+                                    } // else this task might be submitted too late to precede the reroute
+                                    break;
+                                case URGENT:
+                                    // may run either before or after reroute
+                                    break;
+                                case HIGH:
+                                case NORMAL:
+                                    assertTrue("should have rerouted before " + priority + " priority task", rerouteExecuted.get());
+                                    break;
+                                default:
+                                    fail("unexpected priority: " + priority);
+                                    break;
                             }
+                            return currentState;
+                        }
 
-                            @Override
-                            public void onFailure(String source, Exception e) {
-                                throw new AssertionError(source, e);
-                            }
+                        @Override
+                        public void onFailure(Exception e) {
+                            throw new AssertionError(source, e);
+                        }
 
-                            @Override
-                            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                                tasksCompletedCountDown.countDown();
-                            }
-                        },
-                        ClusterStateTaskExecutor.unbatched()
-                    );
+                        @Override
+                        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                            tasksCompletedCountDown.countDown();
+                        }
+                    }, ClusterStateTaskExecutor.unbatched());
                     if (submittedConcurrentlyWithReroute) {
                         tasksSubmittedCountDown.countDown();
                     }

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -148,7 +148,7 @@ public class MasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 taskFailed[0] = true;
                 latch1.countDown();
             }
@@ -166,7 +166,7 @@ public class MasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 taskFailed[0] = true;
                 latch2.countDown();
             }
@@ -210,7 +210,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     assertFalse(threadPool.getThreadContext().isSystemContext());
                     assertEquals(expectedHeaders, threadPool.getThreadContext().getHeaders());
                     assertEquals(expectedResponseHeaders, threadPool.getThreadContext().getResponseHeaders());
@@ -287,7 +287,7 @@ public class MasterServiceTests extends ESTestCase {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {}
+                    public void onFailure(Exception e) {}
                 }
             );
 
@@ -406,7 +406,7 @@ public class MasterServiceTests extends ESTestCase {
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -423,7 +423,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {}
+                public void onFailure(Exception e) {}
             }, ClusterStateTaskExecutor.unbatched());
             masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
                 @Override
@@ -438,7 +438,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -452,7 +452,7 @@ public class MasterServiceTests extends ESTestCase {
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -581,7 +581,7 @@ public class MasterServiceTests extends ESTestCase {
         final CountDownLatch updateLatch = new CountDownLatch(totalTaskCount);
         final ClusterStateTaskListener listener = new ClusterStateTaskListener() {
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError(e);
             }
 
@@ -700,7 +700,7 @@ public class MasterServiceTests extends ESTestCase {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {}
+                    public void onFailure(Exception e) {}
                 }
             );
 
@@ -824,7 +824,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -844,7 +844,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     latch.countDown();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -862,7 +862,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -880,7 +880,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -896,7 +896,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -912,7 +912,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail(); // maybe we should notify here?
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -930,7 +930,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -997,7 +997,7 @@ public class MasterServiceTests extends ESTestCase {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         latch.countDown();
                     }
 
@@ -1042,7 +1042,7 @@ public class MasterServiceTests extends ESTestCase {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         fail();
                     }
 
@@ -1102,7 +1102,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             };
@@ -1118,7 +1118,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     fail();
                 }
             }, ClusterStateTaskExecutor.unbatched());

--- a/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
@@ -169,7 +169,7 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
                 }
 
                 @Override
-                public void onFailure(final String source, final Exception e) {
+                public void onFailure(final Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
@@ -733,7 +733,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
                 await.await();
             }
             if (testFailureNextTime.compareAndSet(true, false)) {
-                task.onFailure("testing failure", new RuntimeException("foo"));
+                task.onFailure(new RuntimeException("foo"));
             } else {
                 state.set(after);
                 task.clusterStateProcessed("test", before, after);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1378,7 +1378,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                                 .build()
                         )
                         .build(),
-                    (source, e) -> {}
+                    (e) -> {}
                 );
             }
 
@@ -1395,14 +1395,14 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     }
 
                     @Override
-                    public void onNoLongerMaster(String source) {
+                    public void onNoLongerMaster() {
                         // in this case, we know for sure that event was not processed by the system and will not change history
                         // remove event to help avoid bloated history and state space explosion in linearizability checker
                         history.remove(eventId);
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         // do not remove event from history, the write might still take place
                         // instead, complete history when checking for linearizability
                     }
@@ -1418,7 +1418,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         // reads do not change state
                         // remove event to help avoid bloated history and state space explosion in linearizability checker
                         history.remove(eventId);
@@ -1444,15 +1444,15 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         }
 
                         @Override
-                        public void onFailure(String source, Exception e) {
-                            logger.debug(() -> new ParameterizedMessage("failed to publish: [{}]", source), e);
-                            taskListener.onFailure(source, e);
+                        public void onFailure(Exception e) {
+                            logger.debug("publication failed", e);
+                            taskListener.onFailure(e);
                         }
 
                         @Override
-                        public void onNoLongerMaster(String source) {
-                            logger.trace("no longer master: [{}]", source);
-                            taskListener.onNoLongerMaster(source);
+                        public void onNoLongerMaster() {
+                            logger.trace("no longer master");
+                            taskListener.onNoLongerMaster();
                         }
 
                         @Override

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -646,7 +646,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 future.onFailure(e);
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -89,7 +89,7 @@ public class ClusterServiceUtils {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 fail("unexpected exception" + e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/BlockMasterServiceOnMaster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/BlockMasterServiceOnMaster.java
@@ -60,7 +60,7 @@ public class BlockMasterServiceOnMaster extends SingleNodeDisruption {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error("unexpected error during disruption", e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/BusyMasterServiceDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/BusyMasterServiceDisruption.java
@@ -54,7 +54,7 @@ public class BusyMasterServiceDisruption extends SingleNodeDisruption {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error("unexpected error during disruption", e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
@@ -92,7 +92,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError();
             }
         }, ClusterStateTaskExecutor.unbatched());
@@ -132,7 +132,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError();
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -197,7 +197,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     latch.countDown();
                     fail("unexpected error [" + e.getMessage() + "]");
                 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -1223,7 +1223,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError(e);
             }
         }, ClusterStateTaskExecutor.unbatched());
@@ -1293,7 +1293,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError(e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -323,7 +323,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                         }
 
                         @Override
-                        public void onFailure(String source, Exception e) {
+                        public void onFailure(Exception e) {
                             handler.accept(e);
                         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -94,7 +94,7 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
             }
 
             @Override
-            public void onFailure(final String source, final Exception e) {
+            public void onFailure(final Exception e) {
                 listener.onFailure(e);
             }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -904,7 +904,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 latch.countDown();
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
@@ -30,6 +30,7 @@ public class StartBasicClusterTask extends ClusterStateUpdateTask {
     private final Logger logger;
     private final String clusterName;
     private final PostStartBasicRequest request;
+    private final String description;
     private final ActionListener<PostStartBasicResponse> listener;
     private final Clock clock;
     private AtomicReference<Map<String, String[]>> ackMessages = new AtomicReference<>(Collections.emptyMap());
@@ -39,11 +40,13 @@ public class StartBasicClusterTask extends ClusterStateUpdateTask {
         String clusterName,
         Clock clock,
         PostStartBasicRequest request,
+        String description,
         ActionListener<PostStartBasicResponse> listener
     ) {
         this.logger = logger;
         this.clusterName = clusterName;
         this.request = request;
+        this.description = description;
         this.listener = listener;
         this.clock = clock;
     }
@@ -90,8 +93,8 @@ public class StartBasicClusterTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, @Nullable Exception e) {
-        logger.error(new ParameterizedMessage("unexpected failure during [{}]", source), e);
+    public void onFailure(@Nullable Exception e) {
+        logger.error(new ParameterizedMessage("unexpected failure during [{}]", description), e);
         listener.onFailure(e);
     }
 
@@ -112,5 +115,9 @@ public class StartBasicClusterTask extends ClusterStateUpdateTask {
             .expiryDate(LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS);
 
         return SelfGeneratedLicense.create(specBuilder, currentState.nodes());
+    }
+
+    public String getDescription() {
+        return description;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.license;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
@@ -105,7 +104,7 @@ public class StartTrialClusterTask extends ClusterStateUpdateTask {
 
     @Override
     public void onFailure(@Nullable Exception e) {
-        logger.error(new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE), e);
+        logger.error("unexpected failure during [" + TASK_SOURCE + "]", e);
         listener.onFailure(e);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -33,6 +33,8 @@ public class StartTrialClusterTask extends ClusterStateUpdateTask {
         new String[] { "With a trial license, X-Pack security features are available, but are not enabled by default." }
     );
 
+    static final String TASK_SOURCE = "started trial license";
+
     private final Logger logger;
     private final String clusterName;
     private final PostStartTrialRequest request;
@@ -102,8 +104,8 @@ public class StartTrialClusterTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, @Nullable Exception e) {
-        logger.error(new ParameterizedMessage("unexpected failure during [{}]", source), e);
+    public void onFailure(@Nullable Exception e) {
+        logger.error(new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE), e);
         listener.onFailure(e);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
@@ -25,6 +25,8 @@ import java.util.UUID;
 public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
     private static final Logger logger = LogManager.getLogger(StartupSelfGeneratedLicenseTask.class);
 
+    static final String TASK_SOURCE = "maybe generate license for cluster";
+
     /**
      * Max number of nodes licensed by generated trial license
      */
@@ -98,8 +100,8 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, @Nullable Exception e) {
-        logger.error((Supplier<?>) () -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+    public void onFailure(@Nullable Exception e) {
+        logger.error((Supplier<?>) () -> new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE), e);
     }
 
     private ClusterState extendBasic(ClusterState currentState, LicensesMetadata currentLicenseMetadata) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicensesIntegrationTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicensesIntegrationTestCase.java
@@ -55,7 +55,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
             }
 
             @Override
-            public void onFailure(String source, @Nullable Exception e) {
+            public void onFailure(@Nullable Exception e) {
                 logger.error("error on metadata cleanup after test", e);
             }
         }, ClusterStateTaskExecutor.unbatched());
@@ -83,7 +83,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
             }
 
             @Override
-            public void onFailure(String source, @Nullable Exception e) {
+            public void onFailure(@Nullable Exception e) {
                 logger.error("error on metadata cleanup after test", e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
@@ -93,7 +93,7 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
             new ClusterStateUpdateTask(Priority.HIGH, request.masterNodeTimeout()) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/PromoteDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/PromoteDataStreamTransportAction.java
@@ -68,7 +68,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
             new ClusterStateUpdateTask(Priority.HIGH, request.masterNodeTimeout()) {
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichStore.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichStore.java
@@ -201,7 +201,7 @@ public final class EnrichStore {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 handler.accept(e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
@@ -160,7 +160,7 @@ public class ClusterStateWaitThresholdBreachTests extends ESIntegTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new AssertionError(e);
             }
         }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -233,7 +233,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
     }
 
     @Override
-    public void handleFailure(String source, Exception e) {
+    public void handleFailure(Exception e) {
         logger.warn(new ParameterizedMessage("policy [{}] for index [{}] failed on step [{}].", policy, index, startStep.getKey()), e);
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -61,14 +61,14 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
     }
 
     @Override
-    public final void onFailure(String source, Exception e) {
+    public final void onFailure(Exception e) {
         listener.onFailure(e);
-        handleFailure(source, e);
+        handleFailure(e);
     }
 
     /**
      * Add a listener that is resolved once this update has been processed or failed and before either the
-     * {@link #onClusterStateProcessed(String, ClusterState, ClusterState)} or the {@link #handleFailure(String, Exception)} hooks are
+     * {@link #onClusterStateProcessed(String, ClusterState, ClusterState)} or the {@link #handleFailure(Exception)} hooks are
      * executed.
      */
     public final void addListener(ActionListener<Void> actionListener) {
@@ -91,8 +91,8 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
     public abstract int hashCode();
 
     /**
-     * This method is functionally the same as {@link ClusterStateTaskListener#onFailure(String, Exception)} and implementations can
+     * This method is functionally the same as {@link ClusterStateTaskListener#onFailure(Exception)} and implementations can
      * override it as they would override {@code ClusterStateUpdateTask#onFailure}.
      */
-    protected abstract void handleFailure(String source, Exception e);
+    protected abstract void handleFailure(Exception e);
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -302,7 +302,7 @@ class IndexLifecycleRunner {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         logger.error(
                             new ParameterizedMessage(
                                 "retry execution of step [{}] for index [{}] failed",

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
@@ -85,7 +85,7 @@ public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
+    public void onFailure(Exception e) {
         final MessageSupplier messageSupplier = () -> new ParameterizedMessage(
             "policy [{}] for index [{}] failed trying to move from step [{}] to the ERROR step.",
             policy,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -90,7 +90,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
     }
 
     @Override
-    public void handleFailure(String source, Exception e) {
+    public void handleFailure(Exception e) {
         logger.warn(
             new ParameterizedMessage(
                 "policy [{}] for index [{}] failed trying to move from step [{}] to step [{}].",

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTask.java
@@ -149,7 +149,7 @@ public class OperationModeUpdateTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
+    public void onFailure(Exception e) {
         logger.error("unable to update lifecycle metadata with new ilm mode [" + ilmMode + "], slm mode [" + slmMode + "]", e);
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -66,7 +66,7 @@ public class SetStepInfoUpdateTask extends IndexLifecycleClusterStateUpdateTask 
     }
 
     @Override
-    public void handleFailure(String source, Exception e) {
+    public void handleFailure(Exception e) {
         logger.warn(
             new ParameterizedMessage(
                 "policy [{}] for index [{}] failed trying to set step info for step [{}].",

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
@@ -131,7 +131,7 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRemoveIndexLifecyclePolicyAction.java
@@ -71,7 +71,7 @@ public class TransportRemoveIndexLifecyclePolicyAction extends TransportMasterNo
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -280,12 +280,12 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             logger.error(
-                "failed to record snapshot policy execution status for snapshot [{}] in policy [{}], (source: [{}]): {}",
+                "failed to record snapshot policy execution status [{}] for snapshot [{}] in policy [{}]: {}",
+                exception.isPresent() ? "failure" : "success",
                 snapshotName,
                 policyName,
-                source,
                 e
             );
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -449,7 +449,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     void updateStateWithStats(SnapshotLifecycleStats newStats) {
         clusterService.submitStateUpdateTask(
-            "update_slm_stats",
+            UpdateSnapshotLifecycleStatsTask.TASK_SOURCE,
             new UpdateSnapshotLifecycleStatsTask(newStats),
             ClusterStateTaskExecutor.unbatched()
         );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/UpdateSnapshotLifecycleStatsTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/UpdateSnapshotLifecycleStatsTask.java
@@ -26,6 +26,8 @@ public class UpdateSnapshotLifecycleStatsTask extends ClusterStateUpdateTask {
 
     private final SnapshotLifecycleStats runStats;
 
+    static final String TASK_SOURCE = "update_slm_stats";
+
     UpdateSnapshotLifecycleStatsTask(SnapshotLifecycleStats runStats) {
         this.runStats = runStats;
     }
@@ -52,11 +54,10 @@ public class UpdateSnapshotLifecycleStatsTask extends ClusterStateUpdateTask {
     }
 
     @Override
-    public void onFailure(String source, Exception e) {
+    public void onFailure(Exception e) {
         logger.error(
             new ParameterizedMessage(
-                "failed to update cluster state with snapshot lifecycle stats, " + "source: [{}], missing stats: [{}]",
-                source,
+                "failed to update cluster state with snapshot lifecycle stats, " + "source: [" + TASK_SOURCE + "], missing stats: [{}]",
                 runStats
             ),
             e

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -283,7 +283,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         long now = randomNonNegativeLong();
         ExecuteStepsUpdateTask task = new ExecuteStepsUpdateTask(mixedPolicyName, index, startStep, policyStepsRegistry, null, () -> now);
         Exception expectedException = new RuntimeException();
-        task.onFailure(randomAlphaOfLength(10), expectedException);
+        task.onFailure(expectedException);
     }
 
     public void testClusterActionStepThrowsException() throws Exception {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -177,7 +177,7 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
             state -> {}
         );
         Exception expectedException = new RuntimeException();
-        task.onFailure(randomAlphaOfLength(10), expectedException);
+        task.onFailure(expectedException);
     }
 
     /**

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -133,7 +133,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         final Logger taskLogger = LogManager.getLogger(SetStepInfoUpdateTask.class);
         Loggers.addAppender(taskLogger, mockAppender);
         try {
-            task.onFailure(randomAlphaOfLength(10), new RuntimeException("test exception"));
+            task.onFailure(new RuntimeException("test exception"));
             mockAppender.assertAllExpectationsMatched();
         } finally {
             Loggers.removeAppender(taskLogger, mockAppender);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
@@ -106,7 +106,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.warn("failed to allocate models", e);
                 }
 
@@ -134,7 +134,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -156,7 +156,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -175,7 +175,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -194,7 +194,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 
@@ -214,7 +214,7 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -242,7 +242,7 @@ public class TransportRollupAction extends AcknowledgedTransportMasterNodeAction
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     listener.onFailure(e);
                 }
             }, ClusterStateTaskExecutor.unbatched());
@@ -372,7 +372,7 @@ public class TransportRollupAction extends AcknowledgedTransportMasterNodeAction
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 deleteTmpIndex(
                     originalIndexName,
                     tmpIndexName,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
@@ -77,7 +77,7 @@ public class SearchableSnapshotIndexMetadataUpgrader {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.warn(
                         "upgrading frozen indices to have frozen shard limit group failed, will retry on the next cluster state update",
                         e

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -2526,7 +2526,7 @@ public final class TokenService {
                     }
 
                     @Override
-                    public void onFailure(String source, Exception e) {
+                    public void onFailure(Exception e) {
                         installTokenMetadataInProgress.set(false);
                         logger.error("unable to install token metadata", e);
                     }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -99,7 +99,7 @@ public class NodeSeenService implements ClusterStateListener {
                 }
 
                 @Override
-                public void onFailure(String source, Exception e) {
+                public void onFailure(Exception e) {
                     logger.warn(new ParameterizedMessage("failed to mark shutting down nodes as seen: {}", nodesNotPreviouslySeen), e);
                 }
             }, ClusterStateTaskExecutor.unbatched());

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -84,7 +84,7 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error(new ParameterizedMessage("failed to delete shutdown for node [{}]", request.getNodeId()), e);
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -99,7 +99,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error(new ParameterizedMessage("failed to put shutdown for node [{}]", request.getNodeId()), e);
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherServiceAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherServiceAction.java
@@ -98,7 +98,7 @@ public class TransportWatcherServiceAction extends AcknowledgedTransportMasterNo
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 logger.error(
                     new ParameterizedMessage("could not update watcher stopped status to [{}], source [{}]", manuallyStopped, source),
                     e


### PR DESCRIPTION
Today `ClusterStateTaskListener#onFailure` and
`ClusterStateTaskListener#onNoLongerMaster` take the `source` of the
failing task as an argument in order to describe the task in logs and
exception messages. In practice every implementation knows the source of
the task for which it's listening, so there's no need for the master
service to pass this data in. Moreover this argument stands in the way
of some future simplifications, for instance by making it impossible to
treat a `ClusterStateTaskListener` as an `ActionListener`.

This commit removes the unnecessary `source` argument from these
methods.