### PR TITLE
Limit Gradle JVM Heap to 4G

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
 # We need to declare --add-exports to make spotless working seamlessly with jdk16
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m -Xmx4g --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
We don't set any Xmx limit. On larger workstations this means that
Gradle will take up to 25% of system memory on newer JVMs which is
needlessly much on e.g. a 64G RAM workstation.
It seems 4G as a limit should work fine and allow for faster local
builds by leaving more memory for the rest of the system?
