### PR TITLE
[DOCS] Add note to that log4j customization is outside the support scope

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -14,6 +14,9 @@ If you run {es} from the command line, {es} prints logs to the standard output
 [[loggin-configuration]]
 === Logging configuration
 
+NOTE: Elastic recommends keeping the Log4j configuration that is shipped by default.
+Customizations of the Log4j configuration are outside the scope of Elastic support.
+
 Elasticsearch uses https://logging.apache.org/log4j/2.x/[Log4j 2] for
 logging. Log4j 2 can be configured using the log4j2.properties
 file. Elasticsearch exposes three properties, `${sys:es.logs.base_path}`,

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -14,8 +14,8 @@ If you run {es} from the command line, {es} prints logs to the standard output
 [[loggin-configuration]]
 === Logging configuration
 
-NOTE: Elastic recommends keeping the Log4j configuration that is shipped by default.
-Customizations of the Log4j configuration are outside the scope of Elastic support.
+IMPORTANT: Elastic strongly recommends using the Log4j 2 configuration that is shipped by default.
+
 
 Elasticsearch uses https://logging.apache.org/log4j/2.x/[Log4j 2] for
 logging. Log4j 2 can be configured using the log4j2.properties


### PR DESCRIPTION
log4j is a third party library which is being used for Elasticsearch logging. Hence, log4j customizations are out of scope of the Elastic support offering (e.g. `I need to rollover every X days or XXXMB, with a naming pattern of x-y-dd-zz.json - how to do this?`) and this should be documented more prominently.