### PR TITLE
Remove system-index write-access from superuser role

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
@@ -27,7 +27,7 @@ testClusters.register("runTask") {
       }
       setting 'xpack.security.enabled', 'true'
       keystore 'bootstrap.password', 'password'
-      user username: 'elastic-admin', password: 'elastic-password', role: 'superuser'
+      user username: 'elastic-admin', password: 'elastic-password', role: '_es_test_root'
     }
 }
 

--- a/build-tools-internal/src/main/resources/roles.yml
+++ b/build-tools-internal/src/main/resources/roles.yml
@@ -1,0 +1,7 @@
+_root:
+    cluster: [ "ALL" ]
+    indices:
+        - names: [ "*" ]
+          allow_restricted_indices: true
+          privileges: [ "ALL" ]
+    run_as: [ "*" ]

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -674,6 +674,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                     paramMap.entrySet().stream().flatMap(entry -> Stream.of(entry.getKey(), entry.getValue())).toArray(String[]::new)
                 )
             );
+
+            // If we added users, then also add the standard test roles
+            rolesFile(getBuildPluginFile("/roles.yml"));
         }
         if (roleFiles.isEmpty() == false) {
             logToProcessStdout("Setting up roles.yml");
@@ -751,8 +754,12 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         Map<String, String> cred = new LinkedHashMap<>();
         cred.put("useradd", userSpec.getOrDefault("username", "test_user"));
         cred.put("-p", userSpec.getOrDefault("password", "x-pack-test-password"));
-        cred.put("-r", userSpec.getOrDefault("role", "superuser"));
+        cred.put("-r", userSpec.getOrDefault("role", "_es_test_root"));
         credentials.add(cred);
+    }
+
+    private File getBuildPluginFile(String name) {
+        return project.getRootProject().file("build-tools/src/main/resources/" + name);
     }
 
     @Override

--- a/build-tools/src/main/resources/roles.yml
+++ b/build-tools/src/main/resources/roles.yml
@@ -1,0 +1,13 @@
+
+# The roles below are automatically defined by the "testcluster" setup
+_es_test_root:
+  cluster: [ "ALL" ]
+  indices:
+    - names: [ "*" ]
+      allow_restricted_indices: true
+      privileges: [ "ALL" ]
+  run_as: [ "*" ]
+  applications:
+    - application: "*"
+      privileges: [ "*" ]
+      resources: [ "*" ]

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -111,7 +111,7 @@ testClusters.configureEach {
   setting 'indices.lifecycle.poll_interval', '1000ms'
   setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'xpack.security.transport.ssl.truststore.secure_password', 'testnode'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: clusterUserNameProvider.get(),
     password: clusterPasswordProvider.get(),
     role: providers.systemProperty('tests.rest.cluster.role').orElse('admin').forUseAtConfigurationTime().get()

--- a/qa/system-indices/build.gradle
+++ b/qa/system-indices/build.gradle
@@ -26,5 +26,5 @@ testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.autoconfiguration.enabled', 'false'
-  user username: 'rest_user', password: 'rest-user-password', role: 'superuser'
+  user username: 'rest_user', password: 'rest-user-password'
 }

--- a/x-pack/docs/en/rest-api/security/authenticate.asciidoc
+++ b/x-pack/docs/en/rest-api/security/authenticate.asciidoc
@@ -61,4 +61,4 @@ The following example output provides information about the "rdeniro" user:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"rdeniro"/"$body.username"/]
-// TESTRESPONSE[s/"admin"/"superuser"/]
+// TESTRESPONSE[s/"admin"/"_es_test_root"/]

--- a/x-pack/docs/en/rest-api/security/get-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-tokens.asciidoc
@@ -146,6 +146,7 @@ seconds) that the token expires in, and the type:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
+// TESTRESPONSE[s/superuser/_es_test_root/]
 
 The token returned by this API can be used by sending a request with an
 `Authorization` header with a value having the prefix "Bearer " followed
@@ -204,6 +205,7 @@ seconds) that the token expires in, the type, and the refresh token:
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
+// TESTRESPONSE[s/superuser/_es_test_root/]
 
 [[security-api-refresh-token]]
 To extend the life of an existing token obtained using the `password` grant type,
@@ -254,6 +256,7 @@ be used one time.
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
+// TESTRESPONSE[s/superuser/_es_test_root/]
 
 The following example obtains a access token and refresh token using the `kerberos` grant type,
 which simply creates a token in exchange for the base64 encoded kerberos ticket:

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -106,6 +106,7 @@ The get token API returns the following information about the access token:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
+// TESTRESPONSE[s/superuser/_es_test_root/]
 
 This access token can now be immediately invalidated, as shown in the following
 example:
@@ -165,6 +166,7 @@ The get token API returns the following information:
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
+// TESTRESPONSE[s/superuser/_es_test_root/]
 
 The refresh token can now also be immediately invalidated as shown
 in the following example:

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -50,7 +50,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
         "superuser",
         new String[] { "all" },
         new RoleDescriptor.IndicesPrivileges[] {
-            RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("all").allowRestrictedIndices(true).build() },
+            RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("all").allowRestrictedIndices(false).build(),
+            RoleDescriptor.IndicesPrivileges.builder()
+                .indices("*")
+                .privileges("monitor", "read", "view_index_metadata", "read_cross_cluster")
+                .allowRestrictedIndices(true)
+                .build() },
         new RoleDescriptor.ApplicationResourcePrivileges[] {
             RoleDescriptor.ApplicationResourcePrivileges.builder().application("*").privileges("*").resources("*").build() },
         null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/XPackSecurityUser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/XPackSecurityUser.java
@@ -6,6 +6,11 @@
  */
 package org.elasticsearch.xpack.core.security.user;
 
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.support.MetadataUtils;
+
+import java.util.Map;
+
 /**
  * internal user that manages xpack security. Has all cluster/indices permissions.
  */
@@ -14,6 +19,17 @@ public class XPackSecurityUser extends User {
     public static final String NAME = UsernamesField.XPACK_SECURITY_NAME;
     public static final XPackSecurityUser INSTANCE = new XPackSecurityUser();
     private static final String ROLE_NAME = UsernamesField.XPACK_SECURITY_ROLE;
+    public static final RoleDescriptor ROLE_DESCRIPTOR = new RoleDescriptor(
+        ROLE_NAME,
+        new String[] { "all" },
+        new RoleDescriptor.IndicesPrivileges[] {
+            RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("all").allowRestrictedIndices(true).build() },
+        null,
+        null,
+        new String[] { "*" },
+        MetadataUtils.DEFAULT_RESERVED_METADATA,
+        Map.of()
+    );
 
     private XPackSecurityUser() {
         super(NAME, ROLE_NAME);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/test/SecuritySettingsSourceField.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/test/SecuritySettingsSourceField.java
@@ -13,5 +13,18 @@ public final class SecuritySettingsSourceField {
     public static final String TEST_PASSWORD = "x-pack-test-password";
     public static final String TEST_INVALID_PASSWORD = "invalid-test-password";
 
+    public static final String ES_TEST_ROOT_ROLE = "_es_test_root";
+    public static final String ES_TEST_ROOT_ROLE_YML = """
+        _es_test_root:
+          cluster: [ "ALL" ]
+          indices:
+            - names: [ "*" ]
+              allow_restricted_indices: true
+              privileges: [ "ALL" ]
+          run_as: [ "*" ]
+          # The _es_test_root role doesn't have any application privileges because that would require loading data (Application Privileges)
+          # from the security index, which can causes problems if the index is not available
+        """;
+
     private SecuritySettingsSourceField() {}
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1588,31 +1588,60 @@ public class ReservedRolesStoreTests extends ESTestCase {
         iac = superuserRole.indices().authorize(UpdateSettingsAction.NAME, Sets.newHashSet("aaaaaa", "ba"), lookup, fieldPermissionsCache);
         assertThat(iac.getIndexPermissions("aaaaaa").isGranted(), is(true));
         assertThat(iac.getIndexPermissions("b").isGranted(), is(true));
+
+        // Read security indices => allowed
         iac = superuserRole.indices()
             .authorize(
-                randomFrom(IndexAction.NAME, DeleteIndexAction.NAME, SearchAction.NAME),
+                randomFrom(SearchAction.NAME, GetIndexAction.NAME),
                 Sets.newHashSet(RestrictedIndicesNames.SECURITY_MAIN_ALIAS),
                 lookup,
                 fieldPermissionsCache
             );
-        assertThat(iac.getIndexPermissions(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
-        assertThat(iac.getIndexPermissions(internalSecurityIndex).isGranted(), is(true));
+        assertThat("For " + iac, iac.getIndexPermissions(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(true));
+        assertThat("For " + iac, iac.getIndexPermissions(internalSecurityIndex).isGranted(), is(true));
+
+        // Write security indices => denied
+        iac = superuserRole.indices()
+            .authorize(
+                randomFrom(IndexAction.NAME, DeleteIndexAction.NAME),
+                Sets.newHashSet(RestrictedIndicesNames.SECURITY_MAIN_ALIAS),
+                lookup,
+                fieldPermissionsCache
+            );
+        assertThat("For " + iac, iac.getIndexPermissions(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).isGranted(), is(false));
+        assertThat("For " + iac, iac.getIndexPermissions(internalSecurityIndex).isGranted(), is(false));
+
         assertTrue(superuserRole.indices().check(SearchAction.NAME));
         assertFalse(superuserRole.indices().check("unknown"));
 
         assertThat(superuserRole.runAs().check(randomAlphaOfLengthBetween(1, 30)), is(true));
 
+        // Read security indices => allowed
         assertThat(
             superuserRole.indices()
-                .allowedIndicesMatcher(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME, SearchAction.NAME))
+                .allowedIndicesMatcher(randomFrom(GetAction.NAME, IndicesStatsAction.NAME))
                 .test(mockIndexAbstraction(RestrictedIndicesNames.SECURITY_MAIN_ALIAS)),
             is(true)
         );
         assertThat(
             superuserRole.indices()
-                .allowedIndicesMatcher(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME, SearchAction.NAME))
+                .allowedIndicesMatcher(randomFrom(GetAction.NAME, IndicesStatsAction.NAME))
                 .test(mockIndexAbstraction(internalSecurityIndex)),
             is(true)
+        );
+
+        // Write security indices => denied
+        assertThat(
+            superuserRole.indices()
+                .allowedIndicesMatcher(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME))
+                .test(mockIndexAbstraction(RestrictedIndicesNames.SECURITY_MAIN_ALIAS)),
+            is(false)
+        );
+        assertThat(
+            superuserRole.indices()
+                .allowedIndicesMatcher(randomFrom(IndexAction.NAME, DeleteIndexAction.NAME))
+                .test(mockIndexAbstraction(internalSecurityIndex)),
+            is(false)
         );
     }
 

--- a/x-pack/plugin/fleet/build.gradle
+++ b/x-pack/plugin/fleet/build.gradle
@@ -27,5 +27,5 @@ testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.autoconfiguration.enabled', 'false'
-  user username: 'x_pack_rest_user', password: 'x-pack-test-password', role: 'superuser'
+  user username: 'x_pack_rest_user', password: 'x-pack-test-password'
 }

--- a/x-pack/plugin/graph/qa/with-security/build.gradle
+++ b/x-pack/plugin/graph/qa/with-security/build.gradle
@@ -19,7 +19,7 @@ testClusters.configureEach {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
 
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: 'test_admin', password: 'x-pack-test-password'
   user username: 'graph_explorer', password: 'x-pack-test-password', role: 'graph_explorer'
   user username: 'no_graph_explorer', password: 'x-pack-test-password', role: 'no_graph_explorer'

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -35,7 +35,7 @@ testClusters.configureEach {
   setting 'xpack.security.authc.realms.saml.cloud-saml.attributes.name', 'https://idp.test.es.elasticsearch.org/attribute/name'
   setting 'logger.org.elasticsearch.xpack.security.authc.saml', 'TRACE'
   setting 'logger.org.elasticsearch.xpack.idp', 'TRACE'
-  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
+  rolesFile file('src/javaRestTest/resources/roles.yml')
   extraConfigFile 'idp-sign.crt', file('src/javaRestTest/resources/idp-sign.crt')
   extraConfigFile 'idp-sign.key', file('src/javaRestTest/resources/idp-sign.key')
   extraConfigFile 'wildcard_services.json', file('src/javaRestTest/resources/wildcard_services.json')

--- a/x-pack/plugin/ilm/qa/with-security/build.gradle
+++ b/x-pack/plugin/ilm/qa/with-security/build.gradle
@@ -12,6 +12,6 @@ testClusters.configureEach {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "test_ilm", password: "x-pack-test-password", role: "ilm"
 }

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -20,5 +20,5 @@ dependencies {
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
-  user username: 'x_pack_rest_user', password: 'x-pack-test-password', role: 'superuser'
+  user username: 'x_pack_rest_user', password: 'x-pack-test-password'
 }

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -235,7 +235,7 @@ tasks.named("yamlRestTest").configure {
 
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   user username: "ml_admin", password: "x-pack-test-password", role: "minimal,machine_learning_admin,ingest_admin"
   user username: "ml_user", password: "x-pack-test-password", role: "minimal,machine_learning_user"

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -172,7 +172,8 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             throw new UncheckedIOException(e);
         }
         writeFile(xpackConf, "users", "x_pack_rest_user" + ":" + SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING + "\n");
-        writeFile(xpackConf, "users_roles", "superuser:x_pack_rest_user\n");
+        writeFile(xpackConf, "users_roles", SecuritySettingsSourceField.ES_TEST_ROOT_ROLE + ":x_pack_rest_user\n");
+        writeFile(xpackConf, "roles.yml", SecuritySettingsSourceField.ES_TEST_ROOT_ROLE_YML);
 
         Path key;
         Path certificate;

--- a/x-pack/plugin/security/qa/basic-enable-security/build.gradle
+++ b/x-pack/plugin/security/qa/basic-enable-security/build.gradle
@@ -59,7 +59,7 @@ tasks.register("javaRestTestWithSecurityEnabled", StandaloneRestIntegTestTask) {
       extraConfigFile 'transport.key', file('src/javaRestTest/resources/ssl/transport.key')
       extraConfigFile 'transport.crt', file('src/javaRestTest/resources/ssl/transport.crt')
       extraConfigFile 'ca.crt', file('src/javaRestTest/resources/ssl/ca.crt')
-      extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
+      rolesFile file('src/javaRestTest/resources/roles.yml')
 
       user username: "admin_user", password: "admin-password"
       user username: "security_test_user", password: "security-test-password", role: "security_test_role"

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -20,7 +20,7 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   setting 'xpack.security.authc.token.enabled', 'true'
   setting 'xpack.security.authc.api_key.enabled', 'true'
 
-  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
+  rolesFile file('src/javaRestTest/resources/roles.yml')
   user username: "admin_user", password: "admin-password"
   user username: "security_test_user", password: "security-test-password", role: "security_test_role"
   user username: "x_pack_rest_user", password: "x-pack-test-password"

--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -10,7 +10,6 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
 
-  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
   extraConfigFile 'node.key', file('src/javaRestTest/resources/ssl/node.key')
   extraConfigFile 'node.crt', file('src/javaRestTest/resources/ssl/node.crt')
   extraConfigFile 'ca.crt', file('src/javaRestTest/resources/ssl/ca.crt')
@@ -38,7 +37,8 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'node-password'
   keystore 'xpack.security.http.ssl.secure_key_passphrase', 'node-password'
 
-  user username: "test_admin", password: 'x-pack-test-password', role: "superuser"
+  rolesFile file('src/javaRestTest/resources/roles.yml')
+  user username: "test_admin", password: 'x-pack-test-password'
   user username: "elastic/fleet-server", password: 'x-pack-test-password', role: "superuser"
   user username: "service_account_manager", password: 'x-pack-test-password', role: "service_account_manager"
 }

--- a/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
+++ b/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
@@ -78,7 +78,7 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   setting 'xpack.security.authc.realms.oidc.openid7.claims.principal', 'sub'
   keystore 'xpack.security.authc.realms.oidc.openid7.rp.client_secret', 'this-is-my-secret'
 
-  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
+  rolesFile file('src/javaRestTest/resources/roles.yml')
   user username: "admin_user", password: "admin-password"
   user username: "security_test_user", password: "security-test-password", role: "security_test_role"
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRealmsCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRealmsCacheTests.java
@@ -188,7 +188,7 @@ public class ClearRealmsCacheTests extends SecurityIntegTestCase {
 
     @Override
     protected String configRoles() {
-        return SecuritySettingsSource.CONFIG_ROLE_ALLOW_ALL + "\n" + "r1:\n" + "  cluster: all\n";
+        return super.configRoles() + "\n" + "r1:\n" + "  cluster: all\n";
     }
 
     @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -83,6 +83,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
     @Override
     protected String configRoles() {
+        // The definition of TEST_ROLE here is intentionally different than the definition in the superclass.
         return """
             %s:
               cluster: [ all ]
@@ -113,7 +114,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
               indices:
                 - names: 'b'
                   privileges: [all]
-            """.formatted(SecuritySettingsSource.TEST_ROLE);
+            """.formatted(SecuritySettingsSource.TEST_ROLE) + '\n' + SecuritySettingsSourceField.ES_TEST_ROOT_ROLE_YML;
     }
 
     @Override
@@ -168,7 +169,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
         try {
             client.prepareSearch("test", "test2").setQuery(matchAllQuery()).get();
-            fail("expected an authorization exception when one of mulitple indices is forbidden");
+            fail("expected an authorization exception when one of multiple indices is forbidden");
         } catch (ElasticsearchSecurityException e) {
             // expected
             assertThat(e.status(), is(RestStatus.FORBIDDEN));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
@@ -24,7 +24,7 @@ import org.junit.BeforeClass;
 
 import java.nio.file.Path;
 
-import static org.elasticsearch.test.SecuritySettingsSource.TEST_SUPERUSER;
+import static org.elasticsearch.test.SecuritySettingsSource.ES_TEST_ROOT_USER;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -150,7 +150,7 @@ public class SecurityFeatureStateIntegTests extends AbstractPrivilegeTestCase {
 
     private Response performSuperuserRequest(Request request) throws Exception {
         String token = UsernamePasswordToken.basicAuthHeaderValue(
-            TEST_SUPERUSER,
+            ES_TEST_ROOT_USER,
             new SecureString(SecuritySettingsSourceField.TEST_PASSWORD.toCharArray())
         );
         return performAuthenticatedRequest(request, token);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
@@ -71,8 +71,8 @@ public class LicensingTests extends SecurityIntegTestCase {
 
     private static final SecureString HASH_PASSWD = new SecureString(Hasher.BCRYPT4.hash(new SecureString("passwd".toCharArray())));
 
-    private static final String ROLES = SecuritySettingsSource.TEST_ROLE + """
-        :
+    private static final String ROLES = """
+        %s:
           cluster: [ all ]
           indices:
             - names: '*'
@@ -96,15 +96,13 @@ public class LicensingTests extends SecurityIntegTestCase {
           indices:
             - names: 'b'
               privileges: [all]
-        """;
+        """.formatted(SecuritySettingsSource.TEST_ROLE) + '\n' + SecuritySettingsSourceField.ES_TEST_ROOT_ROLE_YML;
 
     private static final String USERS_ROLES = """
-        user:test_user,test_trans_client_user
-        transport_client:test_trans_client_user
         superuser:test_superuser
         role_a:user_a,user_b
         role_b:user_b
-        """;
+        """ + SecuritySettingsSource.CONFIG_STANDARD_USER_ROLES;
 
     @Override
     protected String configRoles() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -82,7 +82,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.test.SecuritySettingsSource.TEST_SUPERUSER;
+import static org.elasticsearch.test.SecuritySettingsSource.ES_TEST_ROOT_USER;
 import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -181,7 +181,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Instant start = Instant.ofEpochMilli(Instant.now().toEpochMilli());
         final RoleDescriptor descriptor = new RoleDescriptor("role", new String[] { "monitor" }, null, null);
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         final CreateApiKeyResponse response = new CreateApiKeyRequestBuilder(client).setName("test key")
             .setExpiration(TimeValue.timeValueHours(TimeUnit.DAYS.toHours(7L)))
@@ -212,7 +212,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final RestHighLevelClient restClient = new TestRestHighLevelClient();
         AuthenticateResponse authResponse = restClient.security()
             .authenticate(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "ApiKey " + base64ApiKeyKeyValue).build());
-        assertThat(authResponse.getUser().getUsername(), equalTo(TEST_SUPERUSER));
+        assertThat(authResponse.getUser().getUsername(), equalTo(ES_TEST_ROOT_USER));
         assertThat(authResponse.getAuthenticationType(), equalTo("api_key"));
 
         // use the first ApiKey for an unauthorized action
@@ -236,7 +236,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         for (int i = 0; i < noOfApiKeys; i++) {
             final RoleDescriptor descriptor = new RoleDescriptor("role", new String[] { "monitor" }, null, null);
             Client client = client().filterWithHeader(
-                Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+                Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
             );
             final CreateApiKeyResponse response = new CreateApiKeyRequestBuilder(client).setName(keyName)
                 .setExpiration(null)
@@ -255,7 +255,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     public void testCreateApiKeyWithoutNameWillFail() {
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         final ActionRequestValidationException e = expectThrows(
             ActionRequestValidationException.class,
@@ -268,7 +268,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         int noOfApiKeys = randomIntBetween(3, 5);
         List<CreateApiKeyResponse> responses = createApiKeys(noOfApiKeys, null).v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingRealmName("file"), listener);
@@ -280,10 +280,10 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         int noOfApiKeys = randomIntBetween(3, 5);
         List<CreateApiKeyResponse> responses = createApiKeys(noOfApiKeys, null).v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingUserName(TEST_SUPERUSER), listener);
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingUserName(ES_TEST_ROOT_USER), listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
         verifyInvalidateResponse(noOfApiKeys, responses, invalidateResponse);
     }
@@ -291,10 +291,10 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     public void testInvalidateApiKeysForRealmAndUser() throws InterruptedException, ExecutionException {
         List<CreateApiKeyResponse> responses = createApiKeys(1, null).v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingRealmAndUserName("file", TEST_SUPERUSER), listener);
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingRealmAndUserName("file", ES_TEST_ROOT_USER), listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
         verifyInvalidateResponse(1, responses, invalidateResponse);
     }
@@ -302,7 +302,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     public void testInvalidateApiKeysForApiKeyId() throws InterruptedException, ExecutionException {
         List<CreateApiKeyResponse> responses = createApiKeys(1, null).v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(0).getId(), false), listener);
@@ -313,7 +313,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     public void testInvalidateApiKeysForApiKeyName() throws InterruptedException, ExecutionException {
         List<CreateApiKeyResponse> responses = createApiKeys(1, null).v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(
@@ -355,7 +355,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         // Invalidate the first key
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(apiKey1.v1(), false), listener);
@@ -399,7 +399,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     public void testInvalidatedApiKeysDeletedByRemover() throws Exception {
         Client client = waitForExpiredApiKeysRemoverTriggerReadyAndGetClient().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
 
         List<CreateApiKeyResponse> createdApiKeys = createApiKeys(2, null).v1();
@@ -439,7 +439,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         );
 
         client = waitForExpiredApiKeysRemoverTriggerReadyAndGetClient().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
 
         // invalidate API key to trigger remover
@@ -494,7 +494,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     public void testExpiredApiKeysBehaviorWhenKeysExpired1WeekBeforeAnd1DayBefore() throws Exception {
         Client client = waitForExpiredApiKeysRemoverTriggerReadyAndGetClient().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
 
         int noOfKeys = 4;
@@ -585,7 +585,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         List<CreateApiKeyResponse> responses = tuple.v1();
 
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         // trigger expired keys remover
@@ -613,7 +613,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(noOfApiKeys, null);
         List<CreateApiKeyResponse> responses = tuple.v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         boolean invalidate = randomBoolean();
         List<String> invalidatedApiKeyIds = null;
@@ -647,10 +647,10 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(noOfApiKeys, null);
         List<CreateApiKeyResponse> responses = tuple.v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<GetApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.usingUserName(TEST_SUPERUSER), listener);
+        client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.usingUserName(ES_TEST_ROOT_USER), listener);
         GetApiKeyResponse response = listener.get();
         verifyGetResponse(
             noOfApiKeys,
@@ -666,10 +666,10 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(1, null);
         List<CreateApiKeyResponse> responses = tuple.v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<GetApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.usingRealmAndUserName("file", TEST_SUPERUSER), listener);
+        client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.usingRealmAndUserName("file", ES_TEST_ROOT_USER), listener);
         GetApiKeyResponse response = listener.get();
         verifyGetResponse(1, responses, tuple.v2(), response, Collections.singleton(responses.get(0).getId()), null);
     }
@@ -678,7 +678,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(1, null);
         List<CreateApiKeyResponse> responses = tuple.v1();
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         PlainActionFuture<GetApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.usingApiKeyId(responses.get(0).getId(), false), listener);
@@ -689,7 +689,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     public void testGetApiKeysForApiKeyName() throws InterruptedException, ExecutionException {
         final Map<String, String> headers = Collections.singletonMap(
             "Authorization",
-            basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING)
+            basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING)
         );
 
         final int noOfApiKeys = randomIntBetween(1, 3);
@@ -905,7 +905,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             .flatMap(List::stream)
             .collect(Collectors.toList());
         verifyGetResponse(
-            new String[] { TEST_SUPERUSER, "user_with_manage_api_key_role", "user_with_manage_own_api_key_role" },
+            new String[] { ES_TEST_ROOT_USER, "user_with_manage_api_key_role", "user_with_manage_own_api_key_role" },
             totalApiKeys,
             allApiKeys,
             metadatas,
@@ -1038,7 +1038,12 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     public void testApiKeyAuthorizationApiKeyMustBeAbleToRetrieveItsOwnInformationButNotAnyOtherKeysCreatedBySameOwner()
         throws InterruptedException, ExecutionException {
-        final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(TEST_SUPERUSER, 2, null, (String[]) null);
+        final Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> tuple = createApiKeys(
+            ES_TEST_ROOT_USER,
+            2,
+            null,
+            (String[]) null
+        );
         List<CreateApiKeyResponse> responses = tuple.v1();
         final String base64ApiKeyKeyValue = Base64.getEncoder()
             .encodeToString((responses.get(0).getId() + ":" + responses.get(0).getKey().toString()).getBytes(StandardCharsets.UTF_8));
@@ -1056,17 +1061,17 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             failureListener
         );
         ElasticsearchSecurityException ese = expectThrows(ElasticsearchSecurityException.class, () -> failureListener.actionGet());
-        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/get", TEST_SUPERUSER, responses.get(0).getId());
+        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/get", ES_TEST_ROOT_USER, responses.get(0).getId());
 
         final PlainActionFuture<GetApiKeyResponse> failureListener1 = new PlainActionFuture<>();
         client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.forOwnedApiKeys(), failureListener1);
         ese = expectThrows(ElasticsearchSecurityException.class, () -> failureListener1.actionGet());
-        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/get", TEST_SUPERUSER, responses.get(0).getId());
+        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/get", ES_TEST_ROOT_USER, responses.get(0).getId());
     }
 
     public void testApiKeyWithManageOwnPrivilegeIsAbleToInvalidateItselfButNotAnyOtherKeysCreatedBySameOwner() throws InterruptedException,
         ExecutionException {
-        List<CreateApiKeyResponse> responses = createApiKeys(TEST_SUPERUSER, 2, null, "manage_own_api_key").v1();
+        List<CreateApiKeyResponse> responses = createApiKeys(ES_TEST_ROOT_USER, 2, null, "manage_own_api_key").v1();
         final String base64ApiKeyKeyValue = Base64.getEncoder()
             .encodeToString((responses.get(0).getId() + ":" + responses.get(0).getKey().toString()).getBytes(StandardCharsets.UTF_8));
         Client client = client().filterWithHeader(Map.of("Authorization", "ApiKey " + base64ApiKeyKeyValue));
@@ -1079,12 +1084,12 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             failureListener
         );
         ElasticsearchSecurityException ese = expectThrows(ElasticsearchSecurityException.class, () -> failureListener.actionGet());
-        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/invalidate", TEST_SUPERUSER, responses.get(0).getId());
+        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/invalidate", ES_TEST_ROOT_USER, responses.get(0).getId());
 
         final PlainActionFuture<InvalidateApiKeyResponse> failureListener1 = new PlainActionFuture<>();
         client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.forOwnedApiKeys(), failureListener1);
         ese = expectThrows(ElasticsearchSecurityException.class, () -> failureListener1.actionGet());
-        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/invalidate", TEST_SUPERUSER, responses.get(0).getId());
+        assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/invalidate", ES_TEST_ROOT_USER, responses.get(0).getId());
 
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         client.execute(
@@ -1102,7 +1107,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     public void testDerivedKeys() throws ExecutionException, InterruptedException {
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         final CreateApiKeyResponse response = new CreateApiKeyRequestBuilder(client).setName("key-1")
             .setRoleDescriptors(Collections.singletonList(new RoleDescriptor("role", new String[] { "manage_api_key" }, null, null)))
@@ -1183,7 +1188,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         final RoleDescriptor descriptor = new RoleDescriptor("auth_only", new String[] {}, null, null);
         final Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         final CreateApiKeyResponse createApiKeyResponse = new CreateApiKeyRequestBuilder(client).setName("auth only key")
             .setRoleDescriptors(Collections.singletonList(descriptor))
@@ -1249,7 +1254,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             createApiKeyRequest.setOptions(
                 createApiKeyRequest.getOptions()
                     .toBuilder()
-                    .addHeader("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+                    .addHeader("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
             );
             final ResponseException e2 = expectThrows(ResponseException.class, () -> restClient.performRequest(createApiKeyRequest));
             assertThat(e2.getMessage(), containsString("429 Too Many Requests"));
@@ -1357,7 +1362,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     private Tuple<String, String> createApiKeyAndAuthenticateWithIt() throws IOException {
         Client client = client().filterWithHeader(
-            Collections.singletonMap("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Collections.singletonMap("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
 
         final CreateApiKeyResponse createApiKeyResponse = new CreateApiKeyRequestBuilder(client).setName("test key")
@@ -1388,7 +1393,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         Set<String> validApiKeyIds,
         List<String> invalidatedApiKeyIds
     ) {
-        verifyGetResponse(TEST_SUPERUSER, expectedNumberOfApiKeys, responses, metadatas, response, validApiKeyIds, invalidatedApiKeyIds);
+        verifyGetResponse(ES_TEST_ROOT_USER, expectedNumberOfApiKeys, responses, metadatas, response, validApiKeyIds, invalidatedApiKeyIds);
     }
 
     private void verifyGetResponse(
@@ -1467,7 +1472,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     }
 
     private Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> createApiKeys(int noOfApiKeys, TimeValue expiration) {
-        return createApiKeys(TEST_SUPERUSER, noOfApiKeys, expiration, "monitor");
+        return createApiKeys(ES_TEST_ROOT_USER, noOfApiKeys, expiration, "monitor");
     }
 
     private Tuple<List<CreateApiKeyResponse>, List<Map<String, Object>>> createApiKeys(
@@ -1545,7 +1550,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         putUserRequest.passwordHash(SecuritySettingsSource.TEST_PASSWORD_HASHED.toCharArray());
         PlainActionFuture<PutUserResponse> listener = new PlainActionFuture<>();
         final Client client = client().filterWithHeader(
-            Map.of("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING))
+            Map.of("Authorization", basicAuthHeaderValue(ES_TEST_ROOT_USER, TEST_PASSWORD_SECURE_STRING))
         );
         client.execute(PutUserAction.INSTANCE, putUserRequest, listener);
         final PutUserResponse putUserResponse = listener.get();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -290,7 +290,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                     .addHeader(
                         "Authorization",
                         UsernamePasswordToken.basicAuthHeaderValue(
-                            SecuritySettingsSource.TEST_SUPERUSER,
+                            SecuritySettingsSource.ES_TEST_ROOT_USER,
                             SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                         )
                     )
@@ -321,7 +321,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                     .addHeader(
                         "Authorization",
                         UsernamePasswordToken.basicAuthHeaderValue(
-                            SecuritySettingsSource.TEST_SUPERUSER,
+                            SecuritySettingsSource.ES_TEST_ROOT_USER,
                             SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                         )
                     )
@@ -352,7 +352,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                     .addHeader(
                         "Authorization",
                         UsernamePasswordToken.basicAuthHeaderValue(
-                            SecuritySettingsSource.TEST_SUPERUSER,
+                            SecuritySettingsSource.ES_TEST_ROOT_USER,
                             SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                         )
                     )
@@ -711,7 +711,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                         .addHeader(
                             "Authorization",
                             UsernamePasswordToken.basicAuthHeaderValue(
-                                SecuritySettingsSource.TEST_SUPERUSER,
+                                SecuritySettingsSource.ES_TEST_ROOT_USER,
                                 SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                             )
                         )
@@ -728,7 +728,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
             .addHeader(
                 "Authorization",
                 UsernamePasswordToken.basicAuthHeaderValue(
-                    SecuritySettingsSource.TEST_SUPERUSER,
+                    SecuritySettingsSource.ES_TEST_ROOT_USER,
                     SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                 )
             )
@@ -751,7 +751,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
 
         AuthenticateResponse response = restClient.security().authenticate(superuserOptions);
 
-        assertEquals(SecuritySettingsSource.TEST_SUPERUSER, response.getUser().getUsername());
+        assertEquals(SecuritySettingsSource.ES_TEST_ROOT_USER, response.getUser().getUsername());
         assertEquals("realm", response.getAuthenticationType());
 
         assertAuthenticateWithToken(createTokenResponse.getAccessToken(), SecuritySettingsSource.TEST_USER_NAME);
@@ -763,7 +763,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
             .addHeader(
                 "Authorization",
                 UsernamePasswordToken.basicAuthHeaderValue(
-                    SecuritySettingsSource.TEST_SUPERUSER,
+                    SecuritySettingsSource.ES_TEST_ROOT_USER,
                     SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                 )
             )
@@ -773,7 +773,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
             .createToken(CreateTokenRequest.clientCredentialsGrant(), superuserOptions);
         assertNull(createTokenResponse.getRefreshToken());
 
-        assertAuthenticateWithToken(createTokenResponse.getAccessToken(), SecuritySettingsSource.TEST_SUPERUSER);
+        assertAuthenticateWithToken(createTokenResponse.getAccessToken(), SecuritySettingsSource.ES_TEST_ROOT_USER);
 
         // invalidate
         InvalidateTokenResponse invalidateTokenResponse = restClient.security()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -447,7 +447,7 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
             Collections.singletonMap(
                 "Authorization",
                 UsernamePasswordToken.basicAuthHeaderValue(
-                    SecuritySettingsSource.TEST_SUPERUSER,
+                    SecuritySettingsSource.ES_TEST_ROOT_USER,
                     SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
                 )
             )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -59,8 +59,19 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
     public static final String TEST_USER_NAME = "test_user";
     public static final Hasher HASHER = getFastStoredHashAlgoForTests();
     public static final String TEST_PASSWORD_HASHED = new String(HASHER.hash(new SecureString(TEST_PASSWORD.toCharArray())));
+
     public static final String TEST_ROLE = "user";
-    public static final String TEST_SUPERUSER = "test_superuser";
+    private static final String TEST_ROLE_YML = """
+        user:
+          cluster: [ ALL ]
+          indices:
+            - names: '*'
+              allow_restricted_indices: true
+              privileges: [ ALL ]
+        """;
+
+    public static final String ES_TEST_ROOT_USER = "es_test_root";
+
     public static final RequestOptions SECURITY_REQUEST_OPTIONS = RequestOptions.DEFAULT.toBuilder()
         .addHeader(
             "Authorization",
@@ -79,7 +90,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         + ":"
         + TEST_PASSWORD_HASHED
         + "\n"
-        + TEST_SUPERUSER
+        + ES_TEST_ROOT_USER
         + ":"
         + TEST_PASSWORD_HASHED
         + "\n";
@@ -89,23 +100,11 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         + TEST_USER_NAME
         + ","
         + DEFAULT_TRANSPORT_CLIENT_USER_NAME
-        + "\n"
-        + DEFAULT_TRANSPORT_CLIENT_ROLE
-        + ":"
-        + DEFAULT_TRANSPORT_CLIENT_USER_NAME
-        + "\n"
-        + "superuser:"
-        + TEST_SUPERUSER
-        + "\n";
+        + "\n" //
+        + (DEFAULT_TRANSPORT_CLIENT_ROLE + ":" + DEFAULT_TRANSPORT_CLIENT_USER_NAME + "\n") //
+        + (SecuritySettingsSourceField.ES_TEST_ROOT_ROLE + ":" + ES_TEST_ROOT_USER + "\n");
 
-    public static final String CONFIG_ROLE_ALLOW_ALL = """
-        %s:
-          cluster: [ ALL ]
-          indices:
-            - names: '*'
-              allow_restricted_indices: true
-              privileges: [ ALL ]
-        """.formatted(TEST_ROLE);
+    public static final String CONFIG_STANDARD_ROLES_YML = TEST_ROLE_YML + "\n" + SecuritySettingsSourceField.ES_TEST_ROOT_ROLE_YML;
 
     private final Path parentFolder;
     private final String subfolderPrefix;
@@ -202,7 +201,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
     }
 
     protected String configRoles() {
-        return CONFIG_ROLE_ALLOW_ALL;
+        return CONFIG_STANDARD_ROLES_YML;
     }
 
     protected String configOperatorUsers() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -29,6 +29,8 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
@@ -2005,10 +2007,10 @@ public class AuthorizationServiceTests extends ESTestCase {
         }
     }
 
-    public void testSuperusersCanExecuteOperationAgainstSecurityIndex() throws IOException {
+    public void testSuperusersCanExecuteReadOperationAgainstSecurityIndex() throws IOException {
         final User superuser = new User("custom_admin", ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName());
         roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
-        ClusterState state = mockClusterState(
+        mockClusterState(
             Metadata.builder()
                 .put(
                     new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7).putAlias(
@@ -2025,28 +2027,6 @@ public class AuthorizationServiceTests extends ESTestCase {
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         List<Tuple<String, TransportRequest>> requests = new ArrayList<>();
-        requests.add(
-            new Tuple<>(DeleteAction.NAME, new DeleteRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), "id"))
-        );
-        requests.add(
-            new Tuple<>(
-                BulkAction.NAME + "[s]",
-                createBulkShardRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), DeleteRequest::new)
-            )
-        );
-        requests.add(
-            new Tuple<>(UpdateAction.NAME, new UpdateRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), "id"))
-        );
-        requests.add(new Tuple<>(IndexAction.NAME, new IndexRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7))));
-        requests.add(
-            new Tuple<>(
-                BulkAction.NAME + "[s]",
-                createBulkShardRequest(
-                    randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7),
-                    (index, id) -> new IndexRequest(index).id(id)
-                )
-            )
-        );
         requests.add(new Tuple<>(SearchAction.NAME, new SearchRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7))));
         requests.add(
             new Tuple<>(
@@ -2055,18 +2035,6 @@ public class AuthorizationServiceTests extends ESTestCase {
             )
         );
         requests.add(new Tuple<>(GetAction.NAME, new GetRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), "id")));
-        requests.add(
-            new Tuple<>(
-                TermVectorsAction.NAME,
-                new TermVectorsRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), "id")
-            )
-        );
-        requests.add(
-            new Tuple<>(
-                IndicesAliasesAction.NAME,
-                new IndicesAliasesRequest().addAliasAction(AliasActions.add().alias("security_alias").index(INTERNAL_SECURITY_MAIN_INDEX_7))
-            )
-        );
         requests.add(
             new Tuple<>(ClusterHealthAction.NAME, new ClusterHealthRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7)))
         );
@@ -2094,11 +2062,86 @@ public class AuthorizationServiceTests extends ESTestCase {
         }
     }
 
-    public void testSuperusersCanExecuteOperationAgainstSecurityIndexWithWildcard() throws IOException {
+    public void testSuperusersCannotExecuteWriteOperationAgainstSecurityIndex() throws IOException {
+        final User superuser = new User("custom_admin", ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName());
+        roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
+        mockClusterState(
+            Metadata.builder()
+                .put(
+                    new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7).putAlias(
+                        new AliasMetadata.Builder(SECURITY_MAIN_ALIAS).build()
+                    )
+                        .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
+                        .numberOfShards(1)
+                        .numberOfReplicas(0)
+                        .build(),
+                    true
+                )
+                .build()
+        );
+        final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
+
+        List<Tuple<String, TransportRequest>> requests = new ArrayList<>();
+        requests.add(
+            new Tuple<>(
+                BulkAction.NAME + "[s]",
+                createBulkShardRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), DeleteRequest::new)
+            )
+        );
+        requests.add(
+            new Tuple<>(
+                BulkAction.NAME + "[s]",
+                createBulkShardRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), UpdateRequest::new)
+            )
+        );
+        requests.add(
+            new Tuple<>(
+                BulkAction.NAME + "[s]",
+                createBulkShardRequest(
+                    randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7),
+                    (index, id) -> new IndexRequest(index).id(id)
+                )
+            )
+        );
+        requests.add(
+            new Tuple<>(
+                IndicesAliasesAction.NAME,
+                new IndicesAliasesRequest().addAliasAction(AliasActions.add().alias("security_alias").index(INTERNAL_SECURITY_MAIN_INDEX_7))
+            )
+        );
+        requests.add(
+            new Tuple<>(PutMappingAction.NAME, new PutMappingRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7)))
+        );
+        requests.add(
+            new Tuple<>(DeleteIndexAction.NAME, new DeleteIndexRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7)))
+        );
+        for (final Tuple<String, TransportRequest> requestTuple : requests) {
+            final String action = requestTuple.v1();
+            final TransportRequest request = requestTuple.v2();
+            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+                final Authentication authentication = createAuthentication(superuser);
+                assertThrowsAuthorizationException(
+                    "authentication=[" + authentication + "], action=[" + action + "], request=[" + request + "]",
+                    () -> authorize(authentication, action, request),
+                    action,
+                    superuser.principal()
+                );
+                verify(auditTrail).accessDenied(
+                    eq(requestId),
+                    eq(authentication),
+                    eq(action),
+                    eq(request),
+                    authzInfoRoles(superuser.roles())
+                );
+            }
+        }
+    }
+
+    public void testSuperusersCanExecuteReadOperationAgainstSecurityIndexWithWildcard() throws IOException {
         final User superuser = new User("custom_admin", ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName());
         final Authentication authentication = createAuthentication(superuser);
         roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
-        ClusterState state = mockClusterState(
+        mockClusterState(
             Metadata.builder()
                 .put(
                     new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7).putAlias(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -69,6 +69,7 @@ import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
 import org.elasticsearch.xpack.core.security.index.IndexAuditTrailField;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
+import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
 import org.elasticsearch.xpack.core.security.test.TestRestrictedIndices;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
@@ -117,6 +118,7 @@ import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.R
 import static org.elasticsearch.xpack.security.authc.ApiKeyService.API_KEY_ID_KEY;
 import static org.elasticsearch.xpack.security.authc.ApiKeyServiceTests.Utils.createApiKeyAuthentication;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -314,6 +316,71 @@ public class CompositeRolesStoreTests extends ESTestCase {
         effectiveRoleDescriptors.set(null);
     }
 
+    public void testSuperuserIsEffectiveWhenOtherRolesUnavailable() {
+        final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
+        doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
+        when(fileRolesStore.roleDescriptors(anySet())).thenReturn(Collections.emptySet());
+
+        final NativeRolesStore nativeRolesStore = mock(NativeRolesStore.class);
+        doCallRealMethod().when(nativeRolesStore).accept(anySet(), anyActionListener());
+        doAnswer((invocationOnMock) -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<RoleRetrievalResult> callback = (ActionListener<RoleRetrievalResult>) invocationOnMock.getArguments()[1];
+            final RuntimeException exception = new RuntimeException("Test(" + getTestName() + ") - native roles unavailable");
+            if (randomBoolean()) {
+                callback.onFailure(exception);
+            } else {
+                callback.onResponse(RoleRetrievalResult.failure(exception));
+
+            }
+            return null;
+        }).when(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
+
+        final ReservedRolesStore reservedRolesStore = spy(new ReservedRolesStore());
+        final NativePrivilegeStore nativePrivilegeStore = mock(NativePrivilegeStore.class);
+        doAnswer((invocationOnMock) -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Collection<ApplicationPrivilegeDescriptor>> callback = (ActionListener<
+                Collection<ApplicationPrivilegeDescriptor>>) invocationOnMock.getArguments()[2];
+            callback.onResponse(Collections.emptyList());
+            return null;
+        }).when(nativePrivilegeStore).getPrivileges(anySet(), anySet(), anyActionListener());
+
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            fileRolesStore,
+            nativeRolesStore,
+            reservedRolesStore,
+            nativePrivilegeStore,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        final Set<String> roles = Set.of(randomAlphaOfLengthBetween(1, 6), "superuser", randomAlphaOfLengthBetween(7, 12));
+        PlainActionFuture<Role> future = new PlainActionFuture<>();
+        getRoleForRoleNames(compositeRolesStore, roles, future);
+
+        final Role role = future.actionGet();
+        assertThat(role.names(), arrayContaining("superuser"));
+        assertThat(role.application().getApplicationNames(), containsInAnyOrder("*"));
+        assertThat(role.cluster().privileges(), containsInAnyOrder(ClusterPrivilegeResolver.ALL));
+        assertThat(role.indices().check(SearchAction.NAME), Matchers.is(true));
+        assertThat(role.indices().check(IndexAction.NAME), Matchers.is(true));
+
+        final Predicate<String> indexActionPredicate = Automatons.predicate(
+            role.indices().allowedActionsMatcher("index-" + randomAlphaOfLengthBetween(1, 12))
+        );
+        assertThat(indexActionPredicate.test(SearchAction.NAME), is(true));
+        assertThat(indexActionPredicate.test(IndexAction.NAME), is(true));
+
+        final Predicate<String> securityActionPredicate = Automatons.predicate(role.indices().allowedActionsMatcher(".security"));
+        assertThat(securityActionPredicate.test(SearchAction.NAME), is(true));
+        assertThat(securityActionPredicate.test(IndexAction.NAME), is(false));
+    }
+
     public void testNegativeLookupsAreCached() {
         final FileRolesStore fileRolesStore = mock(FileRolesStore.class);
         doCallRealMethod().when(fileRolesStore).accept(anySet(), anyActionListener());
@@ -359,11 +426,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         assertThat(effectiveRoleDescriptors.get().isEmpty(), is(true));
         effectiveRoleDescriptors.set(null);
         assertEquals(Role.EMPTY, role);
-        verify(reservedRolesStore).accept(anySet(), anyActionListener());
-        verify(fileRolesStore).accept(anySet(), anyActionListener());
-        verify(fileRolesStore).roleDescriptors(eq(Collections.singleton(roleName)));
-        verify(nativeRolesStore).accept(anySet(), anyActionListener());
-        verify(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
+        verify(reservedRolesStore).accept(eq(Set.of(roleName)), anyActionListener());
+        verify(fileRolesStore).accept(eq(Set.of(roleName)), anyActionListener());
+        verify(fileRolesStore).roleDescriptors(eq(Set.of(roleName)));
+        verify(nativeRolesStore).accept(eq(Set.of(roleName)), anyActionListener());
+        verify(nativeRolesStore).getRoleDescriptors(eq(Set.of(roleName)), anyActionListener());
 
         final int numberOfTimesToCall = scaledRandomIntBetween(0, 32);
         final boolean getSuperuserRole = randomBoolean()
@@ -374,19 +441,21 @@ public class CompositeRolesStoreTests extends ESTestCase {
         for (int i = 0; i < numberOfTimesToCall; i++) {
             future = new PlainActionFuture<>();
             compositeRolesStore.roles(names, future);
-            future.actionGet();
-            if (getSuperuserRole && i == 0) {
-                assertThat(effectiveRoleDescriptors.get(), containsInAnyOrder(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR));
-                effectiveRoleDescriptors.set(null);
+            final Role role1 = future.actionGet();
+            if (getSuperuserRole) {
+                assertThat(role1.names(), arrayContaining("superuser"));
+                final Collection<RoleDescriptor> descriptors = effectiveRoleDescriptors.get();
+                assertThat(descriptors, hasSize(1));
+                assertThat(descriptors.iterator().next().getName(), is("superuser"));
             } else {
                 assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
             }
         }
 
-        if (getSuperuserRole && numberOfTimesToCall > 0) {
-            // the superuser role was requested so we get the role descriptors again
+        if (getSuperuserRole) {
+            verify(nativePrivilegeStore).getPrivileges(eq(Set.of("*")), eq(Set.of("*")), anyActionListener());
+            // We can't verify the contents of the Set here because the set is mutated inside the method
             verify(reservedRolesStore, times(2)).accept(anySet(), anyActionListener());
-            verify(nativePrivilegeStore).getPrivileges(isASet(), isASet(), anyActionListener());
         }
         verifyNoMoreInteractions(fileRolesStore, reservedRolesStore, nativeRolesStore, nativePrivilegeStore);
     }
@@ -1631,6 +1700,21 @@ public class CompositeRolesStoreTests extends ESTestCase {
         );
     }
 
+    public void testXPackSecurityUserCanAccessAnyIndex() {
+        for (String action : Arrays.asList(GetAction.NAME, DeleteAction.NAME, SearchAction.NAME, IndexAction.NAME)) {
+            Predicate<IndexAbstraction> predicate = getXPackSecurityRole().indices().allowedIndicesMatcher(action);
+
+            IndexAbstraction index = mockIndexAbstraction(randomAlphaOfLengthBetween(3, 12));
+            assertThat(predicate.test(index), Matchers.is(true));
+
+            index = mockIndexAbstraction("." + randomAlphaOfLengthBetween(3, 12));
+            assertThat(predicate.test(index), Matchers.is(true));
+
+            index = mockIndexAbstraction(".security-" + randomIntBetween(1, 16));
+            assertThat(predicate.test(index), Matchers.is(true));
+        }
+    }
+
     public void testXPackUserCanAccessNonRestrictedIndices() {
         CharacterRunAutomaton restrictedAutomaton = new CharacterRunAutomaton(RESTRICTED_INDICES_AUTOMATON);
         for (String action : Arrays.asList(GetAction.NAME, DeleteAction.NAME, SearchAction.NAME, IndexAction.NAME)) {
@@ -1730,23 +1814,23 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }
     }
 
+    private void getRoleForRoleNames(CompositeRolesStore rolesStore, Collection<String> roleNames, ActionListener<Role> listener) {
+        rolesStore.roles(Sets.newHashSet(roleNames), listener);
+    }
+
+    private Role getXPackSecurityRole() {
+        return getInternalUserRole(CompositeRolesStore::getXpackSecurityRole);
+    }
+
     private Role getXPackUserRole() {
-        CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
-            SECURITY_ENABLED_SETTINGS,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-        return compositeRolesStore.getXpackUserRole();
+        return getInternalUserRole(CompositeRolesStore::getXpackUserRole);
     }
 
     private Role getAsyncSearchUserRole() {
+        return getInternalUserRole(CompositeRolesStore::getAsyncSearchUserRole);
+    }
+
+    private Role getInternalUserRole(Function<CompositeRolesStore, Role> getter) {
         CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
             SECURITY_ENABLED_SETTINGS,
             null,
@@ -1759,7 +1843,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             null,
             null
         );
-        return compositeRolesStore.getAsyncSearchUserRole();
+        return getter.apply(compositeRolesStore);
     }
 
     private CompositeRolesStore buildCompositeRolesStore(

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.license.self_generated.type', 'trial'
     // Setup roles used by tests
-    extraConfigFile 'roles.yml', mainProject.file('roles.yml')
+    rolesFile mainProject.file('roles.yml')
     /* Setup the one admin user that we run the tests as.
      * Tests use "run as" to get different users. */
     user username: "test_admin", password: "x-pack-test-password"

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     // skip automatically creating the "elastic" user (and the associated .security index)
     setting 'xpack.security.autoconfiguration.enabled', 'false'
     // Setup roles used by tests
-    extraConfigFile 'roles.yml', mainProject.file('roles.yml')
+    rolesFile mainProject.file('roles.yml')
     /* Setup the one admin user that we run the tests as.
      * Tests use "run as" to get different users. */
     user username: "test_admin", password: "x-pack-test-password"

--- a/x-pack/plugin/text-structure/qa/text-structure-with-security/build.gradle
+++ b/x-pack/plugin/text-structure/qa/text-structure-with-security/build.gradle
@@ -21,7 +21,7 @@ tasks.named("yamlRestTest").configure {
 
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   user username: "text_structure_user", password: "x-pack-test-password", role: "minimal,monitor_text_structure"
   user username: "no_text_structure", password: "x-pack-test-password", role: "minimal"

--- a/x-pack/plugin/watcher/qa/with-security/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-security/build.gradle
@@ -31,7 +31,7 @@ testClusters.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'logger.org.elasticsearch.xpack.watcher', 'debug'
   setting 'logger.org.elasticsearch.xpack.core.watcher', 'debug'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "test_admin", password: "x-pack-test-password"
   user username: "x_pack_rest_user", password: "x-pack-test-password", role: "watcher_manager"
   user username: "watcher_manager", password: "x-pack-test-password", role: "watcher_manager"

--- a/x-pack/qa/multi-node/build.gradle
+++ b/x-pack/qa/multi-node/build.gradle
@@ -13,7 +13,7 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "test-user", password: "x-pack-test-password", role: "test"
   user username: "super-user", password: "x-pack-super-password"
 }

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -26,7 +26,8 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   extraConfigFile 'transport.key', file('src/test/resources/ssl/transport.key')
   extraConfigFile 'transport.crt', file('src/test/resources/ssl/transport.crt')
   extraConfigFile 'ca.crt', file('src/test/resources/ssl/ca.crt')
-  extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
+
+  rolesFile file('src/test/resources/roles.yml')
 
   user username: 'admin_user', password: 'admin-password'
   user username:'test-user' ,password: 'test-user-password', role: 'user_role'

--- a/x-pack/qa/runtime-fields/with-security/build.gradle
+++ b/x-pack/qa/runtime-fields/with-security/build.gradle
@@ -11,6 +11,6 @@ testClusters.configureEach {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
-  extraConfigFile 'roles.yml', file('roles.yml')
+  rolesFile file('roles.yml')
   user username: "test", password: "x-pack-test-password", role: "test"
 }


### PR DESCRIPTION
This commit changes the superuser role (as used by the "elastic"
builtin user) so that it no longer has any sort of write access to
restricted indices (system indices).
This improves the safety and security of the cluster, as it means
that there are no out-of-the-box users or roles that can write to,
delete or close the security index.

Superusers can still read from (and monitor) system indices.

Other roles (and users) can still access system indices as specified
in their descriptor. These can be custom such as the
"_es_test_root" role used in the integration test suite, or builtin
roles such as kibana_system.

Backport of: #81400
