### PR TITLE
[7.17] ILM step retry safe refresh of the cached phase (#82613)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -193,6 +193,37 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> assertThat(getOnlyIndexSettings(client(), index).get("index.frozen"), equalTo("true")));
     }
 
+    public void testUpdatePolicyToNotContainFailedStep() throws Exception {
+        createNewSingletonPolicy(client(), policy, "delete", new DeleteAction(true));
+        createIndexWithSettings(
+            client(),
+            index,
+            alias,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.SETTING_READ_ONLY, true)
+                .put("index.lifecycle.name", policy)
+        );
+
+        assertBusy(
+            () -> assertThat((Integer) explainIndex(client(), index).get(FAILED_STEP_RETRY_COUNT_FIELD), greaterThanOrEqualTo(1)),
+            30,
+            TimeUnit.SECONDS
+        );
+        assertTrue(indexExists(index));
+
+        // updating the policy to not contain the delete phase at all
+        createNewSingletonPolicy(client(), policy, "hot", new RolloverAction(null, null, null, 1L));
+
+        // ILM must honour the cached delete phase and eventually delete the index
+        Request request = new Request("PUT", index + "/_settings");
+        request.setJsonEntity("{\"index.blocks.read_only\":false}");
+        assertOK(client().performRequest(request));
+
+        assertBusy(() -> assertFalse(indexExists(index)));
+    }
+
     public void testAllocateOnlyAllocation() throws Exception {
         createIndexWithSettings(
             client(),

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -828,24 +828,24 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertThat(executionState.getFailedStepRetryCount(), is(1));
     }
 
- public void testMoveToFailedStepDoesntRefreshCachedPhaseWhenUnsafe() {
-        String initialPhaseDefinition = "" +
-            "{\n" +
-            "        \"policy\" : \"my-policy\",\n" +
-            "        \"phase_definition\" : {\n" +
-            "          \"min_age\" : \"20m\",\n" +
-            "          \"actions\" : {\n" +
-            "            \"rollover\" : {\n" +
-            "              \"max_age\" : \"5s\"\n" +
-            "            },\n" +
-            "            \"set_priority\" : {\n" +
-            "              \"priority\" : 150\n" +
-            "            }\n" +
-            "          }\n" +
-            "        },\n" +
-            "        \"version\" : 1,\n" +
-            "        \"modified_date_in_millis\" : 1578521007076\n" +
-            "}\n";
+    public void testMoveToFailedStepDoesntRefreshCachedPhaseWhenUnsafe() {
+        String initialPhaseDefinition = ""
+            + "{\n"
+            + "        \"policy\" : \"my-policy\",\n"
+            + "        \"phase_definition\" : {\n"
+            + "          \"min_age\" : \"20m\",\n"
+            + "          \"actions\" : {\n"
+            + "            \"rollover\" : {\n"
+            + "              \"max_age\" : \"5s\"\n"
+            + "            },\n"
+            + "            \"set_priority\" : {\n"
+            + "              \"priority\" : 150\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"version\" : 1,\n"
+            + "        \"modified_date_in_millis\" : 1578521007076\n"
+            + "}\n";
         String failedStep = "check-rollover-ready";
         LifecycleExecutionState.Builder currentExecutionState = LifecycleExecutionState.builder()
             .setPhase("hot")


### PR DESCRIPTION
When ILM retries a step (moving from the ERROR step back to the
failed_step) we always refreshed the ILM cached phase (the use case here
was that the policy might've been changed for an index due to
accidentally configuring the wrong policy).

In the case when the `failed_step` doesn't exit in the policy though,
refreshing the cached phase would block ILM as the retried step (the
`failed_step`) would not be recognized anymore.

This commit changes retrying an ILM step to only refresh the cached
phase if the failed_step's action and phase are still present in the
policy. If the action or even phase were removed, ILM will honour the
cached phase.

(cherry picked from commit e456eb7f9f89a68929551510ac4f1d50f4f96ea2)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #82613 