### PR TITLE
Add fields emulation flag as no-op to search request for bwc (#82539)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -167,7 +167,10 @@ public class RestSearchAction extends BaseRestHandler {
         if (request.hasParam("pre_filter_shard_size")) {
             searchRequest.setPreFilterShardSize(request.paramAsInt("pre_filter_shard_size", SearchRequest.DEFAULT_PRE_FILTER_SHARD_SIZE));
         }
-
+        if (request.hasParam("enable_fields_emulation")) {
+            // this flag is a no-op from 8.0 on, we only want to consume it so its presence doesn't cause errors
+            request.paramAsBoolean("enable_fields_emulation", false);
+        }
         if (request.hasParam("max_concurrent_shard_requests")) {
             // only set if we have the parameter since we auto adjust the max concurrency on the coordinator
             // based on the number of nodes in the cluster

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.rest.action.search;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
@@ -52,6 +53,20 @@ public class RestSearchActionTests extends RestActionTestCase {
 
         dispatchRequest(request);
         assertCriticalWarnings(RestSearchAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    /**
+     * The "enable_fields_emulation" flag on search requests is a no-op but should not raise an error
+     */
+    public void testEnableFieldsEmulationNoErrors() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("enable_fields_emulation", "true");
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
+            Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
+        ).withMethod(RestRequest.Method.GET).withPath("/some_index/_search").withParams(params).build();
+
+        action.handleRequest(request, new FakeRestChannel(request, false, 1), verifyingClient);
     }
 
     /**


### PR DESCRIPTION
This change adds the 'enable_fields_emulation' flag as a REST parameter to 8.0+ nodes
in order for clients on 7.last (e.g. Kibana) to be able to use it in rolling upgrade scenarios.
We don't need any implementation of the functionality behind it on 8.0+ nodes, because
CCS is only supported for them to at most 7.last which already understands and
implements the "fields" option, so emulation on older version is not necessary.

Closes #82485