### PR TITLE
Fix SimpleFeatureFactoryTests#testRectangle

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
@@ -118,11 +118,10 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82592")
     public void testRectangle() throws IOException {
         int z = randomIntBetween(3, 10);
-        int x = randomIntBetween(1, (1 << z) - 2);
-        int y = randomIntBetween(1, (1 << z) - 2);
+        int x = randomIntBetween(2, (1 << z) - 1);
+        int y = randomIntBetween(2, (1 << z) - 1);
         int extent = randomIntBetween(1 << 8, 1 << 14);
         SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
         {


### PR DESCRIPTION
Make sure we never build invalid combinations of z/x/y/

closes https://github.com/elastic/elasticsearch/issues/82592