### PR TITLE
Ignore fields with no content when querying wildcard fields (#81985)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.benchmark.search;
+
+import org.apache.logging.log4j.util.Strings;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.mapper.MapperRegistry;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.search.QueryParserHelper;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class QueryParserHelperBenchmark {
+
+    private static final int NUMBER_OF_MAPPING_FIELDS = 1000;
+
+    private Directory directory;
+    private IndexReader indexReader;
+    private MapperService mapperService;
+
+    @Setup
+    public void setup() throws IOException {
+        // pre: set up MapperService and SearchExecutionContext
+        List<String> fields = new ArrayList<>();
+        for (int i = 0; i < NUMBER_OF_MAPPING_FIELDS; i++) {
+            fields.add(String.format("""
+                "field%d":{"type":"long"}""", i));
+        }
+        String mappings = """
+            {"_doc":{"properties":{""" + Strings.join(fields, ',') + "}}}";
+
+        mapperService = createMapperService(mappings);
+        IndexWriterConfig iwc = new IndexWriterConfig(IndexShard.buildIndexAnalyzer(mapperService));
+        directory = new ByteBuffersDirectory();
+        IndexWriter iw = new IndexWriter(directory, iwc);
+
+        for (int i = 0; i < 2000; i++) {
+            ParsedDocument doc = mapperService.documentMapper().parse(buildDoc(i));
+            iw.addDocument(doc.rootDoc());
+            if (i % 100 == 0) {
+                iw.commit();
+            }
+        }
+        iw.close();
+
+        indexReader = DirectoryReader.open(directory);
+    }
+
+    private SourceToParse buildDoc(int docId) {
+        List<String> fields = new ArrayList<>();
+        for (int i = 0; i < NUMBER_OF_MAPPING_FIELDS; i++) {
+            if (i % 2 == 0) continue;
+            if (i % 3 == 0 && (docId < (NUMBER_OF_MAPPING_FIELDS / 2))) continue;
+            fields.add(String.format("""
+                "field%d":1""", i));
+        }
+        String source = "{" + String.join(",", fields) + "}";
+        return new SourceToParse("index", "" + docId, new BytesArray(source), XContentType.JSON);
+    }
+
+    @TearDown
+    public void tearDown() {
+        IOUtils.closeWhileHandlingException(indexReader, directory);
+    }
+
+    @Benchmark
+    public void expand() {
+        Map<String, Float> fields = QueryParserHelper.resolveMappingFields(buildSearchExecutionContext(), Map.of("*", 1f));
+        assert fields.size() > 0 && fields.size() < NUMBER_OF_MAPPING_FIELDS;
+    }
+
+    protected SearchExecutionContext buildSearchExecutionContext() {
+        final SimilarityService similarityService = new SimilarityService(mapperService.getIndexSettings(), null, Map.of());
+        final long nowInMillis = 1;
+        return new SearchExecutionContext(
+            0,
+            0,
+            mapperService.getIndexSettings(),
+            null,
+            (ft, idxName, lookup) -> ft.fielddataBuilder(idxName, lookup)
+                .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService()),
+            mapperService,
+            mapperService.mappingLookup(),
+            similarityService,
+            null,
+            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+            new NamedWriteableRegistry(ClusterModule.getNamedWriteables()),
+            null,
+            new IndexSearcher(indexReader),
+            () -> nowInMillis,
+            null,
+            null,
+            () -> true,
+            null,
+            Collections.emptyMap()
+        );
+    }
+
+    protected final MapperService createMapperService(String mappings) {
+        Settings settings = Settings.builder()
+            .put("index.number_of_replicas", 0)
+            .put("index.number_of_shards", 1)
+            .put("index.version.created", Version.CURRENT)
+            .build();
+        IndexMetadata meta = IndexMetadata.builder("index").settings(settings).build();
+        IndexSettings indexSettings = new IndexSettings(meta, settings);
+        MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
+
+        SimilarityService similarityService = new SimilarityService(indexSettings, null, Map.of());
+        MapperService mapperService = new MapperService(
+            indexSettings,
+            new IndexAnalyzers(
+                Map.of("default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
+                Map.of(),
+                Map.of()
+            ),
+            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+            similarityService,
+            mapperRegistry,
+            () -> { throw new UnsupportedOperationException(); },
+            () -> true,
+            new ScriptCompiler() {
+                @Override
+                public <T> T compile(Script script, ScriptContext<T> scriptContext) {
+                    throw new UnsupportedOperationException();
+                }
+            }
+        );
+
+        try {
+            mapperService.merge("_doc", new CompressedXContent(mappings), MapperService.MergeReason.MAPPING_UPDATE);
+            return mapperService;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -211,6 +211,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(name());
+        }
+
+        @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             long scaledValue = Math.round(scale(value));

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -428,6 +428,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return false;
+        }
+
+        @Override
         public Query prefixQuery(
             String value,
             MultiTermQuery.RewriteMethod method,
@@ -558,6 +563,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
 
         void setPrefixFieldType(PrefixFieldType prefixFieldType) {
             this.prefixFieldType = prefixFieldType;
+        }
+
+        @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return false;
         }
 
         @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -148,7 +148,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
     }
 
     public void testExplainValidateQueryTwoNodes() throws IOException {
-        createIndex("test");
+        createIndex("test", Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).build());
         ensureGreen();
         client().admin()
             .indices()
@@ -182,6 +182,9 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
+        for (int i = 0; i < 10; i++) {
+            client().prepareIndex("test").setSource("foo", "text", "bar", i, "baz", "blort").execute().actionGet();
+        }
         refresh();
 
         for (Client client : internalCluster().getClients()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -447,6 +447,11 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(this.name());
+        }
+
+        @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -110,6 +110,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return true;
+        }
+
+        @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return new StoredValueFetcher(context.lookup(), NAME);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -213,6 +213,11 @@ public class IpFieldMapper extends FieldMapper {
             return CONTENT_TYPE;
         }
 
+        @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(name());
+        }
+
         private static InetAddress parse(Object value) {
             if (value instanceof InetAddress) {
                 return (InetAddress) value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -454,6 +454,18 @@ public abstract class MappedFieldType {
     }
 
     /**
+     * @return if the field may have values in the underlying index
+     *
+     * Note that this should only return {@code false} if it is not possible for it to
+     * match on a term query.
+     *
+     * @see org.elasticsearch.index.search.QueryParserHelper
+     */
+    public boolean mayExistInIndex(SearchExecutionContext context) {
+        return true;
+    }
+
+    /**
      * Pick a {@link DocValueFormat} that can be used to display and parse
      * values of fields of this type.
      */

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
@@ -81,6 +81,11 @@ public class NestedPathFieldMapper extends MetadataFieldMapper {
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
+
+        @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return false;
+        }
     }
 
     private NestedPathFieldMapper(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1131,6 +1131,11 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(this.name());
+        }
+
+        @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             return type.termQuery(name(), value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -226,6 +226,11 @@ public class RangeFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(this.name());
+        }
+
+        @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -133,6 +133,11 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return false;
+        }
+
+        @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
@@ -49,6 +49,11 @@ public abstract class TermBasedFieldType extends SimpleMappedFieldType {
     }
 
     @Override
+    public boolean mayExistInIndex(SearchExecutionContext context) {
+        return context.fieldExistsInIndex(name());
+    }
+
+    @Override
     public Query termQuery(Object value, SearchExecutionContext context) {
         failIfNotIndexed();
         return new TermQuery(new Term(name(), indexedValueForSearch(value)));

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -525,6 +525,11 @@ public class TextFieldMapper extends FieldMapper {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return false;
+        }
+
         boolean accept(int length) {
             return length >= minChars - 1 && length <= maxChars;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -617,6 +617,11 @@ public final class FlattenedFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(name());
+        }
+
+        @Override
         public Object valueForDisplay(Object value) {
             if (value == null) {
                 return null;

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -134,7 +134,7 @@ public final class QueryParserHelper {
             }
 
             if (acceptAllTypes == false) {
-                if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE) {
+                if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE || fieldType.mayExistInIndex(context) == false) {
                     continue;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/index/query/CombinedFieldsQueryParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/CombinedFieldsQueryParsingTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.sandbox.search.CombinedFieldQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
@@ -28,6 +29,7 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -42,10 +44,11 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class CombinedFieldsQueryParsingTests extends MapperServiceTestCase {
     private SearchExecutionContext context;
+    private MapperService mapperService;
 
     @Before
     public void createSearchExecutionContext() throws IOException {
-        MapperService mapperService = createMapperService(
+        this.mapperService = createMapperService(
             XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject(MapperService.SINGLE_MAPPING_NAME)
@@ -130,13 +133,21 @@ public class CombinedFieldsQueryParsingTests extends MapperServiceTestCase {
     }
 
     public void testWildcardFieldPattern() throws Exception {
-        Query query = combinedFieldsQuery("quick fox").field("field*").toQuery(context);
-        assertThat(query, instanceOf(BooleanQuery.class));
 
-        BooleanQuery booleanQuery = (BooleanQuery) query;
-        assertThat(booleanQuery.clauses().size(), equalTo(2));
-        assertThat(booleanQuery.clauses().get(0).getQuery(), instanceOf(CombinedFieldQuery.class));
-        assertThat(booleanQuery.clauses().get(1).getQuery(), instanceOf(CombinedFieldQuery.class));
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field1" : "foo", "field2" : "foo" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            SearchExecutionContext searcherContext = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
+            Query query = combinedFieldsQuery("quick fox").field("field*").toQuery(searcherContext);
+            assertThat(query, instanceOf(BooleanQuery.class));
+
+            BooleanQuery booleanQuery = (BooleanQuery) query;
+            assertThat(booleanQuery.clauses().size(), equalTo(2));
+            assertThat(booleanQuery.clauses().get(0).getQuery(), instanceOf(CombinedFieldQuery.class));
+            assertThat(booleanQuery.clauses().get(1).getQuery(), instanceOf(CombinedFieldQuery.class));
+        });
     }
 
     public void testOperator() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderMultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderMultiFieldTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MultiMatchQueryBuilderMultiFieldTests extends MapperServiceTestCase {
+
+    public void testDefaultField() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            IndexSearcher searcher = new IndexSearcher(ir);
+
+            {
+                // default value 'index.query.default_field = *' sets leniency to true
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher);
+                Query query = new MultiMatchQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains '*' sets leniency to true
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "*").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new MultiMatchQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains no wildcards, leniency = false
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_date").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Exception e = expectThrows(Exception.class, () -> new MultiMatchQueryBuilder("hello").toQuery(context));
+                assertThat(e.getMessage(), containsString("failed to parse date field [hello]"));
+            }
+
+            {
+                // default field list contains boost
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_text2^4").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new MultiMatchQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(new TermQuery(new Term("f_text1", "hello")), new BoostQuery(new TermQuery(new Term("f_text2", "hello")), 4f)),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // set tiebreaker
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher);
+                Query query = new MultiMatchQueryBuilder("hello").tieBreaker(0.5f).toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    0.5f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+        });
+    }
+
+    public void testFieldListIncludesWildcard() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
+            Query expected = new DisjunctionMaxQuery(
+                List.of(
+                    new TermQuery(new Term("f_text1", "hello")),
+                    new TermQuery(new Term("f_text2", "hello")),
+                    new TermQuery(new Term("f_keyword1", "hello")),
+                    new TermQuery(new Term("f_keyword2", "hello")),
+                    new MatchNoDocsQuery()
+                ),
+                0f
+            );
+            assertEquals(expected, new MultiMatchQueryBuilder("hello").field("*").toQuery(context));
+            assertEquals(expected, new MultiMatchQueryBuilder("hello").field("f_text1").field("*").toQuery(context));
+        });
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderMultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderMultiFieldTests.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class QueryStringQueryBuilderMultiFieldTests extends MapperServiceTestCase {
+
+    public void testToQueryFieldsWildcard() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text" : { "type" : "text" },
+                "f_keyword" : { "type" : "keyword" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text" : "foo", "f_keyword" : "bar" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            Query query = queryStringQuery("test").field("f*").toQuery(createSearchExecutionContext(mapperService, new IndexSearcher(ir)));
+            Query expected = new DisjunctionMaxQuery(
+                List.of(new TermQuery(new Term("f_text", "test")), new TermQuery(new Term("f_keyword", "test"))),
+                0
+            );
+            assertEquals(expected, query);
+        });
+    }
+
+    public void testDefaultField() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            IndexSearcher searcher = new IndexSearcher(ir);
+
+            {
+                // default value 'index.query.default_field = *' sets leniency to true
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher);
+                Query query = new QueryStringQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains '*' sets leniency to true
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "*").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new QueryStringQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains no wildcards, leniency = false
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_date").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Exception e = expectThrows(Exception.class, () -> new QueryStringQueryBuilder("hello").toQuery(context));
+                assertThat(e.getMessage(), containsString("failed to parse date field [hello]"));
+            }
+
+            {
+                // default field list contains boost
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_text2^4").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new QueryStringQueryBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(new TermQuery(new Term("f_text1", "hello")), new BoostQuery(new TermQuery(new Term("f_text2", "hello")), 4f)),
+                    0f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+        });
+    }
+
+    public void testFieldListIncludesWildcard() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
+            Query expected = new DisjunctionMaxQuery(
+                List.of(
+                    new TermQuery(new Term("f_text1", "hello")),
+                    new TermQuery(new Term("f_text2", "hello")),
+                    new TermQuery(new Term("f_keyword1", "hello")),
+                    new TermQuery(new Term("f_keyword2", "hello")),
+                    new MatchNoDocsQuery()
+                ),
+                0f
+            );
+            assertEquals(expected, new QueryStringQueryBuilder("hello").field("*").toQuery(context));
+            assertEquals(expected, new QueryStringQueryBuilder("hello").field("f_text1").field("*").toQuery(context));
+        });
+    }
+
+    public void testMergeBoosts() throws IOException {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text" : { "type" : "text" },
+                "f_keyword" : { "type" : "keyword" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text" : "foo", "f_keyword" : "bar" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            Query query = queryStringQuery("first").type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
+                .field("f_text", 0.3f)
+                .field("f*", 0.5f)
+                .toQuery(createSearchExecutionContext(mapperService, new IndexSearcher(ir)));
+            Query expected = new DisjunctionMaxQuery(
+                List.of(
+                    new BoostQuery(new TermQuery(new Term("f_text", "first")), 0.15f),
+                    new BoostQuery(new TermQuery(new Term("f_keyword", "first")), 0.5f)
+                ),
+                1
+            );
+            assertEquals(expected, query);
+        });
+    }
+
+    /**
+     * Query terms that contain "now" can trigger a query to not be cacheable.
+     * This test checks the search context cacheable flag is updated accordingly.
+     */
+    public void testCachingStrategiesWithNow() throws IOException {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            IndexSearcher searcher = new IndexSearcher(ir);
+
+            // if we hit all fields, this should contain a date field and should disable cachability
+            String query = "now " + randomAlphaOfLengthBetween(4, 10);
+            QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(query);
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), false);
+
+            // querying the date field directly with 'now' disables cachability
+            queryBuilder = new QueryStringQueryBuilder("now").field("f_date");
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), false);
+
+            // but it's only lower case that matters
+            query = randomFrom("NoW", "nOw", "NOW") + " " + randomAlphaOfLengthBetween(4, 10);
+            queryBuilder = new QueryStringQueryBuilder(query);
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), true);
+        });
+    }
+
+    private void assertQueryCachability(QueryStringQueryBuilder qb, SearchExecutionContext context, boolean cachingExpected)
+        throws IOException {
+        assert context.isCacheable();
+        /*
+         * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
+         * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
+         * actual lucene query
+         */
+        PlainActionFuture<QueryBuilder> future = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(qb, new SearchExecutionContext(context), future);
+        QueryBuilder rewritten = future.actionGet();
+        assertNotNull(rewritten.toQuery(context));
+        assertEquals(
+            "query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(),
+            cachingExpected,
+            context.isCacheable()
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -60,7 +60,6 @@ import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -493,15 +492,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testToQueryMultipleFieldsDisMaxQuery() throws Exception {
         Query query = queryStringQuery("test").field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME).toQuery(createSearchExecutionContext());
-        Query expected = new DisjunctionMaxQuery(
-            List.of(new TermQuery(new Term(TEXT_FIELD_NAME, "test")), new TermQuery(new Term(KEYWORD_FIELD_NAME, "test"))),
-            0
-        );
-        assertEquals(expected, query);
-    }
-
-    public void testToQueryFieldsWildcard() throws Exception {
-        Query query = queryStringQuery("test").field("mapped_str*").toQuery(createSearchExecutionContext());
         Query expected = new DisjunctionMaxQuery(
             List.of(new TermQuery(new Term(TEXT_FIELD_NAME, "test")), new TermQuery(new Term(KEYWORD_FIELD_NAME, "test"))),
             0
@@ -1205,64 +1195,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     }
 
-    public void testDefaultField() throws Exception {
-        SearchExecutionContext context = createSearchExecutionContext();
-        // default value `*` sets leniency to true
-        Query query = new QueryStringQueryBuilder("hello").toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-
-        try {
-            // `*` is in the list of the default_field => leniency set to true
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", TEXT_FIELD_NAME, "*", KEYWORD_FIELD_NAME).build()
-                    )
-                );
-            query = new QueryStringQueryBuilder("hello").toQuery(context);
-            assertQueryWithAllFieldsWildcard(query);
-
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", TEXT_FIELD_NAME, KEYWORD_FIELD_NAME + "^5").build()
-                    )
-                );
-            query = new QueryStringQueryBuilder("hello").toQuery(context);
-            Query expected = new DisjunctionMaxQuery(
-                Arrays.asList(
-                    new TermQuery(new Term(TEXT_FIELD_NAME, "hello")),
-                    new BoostQuery(new TermQuery(new Term(KEYWORD_FIELD_NAME, "hello")), 5.0f)
-                ),
-                0.0f
-            );
-            assertEquals(expected, query);
-        } finally {
-            // Reset the default value
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", "*").build()
-                    )
-                );
-        }
-    }
-
-    public void testAllFieldsWildcard() throws Exception {
-        SearchExecutionContext context = createSearchExecutionContext();
-        Query query = new QueryStringQueryBuilder("hello").field("*").toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-
-        query = new QueryStringQueryBuilder("hello").field(TEXT_FIELD_NAME).field("*").field(KEYWORD_FIELD_NAME).toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-    }
-
     /**
      * the quote analyzer should overwrite any other forced analyzer in quoted parts of the query
      */
@@ -1472,22 +1404,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(exc.getMessage(), CoreMatchers.containsString("negative [boost]"));
     }
 
-    public void testMergeBoosts() throws IOException {
-        Query query = new QueryStringQueryBuilder("first").type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
-            .field(TEXT_FIELD_NAME, 0.3f)
-            .field(TEXT_FIELD_NAME.substring(0, TEXT_FIELD_NAME.length() - 2) + "*", 0.5f)
-            .toQuery(createSearchExecutionContext());
-        assertThat(query, instanceOf(DisjunctionMaxQuery.class));
-        Collection<Query> disjuncts = ((DisjunctionMaxQuery) query).getDisjuncts();
-        assertThat(
-            disjuncts,
-            hasItems(
-                new BoostQuery(new TermQuery(new Term(TEXT_FIELD_NAME, "first")), 0.075f),
-                new BoostQuery(new TermQuery(new Term(KEYWORD_FIELD_NAME, "first")), 0.5f)
-            )
-        );
-    }
-
     private static IndexMetadata newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {
         Settings build = Settings.builder().put(oldIndexSettings).put(indexSettings).build();
         return IndexMetadata.builder(name).settings(build).build();
@@ -1506,44 +1422,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(
             disjunctionMaxQuery.getDisjuncts(),
             hasItems(new TermQuery(new Term(TEXT_FIELD_NAME, "hello")), new TermQuery(new Term(KEYWORD_FIELD_NAME, "hello")))
-        );
-    }
-
-    /**
-     * Query terms that contain "now" can trigger a query to not be cacheable.
-     * This test checks the search context cacheable flag is updated accordingly.
-     */
-    public void testCachingStrategiesWithNow() throws IOException {
-        // if we hit all fields, this should contain a date field and should diable cachability
-        String query = "now " + randomAlphaOfLengthBetween(4, 10);
-        QueryStringQueryBuilder queryStringQueryBuilder = new QueryStringQueryBuilder(query);
-        assertQueryCachability(queryStringQueryBuilder, false);
-
-        // if we hit a date field with "now", this should diable cachability
-        queryStringQueryBuilder = new QueryStringQueryBuilder("now");
-        queryStringQueryBuilder.field(DATE_FIELD_NAME);
-        assertQueryCachability(queryStringQueryBuilder, false);
-
-        // everything else is fine on all fields
-        query = randomFrom("NoW", "nOw", "NOW") + " " + randomAlphaOfLengthBetween(4, 10);
-        queryStringQueryBuilder = new QueryStringQueryBuilder(query);
-        assertQueryCachability(queryStringQueryBuilder, true);
-    }
-
-    private void assertQueryCachability(QueryStringQueryBuilder qb, boolean cachingExpected) throws IOException {
-        SearchExecutionContext context = createSearchExecutionContext();
-        assert context.isCacheable();
-        /*
-         * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
-         * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
-         * actual lucene query
-         */
-        QueryBuilder rewritten = rewriteQuery(qb, new SearchExecutionContext(context));
-        assertNotNull(rewritten.toQuery(context));
-        assertEquals(
-            "query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(),
-            cachingExpected,
-            context.isCacheable()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderMultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderMultiFieldTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SimpleQueryStringBuilderMultiFieldTests extends MapperServiceTestCase {
+
+    public void testDefaultField() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            IndexSearcher searcher = new IndexSearcher(ir);
+
+            {
+                // default value 'index.query.default_field = *' sets leniency to true
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher);
+                Query query = new SimpleQueryStringBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    1f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains '*' sets leniency to true
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "*").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new SimpleQueryStringBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(
+                        new TermQuery(new Term("f_text1", "hello")),
+                        new TermQuery(new Term("f_text2", "hello")),
+                        new TermQuery(new Term("f_keyword1", "hello")),
+                        new TermQuery(new Term("f_keyword2", "hello")),
+                        new MatchNoDocsQuery()
+                    ),
+                    1f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+            {
+                // default field list contains no wildcards, leniency = false
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_date").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Exception e = expectThrows(Exception.class, () -> new SimpleQueryStringBuilder("hello").toQuery(context));
+                assertThat(e.getMessage(), containsString("failed to parse date field [hello]"));
+            }
+
+            {
+                // default field list contains boost
+                Settings settings = Settings.builder().putList("index.query.default_field", "f_text1", "f_text2^4").build();
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, searcher, settings);
+                Query query = new SimpleQueryStringBuilder("hello").toQuery(context);
+                Query expected = new DisjunctionMaxQuery(
+                    List.of(new TermQuery(new Term("f_text1", "hello")), new BoostQuery(new TermQuery(new Term("f_text2", "hello")), 4f)),
+                    1f
+                );
+                assertThat(query, equalTo(expected));
+            }
+
+        });
+    }
+
+    public void testFieldListIncludesWildcard() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_text2" : { "type" : "text" },
+                "f_keyword1" : { "type" : "keyword" },
+                "f_keyword2" : { "type" : "keyword" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_text2" : "bar", "f_keyword1" : "baz", "f_keyword2" : "buz", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
+            Query expected = new DisjunctionMaxQuery(
+                List.of(
+                    new TermQuery(new Term("f_text1", "hello")),
+                    new TermQuery(new Term("f_text2", "hello")),
+                    new TermQuery(new Term("f_keyword1", "hello")),
+                    new TermQuery(new Term("f_keyword2", "hello")),
+                    new MatchNoDocsQuery()
+                ),
+                1f
+            );
+            assertEquals(expected, new SimpleQueryStringBuilder("hello").field("*").toQuery(context));
+            assertEquals(expected, new SimpleQueryStringBuilder("hello").field("f_text1").field("*").toQuery(context));
+        });
+    }
+
+    /**
+     * Query terms that contain "now" can trigger a query to not be cacheable.
+     * This test checks the search context cacheable flag is updated accordingly.
+     */
+    public void testCachingStrategiesWithNow() throws IOException {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "f_text1" : { "type" : "text" },
+                "f_date" : { "type" : "date" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "f_text1" : "foo", "f_date" : "2021-12-20T00:00:00" }
+            """));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            IndexSearcher searcher = new IndexSearcher(ir);
+
+            // if we hit all fields, this should contain a date field and should disable cachability
+            String query = "now " + randomAlphaOfLengthBetween(4, 10);
+            SimpleQueryStringBuilder queryBuilder = new SimpleQueryStringBuilder(query);
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), false);
+
+            // querying the date field directly with 'now' disables cachability
+            queryBuilder = new SimpleQueryStringBuilder("now").field("f_date");
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), false);
+
+            // but it's only lower case that matters
+            query = randomFrom("NoW", "nOw", "NOW") + " " + randomAlphaOfLengthBetween(4, 10);
+            queryBuilder = new SimpleQueryStringBuilder(query);
+            assertQueryCachability(queryBuilder, createSearchExecutionContext(mapperService, searcher), true);
+        });
+    }
+
+    private void assertQueryCachability(SimpleQueryStringBuilder qb, SearchExecutionContext context, boolean cachingExpected)
+        throws IOException {
+        assert context.isCacheable();
+        /*
+         * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
+         * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
+         * actual lucene query
+         */
+        PlainActionFuture<QueryBuilder> future = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(qb, new SearchExecutionContext(context), future);
+        QueryBuilder rewritten = future.actionGet();
+        assertNotNull(rewritten.toQuery(context));
+        assertEquals(
+            "query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(),
+            cachingExpected,
+            context.isCacheable()
+        );
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -27,8 +27,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.SimpleQueryStringQueryParser;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -44,8 +42,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -246,24 +242,6 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         SimpleQueryStringBuilder qb = createTestQueryBuilder();
         NullPointerException e = expectThrows(NullPointerException.class, () -> qb.fields(null));
         assertEquals("fields cannot be null", e.getMessage());
-    }
-
-    public void testDefaultFieldParsing() throws IOException {
-        String query = randomAlphaOfLengthBetween(1, 10).toLowerCase(Locale.ROOT);
-        String contentString = """
-            {
-              "simple_query_string": {
-                "query": "%s"
-              }
-            }""".formatted(query);
-        SimpleQueryStringBuilder queryBuilder = (SimpleQueryStringBuilder) parseQuery(contentString);
-        assertThat(queryBuilder.value(), equalTo(query));
-        assertThat(queryBuilder.fields(), notNullValue());
-        assertThat(queryBuilder.fields().size(), equalTo(0));
-        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
-
-        Query luceneQuery = queryBuilder.toQuery(searchExecutionContext);
-        assertThat(luceneQuery, anyOf(instanceOf(BooleanQuery.class), instanceOf(DisjunctionMaxQuery.class)));
     }
 
     /*
@@ -621,64 +599,6 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), parser.parse("\"bar\""));
     }
 
-    public void testDefaultField() throws Exception {
-        SearchExecutionContext context = createSearchExecutionContext();
-        // default value `*` sets leniency to true
-        Query query = new SimpleQueryStringBuilder("hello").toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-
-        try {
-            // `*` is in the list of the default_field => leniency set to true
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", TEXT_FIELD_NAME, "*", KEYWORD_FIELD_NAME).build()
-                    )
-                );
-            query = new SimpleQueryStringBuilder("hello").toQuery(context);
-            assertQueryWithAllFieldsWildcard(query);
-
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", TEXT_FIELD_NAME, KEYWORD_FIELD_NAME + "^5").build()
-                    )
-                );
-            query = new SimpleQueryStringBuilder("hello").toQuery(context);
-            Query expected = new DisjunctionMaxQuery(
-                Arrays.asList(
-                    new TermQuery(new Term(TEXT_FIELD_NAME, "hello")),
-                    new BoostQuery(new TermQuery(new Term(KEYWORD_FIELD_NAME, "hello")), 5.0f)
-                ),
-                1.0f
-            );
-            assertEquals(expected, query);
-        } finally {
-            // Reset to the default value
-            context.getIndexSettings()
-                .updateIndexMetadata(
-                    newIndexMeta(
-                        "index",
-                        context.getIndexSettings().getSettings(),
-                        Settings.builder().putList("index.query.default_field", "*").build()
-                    )
-                );
-        }
-    }
-
-    public void testAllFieldsWildcard() throws Exception {
-        SearchExecutionContext context = createSearchExecutionContext();
-        Query query = new SimpleQueryStringBuilder("hello").field("*").toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-
-        query = new SimpleQueryStringBuilder("hello").field(TEXT_FIELD_NAME).field("*").field(KEYWORD_FIELD_NAME).toQuery(context);
-        assertQueryWithAllFieldsWildcard(query);
-    }
-
     public void testToFuzzyQuery() throws Exception {
         Query query = new SimpleQueryStringBuilder("text~2").field(TEXT_FIELD_NAME)
             .fuzzyPrefixLength(2)
@@ -797,65 +717,6 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 .toQuery(createSearchExecutionContext())
         );
         assertThat(exc.getMessage(), containsString("negative [boost]"));
-    }
-
-    private static IndexMetadata newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {
-        Settings build = Settings.builder().put(oldIndexSettings).put(indexSettings).build();
-        return IndexMetadata.builder(name).settings(build).build();
-    }
-
-    private void assertQueryWithAllFieldsWildcard(Query query) {
-        assertEquals(DisjunctionMaxQuery.class, query.getClass());
-        DisjunctionMaxQuery disjunctionMaxQuery = (DisjunctionMaxQuery) query;
-        int noMatchNoDocsQueries = 0;
-        for (Query q : disjunctionMaxQuery.getDisjuncts()) {
-            if (q.getClass() == MatchNoDocsQuery.class) {
-                noMatchNoDocsQueries++;
-            }
-        }
-        assertEquals(9, noMatchNoDocsQueries);
-        assertThat(
-            disjunctionMaxQuery.getDisjuncts(),
-            hasItems(new TermQuery(new Term(TEXT_FIELD_NAME, "hello")), new TermQuery(new Term(KEYWORD_FIELD_NAME, "hello")))
-        );
-    }
-
-    /**
-     * Query terms that contain "now" can trigger a query to not be cacheable.
-     * This test checks the search context cacheable flag is updated accordingly.
-     */
-    public void testCachingStrategiesWithNow() throws IOException {
-        // if we hit all fields, this should contain a date field and should diable cachability
-        String query = "now " + randomAlphaOfLengthBetween(4, 10);
-        SimpleQueryStringBuilder queryBuilder = new SimpleQueryStringBuilder(query);
-        assertQueryCachability(queryBuilder, false);
-
-        // if we hit a date field with "now", this should diable cachability
-        queryBuilder = new SimpleQueryStringBuilder("now");
-        queryBuilder.field(DATE_FIELD_NAME);
-        assertQueryCachability(queryBuilder, false);
-
-        // everything else is fine on all fields
-        query = randomFrom("NoW", "nOw", "NOW") + " " + randomAlphaOfLengthBetween(4, 10);
-        queryBuilder = new SimpleQueryStringBuilder(query);
-        assertQueryCachability(queryBuilder, true);
-    }
-
-    private void assertQueryCachability(SimpleQueryStringBuilder qb, boolean cachingExpected) throws IOException {
-        SearchExecutionContext context = createSearchExecutionContext();
-        assert context.isCacheable();
-        /*
-         * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
-         * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
-         * actual lucene query
-         */
-        QueryBuilder rewritten = rewriteQuery(qb, new SearchExecutionContext(context));
-        assertNotNull(rewritten.toQuery(context));
-        assertEquals(
-            "query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(),
-            cachingExpected,
-            context.isCacheable()
-        );
     }
 
     public void testLenientFlag() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.search;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
@@ -22,29 +23,71 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class QueryParserHelperTests extends MapperServiceTestCase {
 
-    public void testUnmappedFieldsDoNotContributeToFieldCount() throws IOException {
+    public void testEmptyFieldResolution() throws IOException {
 
         MapperService mapperService = createMapperService(mapping(b -> {
             b.startObject("field1").field("type", "text").endObject();
             b.startObject("field2").field("type", "text").endObject();
         }));
 
+        // We check that expanded fields are actually present in the underlying lucene index,
+        // so a resolution against an empty index will result in 0 fields
         SearchExecutionContext context = createSearchExecutionContext(mapperService);
         {
             Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("*", 1.0f));
-            assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2"));
+            assertTrue(resolvedFields.isEmpty());
         }
 
+        // If you ask for a specific mapped field, we will resolve it
         {
-            Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("*", 1.0f, "unmapped", 2.0f));
-            assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2"));
-            assertFalse(resolvedFields.containsKey("unmapped"));
+            Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("field1", 1.0f));
+            assertThat(resolvedFields.keySet(), containsInAnyOrder("field1"));
         }
 
+        // But unmapped fields will not be resolved
         {
             Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("unmapped", 1.0f));
             assertTrue(resolvedFields.isEmpty());
         }
+    }
+
+    public void testIndexedFieldResolution() throws IOException {
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field1").field("type", "text").endObject();
+            b.startObject("field2").field("type", "text").endObject();
+            b.startObject("field3").field("type", "text").endObject();
+        }));
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("field1", "foo");
+            b.field("field2", "bar");
+        }));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
+
+            // field1 and field2 are present in the index, so they get resolved; field3 is in the mappings but
+            // not in the actual index, so it is ignored
+            {
+                Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f));
+                assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2"));
+                assertFalse(resolvedFields.containsKey("field3"));
+            }
+
+            // unmapped fields get ignored
+            {
+                Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("*", 1.0f, "unmapped", 2.0f));
+                assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2"));
+                assertFalse(resolvedFields.containsKey("unmapped"));
+            }
+
+            {
+                Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("unmapped", 1.0f));
+                assertTrue(resolvedFields.isEmpty());
+            }
+        });
     }
 
     public void testFieldExpansionAboveLimitThrowsException() throws IOException {
@@ -53,21 +96,29 @@ public class QueryParserHelperTests extends MapperServiceTestCase {
                 b.startObject("field" + i).field("type", "long").endObject();
             }
         }));
-        SearchExecutionContext context = createSearchExecutionContext(mapperService);
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            for (int i = 0; i < 10; i++) {
+                b.field("field" + i, 1L);
+            }
+        }));
 
-        int originalMaxClauseCount = IndexSearcher.getMaxClauseCount();
-        try {
-            IndexSearcher.setMaxClauseCount(4);
-            Exception e = expectThrows(
-                IllegalArgumentException.class,
-                () -> QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f))
-            );
-            assertThat(e.getMessage(), containsString("field expansion matches too many fields"));
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
 
-            IndexSearcher.setMaxClauseCount(10);
-            assertThat(QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f)).keySet(), hasSize(10));
-        } finally {
-            IndexSearcher.setMaxClauseCount(originalMaxClauseCount);
-        }
+            int originalMaxClauseCount = IndexSearcher.getMaxClauseCount();
+            try {
+                IndexSearcher.setMaxClauseCount(4);
+                Exception e = expectThrows(
+                    IllegalArgumentException.class,
+                    () -> QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f))
+                );
+                assertThat(e.getMessage(), containsString("field expansion matches too many fields"));
+
+                IndexSearcher.setMaxClauseCount(10);
+                assertThat(QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f)).keySet(), hasSize(10));
+            } finally {
+                IndexSearcher.setMaxClauseCount(originalMaxClauseCount);
+            }
+        });
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -323,6 +323,11 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return delegateFieldType().mayExistInIndex(context);    // TODO how does searching actually work here?
+        }
+
+        @Override
         public Query existsQuery(SearchExecutionContext context) {
             return delegateFieldType().existsQuery(context);
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -217,6 +217,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(name());
+        }
+
+        @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             Long longValue = parseTerm(value);

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -266,6 +266,11 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean mayExistInIndex(SearchExecutionContext context) {
+            return context.fieldExistsInIndex(name());
+        }
+
+        @Override
         public Query normalizedWildcardQuery(String value, MultiTermQuery.RewriteMethod method, SearchExecutionContext context) {
             return wildcardQuery(value, method, false, context);
         }


### PR DESCRIPTION
The query_string, simple_query_string, combined_fields and multi_match
queries all allow you to query a large number of fields, based on wildcard field name
matches. By default, the wildcard match is *, meaning that these queries will try
and match against every single field in your index. This can cause problems if you
have a very large number of fields defined, and your elasticsearch instance has a
fairly low maximum query clause count.

In many cases, users may have many more fields defined in their mappings than are
actually populated in their index. For example, indexes using ECS mappings may
well only use a small subset of these mapped fields for their data. In these situations,
we can put a limit on the number of fields being searched by doing a quick check of
the Lucene index metadata to see if a mapped field actually has content in the index;
if it doesn't exist, we can trivially skip it.

This commit adds a check to QueryParserHelper.resolveMappingField() that strips
out fields with no content if the field name to resolve contains a wildcard. The check
is delegated down to MappedFieldType and by default returns `true`, but the standard
indexable field types (numeric, text, keyword, range, etc) will check their fieldnames
against the names in the underlying lucene FieldInfos and return `false` if they do not
appear there.