### PR TITLE
[7.14] [DOCS] Add 7.13 breaking change for ESS searchable snapshot shared cache (#80795)

### DIFF
--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -91,6 +91,26 @@ SSL/TLS versions on your JDK].
 [[breaking_713_settings_changes]]
 ==== Settings changes
 
+[[breaking_713_searchable_snapshot_cache_ess]]
+.`xpack.searchable.snapshot.shared_cache.size` is no longer a supported user setting for {ess}
+[%collapsible]
+====
+*Details* +
+You can no longer configure
+{ref}/searchable-snapshots.html#searchable-snapshots-shared-cache[`xpack.searchable.snapshot.shared_cache.size`]
+on {ess} deployments running {es} 7.13 or a later version. This setting reserves
+disk space for the shared cache of partially mounted indices. {es} now
+automatically configures the setting to 90% of total disk space for frozen data
+tier nodes and to `0b` for non-frozen data tier nodes.
+
+*Impact* +
+If you use {ess} and previously configured
+`xpack.searchable.snapshot.shared_cache.size`, remove it from your
+{cloud}/ec-add-user-settings.html[user settings] before upgrading to 7.13 or a
+later version. Otherwise, attempts to upgrade the deployment will fail and
+return an error.
+====
+
 [[breaking_713_frozen_multiple_data_paths_changes]]
 .Changes to the frozen tier and multiple data paths
 [%collapsible]


### PR DESCRIPTION
This is an automatic backport of pull request #80795 to 7.14.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information