### PR TITLE
[DOCS] forceMergeDeletes is used instead of expungeDeletes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -38,7 +38,7 @@ import org.elasticsearch.core.SuppressForbidden;
  * <ul>
  * <li><code>index.merge.policy.expunge_deletes_allowed</code>:
  *
- *     When expungeDeletes is called, we only merge away a segment if its delete
+ *     When forceMergeDeletes is called, we only merge away a segment if its delete
  *     percentage is over this threshold. Default is <code>10</code>.
  *
  * <li><code>index.merge.policy.floor_segment</code>:


### PR DESCRIPTION
Lucene `expungeDeletes` method no longer exists.
`forceMergeDeletes` is the correct method