### PR TITLE
[DOCS] Re-add cluster settings precedence

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -18,6 +18,11 @@ Configures <<dynamic-cluster-setting,dynamic cluster settings>>.
 * If the {es} {security-features} are enabled, you must have the `manage`
 <<privileges-list-cluster,cluster privilege>> to use this API.
 
+[[cluster-update-settings-api-desc]]
+==== {api-description-title}
+
+include::{es-repo-dir}/setup/configuration.asciidoc[tag=cluster-setting-precedence]
+
 [[cluster-update-settings-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -21,6 +21,7 @@ Configures <<dynamic-cluster-setting,dynamic cluster settings>>.
 [[cluster-update-settings-api-desc]]
 ==== {api-description-title}
 
+:strip-api-link: true
 include::{es-repo-dir}/setup/configuration.asciidoc[tag=cluster-setting-precedence]
 
 [[cluster-update-settings-api-query-params]]

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -113,6 +113,7 @@ Cluster and node settings can be categorized based on how they are configured:
 Dynamic::
 +
 --
+// tag::cluster-setting-precedence[]
 You can configure and update dynamic settings on a running cluster using the
 <<cluster-update-settings,cluster update settings API>>. You can also configure
 dynamic settings locally on an unstarted or shut down node using
@@ -149,6 +150,7 @@ nodes.
 ====
 
 include::{es-repo-dir}/cluster/update-settings.asciidoc[tag=transient-settings-warning]
+// end::cluster-setting-precedence[]
 --
 
 [[static-cluster-setting]]

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -115,9 +115,14 @@ Dynamic::
 --
 // tag::cluster-setting-precedence[]
 You can configure and update dynamic settings on a running cluster using the
-<<cluster-update-settings,cluster update settings API>>. You can also configure
-dynamic settings locally on an unstarted or shut down node using
-`elasticsearch.yml`.
+ifdef::strip-api-link[]
+cluster update settings API.
+endif::strip-api-link[]
+ifndef::strip-api-link[]
+<<cluster-update-settings,cluster update settings API>>.
+endif::strip-api-link[]
+You can also configure dynamic settings locally on an unstarted or shut down
+node using `elasticsearch.yml`.
 
 Updates made using the cluster update settings API can be _persistent_, which
 apply across cluster restarts, or _transient_, which reset after a cluster
@@ -142,11 +147,16 @@ If you use {ess}, use the {cloud}/ec-add-user-settings.html[user settings]
 feature to configure all cluster settings. This method lets {ess} automatically
 reject unsafe settings that could break your cluster.
 
-If you run {es} on your own hardware, use the <<cluster-update-settings,cluster
-update settings API>> to configure dynamic cluster settings. Only use
-`elasticsearch.yml` for static cluster settings and node settings. The API
-doesn't require a restart and ensures a setting's value is the same on all
-nodes.
+If you run {es} on your own hardware, use the
+ifdef::strip-api-link[]
+cluster update settings API
+endif::strip-api-link[]
+ifndef::strip-api-link[]
+<<cluster-update-settings,cluster update settings API>>
+endif::strip-api-link[]
+to configure dynamic cluster settings. Only use `elasticsearch.yml` for static
+cluster settings and node settings. The API doesn't require a restart and
+ensures a setting's value is the same on all nodes.
 ====
 
 include::{es-repo-dir}/cluster/update-settings.asciidoc[tag=transient-settings-warning]


### PR DESCRIPTION
Adds some tags and an include statement to re-add cluster settings precedence information to the cluster update settings API page. This should aid with discoverability.

Closes https://github.com/elastic/elasticsearch/issues/82634

Relates to https://github.com/elastic/elasticsearch/pull/79579

