### PR TITLE
Combine join task and listener

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -396,15 +397,13 @@ public class JoinHelper {
     class LeaderJoinAccumulator implements JoinAccumulator {
         @Override
         public void handleJoinRequest(DiscoveryNode sender, ActionListener<Void> joinListener) {
-            final JoinTaskExecutor.Task task = new JoinTaskExecutor.Task(sender, joinReasonService.getJoinReason(sender, Mode.LEADER));
-            assert joinTaskExecutor != null;
-            masterService.submitStateUpdateTask(
-                "node-join",
-                task,
-                ClusterStateTaskConfig.build(Priority.URGENT),
-                joinTaskExecutor,
-                new JoinTaskListener(task, joinListener)
+            final JoinTaskExecutor.Task task = new JoinTaskExecutor.Task(
+                sender,
+                joinReasonService.getJoinReason(sender, Mode.LEADER),
+                joinListener
             );
+            assert joinTaskExecutor != null;
+            masterService.submitStateUpdateTask("node-join", task, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor, task);
         }
 
         @Override
@@ -458,18 +457,17 @@ public class JoinHelper {
             closed = true;
             if (newMode == Mode.LEADER) {
                 final Map<JoinTaskExecutor.Task, ClusterStateTaskListener> pendingAsTasks = new LinkedHashMap<>();
-                joinRequestAccumulator.forEach((node, listener) -> {
-                    final JoinTaskExecutor.Task task = new JoinTaskExecutor.Task(
-                        node,
-                        joinReasonService.getJoinReason(node, Mode.CANDIDATE)
-                    );
-                    pendingAsTasks.put(task, new JoinTaskListener(task, listener));
-                });
+                final Consumer<JoinTaskExecutor.Task> pendingTaskAdder = task -> pendingAsTasks.put(task, task);
+                joinRequestAccumulator.forEach(
+                    (node, listener) -> pendingTaskAdder.accept(
+                        new JoinTaskExecutor.Task(node, joinReasonService.getJoinReason(node, Mode.CANDIDATE), listener)
+                    )
+                );
 
                 final String stateUpdateSource = "elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
 
-                pendingAsTasks.put(JoinTaskExecutor.newBecomeMasterTask(), (e) -> {});
-                pendingAsTasks.put(JoinTaskExecutor.newFinishElectionTask(), (e) -> {});
+                pendingTaskAdder.accept(JoinTaskExecutor.newBecomeMasterTask());
+                pendingTaskAdder.accept(JoinTaskExecutor.newFinishElectionTask());
                 joinTaskExecutor = joinTaskExecutorGenerator.get();
                 masterService.submitStateUpdateTasks(
                     stateUpdateSource,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -159,7 +160,13 @@ public class JoinTaskExecutorTests extends ESTestCase {
 
         final ClusterStateTaskExecutor.ClusterTasksResult<JoinTaskExecutor.Task> result = joinTaskExecutor.execute(
             clusterState,
-            List.of(new JoinTaskExecutor.Task(actualNode, "test"))
+            List.of(
+                new JoinTaskExecutor.Task(
+                    actualNode,
+                    "test",
+                    ActionListener.wrap(() -> { throw new AssertionError("should not complete publication"); })
+                )
+            )
         );
         assertThat(result.executionResults.entrySet(), hasSize(1));
         final ClusterStateTaskExecutor.TaskResult taskResult = result.executionResults.values().iterator().next();

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -364,7 +365,15 @@ public class ClusterStateChanges {
         return runTasks(
             joinTaskExecutor,
             clusterState,
-            nodes.stream().map(node -> new JoinTaskExecutor.Task(node, "dummy reason")).collect(Collectors.toList())
+            nodes.stream()
+                .map(
+                    node -> new JoinTaskExecutor.Task(
+                        node,
+                        "dummy reason",
+                        ActionListener.wrap(() -> { throw new AssertionError("should not complete publication"); })
+                    )
+                )
+                .collect(Collectors.toList())
         );
     }
 
@@ -372,7 +381,17 @@ public class ClusterStateChanges {
         List<JoinTaskExecutor.Task> joinNodes = new ArrayList<>();
         joinNodes.add(JoinTaskExecutor.newBecomeMasterTask());
         joinNodes.add(JoinTaskExecutor.newFinishElectionTask());
-        joinNodes.addAll(nodes.stream().map(node -> new JoinTaskExecutor.Task(node, "dummy reason")).collect(Collectors.toList()));
+        joinNodes.addAll(
+            nodes.stream()
+                .map(
+                    node -> new JoinTaskExecutor.Task(
+                        node,
+                        "dummy reason",
+                        ActionListener.wrap(() -> { throw new AssertionError("should not complete publication"); })
+                    )
+                )
+                .collect(Collectors.toList())
+        );
 
         return runTasks(joinTaskExecutor, clusterState, joinNodes);
     }


### PR DESCRIPTION
Today join tasks executed by the master have a separate
`ClusterStateTaskListener` to feed back the join result to the joining
node. It'd be preferable to use the task itself as the listener. This
commit does that.

Relates #82644