### PR TITLE
Handle degenerated rectangles in vector tiles 

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
@@ -118,6 +118,7 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82592")
     public void testRectangle() throws IOException {
         int z = randomIntBetween(3, 10);
         int x = randomIntBetween(1, (1 << z) - 2);

--- a/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
@@ -120,8 +120,8 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
 
     public void testRectangle() throws IOException {
         int z = randomIntBetween(3, 10);
-        int x = randomIntBetween(1, (1 << z) - 1);
-        int y = randomIntBetween(1, (1 << z) - 1);
+        int x = randomIntBetween(1, (1 << z) - 2);
+        int y = randomIntBetween(1, (1 << z) - 2);
         int extent = randomIntBetween(1 << 8, 1 << 14);
         SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
         {
@@ -129,8 +129,30 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
             assertThat(builder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat()).length, Matchers.greaterThan(0));
         }
         {
-            Rectangle r = GeoTileUtils.toBoundingBox(x - 1, y, z);
+            Rectangle r = GeoTileUtils.toBoundingBox(x - 2, y, z);
             assertThat(builder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat()).length, Matchers.equalTo(0));
+        }
+    }
+
+    public void testDegeneratedRectangle() throws IOException {
+        int z = randomIntBetween(3, 10);
+        int x = randomIntBetween(1, (1 << z) - 1);
+        int y = randomIntBetween(1, (1 << z) - 1);
+        int extent = randomIntBetween(1 << 8, 1 << 14);
+        SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
+        {
+            Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
+            // box is a point
+            assertThat(builder.box(r.getMaxLon(), r.getMaxLon(), r.getMaxLat(), r.getMaxLat()).length, Matchers.greaterThan(0));
+            assertThat(builder.box(r.getMaxLon(), r.getMaxLon(), r.getMinLat(), r.getMinLat()).length, Matchers.greaterThan(0));
+            assertThat(builder.box(r.getMinLon(), r.getMinLon(), r.getMaxLat(), r.getMaxLat()).length, Matchers.greaterThan(0));
+            assertThat(builder.box(r.getMinLon(), r.getMinLon(), r.getMinLat(), r.getMinLat()).length, Matchers.greaterThan(0));
+        }
+        {
+            Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
+            // box is a line
+            assertThat(builder.box(r.getMinLon(), r.getMinLon(), r.getMinLat(), r.getMaxLat()).length, Matchers.greaterThan(0));
+            assertThat(builder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMinLat()).length, Matchers.greaterThan(0));
         }
     }
 }

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -273,9 +273,8 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(1));
             assertLayer(tile, META_LAYER, 4096, 1, 8);
             final VectorTile.Tile.Layer layer = getLayer(tile, META_LAYER);
-            // edge case: because all points are the same, the bounding box is a point and cannot be expressed as a polygon.
-            // Therefore the feature ends-up without a geometry.
-            assertThat(layer.getFeatures(0).hasType(), Matchers.equalTo(false));
+            // edge case: because all points are the same, the bounding box is a point
+            assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POINT));
         }
         {
             final Request mvtRequest = new Request(

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -247,18 +247,12 @@ public class FeatureFactory {
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Rectangle rectangle) throws RuntimeException {
-            // TODO: handle degenerated rectangles?
             final double xMin = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMinX());
             final double yMin = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMinY());
             final double xMax = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMaxX());
             final double yMax = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMaxY());
-            final Coordinate[] coordinates = new Coordinate[5];
-            coordinates[0] = new Coordinate(xMin, yMin);
-            coordinates[1] = new Coordinate(xMax, yMin);
-            coordinates[2] = new Coordinate(xMax, yMax);
-            coordinates[3] = new Coordinate(xMin, yMax);
-            coordinates[4] = new Coordinate(xMin, yMin);
-            return geomFactory.createPolygon(coordinates);
+            final Envelope envelope = new Envelope(xMin, xMax, yMin, yMax);
+            return geomFactory.toGeometry(envelope);
         }
     }
 

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
@@ -61,4 +61,27 @@ public class FeatureFactoriesConsistencyTests extends ESTestCase {
             assertArrayEquals(extent + "", b1, b2);
         }
     }
+
+    public void testDegeneratedRectangle() throws IOException {
+        int z = randomIntBetween(3, 10);
+        int x = randomIntBetween(1, (1 << z) - 1);
+        int y = randomIntBetween(1, (1 << z) - 1);
+        int extent = randomIntBetween(1 << 8, 1 << 14);
+        SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
+        FeatureFactory factory = new FeatureFactory(z, x, y, extent);
+        {
+            Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
+            // box is a point
+            byte[] b1 = builder.box(r.getMaxLon(), r.getMaxLon(), r.getMaxLat(), r.getMaxLat());
+            byte[] b2 = factory.getFeatures(new Rectangle(r.getMaxLon(), r.getMaxLon(), r.getMaxLat(), r.getMaxLat())).get(0);
+            assertArrayEquals(extent + "", b1, b2);
+        }
+        {
+            Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
+            // box is a line
+            byte[] b1 = builder.box(r.getMinLon(), r.getMinLon(), r.getMinLat(), r.getMaxLat());
+            byte[] b2 = factory.getFeatures(new Rectangle(r.getMinLon(), r.getMinLon(), r.getMaxLat(), r.getMinLat())).get(0);
+            assertArrayEquals(extent + "", b1, b2);
+        }
+    }
 }


### PR DESCRIPTION
urrently we cannot convert degenerated rectangles to mvt features and the geometry is ignored. The problem is that when creating a polygon with no width and/or not height, it gets removed by the simplification algorithm. Therefore in order to take into account the feature we need to downgraded the rectangle to either a line or a point.

This is actually what JTS does with envelopes in the method #toGeometry(Envelope). This makes it consistent and no rectangle is ignored regardless of the area it covers.

backport #82404