### PR TITLE
[7.17] Prevent 6.8 indices upgrade to 8.0 (#82689)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -626,7 +626,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     .putCustom(IndexGraveyard.TYPE, IndexGraveyard.builder().addTombstone(metadata.index("test").getIndex()).build())
                     .build()
             );
-            NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(nodeId, Version.CURRENT), paths);
+            NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(nodeId, Version.CURRENT, Version.CURRENT), paths);
         });
 
         ensureGreen();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -211,6 +211,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     private SortedMap<String, IndexAbstraction> indicesLookup;
 
+    private final Version oldestIndexVersion;
+
     private Metadata(
         String clusterUUID,
         boolean clusterUUIDCommitted,
@@ -231,7 +233,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         String[] visibleOpenIndices,
         String[] allClosedIndices,
         String[] visibleClosedIndices,
-        SortedMap<String, IndexAbstraction> indicesLookup
+        SortedMap<String, IndexAbstraction> indicesLookup,
+        Version oldestIndexVersion
     ) {
         this.clusterUUID = clusterUUID;
         this.clusterUUIDCommitted = clusterUUIDCommitted;
@@ -253,6 +256,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         this.allClosedIndices = allClosedIndices;
         this.visibleClosedIndices = visibleClosedIndices;
         this.indicesLookup = indicesLookup;
+        this.oldestIndexVersion = oldestIndexVersion;
     }
 
     public Metadata withIncrementedVersion() {
@@ -276,7 +280,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             visibleOpenIndices,
             allClosedIndices,
             visibleClosedIndices,
-            indicesLookup
+            indicesLookup,
+            oldestIndexVersion
         );
     }
 
@@ -317,6 +322,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     public CoordinationMetadata coordinationMetadata() {
         return this.coordinationMetadata;
+    }
+
+    public Version oldestIndexVersion() {
+        return this.oldestIndexVersion;
     }
 
     public boolean hasAlias(String alias) {
@@ -1717,6 +1726,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             final List<String> allClosedIndices = new ArrayList<>();
             final List<String> visibleClosedIndices = new ArrayList<>();
             final Set<String> allAliases = new HashSet<>();
+
+            int oldestIndexVersionId = Version.CURRENT.id;
+
             for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
                 final IndexMetadata indexMetadata = cursor.value;
                 final String name = indexMetadata.getIndex().getName();
@@ -1738,6 +1750,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     }
                 }
                 indexMetadata.getAliases().keysIt().forEachRemaining(allAliases::add);
+                oldestIndexVersionId = Math.min(oldestIndexVersionId, indexMetadata.getCreationVersion().id);
             }
 
             final ArrayList<String> duplicates = new ArrayList<>();
@@ -1859,7 +1872,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 visibleOpenIndicesArray,
                 allClosedIndicesArray,
                 visibleClosedIndicesArray,
-                indicesLookup
+                indicesLookup,
+                Version.fromId(oldestIndexVersionId)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -473,7 +473,8 @@ public final class NodeEnvironment implements Closeable {
             final NodeMetadata legacyMetadata = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, paths);
             if (legacyMetadata == null) {
                 assert nodeIds.isEmpty() : nodeIds;
-                metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, metadata.oldestIndexVersion());
+                // If we couldn't find legacy metadata, we set the latest index version to this version
+                metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, Version.CURRENT);
             } else {
                 assert nodeIds.equals(Collections.singleton(legacyMetadata.nodeId())) : nodeIds + " doesn't match " + legacyMetadata;
                 metadata = legacyMetadata;

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -473,7 +473,8 @@ public final class NodeEnvironment implements Closeable {
             final NodeMetadata legacyMetadata = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, paths);
             if (legacyMetadata == null) {
                 assert nodeIds.isEmpty() : nodeIds;
-                // If we couldn't find legacy metadata, we set the latest index version to this version
+                // If we couldn't find legacy metadata, we set the latest index version to this version. This happens
+                // when we are starting a new node and there are no indices to worry about.
                 metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, Version.CURRENT);
             } else {
                 assert nodeIds.equals(Collections.singleton(legacyMetadata.nodeId())) : nodeIds + " doesn't match " + legacyMetadata;

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -267,7 +267,7 @@ public final class NodeEnvironment implements Closeable {
             sharedDataPath = null;
             locks = null;
             nodeLockId = -1;
-            nodeMetadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT);
+            nodeMetadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, Version.CURRENT);
             return;
         }
         boolean success = false;
@@ -473,7 +473,7 @@ public final class NodeEnvironment implements Closeable {
             final NodeMetadata legacyMetadata = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, paths);
             if (legacyMetadata == null) {
                 assert nodeIds.isEmpty() : nodeIds;
-                metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT);
+                metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, metadata.oldestIndexVersion());
             } else {
                 assert nodeIds.equals(Collections.singleton(legacyMetadata.nodeId())) : nodeIds + " doesn't match " + legacyMetadata;
                 metadata = legacyMetadata;

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -565,7 +565,7 @@ public class GatewayMetaState implements Closeable {
                     getWriterSafe().writeIncrementalTermUpdateAndCommit(
                         currentTerm,
                         lastAcceptedState.version(),
-                        lastAcceptedState.metadata().oldestIndexVersion().id
+                        lastAcceptedState.metadata().oldestIndexVersion()
                     );
                 }
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -107,7 +107,7 @@ public class GatewayMetaState implements Closeable {
             final Tuple<Manifest, Metadata> manifestClusterStateTuple;
             try {
                 NodeMetadata.FORMAT.writeAndCleanup(
-                    new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT),
+                    new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT, Version.V_EMPTY),
                     persistedClusterStateService.getDataPaths()
                 );
                 manifestClusterStateTuple = metaStateService.loadFullState();
@@ -118,6 +118,19 @@ public class GatewayMetaState implements Closeable {
                 .version(manifestClusterStateTuple.v1().getClusterStateVersion())
                 .metadata(manifestClusterStateTuple.v2())
                 .build();
+
+            try {
+                NodeMetadata.FORMAT.writeAndCleanup(
+                    new NodeMetadata(
+                        persistedClusterStateService.getNodeId(),
+                        Version.CURRENT,
+                        clusterState.metadata().oldestIndexVersion()
+                    ),
+                    persistedClusterStateService.getDataPaths()
+                );
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
 
             final IncrementalClusterStateWriter incrementalClusterStateWriter = new IncrementalClusterStateWriter(
                 settings,
@@ -182,7 +195,11 @@ public class GatewayMetaState implements Closeable {
                     }
                     // write legacy node metadata to prevent accidental downgrades from spawning empty cluster state
                     NodeMetadata.FORMAT.writeAndCleanup(
-                        new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT),
+                        new NodeMetadata(
+                            persistedClusterStateService.getNodeId(),
+                            Version.CURRENT,
+                            clusterState.metadata().oldestIndexVersion()
+                        ),
                         persistedClusterStateService.getDataPaths()
                     );
                     success = true;
@@ -216,7 +233,11 @@ public class GatewayMetaState implements Closeable {
                     metaStateService.deleteAll();
                     // write legacy node metadata to prevent downgrades from spawning empty cluster state
                     NodeMetadata.FORMAT.writeAndCleanup(
-                        new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT),
+                        new NodeMetadata(
+                            persistedClusterStateService.getNodeId(),
+                            Version.CURRENT,
+                            clusterState.metadata().oldestIndexVersion()
+                        ),
                         persistedClusterStateService.getDataPaths()
                     );
                 } catch (IOException e) {
@@ -541,7 +562,11 @@ public class GatewayMetaState implements Closeable {
                     getWriterSafe().writeFullStateAndCommit(currentTerm, lastAcceptedState);
                 } else {
                     writeNextStateFully = true; // in case of failure; this flag is cleared on success
-                    getWriterSafe().writeIncrementalTermUpdateAndCommit(currentTerm, lastAcceptedState.version());
+                    getWriterSafe().writeIncrementalTermUpdateAndCommit(
+                        currentTerm,
+                        lastAcceptedState.version(),
+                        lastAcceptedState.metadata().oldestIndexVersion().id
+                    );
                 }
             } catch (IOException e) {
                 throw new ElasticsearchException(e);

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -504,7 +504,8 @@ public class PersistedClusterStateService {
 
         final Map<String, String> userData = reader.getIndexCommit().getUserData();
         logger.trace("loaded metadata [{}] from [{}]", userData, reader.directory());
-        assert userData.size() == COMMIT_DATA_SIZE : userData;
+        assert (userData.size() == COMMIT_DATA_SIZE)
+            || ((userData.size() == COMMIT_DATA_SIZE - 1) && (userData.containsKey(OLDEST_INDEX_VERSION_KEY) == false)) : userData;
         assert userData.get(CURRENT_TERM_KEY) != null;
         assert userData.get(LAST_ACCEPTED_VERSION_KEY) != null;
         assert userData.get(NODE_ID_KEY) != null;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1949,6 +1949,44 @@ public class MetadataTests extends ESTestCase {
         }
     }
 
+    public void testOldestIndexComputation() {
+        Metadata metadata = buildIndicesWithVersions(
+            new Version[] { Version.V_6_1_0, Version.CURRENT, Version.fromId(Version.CURRENT.id + 1) }
+        ).build();
+
+        assertEquals(Version.V_6_1_0, metadata.oldestIndexVersion());
+
+        Metadata.Builder b = Metadata.builder();
+        assertEquals(Version.CURRENT, b.build().oldestIndexVersion());
+
+        Throwable ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> buildIndicesWithVersions(new Version[] { Version.V_6_1_0, Version.V_EMPTY, Version.fromId(Version.CURRENT.id + 1) })
+                .build()
+        );
+
+        assertEquals("[index.version.created] is not present in the index settings for index with UUID [null]", ex.getMessage());
+    }
+
+    private Metadata.Builder buildIndicesWithVersions(Version[] indexVersions) {
+
+        final List<Index> indices = new ArrayList<>();
+        int lastIndexNum = randomIntBetween(9, 50);
+        Metadata.Builder b = Metadata.builder();
+        for (int k = 0; k < indexVersions.length; k++) {
+            IndexMetadata im = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("index", lastIndexNum))
+                .settings(settings(indexVersions[k]))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            indices.add(im.getIndex());
+            lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
+        }
+
+        return b;
+    }
+
     public static Metadata randomMetadata() {
         return randomMetadata(1);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1968,19 +1968,16 @@ public class MetadataTests extends ESTestCase {
         assertEquals("[index.version.created] is not present in the index settings for index with UUID [null]", ex.getMessage());
     }
 
-    private Metadata.Builder buildIndicesWithVersions(Version[] indexVersions) {
-
-        final List<Index> indices = new ArrayList<>();
+    private Metadata.Builder buildIndicesWithVersions(Version... indexVersions) {
         int lastIndexNum = randomIntBetween(9, 50);
         Metadata.Builder b = Metadata.builder();
-        for (int k = 0; k < indexVersions.length; k++) {
+        for (Version indexVersion : indexVersions) {
             IndexMetadata im = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("index", lastIndexNum))
-                .settings(settings(indexVersions[k]))
+                .settings(settings(indexVersion))
                 .numberOfShards(1)
                 .numberOfReplicas(1)
                 .build();
             b.put(im, false);
-            indices.add(im.getIndex());
             lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
         }
 

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -34,22 +34,34 @@ public class NodeMetadataTests extends ESTestCase {
 
     public void testEqualsHashcodeSerialization() {
         final Path tempDir = createTempDir();
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(new NodeMetadata(randomAlphaOfLength(10), randomVersion()), nodeMetadata -> {
-            final long generation = NodeMetadata.FORMAT.writeAndCleanup(nodeMetadata, tempDir);
-            final Tuple<NodeMetadata, Long> nodeMetadataLongTuple = NodeMetadata.FORMAT.loadLatestStateWithGeneration(
-                logger,
-                xContentRegistry(),
-                tempDir
-            );
-            assertThat(nodeMetadataLongTuple.v2(), equalTo(generation));
-            return nodeMetadataLongTuple.v1();
-        }, nodeMetadata -> {
-            if (randomBoolean()) {
-                return new NodeMetadata(randomAlphaOfLength(21 - nodeMetadata.nodeId().length()), nodeMetadata.nodeVersion());
-            } else {
-                return new NodeMetadata(nodeMetadata.nodeId(), randomValueOtherThan(nodeMetadata.nodeVersion(), this::randomVersion));
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+            new NodeMetadata(randomAlphaOfLength(10), randomVersion(), Version.CURRENT),
+            nodeMetadata -> {
+                final long generation = NodeMetadata.FORMAT.writeAndCleanup(nodeMetadata, tempDir);
+                final Tuple<NodeMetadata, Long> nodeMetadataLongTuple = NodeMetadata.FORMAT.loadLatestStateWithGeneration(
+                    logger,
+                    xContentRegistry(),
+                    tempDir
+                );
+                assertThat(nodeMetadataLongTuple.v2(), equalTo(generation));
+                return nodeMetadataLongTuple.v1();
+            },
+            nodeMetadata -> {
+                if (randomBoolean()) {
+                    return new NodeMetadata(
+                        randomAlphaOfLength(21 - nodeMetadata.nodeId().length()),
+                        nodeMetadata.nodeVersion(),
+                        Version.CURRENT
+                    );
+                } else {
+                    return new NodeMetadata(
+                        nodeMetadata.nodeId(),
+                        randomValueOtherThan(nodeMetadata.nodeVersion(), this::randomVersion),
+                        Version.CURRENT
+                    );
+                }
             }
-        });
+        );
     }
 
     public void testReadsFormatWithoutVersion() throws IOException {
@@ -75,7 +87,8 @@ public class NodeMetadataTests extends ESTestCase {
             randomValueOtherThanMany(
                 v -> v.after(Version.CURRENT) || v.before(Version.CURRENT.minimumIndexCompatibilityVersion()),
                 this::randomVersion
-            )
+            ),
+            Version.CURRENT
         ).upgradeToCurrentVersion();
         assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
         assertThat(nodeMetadata.nodeId(), equalTo(nodeId));
@@ -83,7 +96,7 @@ public class NodeMetadataTests extends ESTestCase {
 
     public void testUpgradesMissingVersion() {
         final String nodeId = randomAlphaOfLength(10);
-        final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, Version.V_EMPTY).upgradeToCurrentVersion();
+        final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, Version.V_EMPTY, Version.CURRENT).upgradeToCurrentVersion();
         assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
         assertThat(nodeMetadata.nodeId(), equalTo(nodeId));
     }
@@ -91,7 +104,7 @@ public class NodeMetadataTests extends ESTestCase {
     public void testDoesNotUpgradeFutureVersion() {
         final IllegalStateException illegalStateException = expectThrows(
             IllegalStateException.class,
-            () -> new NodeMetadata(randomAlphaOfLength(10), tooNewVersion()).upgradeToCurrentVersion()
+            () -> new NodeMetadata(randomAlphaOfLength(10), tooNewVersion(), Version.CURRENT).upgradeToCurrentVersion()
         );
         assertThat(
             illegalStateException.getMessage(),
@@ -102,7 +115,7 @@ public class NodeMetadataTests extends ESTestCase {
     public void testDoesNotUpgradeAncientVersion() {
         final IllegalStateException illegalStateException = expectThrows(
             IllegalStateException.class,
-            () -> new NodeMetadata(randomAlphaOfLength(10), tooOldVersion()).upgradeToCurrentVersion()
+            () -> new NodeMetadata(randomAlphaOfLength(10), tooOldVersion(), Version.CURRENT).upgradeToCurrentVersion()
         );
         assertThat(
             illegalStateException.getMessage(),

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -47,18 +47,25 @@ public class NodeMetadataTests extends ESTestCase {
                 return nodeMetadataLongTuple.v1();
             },
             nodeMetadata -> {
-                if (randomBoolean()) {
-                    return new NodeMetadata(
-                        randomAlphaOfLength(21 - nodeMetadata.nodeId().length()),
-                        nodeMetadata.nodeVersion(),
-                        Version.CURRENT
-                    );
-                } else {
-                    return new NodeMetadata(
-                        nodeMetadata.nodeId(),
-                        randomValueOtherThan(nodeMetadata.nodeVersion(), this::randomVersion),
-                        Version.CURRENT
-                    );
+                switch (randomInt(3)) {
+                    case 0:
+                        return new NodeMetadata(
+                            randomAlphaOfLength(21 - nodeMetadata.nodeId().length()),
+                            nodeMetadata.nodeVersion(),
+                            Version.CURRENT
+                        );
+                    case 1:
+                        return new NodeMetadata(
+                            nodeMetadata.nodeId(),
+                            randomValueOtherThan(nodeMetadata.nodeVersion(), this::randomVersion),
+                            Version.CURRENT
+                        );
+                    default:
+                        return new NodeMetadata(
+                            nodeMetadata.nodeId(),
+                            nodeMetadata.nodeVersion(),
+                            randomValueOtherThan(Version.CURRENT, this::randomVersion)
+                        );
                 }
             }
         );

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -526,7 +526,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     if (randomBoolean()) {
                         writeState(writer, newTerm, newState, clusterState);
                     } else {
-                        writer.commit(newTerm, newState.version());
+                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion().id);
                     }
                 }).getMessage(), containsString("simulated"));
                 assertFalse(writer.isOpen());
@@ -578,7 +578,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     if (randomBoolean()) {
                         writeState(writer, newTerm, newState, clusterState);
                     } else {
-                        writer.commit(newTerm, newState.version());
+                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion().id);
                     }
                 }).getMessage(), containsString("simulated"));
                 assertFalse(writer.isOpen());

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -527,7 +527,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     if (randomBoolean()) {
                         writeState(writer, newTerm, newState, clusterState);
                     } else {
-                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion().id);
+                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion());
                     }
                 }).getMessage(), containsString("simulated"));
                 assertFalse(writer.isOpen());
@@ -579,7 +579,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     if (randomBoolean()) {
                         writeState(writer, newTerm, newState, clusterState);
                     } else {
-                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion().id);
+                        writer.commit(newTerm, newState.version(), newState.metadata().oldestIndexVersion());
                     }
                 }).getMessage(), containsString("simulated"));
                 assertFalse(writer.isOpen());
@@ -1267,18 +1267,16 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
 
         final Version[] indexVersions = new Version[] { Version.V_6_1_0, Version.CURRENT, Version.fromId(Version.CURRENT.id + 1) };
-        final List<Index> indices = new ArrayList<>();
         int lastIndexNum = randomIntBetween(9, 50);
         Metadata.Builder b = Metadata.builder();
-        for (int k = 0; k < indexVersions.length; k++) {
+        for (Version indexVersion : indexVersions) {
             String indexUUID = UUIDs.randomBase64UUID(random());
             IndexMetadata im = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("index", lastIndexNum))
-                .settings(settings(indexVersions[k]).put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))
+                .settings(settings(indexVersion).put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))
                 .numberOfShards(1)
                 .numberOfReplicas(1)
                 .build();
             b.put(im, false);
-            indices.add(im.getIndex());
             lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
         }
 

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -1257,6 +1258,48 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     }
                 }
             }
+        }
+    }
+
+    public void testOldestIndexVersionIsCorrectlySerialized() throws IOException {
+        final Path[] dataPaths1 = createDataPaths();
+        final Path[] dataPaths2 = createDataPaths();
+        final Path[] combinedPaths = Stream.concat(Arrays.stream(dataPaths1), Arrays.stream(dataPaths2)).toArray(Path[]::new);
+
+        final Version[] indexVersions = new Version[] { Version.V_6_1_0, Version.CURRENT, Version.fromId(Version.CURRENT.id + 1) };
+        final List<Index> indices = new ArrayList<>();
+        int lastIndexNum = randomIntBetween(9, 50);
+        Metadata.Builder b = Metadata.builder();
+        for (int k = 0; k < indexVersions.length; k++) {
+            String indexUUID = UUIDs.randomBase64UUID(random());
+            IndexMetadata im = IndexMetadata.builder(DataStream.getDefaultBackingIndexName("index", lastIndexNum))
+                .settings(settings(indexVersions[k]).put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            indices.add(im.getIndex());
+            lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
+        }
+
+        Metadata metadata = b.build();
+
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment(combinedPaths)) {
+            try (Writer writer = newPersistedClusterStateService(nodeEnvironment).createWriter()) {
+                final ClusterState clusterState = loadPersistedClusterState(newPersistedClusterStateService(nodeEnvironment));
+                writeState(
+                    writer,
+                    0L,
+                    ClusterState.builder(clusterState).metadata(metadata).version(randomLongBetween(1L, Long.MAX_VALUE)).build(),
+                    clusterState
+                );
+            }
+
+            PersistedClusterStateService.OnDiskState fromDisk = newPersistedClusterStateService(nodeEnvironment).loadBestOnDiskState();
+            NodeMetadata nodeMetadata = PersistedClusterStateService.nodeMetadata(nodeEnvironment.nodeDataPaths());
+
+            assertEquals(Version.V_6_1_0, nodeMetadata.oldestIndexVersion());
+            assertEquals(Version.V_6_1_0, fromDisk.metadata.oldestIndexVersion());
         }
     }
 


### PR DESCRIPTION
This PR is a backport of #82689 with small change to only compute the latest index version, but not act on it.

The check to prevent ES start because of old indices is only applicable to versions 8.0+, since all 7 versions can still work with the older 6.8 index format.