### PR TITLE
[Test] Only excercise assertions when necessary

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -457,7 +457,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
             }
         }
-        if (getSuperuserRole) {
+        if (numberOfTimesToCall > 0 && getSuperuserRole) {
             verify(nativePrivilegeStore).getPrivileges(eq(Set.of("*")), eq(Set.of("*")), anyActionListener());
             // We can't verify the contents of the Set here because the set is mutated inside the method
             verify(reservedRolesStore, times(2)).accept(anySet(), anyActionListener());


### PR DESCRIPTION
In negative caching test, the actual number of invocations can be zero.
When that happens, there is no need to run the assertions.

Resolves: #82656
