### PR TITLE
[DOCS] Pointing redirect for track_total_hits to correct reference

### DIFF
--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -24,7 +24,7 @@ missing them.
 Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
 ways to change <<relevance-scores,relevance scores>>, the
 `rank_feature` query efficiently skips non-competitive hits when the
-<<search-uri-request,`track_total_hits`>> parameter is **not** `true`. This can
+<<track-total-hits,`track_total_hits`>> parameter is **not** `true`. This can
 dramatically improve query speed.
 
 [[rank-feature-query-functions]]


### PR DESCRIPTION
pointing the reference for track_total_hits to track-total-hits which will redirect it to https://www.elastic.co/guide/en/elasticsearch/reference/7.16/search-your-data.html#track-total-hits