### PR TITLE
Fix PCSServiceTests#testHandlesShuffledDocuments

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -1120,7 +1120,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 && corruptDocIsLastPage;
             if (isOnlyPageForIndex == false // don't remove the only doc for an index, this just loses the index and doesn't corrupt
                 && rarely()) {
-                documents.remove(between(0, documents.size() - 1));
+                documents.remove(corruptIndex);
             } else {
                 if (randomBoolean()) {
                     corruptDocument.removeFields(PAGE_FIELD_NAME);


### PR DESCRIPTION
- Certain corruptions could trigger a `ZipException` rather than a
  `CorruptStateException`. Addressed by throwing a more specific
  exception in production code,
- Rarely we'd delete the wrong doc which would not be detected as a
  corruption.

Closes #82697