### PR TITLE
fix: update skip version after backporting to 7.17.0 and 8.0.0

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -386,8 +386,8 @@ setup:
 ---
 "Range aggregation on date field":
   - skip:
-      version: " - 8.0.99"
-      reason: Fixed in 8.1.0
+      version: " - 7.16.99"
+      reason: Fixed in 8.1.0 and backported to 7.17.0
 
   - do:
       search:


### PR DESCRIPTION
Update the yaml skip version after back-porting #82732 to `7.17.0` and `8.0.0`.
