### PR TITLE
Exclude doc-value-only fields from all fields queries

### DIFF
--- a/docs/changelog/82712.yaml
+++ b/docs/changelog/82712.yaml
@@ -1,0 +1,6 @@
+pr: 82712
+summary: Exclude doc-value-only fields from all fields queries
+area: Search
+type: enhancement
+issues:
+ - 82710

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -132,13 +132,13 @@ public final class QueryParserHelper {
                 // Ignore metadata fields
                 continue;
             }
+            if (acceptMetadataField == false && fieldType.isIndexed() == false)  {
+                // Don't include runtime fields or doc-value-only fields when expanding '*'
+                continue;
+            }
 
             if (acceptAllTypes == false) {
                 if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE || fieldType.mayExistInIndex(context) == false) {
-                    continue;
-                }
-                // Don't expand doc-value-only fields, as they search very slowly
-                if (fieldType.isIndexed() == false) {
                     continue;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -111,7 +111,7 @@ public final class QueryParserHelper {
             }
 
             MappedFieldType fieldType = context.getFieldType(fieldName);
-            if (allField && (fieldType.name().startsWith("_") || fieldType.isIndexed())) {
+            if (allField && (fieldType.name().startsWith("_") || fieldType.isIndexed() == false)) {
                 // Ignore metadata fields, runtime fields and doc-value-only fields
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -137,6 +137,10 @@ public final class QueryParserHelper {
                 if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE || fieldType.mayExistInIndex(context) == false) {
                     continue;
                 }
+                // Don't expand doc-value-only fields, as they search very slowly
+                if (fieldType.isIndexed() == false) {
+                    continue;
+                }
             }
 
             // Deduplicate aliases and their concrete fields.

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -132,7 +132,7 @@ public final class QueryParserHelper {
                 // Ignore metadata fields
                 continue;
             }
-            if (acceptMetadataField == false && fieldType.isIndexed() == false)  {
+            if (acceptMetadataField == false && fieldType.isIndexed() == false) {
                 // Don't include runtime fields or doc-value-only fields when expanding '*'
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -130,7 +130,7 @@ public class QueryStringQueryParser extends QueryParser {
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
     public QueryStringQueryParser(SearchExecutionContext context, boolean lenient) {
-        this(context, "*", resolveMappingField(context, "*", 1.0f, false, false, null), lenient);
+        this(context, "*", resolveMappingField(context, "*", 1.0f, null), lenient);
     }
 
     private QueryStringQueryParser(
@@ -264,22 +264,7 @@ public class QueryStringQueryParser extends QueryParser {
     private Map<String, Float> extractMultiFields(String field, boolean quoted) {
         Map<String, Float> extractedFields;
         if (field != null) {
-            boolean allFields = Regex.isMatchAllPattern(field);
-            if (allFields && this.field != null && this.field.equals(field)) {
-                // "*" is the default field
-                extractedFields = fieldsAndWeights;
-            }
-            boolean multiFields = Regex.isSimpleMatchPattern(field);
-            // Filters unsupported fields if a pattern is requested
-            // Filters metadata fields if all fields are requested
-            extractedFields = resolveMappingField(
-                context,
-                field,
-                1.0f,
-                allFields == false,
-                multiFields == false,
-                quoted ? quoteFieldSuffix : null
-            );
+            extractedFields = resolveMappingField(context, field, 1.0f, quoted ? quoteFieldSuffix : null);
         } else if (quoted && quoteFieldSuffix != null) {
             extractedFields = resolveMappingFields(context, fieldsAndWeights, quoteFieldSuffix);
         } else {

--- a/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
@@ -71,10 +71,11 @@ public class QueryParserHelperTests extends MapperServiceTestCase {
             SearchExecutionContext context = createSearchExecutionContext(mapperService, new IndexSearcher(ir));
 
             // field1 and field2 are present in the index, so they get resolved; field3 is in the mappings but
-            // not in the actual index, so it is ignored
+            // not in the actual index, so it is ignored; field4 is slow but still gets resolved because the
+            // wildcard request is partial
             {
                 Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, Map.of("field*", 1.0f));
-                assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2"));
+                assertThat(resolvedFields.keySet(), containsInAnyOrder("field1", "field2", "field4"));
                 assertFalse(resolvedFields.containsKey("field3"));
             }
 

--- a/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/QueryParserHelperTests.java
@@ -57,11 +57,13 @@ public class QueryParserHelperTests extends MapperServiceTestCase {
             b.startObject("field1").field("type", "text").endObject();
             b.startObject("field2").field("type", "text").endObject();
             b.startObject("field3").field("type", "text").endObject();
+            b.startObject("field4").field("type", "long").field("index", false).endObject();
         }));
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
             b.field("field1", "foo");
             b.field("field2", "bar");
+            b.field("field4", 100);
         }));
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {


### PR DESCRIPTION
Doc-value-only fields can be searched (slowly) by doing a table scan; this
commit ensures that these fields are not included in an all-field query, ie
a `query_string` or similar query against `*`, to prevent these queries 
becoming unreasonably slow.

Fixes #82710 