### PR TITLE
Replace superuser role for API keys (#81977)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -422,7 +422,11 @@ public class CompositeRolesStore {
         final Role existing = roleCache.get(roleKey);
         if (existing == null) {
             final long invalidationCounter = numInvalidation.get();
-            final List<RoleDescriptor> roleDescriptors = apiKeyService.parseRoleDescriptors(apiKeyIdAndBytes.v1(), apiKeyIdAndBytes.v2());
+            final List<RoleDescriptor> roleDescriptors = apiKeyService.parseRoleDescriptors(
+                apiKeyIdAndBytes.v1(),
+                apiKeyIdAndBytes.v2(),
+                limitedBy ? ApiKeyService.ApiKeyRoleType.LIMITED_BY : ApiKeyService.ApiKeyRoleType.ASSIGNED
+            );
             buildThenMaybeCacheRole(roleKey, roleDescriptors, Collections.emptySet(), true, invalidationCounter, roleActionListener);
         } else {
             roleActionListener.onResponse(existing);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -598,7 +598,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(result.getRoleDescriptors().get(0), equalTo(superuserRoleDescriptor));
 
         assertThat(result.getLimitedByRoleDescriptors().size(), is(1));
-        // Limited role descriptor should always be the update superuser descriptor
+        // Limited role descriptor should always be the updated superuser role descriptor
         assertThat(result.getLimitedByRoleDescriptors().get(0), equalTo(SUPERUSER_ROLE_DESCRIPTOR));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -563,7 +563,9 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testGetRolesForApiKeyNotInContext() throws Exception {
         final boolean useLegacySuperuserRole = randomBoolean();
-        final RoleDescriptor superuserRoleDescriptor = useLegacySuperuserRole ? LEGACY_SUPERUSER_ROLE_DESCRIPTOR : SUPERUSER_ROLE_DESCRIPTOR;
+        final RoleDescriptor superuserRoleDescriptor = useLegacySuperuserRole
+            ? LEGACY_SUPERUSER_ROLE_DESCRIPTOR
+            : SUPERUSER_ROLE_DESCRIPTOR;
         Map<String, Object> superUserRdMap;
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             superUserRdMap = XContentHelper.convertToMap(
@@ -575,10 +577,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         Map<String, Object> authMetadata = new HashMap<>();
         authMetadata.put(ApiKeyService.API_KEY_ID_KEY, randomAlphaOfLength(12));
         authMetadata.put(API_KEY_ROLE_DESCRIPTORS_KEY, Collections.singletonMap(superuserRoleDescriptor.getName(), superUserRdMap));
-        authMetadata.put(
-            API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY,
-            Collections.singletonMap(superuserRoleDescriptor.getName(), superUserRdMap)
-        );
+        authMetadata.put(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY, Collections.singletonMap(superuserRoleDescriptor.getName(), superUserRdMap));
 
         final Authentication authentication = new Authentication(
             new User("joe"),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1551,8 +1551,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
         roleFuture.actionGet();
         assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
         verify(apiKeyService, times(2)).getApiKeyIdAndRoleBytes(eq(authentication), anyBoolean());
-        verify(apiKeyService).parseRoleDescriptors("key-id-1", roleBytes);
-        verify(apiKeyService).parseRoleDescriptors("key-id-1", limitedByRoleBytes);
+        verify(apiKeyService).parseRoleDescriptors("key-id-1", roleBytes, ApiKeyService.ApiKeyRoleType.ASSIGNED);
+        verify(apiKeyService).parseRoleDescriptors("key-id-1", limitedByRoleBytes, ApiKeyService.ApiKeyRoleType.LIMITED_BY);
 
         // Different API key with the same roles should read from cache
         authentication = new Authentication(
@@ -1576,7 +1576,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         roleFuture.actionGet();
         assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
         verify(apiKeyService, times(2)).getApiKeyIdAndRoleBytes(eq(authentication), anyBoolean());
-        verify(apiKeyService, never()).parseRoleDescriptors(eq("key-id-2"), any(BytesReference.class));
+        verify(apiKeyService, never()).parseRoleDescriptors(eq("key-id-2"), any(BytesReference.class), any());
 
         // Different API key with the same limitedBy role should read from cache, new role should be built
         final BytesArray anotherRoleBytes = new BytesArray("{\"b role\": {\"cluster\": [\"manage_security\"]}}");
@@ -1601,7 +1601,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         roleFuture.actionGet();
         assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
         verify(apiKeyService).getApiKeyIdAndRoleBytes(eq(authentication), eq(false));
-        verify(apiKeyService).parseRoleDescriptors("key-id-3", anotherRoleBytes);
+        verify(apiKeyService).parseRoleDescriptors("key-id-3", anotherRoleBytes, ApiKeyService.ApiKeyRoleType.ASSIGNED);
     }
 
     private Authentication createAuthentication() {

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -32,6 +33,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleStats;
 import org.hamcrest.Matcher;
@@ -324,6 +326,90 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             final Request getUserRequest = new Request("GET", "/_security/user");
             getUserRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", authHeader));
             final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(getUserRequest));
+            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            assertThat(e.getMessage(), containsString("is unauthorized"));
+        }
+    }
+
+    public void testApiKeySuperuser() throws IOException {
+        if (isRunningAgainstOldCluster()) {
+            final Request createUserRequest = new Request("PUT", "/_security/user/api_key_super_creator");
+            createUserRequest.setJsonEntity("""
+                {
+                   "password" : "l0ng-r4nd0m-p@ssw0rd",
+                   "roles" : [ "superuser", "monitoring_user" ]
+                }""");
+            client().performRequest(createUserRequest);
+
+            // Create API key
+            final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
+            createApiKeyRequest.setOptions(
+                RequestOptions.DEFAULT.toBuilder()
+                    .addHeader(
+                        "Authorization",
+                        UsernamePasswordToken.basicAuthHeaderValue(
+                            "api_key_super_creator",
+                            new SecureString("l0ng-r4nd0m-p@ssw0rd".toCharArray())
+                        )
+                    )
+            );
+            createApiKeyRequest.setJsonEntity("""
+                {
+                   "name": "super_legacy_key"
+                }""");
+            final Map<String, Object> createApiKeyResponse = entityAsMap(client().performRequest(createApiKeyRequest));
+            final byte[] keyBytes = (createApiKeyResponse.get("id") + ":" + createApiKeyResponse.get("api_key")).getBytes(
+                StandardCharsets.UTF_8
+            );
+            final String apiKeyAuthHeader = "ApiKey " + Base64.getEncoder().encodeToString(keyBytes);
+            // Save the API key info across restart
+            final Request saveApiKeyRequest = new Request("PUT", "/api_keys/_doc/super_legacy_key");
+            saveApiKeyRequest.setJsonEntity("{\"auth_header\":\"" + apiKeyAuthHeader + "\"}");
+            assertOK(client().performRequest(saveApiKeyRequest));
+
+            if (getOldClusterVersion().before(Version.V_8_0_0)) {
+                final Request indexRequest = new Request("POST", ".security/_doc");
+                indexRequest.setJsonEntity("""
+                    {
+                      "doc_type": "foo"
+                    }""");
+                indexRequest.setOptions(
+                    expectWarnings(
+                        "this request accesses system indices: [.security-7], but in a future major "
+                            + "version, direct access to system indices will be prevented by default"
+                    ).toBuilder().addHeader("Authorization", apiKeyAuthHeader)
+                );
+                assertOK(client().performRequest(indexRequest));
+            }
+        } else {
+            final Request getRequest = new Request("GET", "/api_keys/_doc/super_legacy_key");
+            final Map<String, Object> getResponseMap = responseAsMap(client().performRequest(getRequest));
+            @SuppressWarnings("unchecked")
+            final String apiKeyAuthHeader = ((Map<String, String>) getResponseMap.get("_source")).get("auth_header");
+
+            // read is ok
+            final Request searchRequest = new Request("GET", ".security/_search");
+            searchRequest.setOptions(
+                expectWarnings(
+                    "this request accesses system indices: [.security-7], but in a future major "
+                        + "version, direct access to system indices will be prevented by default"
+                ).toBuilder().addHeader("Authorization", apiKeyAuthHeader)
+            );
+            assertOK(client().performRequest(searchRequest));
+
+            // write must not be allowed
+            final Request indexRequest = new Request("POST", ".security/_doc");
+            indexRequest.setJsonEntity("""
+                {
+                  "doc_type": "foo"
+                }""");
+            indexRequest.setOptions(
+                expectWarnings(
+                    "this request accesses system indices: [.security-7], but in a future major "
+                        + "version, direct access to system indices will be prevented by default"
+                ).toBuilder().addHeader("Authorization", apiKeyAuthHeader)
+            );
+            final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(indexRequest));
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
             assertThat(e.getMessage(), containsString("is unauthorized"));
         }


### PR DESCRIPTION
This PR replace superuser role of an API key with the new limited
superuser role to prevent write access to system indices.

The replacement should only happen to the builtin superuser role.
If there is a user-created role that has the exact same definition as
the superuser role, it will not be replaced because we consider users
are explicitly opt-in for ALL access in this scenario.

Relates: #81400
