### PR TITLE
Simplify logging in InternalClusterInfoService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -177,7 +177,10 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     logger.trace("received node stats response");
 
                     for (final FailedNodeException failure : nodesStatsResponse.failures()) {
-                        logger.warn(new ParameterizedMessage("failed to retrieve stats for node [{}]", failure.nodeId()), failure.getCause());
+                        logger.warn(
+                            new ParameterizedMessage("failed to retrieve stats for node [{}]", failure.nodeId()),
+                            failure.getCause()
+                        );
                     }
 
                     ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsagesBuilder = ImmutableOpenMap.builder();
@@ -218,13 +221,13 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                         for (final DefaultShardOperationFailedException shardFailure : indicesStatsResponse.getShardFailures()) {
                             if (shardFailure.getCause()instanceof final FailedNodeException failedNodeException) {
                                 if (failedNodeIds.add(failedNodeException.nodeId())) {
-                                        logger.warn(
-                                            new ParameterizedMessage(
-                                                "failed to retrieve shard stats from node [{}]",
-                                                failedNodeException.nodeId()
-                                            ),
-                                            failedNodeException.getCause()
-                                        );
+                                    logger.warn(
+                                        new ParameterizedMessage(
+                                            "failed to retrieve shard stats from node [{}]",
+                                            failedNodeException.nodeId()
+                                        ),
+                                        failedNodeException.getCause()
+                                    );
                                 }
                                 logger.trace(
                                     new ParameterizedMessage(

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -177,12 +177,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     logger.trace("received node stats response");
 
                     for (final FailedNodeException failure : nodesStatsResponse.failures()) {
-                        final Throwable cause = failure.getCause();
-                        if (logger.isDebugEnabled()) {
-                            logger.warn(new ParameterizedMessage("failed to retrieve stats for node [{}]", failure.nodeId()), cause);
-                        } else {
-                            logger.warn("failed to retrieve stats for node [{}]: {}", failure.nodeId(), cause.getMessage());
-                        }
+                        logger.warn(new ParameterizedMessage("failed to retrieve stats for node [{}]", failure.nodeId()), failure.getCause());
                     }
 
                     ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsagesBuilder = ImmutableOpenMap.builder();
@@ -223,21 +218,13 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                         for (final DefaultShardOperationFailedException shardFailure : indicesStatsResponse.getShardFailures()) {
                             if (shardFailure.getCause()instanceof final FailedNodeException failedNodeException) {
                                 if (failedNodeIds.add(failedNodeException.nodeId())) {
-                                    if (logger.isDebugEnabled()) {
                                         logger.warn(
                                             new ParameterizedMessage(
                                                 "failed to retrieve shard stats from node [{}]",
                                                 failedNodeException.nodeId()
                                             ),
-                                            failedNodeException
+                                            failedNodeException.getCause()
                                         );
-                                    } else {
-                                        logger.warn(
-                                            "failed to retrieve shard stats from node [{}]: {}",
-                                            failedNodeException.nodeId(),
-                                            failedNodeException.getCause().getMessage()
-                                        );
-                                    }
                                 }
                                 logger.trace(
                                     new ParameterizedMessage(


### PR DESCRIPTION
In [1] we decided that the logging introduced in #66993 was a bit sneaky
and not really the pattern we want to follow. We want to hide stack
traces for boring network errors but in practice that means
`NodeDisconnectedException` and `ReceiveTimeoutTransportException` whose
stack traces are already suppressed (see #75671) so really it's fine to
log the full exception at `WARN` level in all cases. This commit does
that.

[1] https://github.com/elastic/elasticsearch/pull/75544/files#r675113968