### PR TITLE
[8.0] [DOCS]  Clarify that `null` values don't create dynamic field mappings (#82769)

### DIFF
--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -22,9 +22,10 @@ Use the `{name}` and `{dynamic_type}` <<template-variables,template variables>>
 in the mapping specification as placeholders.
 
 IMPORTANT: Dynamic field mappings are only added when a field contains a
-concrete value -- not `null` or an empty array. If the
-`null_value` option is used in a `dynamic_template`, it will only be applied
-after the first document with a concrete value for the field has been
+concrete value. {es} doesn't add a dynamic field mapping when the field contains
+`null` or an empty array. If the `null_value` option is used in a
+`dynamic_template`, it will only be applied after the first document with a
+concrete value for the field has been
 indexed.
 
 Dynamic templates are specified as an array of named objects:


### PR DESCRIPTION
This is an automatic backport of pull request #82769 to 8.0.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information