### PR TITLE
Make Script serialization consistent

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -569,8 +569,8 @@ public final class Script implements ToXContentObject, Writeable {
         out.writeString(idOrCode);
         @SuppressWarnings("unchecked")
         Map<String, Object> options = (Map<String, Object>) (Map) this.options;
-        out.writeMap(options);
-        out.writeMap(params);
+        out.writeMapWithConsistentOrder(options);
+        out.writeMapWithConsistentOrder(params);
     }
 
     /**


### PR DESCRIPTION
InnerHitBuilder requires consistent serialization (see InnerHitBuilderTests#testSerializationOrder) and uses `Script` via
`scriptFields`. Currently, this test works only because of the idiosyncrasy of reading a `HashMap` in
`StreamInput#readHashMap`). The method undersize the new map and forces it to rehash, which in turn produces "consistent" order. Obviously, this can break if the `HashMap` changes it internal hashing mechanism or rehashing logic. `HashMap` doesn't
provide any ordering guarantees.
