### PR TITLE
Fix getBuildPluginFile for examples and thirdparty build

### DIFF
--- a/build-tools-internal/src/main/resources/roles.yml
+++ b/build-tools-internal/src/main/resources/roles.yml
@@ -1,7 +1,0 @@
-_root:
-    cluster: [ "ALL" ]
-    indices:
-        - names: [ "*" ]
-          allow_restricted_indices: true
-          privileges: [ "ALL" ]
-    run_as: [ "*" ]

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -17,6 +17,7 @@ import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
@@ -51,6 +52,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     private final String path;
     private final String clusterName;
     private final NamedDomainObjectContainer<ElasticsearchNode> nodes;
+    private final FileOperations fileOperations;
     private final File workingDirBase;
     private final LinkedHashMap<String, Predicate<TestClusterConfiguration>> waitConditions = new LinkedHashMap<>();
     private final Project project;
@@ -69,6 +71,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         FileSystemOperations fileSystemOperations,
         ArchiveOperations archiveOperations,
         ExecOperations execOperations,
+        FileOperations fileOperations,
         File workingDirBase,
         Provider<File> runtimeJava
     ) {
@@ -79,6 +82,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         this.fileSystemOperations = fileSystemOperations;
         this.archiveOperations = archiveOperations;
         this.execOperations = execOperations;
+        this.fileOperations = fileOperations;
         this.workingDirBase = workingDirBase;
         this.runtimeJava = runtimeJava;
         this.nodes = project.container(ElasticsearchNode.class);
@@ -92,6 +96,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                 fileSystemOperations,
                 archiveOperations,
                 execOperations,
+                fileOperations,
                 workingDirBase,
                 runtimeJava
             )
@@ -124,6 +129,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                     fileSystemOperations,
                     archiveOperations,
                     execOperations,
+                    fileOperations,
                     workingDirBase,
                     runtimeJava
                 )

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -24,6 +24,7 @@ import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.elasticsearch.gradle.util.Pair;
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
@@ -758,6 +759,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         credentials.add(cred);
     }
 
+    /**
+     * Todo we should replace usage of mutable project object here.
+     * */
     private File getBuildPluginFile(String name) {
         return project.getRootProject().getName().equals("elasticsearch")
             ? project.getRootProject().file("build-tools/src/main/resources/" + name)
@@ -767,7 +771,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 .filter(b -> b.getName().equals("elasticsearch"))
                 .map(i -> new File(i.getProjectDir(), "build-tools/src/main/resources/" + name))
                 .findFirst()
-                .get();
+                .orElseThrow(() -> new GradleException("Cannot resolve build plugin file " + name +
+                        " from root project " + project.getRootProject()));
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -22,6 +22,7 @@ import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.transform.UnzipTransform;
+import org.elasticsearch.gradle.util.GradleUtils;
 import org.elasticsearch.gradle.util.Pair;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
@@ -759,7 +760,15 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private File getBuildPluginFile(String name) {
-        return project.getRootProject().file("build-tools/src/main/resources/" + name);
+        return project.getRootProject().getName().equals("elaticsearch")
+            ? project.getRootProject().file("build-tools/src/main/resources/" + name)
+            : project.getGradle()
+                .getIncludedBuilds()
+                .stream()
+                .filter(b -> b.getName().equals("elasticsearch"))
+                .map(i -> new File(i.getProjectDir(), "build-tools/src/main/resources/" + name))
+                .findFirst()
+                .get();
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -771,8 +771,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 .map(i -> new File(i.getProjectDir(), "build-tools/src/main/resources/" + name))
                 .filter(f -> f.exists())
                 .findFirst()
-                .orElseThrow(() -> new GradleException("Cannot resolve build plugin file " + name +
-                        " from root project " + project.getRootProject()));
+                .orElseThrow(
+                    () -> new GradleException("Cannot resolve build plugin file " + name + " from root project " + project.getRootProject())
+                );
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -128,7 +128,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final FileSystemOperations fileSystemOperations;
     private final ArchiveOperations archiveOperations;
     private final ExecOperations execOperations;
-    private FileOperations fileOperations;
+    private final FileOperations fileOperations;
     private final AtomicBoolean configurationFrozen = new AtomicBoolean(false);
     private final Path workingDir;
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -768,12 +768,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             : project.getGradle()
                 .getIncludedBuilds()
                 .stream()
-                .filter(b -> {
-                    System.out.println("b.getName() = " + b.getName());
-                    System.out.println("b.getProjectDir() = " + b.getProjectDir());
-                    return b.getName().equals("elasticsearch");
-                })
                 .map(i -> new File(i.getProjectDir(), "build-tools/src/main/resources/" + name))
+                .filter(f -> f.exists())
                 .findFirst()
                 .orElseThrow(() -> new GradleException("Cannot resolve build plugin file " + name +
                         " from root project " + project.getRootProject()));

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -22,7 +22,6 @@ import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.transform.UnzipTransform;
-import org.elasticsearch.gradle.util.GradleUtils;
 import org.elasticsearch.gradle.util.Pair;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
@@ -760,7 +759,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private File getBuildPluginFile(String name) {
-        return project.getRootProject().getName().equals("elaticsearch")
+        return project.getRootProject().getName().equals("elasticsearch")
             ? project.getRootProject().file("build-tools/src/main/resources/" + name)
             : project.getGradle()
                 .getIncludedBuilds()

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -768,7 +768,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             : project.getGradle()
                 .getIncludedBuilds()
                 .stream()
-                .filter(b -> b.getName().equals("elasticsearch"))
+                .filter(b -> {
+                    System.out.println("b.getName() = " + b.getName());
+                    System.out.println("b.getProjectDir() = " + b.getProjectDir());
+                    return b.getName().equals("elasticsearch");
+                })
                 .map(i -> new File(i.getProjectDir(), "build-tools/src/main/resources/" + name))
                 .findFirst()
                 .orElseThrow(() -> new GradleException("Cannot resolve build plugin file " + name +

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -57,6 +58,11 @@ public class TestClustersPlugin implements Plugin<Project> {
 
     @Inject
     protected ExecOperations getExecOperations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected FileOperations getFileOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -116,6 +122,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 getFileSystemOperations(),
                 getArchiveOperations(),
                 getExecOperations(),
+                getFileOperations(),
                 new File(project.getBuildDir(), "testclusters"),
                 runtimeJavaProvider
             );


### PR DESCRIPTION
This fixes our integration tests resolving roles.yaml for our examples build where the root is
not pointing to elasticsearch root folder