### PR TITLE
[8.0] Correctly pre-size HashMaps (#82670)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
@@ -15,12 +15,12 @@ import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.client.TimedRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -31,7 +31,7 @@ public class RolloverRequest extends TimedRequest implements ToXContentObject {
     private final String alias;
     private final String newIndexName;
     private boolean dryRun;
-    private final Map<String, Condition<?>> conditions = new HashMap<>(2);
+    private final Map<String, Condition<?>> conditions = Maps.newMapWithExpectedSize(2);
     // the index name "_na_" is never read back, what matters are settings, mappings and aliases
     private final CreateIndexRequest createIndexRequest = new CreateIndexRequest("_na_");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.client.xpack;
 
 import org.elasticsearch.client.license.LicenseStatus;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser.ValueType;
@@ -16,7 +17,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -276,7 +276,7 @@ public class XPackInfoResponse {
         private final Map<String, FeatureSet> featureSets;
 
         public FeatureSetsInfo(Set<FeatureSet> featureSets) {
-            Map<String, FeatureSet> map = new HashMap<>(featureSets.size());
+            Map<String, FeatureSet> map = Maps.newMapWithExpectedSize(featureSets.size());
             for (FeatureSet featureSet : featureSets) {
                 map.put(featureSet.name, featureSet);
             }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
@@ -41,6 +41,7 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 import org.elasticsearch.xcontent.XContentType;
@@ -48,7 +49,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -198,7 +198,7 @@ public class CCRIT extends ESRestHighLevelClientTestCase {
         final CcrClient ccrClient = highLevelClient().ccr();
 
         final CreateIndexRequest createIndexRequest = new CreateIndexRequest("leader");
-        final Map<String, String> settings = new HashMap<>(3);
+        final Map<String, String> settings = Maps.newMapWithExpectedSize(3);
         final int numberOfShards = randomIntBetween(1, 2);
         settings.put("index.number_of_replicas", "0");
         settings.put("index.number_of_shards", Integer.toString(numberOfShards));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/GetPolicyResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/GetPolicyResponseTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.client.enrich;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -18,7 +19,6 @@ import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -29,7 +29,7 @@ public class GetPolicyResponseTests extends AbstractResponseTestCase<GetEnrichPo
     @Override
     protected GetEnrichPolicyAction.Response createServerTestInstance(XContentType xContentType) {
         int numPolicies = randomIntBetween(0, 8);
-        Map<String, EnrichPolicy> policies = new HashMap<>(numPolicies);
+        Map<String, EnrichPolicy> policies = Maps.newMapWithExpectedSize(numPolicies);
         for (int i = 0; i < numPolicies; i++) {
             policies.put(randomAlphaOfLength(4), createRandomEnrichPolicy(xContentType));
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/NodeAttributesTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/NodeAttributesTests.java
@@ -7,11 +7,11 @@
  */
 package org.elasticsearch.client.ml;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -19,7 +19,7 @@ public class NodeAttributesTests extends AbstractXContentTestCase<NodeAttributes
 
     public static NodeAttributes createRandom() {
         int numberOfAttributes = randomIntBetween(1, 10);
-        Map<String, String> attributes = new HashMap<>(numberOfAttributes);
+        Map<String, String> attributes = Maps.newMapWithExpectedSize(numberOfAttributes);
         for (int i = 0; i < numberOfAttributes; i++) {
             String val = randomAlphaOfLength(10);
             attributes.put("key-" + i, val);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedStatsTests.java
@@ -9,11 +9,11 @@ package org.elasticsearch.client.ml.datafeed;
 
 import org.elasticsearch.client.ml.NodeAttributes;
 import org.elasticsearch.client.ml.NodeAttributesTests;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -31,7 +31,7 @@ public class DatafeedStatsTests extends AbstractXContentTestCase<DatafeedStats> 
         if (randomBoolean()) {
             NodeAttributes randomAttributes = NodeAttributesTests.createRandom();
             int numberOfAttributes = randomIntBetween(1, 10);
-            Map<String, String> attributes = new HashMap<>(numberOfAttributes);
+            Map<String, String> attributes = Maps.newMapWithExpectedSize(numberOfAttributes);
             for (int i = 0; i < numberOfAttributes; i++) {
                 String val = randomAlphaOfLength(10);
                 attributes.put("ml.key-" + i, val);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/RollupCapsResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/RollupCapsResponseTestCase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.rollup.job.config.RollupJobConfig;
 import org.elasticsearch.client.rollup.job.config.RollupJobConfigTests;
 import org.elasticsearch.client.rollup.job.config.TermsGroupConfig;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -64,7 +65,7 @@ abstract class RollupCapsResponseTestCase<T> extends ESTestCase {
     @Before
     private void setupIndices() throws IOException {
         int numIndices = randomIntBetween(1, 5);
-        indices = new HashMap<>(numIndices);
+        indices = Maps.newMapWithExpectedSize(numIndices);
         for (int i = 0; i < numIndices; i++) {
             String indexName = "index_" + randomAlphaOfLength(10);
             int numJobs = randomIntBetween(1, 5);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/PreviewTransformResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/PreviewTransformResponseTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -21,7 +22,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +117,7 @@ public class PreviewTransformResponseTests extends ESTestCase {
 
         Map<String, Object> mappings = null;
         if (randomBoolean()) {
-            mappings = new HashMap<>(size);
+            mappings = Maps.newMapWithExpectedSize(size);
 
             for (int i = 0; i < size; i++) {
                 mappings.put(randomAlphaOfLength(10), Map.of("type", randomAlphaOfLength(10)));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/hlrc/PreviewTransformResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/hlrc/PreviewTransformResponseTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.transform.PreviewTransformResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
@@ -20,7 +21,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformDestIndexSetti
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +48,7 @@ public class PreviewTransformResponseTests extends AbstractResponseTestCase<
         Map<String, Object> mappings = null;
 
         if (randomBoolean()) {
-            mappings = new HashMap<>(size);
+            mappings = Maps.newMapWithExpectedSize(size);
 
             for (int i = 0; i < size; i++) {
                 mappings.put(randomAlphaOfLength(10), Map.of("type", randomAlphaOfLength(10)));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/NodeAttributesTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/NodeAttributesTests.java
@@ -7,11 +7,11 @@
  */
 package org.elasticsearch.client.transform.transforms;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -19,7 +19,7 @@ public class NodeAttributesTests extends AbstractXContentTestCase<NodeAttributes
 
     public static NodeAttributes createRandom() {
         int numberOfAttributes = randomIntBetween(1, 10);
-        Map<String, String> attributes = new HashMap<>(numberOfAttributes);
+        Map<String, String> attributes = Maps.newMapWithExpectedSize(numberOfAttributes);
         for (int i = 0; i < numberOfAttributes; i++) {
             String val = randomAlphaOfLength(10);
             attributes.put("key-" + i, val);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformStatsTests.java
@@ -16,11 +16,11 @@ import org.elasticsearch.client.transform.transforms.TransformIndexerPosition;
 import org.elasticsearch.client.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.client.transform.transforms.TransformProgress;
 import org.elasticsearch.client.transform.transforms.TransformStats;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -31,7 +31,7 @@ public class TransformStatsTests extends AbstractResponseTestCase<
 
     public static org.elasticsearch.xpack.core.transform.transforms.NodeAttributes randomNodeAttributes() {
         int numberOfAttributes = randomIntBetween(1, 10);
-        Map<String, String> attributes = new HashMap<>(numberOfAttributes);
+        Map<String, String> attributes = Maps.newMapWithExpectedSize(numberOfAttributes);
         for (int i = 0; i < numberOfAttributes; i++) {
             String val = randomAlphaOfLength(10);
             attributes.put("key-" + i, val);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/WatcherStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/WatcherStatsResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.client.watcher;
 
 import org.elasticsearch.client.NodesResponseHeader;
 import org.elasticsearch.client.NodesResponseHeaderTestUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -19,7 +20,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -171,7 +171,7 @@ public class WatcherStatsResponseTests extends ESTestCase {
             Map<String, Object> stats = null;
             if (randomBoolean()) {
                 int statsCount = randomInt(10);
-                stats = new HashMap<>(statsCount);
+                stats = Maps.newMapWithExpectedSize(statsCount);
                 for (int j = 0; j < statsCount; j++) {
                     stats.put(randomAlphaOfLength(10), randomNonNegativeLong());
                 }

--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ClientYamlDocsTestClient;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
@@ -40,7 +41,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -297,7 +297,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
                         .replace("$", "\\$")
                 );
             }
-            Map<String, Object> body = new HashMap<>(2);
+            Map<String, Object> body = Maps.newMapWithExpectedSize(2);
             body.put("analyzer", first);
             body.put("text", testText);
             ClientYamlTestResponse response = executionContext.callApi(

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.search.aggregations.matrix.stats;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -19,7 +20,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFactory {
@@ -51,7 +51,7 @@ final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFact
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        Map<String, ValuesSource.Numeric> typedValuesSources = new HashMap<>(valuesSources.size());
+        Map<String, ValuesSource.Numeric> typedValuesSources = Maps.newMapWithExpectedSize(valuesSources.size());
         for (Map.Entry<String, ValuesSource> entry : valuesSources.entrySet()) {
             if (entry.getValue() instanceof ValuesSource.Numeric == false) {
                 throw new AggregationExecutionException(

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.aggregations.matrix.stats;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -108,7 +109,7 @@ public class InternalMatrixStatsTests extends InternalAggregationTestCase<Intern
             case 3:
             default:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MultiPassStats.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MultiPassStats.java
@@ -7,6 +7,8 @@
  */
 package org.elasticsearch.search.aggregations.matrix.stats;
 
+import org.elasticsearch.common.util.Maps;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,8 +26,8 @@ class MultiPassStats {
     private Map<String, Double> variances = new HashMap<>();
     private Map<String, Double> skewness = new HashMap<>();
     private Map<String, Double> kurtosis = new HashMap<>();
-    private Map<String, HashMap<String, Double>> covariances = new HashMap<>();
-    private Map<String, HashMap<String, Double>> correlations = new HashMap<>();
+    private Map<String, Map<String, Double>> covariances = new HashMap<>();
+    private Map<String, Map<String, Double>> correlations = new HashMap<>();
 
     MultiPassStats(String fieldAName, String fieldBName) {
         this.fieldAKey = fieldAName;
@@ -78,12 +80,12 @@ class MultiPassStats {
         kurtosis.put(fieldBKey, kurtB / ((count - 1) * variances.get(fieldBKey) * variances.get(fieldBKey)));
 
         // compute covariance
-        final HashMap<String, Double> fieldACovar = new HashMap<>(2);
+        final Map<String, Double> fieldACovar = Maps.newMapWithExpectedSize(2);
         fieldACovar.put(fieldAKey, 1d);
         cVar /= count - 1;
         fieldACovar.put(fieldBKey, cVar);
         covariances.put(fieldAKey, fieldACovar);
-        final HashMap<String, Double> fieldBCovar = new HashMap<>(2);
+        final Map<String, Double> fieldBCovar = Maps.newMapWithExpectedSize(2);
         fieldBCovar.put(fieldAKey, cVar);
         fieldBCovar.put(fieldBKey, 1d);
         covariances.put(fieldBKey, fieldBCovar);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ForEachProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ForEachProcessor.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
@@ -65,7 +66,7 @@ public final class ForEachProcessor extends AbstractProcessor implements Wrappin
             }
         } else if (o instanceof Map<?, ?> map) {
             List<?> keys = new ArrayList<>(map.keySet());
-            innerExecuteMap(0, new HashMap<Object, Object>(map), keys, new HashMap<>(map.size()), ingestDocument, handler);
+            innerExecuteMap(0, new HashMap<Object, Object>(map), keys, Maps.newMapWithExpectedSize(map.size()), ingestDocument, handler);
         } else if (o instanceof List<?> list) {
             innerExecuteList(0, new ArrayList<>(list), new ArrayList<>(list.size()), ingestDocument, handler);
         } else {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.IngestDocument.Metadata;
@@ -256,7 +257,7 @@ public class AppendProcessorTests extends ESTestCase {
             @Override
             Object randomValue() {
                 int numItems = randomIntBetween(1, 10);
-                Map<String, Object> map = new HashMap<>(numItems);
+                Map<String, Object> map = Maps.newMapWithExpectedSize(numItems);
                 for (int i = 0; i < numItems; i++) {
                     map.put(randomAlphaOfLengthBetween(1, 10), randomFrom(Scalar.values()).randomValue());
                 }

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.useragent;
 
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
@@ -113,7 +114,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                     break;
                 case OS:
                     if (uaClient.operatingSystem() != null) {
-                        Map<String, String> osDetails = new HashMap<>(3);
+                        Map<String, String> osDetails = Maps.newMapWithExpectedSize(3);
                         if (uaClient.operatingSystem().name() != null) {
                             osDetails.put("name", uaClient.operatingSystem().name());
                             StringBuilder sb = new StringBuilder();
@@ -136,7 +137,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                     }
                     break;
                 case DEVICE:
-                    Map<String, String> deviceDetails = new HashMap<>(1);
+                    Map<String, String> deviceDetails = Maps.newMapWithExpectedSize(1);
                     if (uaClient.device() != null && uaClient.device().name() != null) {
                         deviceDetails.put("name", uaClient.device().name());
                         if (extractDeviceType) {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -11,12 +11,12 @@ package org.elasticsearch.script.mustache;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
 
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.iterable.Iterables;
 
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +73,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
         @Override
         public Set<Entry<Object, Object>> entrySet() {
-            Map<Object, Object> map = new HashMap<>(length);
+            Map<Object, Object> map = Maps.newMapWithExpectedSize(length);
             for (int i = 0; i < length; i++) {
                 map.put(i, Array.get(array, i));
             }
@@ -131,7 +131,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
         @Override
         public Set<Entry<Object, Object>> entrySet() {
-            Map<Object, Object> map = new HashMap<>(col.size());
+            Map<Object, Object> map = Maps.newMapWithExpectedSize(col.size());
             int i = 0;
             for (Object item : col) {
                 map.put(i++, item);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.painless.lookup;
 
 import org.elasticsearch.bootstrap.BootstrapInfo;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.MethodWriter;
 import org.elasticsearch.painless.WriterConstants;
@@ -2016,7 +2017,7 @@ public final class PainlessLookupBuilder {
         generateRuntimeMethods();
         cacheRuntimeHandles();
 
-        Map<Class<?>, PainlessClass> classesToPainlessClasses = new HashMap<>(classesToPainlessClassBuilders.size());
+        Map<Class<?>, PainlessClass> classesToPainlessClasses = Maps.newMapWithExpectedSize(classesToPainlessClassBuilders.size());
 
         for (Map.Entry<Class<?>, PainlessClassBuilder> painlessClassBuilderEntry : classesToPainlessClassBuilders.entrySet()) {
             classesToPainlessClasses.put(painlessClassBuilderEntry.getKey(), painlessClassBuilderEntry.getValue().build());

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -53,14 +54,14 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
         super(in);
         this.metricScore = in.readDouble();
         int partialResultSize = in.readVInt();
-        this.details = new HashMap<>(partialResultSize);
+        this.details = Maps.newMapWithExpectedSize(partialResultSize);
         for (int i = 0; i < partialResultSize; i++) {
             String queryId = in.readString();
             EvalQueryQuality partial = new EvalQueryQuality(in);
             this.details.put(queryId, partial);
         }
         int failuresSize = in.readVInt();
-        this.failures = new HashMap<>(failuresSize);
+        this.failures = Maps.newMapWithExpectedSize(failuresSize);
         for (int i = 0; i < failuresSize; i++) {
             String queryId = in.readString();
             this.failures.put(queryId, in.readException());

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
@@ -164,7 +165,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
         @Override
         public void onResponse(MultiSearchResponse multiSearchResponse) {
             int responsePosition = 0;
-            Map<String, EvalQueryQuality> responseDetails = new HashMap<>(specifications.length);
+            Map<String, EvalQueryQuality> responseDetails = Maps.newMapWithExpectedSize(specifications.length);
             for (Item response : multiSearchResponse.getResponses()) {
                 RatedRequest specification = specifications[responsePosition];
                 if (response.isFailure() == false) {

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
@@ -36,7 +37,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -72,7 +72,7 @@ public class RankEvalResponseTests extends ESTestCase {
 
     private static RankEvalResponse createRandomResponse() {
         int numberOfRequests = randomIntBetween(0, 5);
-        Map<String, EvalQueryQuality> partials = new HashMap<>(numberOfRequests);
+        Map<String, EvalQueryQuality> partials = Maps.newMapWithExpectedSize(numberOfRequests);
         for (int i = 0; i < numberOfRequests; i++) {
             String id = randomAlphaOfLengthBetween(3, 10);
             EvalQueryQuality evalQuality = new EvalQueryQuality(id, randomDoubleBetween(0.0, 1.0, true));
@@ -85,7 +85,7 @@ public class RankEvalResponseTests extends ESTestCase {
             partials.put(id, evalQuality);
         }
         int numberOfErrors = randomIntBetween(0, 2);
-        Map<String, Exception> errors = new HashMap<>(numberOfRequests);
+        Map<String, Exception> errors = Maps.newMapWithExpectedSize(numberOfRequests);
         for (int i = 0; i < numberOfErrors; i++) {
             errors.put(randomAlphaOfLengthBetween(3, 10), randomFrom(RANDOM_EXCEPTIONS));
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RoundTripTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
 import org.elasticsearch.index.reindex.AbstractBulkIndexByScrollRequest;
@@ -31,7 +32,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.lucene.util.TestUtil.randomSimpleString;
@@ -52,7 +52,7 @@ public class RoundTripTests extends ESTestCase {
             String username = randomBoolean() ? randomAlphaOfLength(5) : null;
             String password = username != null && randomBoolean() ? randomAlphaOfLength(5) : null;
             int headersCount = randomBoolean() ? 0 : between(1, 10);
-            Map<String, String> headers = new HashMap<>(headersCount);
+            Map<String, String> headers = Maps.newMapWithExpectedSize(headersCount);
             while (headers.size() < headersCount) {
                 headers.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }

--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/RetryingHttpInputStream.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/RetryingHttpInputStream.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.blobstore.url.http;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.rest.RestStatus;
 
@@ -23,7 +24,6 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -219,7 +219,7 @@ class RetryingHttpInputStream extends InputStream {
     private HttpResponseInputStream openInputStream() throws IOException {
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<HttpResponseInputStream>) () -> {
-                final Map<String, String> headers = new HashMap<>(1);
+                final Map<String, String> headers = Maps.newMapWithExpectedSize(1);
 
                 if (isRangeRead()) {
                     headers.put("Range", getBytesRange(Math.addExact(start, totalBytesRead), end));

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -28,7 +29,6 @@ import org.elasticsearch.test.InternalTestCluster;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +59,7 @@ public class Zen2RestApiIT extends ESNetty4IntegTestCase {
         ensureGreen("test");
 
         final DiscoveryNodes discoveryNodes = client().admin().cluster().prepareState().clear().setNodes(true).get().getState().nodes();
-        final Map<String, String> nodeIdsByName = new HashMap<>(discoveryNodes.getSize());
+        final Map<String, String> nodeIdsByName = Maps.newMapWithExpectedSize(discoveryNodes.getSize());
         discoveryNodes.forEach(n -> nodeIdsByName.put(n.getName(), n.getId()));
 
         RestClient restClient = getRestClient();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
@@ -175,7 +176,7 @@ public class EquivalenceIT extends ESIntegTestCase {
         Range range = resp.getAggregations().get("range");
         List<? extends Bucket> buckets = range.getBuckets();
 
-        HashMap<String, Bucket> bucketMap = new HashMap<>(buckets.size());
+        Map<String, Bucket> bucketMap = Maps.newMapWithExpectedSize(buckets.size());
         for (Bucket bucket : buckets) {
             bucketMap.put(bucket.getKeyAsString(), bucket);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.collect.EvictingQueue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -18,7 +19,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +131,7 @@ public class SerialDiffIT extends ESIntegTestCase {
         metric = randomMetric("the_metric", VALUE_FIELD);
         mockHisto = PipelineAggregationHelperTests.generateHistogram(interval, numBuckets, randomDouble(), randomDouble());
 
-        testValues = new HashMap<>(8);
+        testValues = Maps.newMapWithExpectedSize(8);
 
         for (MetricTarget target : MetricTarget.values()) {
             setupExpected(target);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.analysis.AbstractIndexAnalyzerProvider;
 import org.elasticsearch.index.analysis.AnalyzerProvider;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
@@ -60,7 +61,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -2978,7 +2978,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         ensureGreen();
 
         int COUNT = between(20, 100);
-        Map<String, String> prefixes = new HashMap<>(COUNT);
+        Map<String, String> prefixes = Maps.newMapWithExpectedSize(COUNT);
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[COUNT];
         for (int i = 0; i < COUNT; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesMetricsIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -146,7 +147,7 @@ public class TimeSeriesMetricsIT extends ESIntegTestCase {
         createTsdbIndex("dim0", "dim1", "dim2", "dim3", "dim4", "dim5", "dim6", "dim7");
         assertManyTimeSeries(i -> {
             int dimCount = (i & 0x07) + 1;
-            Map<String, Object> dims = new HashMap<>(dimCount);
+            Map<String, Object> dims = Maps.newMapWithExpectedSize(dimCount);
             int offset = (i >> 3) & 0x03;
             String value = Integer.toString(i, Character.MAX_RADIX);
             for (int d = 0; d < dimCount; d++) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.health.ClusterStateHealth;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
@@ -26,7 +27,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -78,7 +78,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
             if (indexList == null || indexList.isEmpty()) {
                 indices = emptyMap();
             } else {
-                indices = new HashMap<>(indexList.size());
+                indices = Maps.newMapWithExpectedSize(indexList.size());
                 for (ClusterIndexHealth indexHealth : indexList) {
                     indices.put(indexHealth.getIndex(), indexHealth);
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -133,7 +134,7 @@ public class SnapshotIndexStatus implements Iterable<SnapshotIndexShardStatus>, 
                 if (shardStatuses == null || shardStatuses.isEmpty()) {
                     indexShards = emptyMap();
                 } else {
-                    indexShards = new HashMap<>(shardStatuses.size());
+                    indexShards = Maps.newMapWithExpectedSize(shardStatuses.size());
                     for (SnapshotIndexShardStatus shardStatus : shardStatuses) {
                         indexShards.put(shardStatus.getShardId().getId(), shardStatus);
                     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -240,7 +241,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
                 indicesStatus = emptyMap();
                 shards = emptyList();
             } else {
-                indicesStatus = new HashMap<>(indices.size());
+                indicesStatus = Maps.newMapWithExpectedSize(indices.size());
                 shards = new ArrayList<>();
                 for (SnapshotIndexStatus index : indices) {
                     indicesStatus.put(index.getIndex(), index);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -187,7 +188,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
 
         private Counts(final List<NodeInfo> nodeInfos) {
             // TODO: do we need to report zeros?
-            final Map<String, Integer> roles = new HashMap<>(DiscoveryNodeRole.roles().size() + 1);
+            final Map<String, Integer> roles = Maps.newMapWithExpectedSize(DiscoveryNodeRole.roles().size() + 1);
             roles.put(COORDINATING_ONLY, 0);
             for (final DiscoveryNodeRole role : DiscoveryNodeRole.roles()) {
                 roles.put(role.roleName(), 0);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponse.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.storedscripts;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptContextInfo;
@@ -22,7 +23,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,7 +57,7 @@ public class GetScriptContextResponse extends ActionResponse implements StatusTo
     GetScriptContextResponse(StreamInput in) throws IOException {
         super(in);
         int size = in.readInt();
-        HashMap<String, ScriptContextInfo> contexts = new HashMap<>(size);
+        Map<String, ScriptContextInfo> contexts = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             ScriptContextInfo info = new ScriptContextInfo(in);
             contexts.put(info.name, info);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.MapperService;
@@ -24,7 +25,6 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -123,7 +123,7 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
     private String rolloverTarget;
     private String newIndexName;
     private boolean dryRun;
-    private final Map<String, Condition<?>> conditions = new HashMap<>(2);
+    private final Map<String, Condition<?>> conditions = Maps.newMapWithExpectedSize(2);
     // the index name "_na_" is never read back, what matters are settings, mappings and aliases
     private CreateIndexRequest createIndexRequest = new CreateIndexRequest("_na_");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
@@ -11,12 +11,12 @@ package org.elasticsearch.action.admin.indices.rollover;
 import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -48,7 +48,7 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
         oldIndex = in.readString();
         newIndex = in.readString();
         int conditionSize = in.readVInt();
-        conditionStatus = new HashMap<>(conditionSize);
+        conditionStatus = Maps.newMapWithExpectedSize(conditionSize);
         for (int i = 0; i < conditionSize; i++) {
             conditionStatus.put(in.readString(), in.readBoolean());
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -12,13 +12,13 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +51,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         resolvedTemplate = in.readOptionalWriteable(Template::new);
         if (in.readBoolean()) {
             int overlappingTemplatesCount = in.readInt();
-            overlappingTemplates = new HashMap<>(overlappingTemplatesCount, 1L);
+            overlappingTemplates = Maps.newMapWithExpectedSize(overlappingTemplatesCount);
             for (int i = 0; i < overlappingTemplatesCount; i++) {
                 String templateName = in.readString();
                 overlappingTemplates.put(templateName, in.readStringList());

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.InnerHitBuilder;
@@ -21,7 +22,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -95,7 +95,7 @@ final class ExpandSearchPhase extends SearchPhase {
                         }
                         SearchHits innerHits = item.getResponse().getHits();
                         if (hit.getInnerHits() == null) {
-                            hit.setInnerHits(new HashMap<>(innerHitBuilders.size()));
+                            hit.setInnerHits(Maps.newMapWithExpectedSize(innerHitBuilders.size()));
                         }
                         hit.getInnerHits().put(innerHitBuilder.getName(), innerHits);
                     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.TotalHits.Relation;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.lucene.grouping.TopFieldGroups;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
@@ -457,7 +458,7 @@ public final class SearchPhaseController {
         // count the total (we use the query result provider here, since we might not get any hits (we scrolled past them))
         final Map<String, List<Suggestion<?>>> groupedSuggestions = hasSuggest ? new HashMap<>() : Collections.emptyMap();
         final Map<String, SearchProfileQueryPhaseResult> profileShardResults = hasProfileResults
-            ? new HashMap<>(queryResults.size())
+            ? Maps.newMapWithExpectedSize(queryResults.size())
             : Collections.emptyMap();
         int from = 0;
         int size = 0;

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.Nullable;
@@ -1238,7 +1239,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         String[] concreteLocalIndices
     ) {
         HashSet<String> searchedIndices = new HashSet<>(Arrays.asList(concreteLocalIndices));
-        HashMap<String, long[]> newWaitForCheckpoints = new HashMap<>(searchRequest.getWaitForCheckpoints().size());
+        Map<String, long[]> newWaitForCheckpoints = Maps.newMapWithExpectedSize(searchRequest.getWaitForCheckpoints().size());
         for (Map.Entry<String, long[]> waitForCheckpointIndex : searchRequest.getWaitForCheckpoints().entrySet()) {
             long[] checkpoints = waitForCheckpointIndex.getValue();
             int checkpointsProvided = checkpoints.length;

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -38,7 +39,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.LongSupplier;
 
@@ -88,7 +88,7 @@ public class UpdateHelper {
      * Tuple of operation and updated {@code _source} is returned.
      */
     Tuple<UpdateOpType, Map<String, Object>> executeScriptedUpsert(Map<String, Object> upsertDoc, Script script, LongSupplier nowInMillis) {
-        Map<String, Object> ctx = new HashMap<>(3);
+        Map<String, Object> ctx = Maps.newMapWithExpectedSize(3);
         // Tell the script that this is a create and not an update
         ctx.put(ContextFields.OP, UpdateOpType.CREATE.toString());
         ctx.put(ContextFields.SOURCE, upsertDoc);
@@ -239,7 +239,7 @@ public class UpdateHelper {
         final XContentType updateSourceContentType = sourceAndContent.v1();
         final Map<String, Object> sourceAsMap = sourceAndContent.v2();
 
-        Map<String, Object> ctx = new HashMap<>(16);
+        Map<String, Object> ctx = Maps.newMapWithExpectedSize(16);
         ctx.put(ContextFields.OP, UpdateOpType.INDEX.toString()); // The default operation is "index"
         ctx.put(ContextFields.INDEX, getResult.getIndex());
         ctx.put(ContextFields.TYPE, MapperService.SINGLE_MAPPING_NAME);

--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -432,14 +433,14 @@ public final class DiffableUtils {
             this.valueSerializer = valueSerializer;
             deletes = in.readList(keySerializer::readKey);
             int diffsCount = in.readVInt();
-            diffs = diffsCount == 0 ? Collections.emptyMap() : new HashMap<>(diffsCount);
+            diffs = diffsCount == 0 ? Collections.emptyMap() : Maps.newMapWithExpectedSize(diffsCount);
             for (int i = 0; i < diffsCount; i++) {
                 K key = keySerializer.readKey(in);
                 Diff<T> diff = valueSerializer.readDiff(in, key);
                 diffs.put(key, diff);
             }
             int upsertsCount = in.readVInt();
-            upserts = upsertsCount == 0 ? Collections.emptyMap() : new HashMap<>(upsertsCount);
+            upserts = upsertsCount == 0 ? Collections.emptyMap() : Maps.newMapWithExpectedSize(upsertsCount);
             for (int i = 0; i < upsertsCount; i++) {
                 K key = keySerializer.readKey(in);
                 T newValue = valueSerializer.read(in, key);

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -753,7 +754,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (source == null) {
                 assert shardStatusByRepoShardId == null || shardStatusByRepoShardId.isEmpty()
                     : "Provided explict repo shard id statuses [" + shardStatusByRepoShardId + "] but no source";
-                final Map<String, Index> res = new HashMap<>(indices.size());
+                final Map<String, Index> res = Maps.newMapWithExpectedSize(indices.size());
                 final ImmutableOpenMap.Builder<RepositoryShardId, ShardSnapshotStatus> byRepoShardIdBuilder = ImmutableOpenMap.builder(
                     shards.size()
                 );
@@ -785,7 +786,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (indexCount == 0) {
                 indices = Collections.emptyMap();
             } else {
-                final Map<String, IndexId> idx = new HashMap<>(indexCount);
+                final Map<String, IndexId> idx = Maps.newMapWithExpectedSize(indexCount);
                 for (int i = 0; i < indexCount; i++) {
                     final IndexId indexId = new IndexId(in);
                     idx.put(indexId.getName(), indexId);

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -65,7 +66,7 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
             if (shardList == null || shardList.isEmpty()) {
                 shards = emptyMap();
             } else {
-                shards = new HashMap<>(shardList.size());
+                shards = Maps.newMapWithExpectedSize(shardList.size());
                 for (ClusterShardHealth shardHealth : shardList) {
                     shards.put(shardHealth.getShardId(), shardHealth);
                 }
@@ -172,7 +173,7 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
         status = ClusterHealthStatus.readFrom(in);
 
         int size = in.readVInt();
-        shards = new HashMap<>(size);
+        shards = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             ClusterShardHealth shardHealth = new ClusterShardHealth(in);
             shards.put(shardHealth.getShardId(), shardHealth);

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -119,7 +120,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         numberOfDataNodes = in.readVInt();
         status = ClusterHealthStatus.readFrom(in);
         int size = in.readVInt();
-        indices = new HashMap<>(size);
+        indices = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             ClusterIndexHealth indexHealth = new ClusterIndexHealth(in);
             indices.put(indexHealth.getIndex(), indexHealth);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
@@ -57,7 +58,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1937,7 +1937,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private static final ToXContent.Params FORMAT_PARAMS;
     static {
-        Map<String, String> params = new HashMap<>(2);
+        Map<String, String> params = Maps.newMapWithExpectedSize(2);
         params.put("binary", "true");
         params.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
         FORMAT_PARAMS = new MapParams(params);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
@@ -2017,7 +2018,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     private static final ToXContent.Params FORMAT_PARAMS;
     static {
-        Map<String, String> params = new HashMap<>(2);
+        Map<String, String> params = Maps.newMapWithExpectedSize(2);
         params.put("binary", "true");
         params.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
         FORMAT_PARAMS = new MapParams(params);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
@@ -24,7 +25,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -272,7 +272,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         final ResponseCollectorService collector
     ) {
 
-        final Map<String, Optional<ResponseCollectorService.ComputedNodeStats>> nodeStats = new HashMap<>(nodeIds.size());
+        final Map<String, Optional<ResponseCollectorService.ComputedNodeStats>> nodeStats = Maps.newMapWithExpectedSize(nodeIds.size());
         for (String nodeId : nodeIds) {
             nodeStats.put(nodeId, collector.getNodeStatistics(nodeId));
         }
@@ -283,7 +283,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         final Map<String, Optional<ResponseCollectorService.ComputedNodeStats>> nodeStats,
         final Map<String, Long> nodeSearchCounts
     ) {
-        final Map<String, Double> nodeRanks = new HashMap<>(nodeStats.size());
+        final Map<String, Double> nodeRanks = Maps.newMapWithExpectedSize(nodeStats.size());
         for (Map.Entry<String, Optional<ResponseCollectorService.ComputedNodeStats>> entry : nodeStats.entrySet()) {
             Optional<ResponseCollectorService.ComputedNodeStats> maybeStats = entry.getValue();
             maybeStats.ifPresent(stats -> {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.core.Nullable;
@@ -646,7 +647,7 @@ public abstract class StreamInput extends InputStream {
         if (size == 0) {
             return Collections.emptyMap();
         }
-        final Map<K, List<V>> map = new HashMap<>(size);
+        final Map<K, List<V>> map = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; ++i) {
             map.put(keyReader.read(this), readList(valueReader));
         }
@@ -795,7 +796,7 @@ public abstract class StreamInput extends InputStream {
         if (size10 == 0) {
             return Collections.emptyMap();
         }
-        Map<String, Object> map10 = new HashMap<>(size10);
+        Map<String, Object> map10 = Maps.newMapWithExpectedSize(size10);
         for (int i = 0; i < size10; i++) {
             map10.put(readString(), readGenericValue());
         }

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 
 import java.util.ArrayList;
@@ -347,7 +348,7 @@ public abstract class AbstractScopedSettings {
                     SettingUpdater affixUpdaterA = setting.newAffixUpdater((k, v) -> namespaces.add(k), logger, (a, b) -> {});
                     affixUpdaterA.apply(current, previous);
                 }
-                Map<String, Settings> namespaceToSettings = new HashMap<>(namespaces.size());
+                Map<String, Settings> namespaceToSettings = Maps.newMapWithExpectedSize(namespaces.size());
                 for (String namespace : namespaces) {
                     Set<String> concreteSettings = new HashSet<>(settings.size());
                     for (Setting.AffixSetting<?> setting : settings) {

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.StringLiteralDeduplicator;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
@@ -133,7 +134,7 @@ public final class Settings implements ToXContentFragment {
     }
 
     private Map<String, Object> getAsStructuredMap() {
-        Map<String, Object> map = new HashMap<>(2);
+        Map<String, Object> map = Maps.newMapWithExpectedSize(2);
         for (Map.Entry<String, Object> entry : settings.entrySet()) {
             processSetting(map, "", entry.getKey(), entry.getValue());
         }
@@ -165,7 +166,7 @@ public final class Settings implements ToXContentFragment {
             String rest = setting.substring(prefixLength + 1);
             Object existingValue = map.get(prefix + key);
             if (existingValue == null) {
-                Map<String, Object> newMap = new HashMap<>(2);
+                Map<String, Object> newMap = Maps.newMapWithExpectedSize(2);
                 processSetting(newMap, "", rest, value);
                 map.put(prefix + key, newMap);
             } else {

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.common.time;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 
 import java.text.ParsePosition;
 import java.time.ZoneId;
@@ -22,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 class JavaDateFormatter implements DateFormatter {
 
     // base fields which should be used for default parsing, when we round up for date math
-    private static final Map<TemporalField, Long> ROUND_UP_BASE_FIELDS = new HashMap<>(6);
+    private static final Map<TemporalField, Long> ROUND_UP_BASE_FIELDS = Maps.newMapWithExpectedSize(6);
 
     {
         ROUND_UP_BASE_FIELDS.put(ChronoField.MONTH_OF_YEAR, 1L);

--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -243,4 +243,20 @@ public class Maps {
         );
     }
 
+    /**
+     * Returns a map with a capacity sufficient to keep expectedSize elements without being resized.
+     *
+     * @param expectedSize the expected amount of elements in the map
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return a new pre-sized {@link HashMap}
+     */
+    public static <K, V> Map<K, V> newMapWithExpectedSize(int expectedSize) {
+        return new HashMap<>(capacity(expectedSize));
+    }
+
+    static int capacity(int expectedSize) {
+        assert expectedSize >= 0;
+        return expectedSize < 2 ? expectedSize + 1 : (int) (expectedSize / 0.75 + 1.0);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.http.HttpTransportSettings;
 
@@ -126,7 +127,7 @@ public final class ThreadContext implements Writeable {
     }
 
     private Map<String, String> headers(ThreadContextStruct context, Set<String> headersToCopy) {
-        Map<String, String> map = new HashMap<>(headersToCopy.size(), 1);
+        Map<String, String> map = Maps.newMapWithExpectedSize(headersToCopy.size());
         for (String header : headersToCopy) {
             if (context.requestHeaders.containsKey(header)) {
                 map.put(header, context.requestHeaders.get(header));
@@ -352,7 +353,7 @@ public final class ThreadContext implements Writeable {
      */
     public Map<String, List<String>> getResponseHeaders() {
         Map<String, Set<String>> responseHeaders = threadLocal.get().responseHeaders;
-        HashMap<String, List<String>> map = new HashMap<>(responseHeaders.size());
+        Map<String, List<String>> map = Maps.newMapWithExpectedSize(responseHeaders.size());
 
         for (Map.Entry<String, Set<String>> entry : responseHeaders.entrySet()) {
             map.put(entry.getKey(), List.copyOf(entry.getValue()));

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -54,6 +54,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.CheckedConsumer;
@@ -540,7 +541,7 @@ public class PersistedClusterStateService {
     private static final ToXContent.Params FORMAT_PARAMS;
 
     static {
-        Map<String, String> params = new HashMap<>(2);
+        Map<String, String> params = Maps.newMapWithExpectedSize(2);
         params.put("binary", "true");
         params.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
         FORMAT_PARAMS = new ToXContent.MapParams(params);
@@ -796,7 +797,9 @@ public class PersistedClusterStateService {
                     }
                 }
 
-                final Map<String, Long> indexMetadataVersionByUUID = new HashMap<>(previouslyWrittenMetadata.indices().size());
+                final Map<String, Long> indexMetadataVersionByUUID = Maps.newMapWithExpectedSize(
+                    previouslyWrittenMetadata.indices().size()
+                );
                 for (IndexMetadata indexMetadata : previouslyWrittenMetadata.indices().values()) {
                     final Long previousValue = indexMetadataVersionByUUID.putIfAbsent(
                         indexMetadata.getIndexUUID(),

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.NodeEnvironment;
@@ -370,7 +371,7 @@ public final class IndexModule {
         private static final Map<String, Type> TYPES;
 
         static {
-            final Map<String, Type> types = new HashMap<>(4);
+            final Map<String, Type> types = Maps.newMapWithExpectedSize(4);
             for (final Type type : values()) {
                 types.put(type.settingsKey, type);
             }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -52,6 +52,7 @@ import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndSeqNo;
 import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
@@ -88,7 +89,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -2560,7 +2560,7 @@ public class InternalEngine extends Engine {
                  * {@link IndexWriter#commit()} call flushes all documents, we defer computation of the maximum sequence number to the time
                  * of invocation of the commit data iterator (which occurs after all documents have been flushed to Lucene).
                  */
-                final Map<String, String> commitData = new HashMap<>(8);
+                final Map<String, String> commitData = Maps.newMapWithExpectedSize(8);
                 commitData.put(Translog.TRANSLOG_UUID_KEY, translog.getTranslogUUID());
                 commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(localCheckpoint));
                 commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
@@ -2805,7 +2805,7 @@ public class InternalEngine extends Engine {
      * Gets the commit data from {@link IndexWriter} as a map.
      */
     private static Map<String, String> commitDataAsMap(final IndexWriter indexWriter) {
-        final Map<String, String> commitData = new HashMap<>(8);
+        final Map<String, String> commitData = Maps.newMapWithExpectedSize(8);
         for (Map.Entry<String, String> entry : indexWriter.getLiveCommitData()) {
             commitData.put(entry.getKey(), entry.getValue());
         }

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
@@ -389,7 +390,7 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
         if (size == 0) {
             fields = emptyMap();
         } else {
-            fields = new HashMap<>(size);
+            fields = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 DocumentField field = new DocumentField(in);
                 fields.put(field.getName(), field);

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -384,7 +385,7 @@ public class CompletionFieldMapper extends FieldMapper {
         // parse
         XContentParser parser = context.parser();
         Token token = parser.currentToken();
-        Map<String, CompletionInputMetadata> inputMap = new HashMap<>(1);
+        Map<String, CompletionInputMetadata> inputMap = Maps.newMapWithExpectedSize(1);
 
         if (token == Token.VALUE_NULL) { // ignore null values
             return;

--- a/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.DeprecationHandler;
@@ -24,7 +25,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -98,7 +98,7 @@ public class RemoteInfo implements Writeable, ToXContentObject {
         username = in.readOptionalString();
         password = in.readOptionalString();
         int headersLength = in.readVInt();
-        Map<String, String> headers = new HashMap<>(headersLength);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(headersLength);
         for (int i = 0; i < headersLength; i++) {
             headers.put(in.readString(), in.readString());
         }

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
@@ -20,7 +21,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class SearchStats implements Writeable, ToXContentFragment {
@@ -271,7 +271,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         openContexts += searchStats.openContexts;
         if (searchStats.groupStats != null && searchStats.groupStats.isEmpty() == false) {
             if (groupStats == null) {
-                groupStats = new HashMap<>(searchStats.groupStats.size());
+                groupStats = Maps.newMapWithExpectedSize(searchStats.groupStats.size());
             }
             for (Map.Entry<String, Stats> entry : searchStats.groupStats.entrySet()) {
                 groupStats.putIfAbsent(entry.getKey(), new Stats());

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardFieldUsageTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardFieldUsageTracker.java
@@ -10,13 +10,13 @@ package org.elasticsearch.index.search.stats;
 
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.search.stats.FieldUsageStats.PerFieldUsageStats;
 import org.elasticsearch.search.internal.FieldUsageTrackingDirectoryReader;
 import org.elasticsearch.search.internal.FieldUsageTrackingDirectoryReader.FieldUsageNotifier;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +44,7 @@ public class ShardFieldUsageTracker {
      * returns information for all fields.
      */
     public FieldUsageStats stats(String... fields) {
-        final Map<String, PerFieldUsageStats> stats = new HashMap<>(perFieldStats.size());
+        final Map<String, PerFieldUsageStats> stats = Maps.newMapWithExpectedSize(perFieldStats.size());
         for (Map.Entry<String, InternalFieldStats> entry : perFieldStats.entrySet()) {
             InternalFieldStats ifs = entry.getValue();
             if (CollectionUtils.isEmpty(fields) || Regex.simpleMatch(fields, entry.getKey())) {

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -17,7 +17,6 @@ import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -39,7 +38,7 @@ public final class ShardSearchStats implements SearchOperationListener {
         SearchStats.Stats total = totalStats.stats();
         Map<String, SearchStats.Stats> groupsSt = null;
         if (CollectionUtils.isEmpty(groups) == false) {
-            groupsSt = new HashMap<>(groupsStats.size());
+            groupsSt = Maps.newMapWithExpectedSize(groupsStats.size());
             if (groups.length == 1 && groups[0].equals("_all")) {
                 for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
                     groupsSt.put(entry.getKey(), entry.getValue().stats());

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.gateway.WriteStateException;
 import org.elasticsearch.index.IndexSettings;
@@ -948,7 +949,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         this.handoffInProgress = false;
         this.appliedClusterStateVersion = -1L;
         this.globalCheckpoint = globalCheckpoint;
-        this.checkpoints = new HashMap<>(1 + indexSettings.getNumberOfReplicas());
+        this.checkpoints = Maps.newMapWithExpectedSize(1 + indexSettings.getNumberOfReplicas());
         this.onGlobalCheckpointUpdated = Objects.requireNonNull(onGlobalCheckpointUpdated);
         this.currentTimeMillisSupplier = Objects.requireNonNull(currentTimeMillisSupplier);
         this.onSyncRetentionLeases = Objects.requireNonNull(onSyncRetentionLeases);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.shard;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
@@ -22,7 +23,6 @@ import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -238,7 +238,7 @@ public final class ShardPath {
                 Map<NodeEnvironment.NodePath, Long> pathToShardCount = env.shardCountPerPath(shardId.getIndex());
 
                 // Compute how much space there is on each path
-                final Map<NodeEnvironment.NodePath, BigInteger> pathsToSpace = new HashMap<>(paths.length);
+                final Map<NodeEnvironment.NodePath, BigInteger> pathsToSpace = Maps.newMapWithExpectedSize(paths.length);
                 for (NodeEnvironment.NodePath nodePath : paths) {
                     FileStore fileStore = nodePath.fileStore;
                     BigInteger usableBytes = BigInteger.valueOf(fileStore.getUsableSpace());

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.Engine;
@@ -44,8 +45,8 @@ import org.elasticsearch.repositories.Repository;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -191,7 +192,7 @@ final class StoreRecovery {
              * document-level semantics.
              */
             writer.setLiveCommitData(() -> {
-                final HashMap<String, String> liveCommitData = new HashMap<>(3);
+                final Map<String, String> liveCommitData = Maps.newMapWithExpectedSize(3);
                 liveCommitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNo));
                 liveCommitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(maxSeqNo));
                 liveCommitData.put(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp));

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
@@ -80,7 +81,7 @@ public final class SimilarityService {
         ScriptService scriptService,
         Map<String, TriFunction<Settings, Version, ScriptService, Similarity>> similarities
     ) {
-        Map<String, Supplier<Similarity>> providers = new HashMap<>(similarities.size());
+        Map<String, Supplier<Similarity>> providers = Maps.newMapWithExpectedSize(similarities.size());
         Map<String, Settings> similaritySettings = indexSettings.getSettings().getGroups(IndexModule.SIMILARITY_SETTINGS_PREFIX);
 
         for (Map.Entry<String, Settings> entry : similaritySettings.entrySet()) {

--- a/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
+++ b/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
@@ -9,10 +9,10 @@
 package org.elasticsearch.index.store;
 
 import org.apache.lucene.index.IndexFileNames;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -128,7 +128,7 @@ public enum LuceneFilesExtensions {
 
     private static final Map<String, LuceneFilesExtensions> extensions;
     static {
-        final Map<String, LuceneFilesExtensions> map = new HashMap<>(values().length);
+        final Map<String, LuceneFilesExtensions> map = Maps.newMapWithExpectedSize(values().length);
         for (LuceneFilesExtensions extension : values()) {
             map.put(extension.extension, extension);
         }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
@@ -620,7 +621,7 @@ public class SystemIndices {
     }
 
     private static Map<String, Feature> buildSystemIndexDescriptorMap(Map<String, Feature> featuresMap) {
-        final Map<String, Feature> map = new HashMap<>(featuresMap.size() + SERVER_SYSTEM_INDEX_DESCRIPTORS.size());
+        final Map<String, Feature> map = Maps.newMapWithExpectedSize(featuresMap.size() + SERVER_SYSTEM_INDEX_DESCRIPTORS.size());
         map.putAll(featuresMap);
         // put the server items last since we expect less of them
         SERVER_SYSTEM_INDEX_DESCRIPTORS.forEach((source, feature) -> {

--- a/server/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.indices.analysis;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.util.Maps;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class PreBuiltCacheFactory {
@@ -77,7 +77,7 @@ public class PreBuiltCacheFactory {
      */
     private static class PreBuiltCacheStrategyElasticsearch<T> implements PreBuiltCache<T> {
 
-        Map<Version, T> mapModel = new HashMap<>(2);
+        Map<Version, T> mapModel = Maps.newMapWithExpectedSize(2);
 
         @Override
         public T get(Version version) {
@@ -100,7 +100,7 @@ public class PreBuiltCacheFactory {
      */
     private static class PreBuiltCacheStrategyLucene<T> implements PreBuiltCache<T> {
 
-        private Map<org.apache.lucene.util.Version, T> mapModel = new HashMap<>(2);
+        private Map<org.apache.lucene.util.Version, T> mapModel = Maps.newMapWithExpectedSize(2);
 
         @Override
         public T get(Version version) {

--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
@@ -28,7 +29,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -546,7 +546,7 @@ public final class ConfigurationUtils {
         if (config instanceof Map) {
             return readProcessor(processorFactories, scriptService, type, (Map<String, Object>) config);
         } else if (config instanceof String && "script".equals(type)) {
-            Map<String, Object> normalizedScript = new HashMap<>(1);
+            Map<String, Object> normalizedScript = Maps.newMapWithExpectedSize(1);
             normalizedScript.put(ScriptType.INLINE.getParseField().getPreferredName(), config);
             return readProcessor(processorFactories, scriptService, type, normalizedScript);
         } else {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.LazyMap;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
@@ -741,7 +742,7 @@ public final class IngestDocument {
 
     public static Object deepCopy(Object value) {
         if (value instanceof Map<?, ?> mapValue) {
-            Map<Object, Object> copy = new HashMap<>(mapValue.size());
+            Map<Object, Object> copy = Maps.newMapWithExpectedSize(mapValue.size());
             for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
                 copy.put(entry.getKey(), deepCopy(entry.getValue()));
             }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -72,7 +73,7 @@ public final class IngestMetadata implements Metadata.Custom {
 
     public IngestMetadata(StreamInput in) throws IOException {
         int size = in.readVInt();
-        Map<String, PipelineConfiguration> pipelines = new HashMap<>(size);
+        Map<String, PipelineConfiguration> pipelines = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             PipelineConfiguration pipeline = PipelineConfiguration.readFrom(in);
             pipelines.put(pipeline.getId(), pipeline);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -11,6 +11,7 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -48,7 +49,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
         this.totalStats = new Stats(in);
         int size = in.readVInt();
         this.pipelineStats = new ArrayList<>(size);
-        this.processorStats = new HashMap<>(size);
+        this.processorStats = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String pipelineId = in.readString();
             Stats pipelineStat = new Stats(in);

--- a/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.ingest;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
@@ -46,7 +47,7 @@ public interface ValueSource {
         if (value instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<Object, Object> mapValue = (Map) value;
-            Map<ValueSource, ValueSource> valueTypeMap = new HashMap<>(mapValue.size());
+            Map<ValueSource, ValueSource> valueTypeMap = Maps.newMapWithExpectedSize(mapValue.size());
             for (Map.Entry<Object, Object> entry : mapValue.entrySet()) {
                 valueTypeMap.put(wrap(entry.getKey(), scriptService, scriptOptions), wrap(entry.getValue(), scriptService, scriptOptions));
             }

--- a/server/src/main/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollector.java
+++ b/server/src/main/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollector.java
@@ -35,12 +35,13 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.grouping.GroupSelector;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.TreeSet;
 
 import static org.apache.lucene.search.SortField.Type.SCORE;
@@ -130,7 +131,7 @@ public class SinglePassGroupingCollector<T> extends SimpleCollector {
     private final int[] reversed;
     private final int topNGroups;
     private final boolean needsScores;
-    private final HashMap<T, SearchGroup<T>> groupMap;
+    private final Map<T, SearchGroup<T>> groupMap;
     private final int compIDXEnd;
 
     private int totalHitCount;
@@ -178,7 +179,7 @@ public class SinglePassGroupingCollector<T> extends SimpleCollector {
         }
 
         spareSlot = topNGroups;
-        groupMap = new HashMap<>(topNGroups);
+        groupMap = Maps.newMapWithExpectedSize(topNGroups);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 
 import java.lang.management.ManagementFactory;
@@ -23,7 +24,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -193,7 +193,7 @@ public class HotThreads {
     Map<Long, ThreadTimeAccumulator> getAllValidThreadInfos(ThreadMXBean threadBean, SunThreadInfo sunThreadInfo, long currentThreadId) {
         long[] threadIds = threadBean.getAllThreadIds();
         ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds);
-        Map<Long, ThreadTimeAccumulator> result = new HashMap<>(threadIds.length);
+        Map<Long, ThreadTimeAccumulator> result = Maps.newMapWithExpectedSize(threadIds.length);
 
         for (int i = 0; i < threadIds.length; i++) {
             if (threadInfos[i] == null || threadIds[i] == currentThreadId) {

--- a/server/src/main/java/org/elasticsearch/node/ResponseCollectorService.java
+++ b/server/src/main/java/org/elasticsearch/node/ResponseCollectorService.java
@@ -16,10 +16,10 @@ import org.elasticsearch.common.ExponentiallyWeightedMovingAverage;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -74,7 +74,7 @@ public final class ResponseCollectorService implements ClusterStateListener {
     public Map<String, ComputedNodeStats> getAllNodeStatistics() {
         final int clientNum = nodeIdToStats.size();
         // Transform the mutable object internally used for accounting into the computed version
-        Map<String, ComputedNodeStats> nodeStats = new HashMap<>(nodeIdToStats.size());
+        Map<String, ComputedNodeStats> nodeStats = Maps.newMapWithExpectedSize(nodeIdToStats.size());
         nodeIdToStats.forEach((k, v) -> { nodeStats.put(k, new ComputedNodeStats(clientNum, v)); });
         return nodeStats;
     }

--- a/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.repositories;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.SnapshotId;
 
@@ -110,11 +111,11 @@ public final class IndexMetaDataGenerations {
         final Map<String, String> updatedIndexMetaIdentifiers = new HashMap<>(identifiers);
         updatedIndexMetaIdentifiers.putAll(newIdentifiers);
         if (newLookup.isEmpty() == false) {
-            final Map<String, String> identifierDeduplicator = new HashMap<>(this.identifiers.size());
+            final Map<String, String> identifierDeduplicator = Maps.newMapWithExpectedSize(this.identifiers.size());
             for (String identifier : identifiers.keySet()) {
                 identifierDeduplicator.put(identifier, identifier);
             }
-            final Map<IndexId, String> fixedLookup = new HashMap<>(newLookup.size());
+            final Map<IndexId, String> fixedLookup = Maps.newMapWithExpectedSize(newLookup.size());
             for (Map.Entry<IndexId, String> entry : newLookup.entrySet()) {
                 final String generation = entry.getValue();
                 fixedLookup.put(entry.getKey(), identifierDeduplicator.getOrDefault(generation, generation));

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -589,7 +590,7 @@ public final class RepositoryData {
      * Resolve the given index names to index ids.
      */
     public Map<String, IndexId> resolveIndices(final List<String> indices) {
-        Map<String, IndexId> resolvedIndices = new HashMap<>(indices.size());
+        Map<String, IndexId> resolvedIndices = Maps.newMapWithExpectedSize(indices.size());
         for (final String indexName : indices) {
             final IndexId indexId = resolveIndexId(indexName);
             resolvedIndices.put(indexId.getName(), indexId);
@@ -612,7 +613,7 @@ public final class RepositoryData {
      * @param inFlightIds      name to index mapping for currently in-flight snapshots not yet in the repository data to fall back to
      */
     public Map<String, IndexId> resolveNewIndices(List<String> indicesToResolve, Map<String, IndexId> inFlightIds) {
-        Map<String, IndexId> snapshotIndices = new HashMap<>(indicesToResolve.size());
+        Map<String, IndexId> snapshotIndices = Maps.newMapWithExpectedSize(indicesToResolve.size());
         for (String index : indicesToResolve) {
             IndexId indexId = indices.get(index);
             if (indexId == null) {
@@ -853,10 +854,10 @@ public final class RepositoryData {
             return IndexMetaDataGenerations.EMPTY;
         }
         // Build a new map that instead of indexing the per-snapshot index generations by index id string, is indexed by IndexId
-        final Map<SnapshotId, Map<IndexId, String>> indexGenerations = new HashMap<>(indexMetaLookup.size());
+        final Map<SnapshotId, Map<IndexId, String>> indexGenerations = Maps.newMapWithExpectedSize(indexMetaLookup.size());
         for (Map.Entry<SnapshotId, Map<String, String>> snapshotIdMapEntry : indexMetaLookup.entrySet()) {
             final Map<String, String> val = snapshotIdMapEntry.getValue();
-            final Map<IndexId, String> forSnapshot = new HashMap<>(val.size());
+            final Map<IndexId, String> forSnapshot = Maps.newMapWithExpectedSize(val.size());
             for (Map.Entry<String, String> generationEntry : val.entrySet()) {
                 forSnapshot.put(indexLookup.get(generationEntry.getKey()), generationEntry.getValue());
             }

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -10,11 +10,11 @@ package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Releasable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +42,7 @@ public abstract class RestResponse {
     public void copyHeaders(ElasticsearchException ex) {
         Set<String> headerKeySet = ex.getHeaderKeys();
         if (customHeaders == null) {
-            customHeaders = new HashMap<>(headerKeySet.size());
+            customHeaders = Maps.newMapWithExpectedSize(headerKeySet.size());
         }
         for (String key : headerKeySet) {
             List<String> values = customHeaders.get(key);
@@ -59,7 +59,7 @@ public abstract class RestResponse {
      */
     public void addHeader(String name, String value) {
         if (customHeaders == null) {
-            customHeaders = new HashMap<>(2);
+            customHeaders = Maps.newMapWithExpectedSize(2);
         }
         List<String> header = customHeaders.get(name);
         if (header == null) {

--- a/server/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -11,9 +11,9 @@ package org.elasticsearch.rest;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.unmodifiableMap;
@@ -473,7 +473,7 @@ public enum RestStatus {
     private static final Map<Integer, RestStatus> CODE_TO_STATUS;
     static {
         RestStatus[] values = values();
-        Map<Integer, RestStatus> codeToStatus = new HashMap<>(values.length);
+        Map<Integer, RestStatus> codeToStatus = Maps.newMapWithExpectedSize(values.length);
         for (RestStatus value : values) {
             codeToStatus.put(value.status, value);
         }

--- a/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
@@ -11,12 +11,12 @@ package org.elasticsearch.script;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -46,7 +46,7 @@ public class ScriptCacheStats implements Writeable, ToXContentFragment {
 
         general = null;
         int size = in.readInt();
-        Map<String, ScriptStats> context = new HashMap<>(size);
+        Map<String, ScriptStats> context = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String name = in.readString();
             context.put(name, new ScriptStats(in));

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -845,7 +846,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     }
 
     CacheHolder contextCacheHolder(Settings settings) {
-        Map<String, ScriptCache> contextCache = new HashMap<>(contexts.size());
+        Map<String, ScriptCache> contextCache = Maps.newMapWithExpectedSize(contexts.size());
         contexts.forEach((k, v) -> contextCache.put(k, contextCache(settings, v)));
         return new CacheHolder(contextCache);
     }
@@ -891,7 +892,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
         }
 
         CacheHolder(Map<String, ScriptCache> context) {
-            Map<String, AtomicReference<ScriptCache>> refs = new HashMap<>(context.size());
+            Map<String, AtomicReference<ScriptCache>> refs = Maps.newMapWithExpectedSize(context.size());
             context.forEach((k, v) -> refs.put(k, new AtomicReference<>(v)));
             contextCache = Collections.unmodifiableMap(refs);
             general = null;
@@ -928,7 +929,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
             if (general != null) {
                 return new ScriptCacheStats(general.stats());
             }
-            Map<String, ScriptStats> context = new HashMap<>(contextCache.size());
+            Map<String, ScriptStats> context = Maps.newMapWithExpectedSize(contextCache.size());
             for (String name : contextCache.keySet()) {
                 context.put(name, contextCache.get(name).get().stats());
             }

--- a/server/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -11,13 +11,13 @@ package org.elasticsearch.script;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +91,7 @@ public class ScriptStats implements Writeable, ToXContentFragment {
         if (contextStats.isEmpty()) {
             return new ScriptCacheStats(this);
         }
-        Map<String, ScriptStats> contexts = new HashMap<>(contextStats.size());
+        Map<String, ScriptStats> contexts = Maps.newMapWithExpectedSize(contextStats.size());
         for (ScriptContextStats contextStats : contextStats) {
             contexts.put(contextStats.getContext(), new ScriptStats(contextStats));
         }

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
@@ -195,7 +196,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         shard(in.readOptionalWriteable(SearchShardTarget::new));
         size = in.readVInt();
         if (size > 0) {
-            innerHits = new HashMap<>(size);
+            innerHits = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readString();
                 SearchHits value = new SearchHits(in);
@@ -217,7 +218,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             DocumentField hitField = new DocumentField(in);
             fields = singletonMap(hitField.getName(), hitField);
         } else {
-            fields = new HashMap<>(size);
+            fields = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 DocumentField field = new DocumentField(in);
                 fields.put(field.getName(), field);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.aggregations;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -16,7 +17,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -71,7 +71,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContentFragment {
      */
     public final Map<String, Aggregation> getAsMap() {
         if (aggregationsAsMap == null) {
-            Map<String, Aggregation> newAggregationsAsMap = new HashMap<>(aggregations.size());
+            Map<String, Aggregation> newAggregationsAsMap = Maps.newMapWithExpectedSize(aggregations.size());
             for (Aggregation aggregation : aggregations) {
                 newAggregationsAsMap.put(aggregation.getName(), aggregation);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator;
 import org.elasticsearch.search.aggregations.metrics.MinAggregator;
 import org.elasticsearch.search.aggregations.metrics.SumAggregator;
@@ -23,7 +24,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -261,7 +261,7 @@ public abstract class AggregatorBase extends Aggregator {
     @Override
     public Aggregator subAggregator(String aggName) {
         if (subAggregatorbyName == null) {
-            subAggregatorbyName = new HashMap<>(subAggregators.length);
+            subAggregatorbyName = Maps.newMapWithExpectedSize(subAggregators.length);
             for (int i = 0; i < subAggregators.length; i++) {
                 subAggregatorbyName.put(subAggregators[i].name(), subAggregators[i]);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.bucket.adjacency;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -178,7 +178,7 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
      * Get the filters. This will be an unmodifiable map
      */
     public Map<String, QueryBuilder> filters() {
-        Map<String, QueryBuilder> result = new HashMap<>(this.filters.size());
+        Map<String, QueryBuilder> result = Maps.newMapWithExpectedSize(this.filters.size());
         for (KeyedFilter keyedFilter : this.filters) {
             result.put(keyedFilter.key(), keyedFilter.filter());
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -158,7 +159,7 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
     @Override
     public InternalBucket getBucketByKey(String key) {
         if (bucketMap == null) {
-            bucketMap = new HashMap<>(buckets.size());
+            bucketMap = Maps.newMapWithExpectedSize(buckets.size());
             for (InternalBucket bucket : buckets) {
                 bucketMap.put(bucket.getKey(), bucket);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.search.aggregations.bucket.adjacency;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +34,7 @@ public class ParsedAdjacencyMatrix extends ParsedMultiBucketAggregation<ParsedAd
     @Override
     public ParsedBucket getBucketByKey(String key) {
         if (bucketMap == null) {
-            bucketMap = new HashMap<>(buckets.size());
+            bucketMap = Maps.newMapWithExpectedSize(buckets.size());
             for (ParsedBucket bucket : buckets) {
                 bucketMap.put(bucket.getKey(), bucket);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
@@ -13,12 +13,12 @@ import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.core.Types.forciblyCast;
@@ -70,7 +70,7 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
         this.bigArrays = bigArrays;
         this.maxSize = size;
         this.arrays = sources;
-        this.map = new HashMap<>(size);
+        this.map = Maps.newMapWithExpectedSize(size);
         this.docCounts = bigArrays.newLongArray(1, false);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -17,7 +18,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -166,7 +166,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
     @Override
     public InternalBucket getBucketByKey(String key) {
         if (bucketMap == null) {
-            bucketMap = new HashMap<>(buckets.size());
+            bucketMap = Maps.newMapWithExpectedSize(buckets.size());
             for (InternalBucket bucket : buckets) {
                 bucketMap.put(bucket.getKey(), bucket);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilters.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.filter;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -18,7 +19,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +41,7 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
     @Override
     public ParsedBucket getBucketByKey(String key) {
         if (bucketMap == null) {
-            bucketMap = new HashMap<>(buckets.size());
+            bucketMap = Maps.newMapWithExpectedSize(buckets.size());
             for (ParsedBucket bucket : buckets) {
                 bucketMap.put(bucket.getKey(), bucket);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsParser.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsParser.java
@@ -9,13 +9,13 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,7 +37,7 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
         String[] bucketsPaths = null;
         String format = null;
         GapPolicy gapPolicy = null;
-        Map<String, Object> params = new HashMap<>(5);
+        Map<String, Object> params = Maps.newMapWithExpectedSize(5);
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregationBuilder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
@@ -83,7 +84,7 @@ public class BucketScriptPipelineAggregationBuilder extends AbstractPipelineAggr
     public BucketScriptPipelineAggregationBuilder(StreamInput in) throws IOException {
         super(in, NAME);
         int mapSize = in.readVInt();
-        bucketsPathsMap = new HashMap<>(mapSize);
+        bucketsPathsMap = Maps.newMapWithExpectedSize(mapSize);
         for (int i = 0; i < mapSize; i++) {
             bucketsPathsMap.put(in.readString(), in.readString());
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.search.aggregations.support;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,7 +24,7 @@ public abstract class MultiValuesSource<VS extends ValuesSource> {
 
     public static class NumericMultiValuesSource extends MultiValuesSource<ValuesSource.Numeric> {
         public NumericMultiValuesSource(Map<String, ValuesSourceConfig> valuesSourceConfigs) {
-            values = new HashMap<>(valuesSourceConfigs.size());
+            values = Maps.newMapWithExpectedSize(valuesSourceConfigs.size());
             for (Map.Entry<String, ValuesSourceConfig> entry : valuesSourceConfigs.entrySet()) {
                 final ValuesSource valuesSource = entry.getValue().getValuesSource();
                 if (valuesSource instanceof ValuesSource.Numeric == false) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.aggregations.support;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.DocValueFormat;
@@ -161,8 +162,8 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
         AggregatorFactory parent,
         Builder subFactoriesBuilder
     ) throws IOException {
-        Map<String, ValuesSourceConfig> configs = new HashMap<>(fields.size());
-        Map<String, QueryBuilder> filters = new HashMap<>(fields.size());
+        Map<String, ValuesSourceConfig> configs = Maps.newMapWithExpectedSize(fields.size());
+        Map<String, QueryBuilder> filters = Maps.newMapWithExpectedSize(fields.size());
         fields.forEach((key, value) -> {
             ValuesSourceConfig config = ValuesSourceConfig.resolveUnregistered(
                 context,

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.lookup;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -18,7 +19,6 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -31,7 +31,7 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
 
     private int docId = -1;
 
-    private final Map<String, DocValuesField> localCacheScriptFieldData = new HashMap<>(4);
+    private final Map<String, DocValuesField> localCacheScriptFieldData = Maps.newMapWithExpectedSize(4);
 
     LeafDocLookup(
         Function<String, MappedFieldType> fieldTypeLookup,

--- a/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
@@ -8,8 +8,9 @@
 
 package org.elasticsearch.search.profile;
 
+import org.elasticsearch.common.util.Maps;
+
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -48,7 +49,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
      * Build a timing count breakdown.
      */
     public final Map<String, Long> toBreakdownMap() {
-        Map<String, Long> map = new HashMap<>(timings.length * 2);
+        Map<String, Long> map = Maps.newMapWithExpectedSize(timings.length * 2);
         for (T timingType : timingTypes) {
             map.put(timingType.toString(), timings[timingType.ordinal()].getApproximateTiming());
             map.put(timingType.toString() + "_count", timings[timingType.ordinal()].getCount());

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResultsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResultsBuilder.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.search.profile;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -31,7 +31,7 @@ public class SearchProfileResultsBuilder {
      * profiling information.
      */
     public SearchProfileResults build(Collection<? extends SearchPhaseResult> fetchResults) {
-        Map<String, SearchProfileShardResult> mergedShardResults = new HashMap<>(queryPhaseResults.size());
+        Map<String, SearchProfileShardResult> mergedShardResults = Maps.newMapWithExpectedSize(queryPhaseResults.size());
         for (SearchPhaseResult r : fetchResults) {
             FetchSearchResult fr = r.fetchResult();
             String key = fr.getSearchShardTarget().toString();

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
@@ -32,7 +33,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -313,7 +313,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
             )
         ) {
             contextParser.nextToken();
-            Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = new HashMap<>(contextMappings.size());
+            Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = Maps.newMapWithExpectedSize(contextMappings.size());
             assert contextParser.currentToken() == XContentParser.Token.START_OBJECT;
             XContentParser.Token currentToken;
             String currentFieldName;

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.suggest.document.ContextSuggestField;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappingParser;
@@ -24,7 +25,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -53,7 +53,7 @@ public class ContextMappings implements ToXContent, Iterable<ContextMapping<?>> 
             throw new UnsupportedOperationException("Maximum of 10 context types are supported was: " + contextMappings.size());
         }
         this.contextMappings = contextMappings;
-        contextNameMap = new HashMap<>(contextMappings.size());
+        contextNameMap = Maps.newMapWithExpectedSize(contextMappings.size());
         for (ContextMapping<?> mapping : contextMappings) {
             contextNameMap.put(mapping.name(), mapping);
         }
@@ -188,7 +188,7 @@ public class ContextMappings implements ToXContent, Iterable<ContextMapping<?>> 
      *
      */
     public Map<String, Set<String>> getNamedContexts(List<CharSequence> contexts) {
-        Map<String, Set<String>> contextMap = new HashMap<>(contexts.size());
+        Map<String, Set<String>> contextMap = Maps.newMapWithExpectedSize(contexts.size());
         for (CharSequence typedContext : contexts) {
             int typeId = typedContext.charAt(0);
             assert typeId < contextMappings.size() : "Returned context has invalid type";

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -11,6 +11,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
@@ -48,7 +49,7 @@ class PhraseSuggestionContext extends SuggestionContext {
     private TemplateScript.Factory scriptFactory;
     private boolean prune = DEFAULT_COLLATE_PRUNE;
     private List<DirectCandidateGenerator> generators = new ArrayList<>();
-    private Map<String, Object> collateScriptParams = new HashMap<>(1);
+    private Map<String, Object> collateScriptParams = Maps.newMapWithExpectedSize(1);
     private WordScorer.WordScorerFactory scorer = DEFAULT_SCORER;
 
     PhraseSuggestionContext(SearchExecutionContext searchExecutionContext) {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -53,6 +53,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -544,7 +545,7 @@ public class RestoreService implements ClusterStateApplier {
                 globalMetadata = repository.getSnapshotGlobalMetadata(snapshotId);
             }
             final Map<String, DataStream> dataStreamsInSnapshot = globalMetadata.dataStreams();
-            dataStreams = new HashMap<>(requestedDataStreams.size());
+            dataStreams = Maps.newMapWithExpectedSize(requestedDataStreams.size());
             for (String requestedDataStream : requestedDataStreams) {
                 final DataStream dataStreamInSnapshot = dataStreamsInSnapshot.get(requestedDataStream);
                 assert dataStreamInSnapshot != null : "DataStream [" + requestedDataStream + "] not found in snapshot";

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -62,6 +62,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -1539,7 +1540,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             metadataListener.whenComplete(meta -> {
                 final Metadata metaForSnapshot = metadataForSnapshot(entry, meta);
 
-                final Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails = new HashMap<>(finalIndices.size());
+                final Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails = Maps.newMapWithExpectedSize(
+                    finalIndices.size()
+                );
                 for (Map.Entry<RepositoryShardId, ShardSnapshotStatus> shardEntry : entry.shardsByRepoShardId().entrySet()) {
                     indexSnapshotDetails.compute(shardEntry.getKey().indexName(), (indexName, current) -> {
                         if (current == SnapshotInfo.IndexSnapshotDetails.SKIPPED) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -15,12 +15,12 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.core.Booleans.parseBoolean;
@@ -57,7 +57,7 @@ public class TransportInfo implements ReportingService.Info {
         address = new BoundTransportAddress(in);
         int size = in.readVInt();
         if (size > 0) {
-            profileAddresses = new HashMap<>(size);
+            profileAddresses = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readString();
                 BoundTransportAddress value = new BoundTransportAddress(in);

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -55,7 +56,6 @@ import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -1165,7 +1165,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         if (actual instanceof ElasticsearchException actualException) {
             if (randomBoolean()) {
                 int nbHeaders = randomIntBetween(1, 5);
-                Map<String, List<String>> randomHeaders = new HashMap<>(nbHeaders);
+                Map<String, List<String>> randomHeaders = Maps.newMapWithExpectedSize(nbHeaders);
 
                 for (int i = 0; i < nbHeaders; i++) {
                     List<String> values = new ArrayList<>();
@@ -1190,7 +1190,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
             if (randomBoolean()) {
                 int nbMetadata = randomIntBetween(1, 5);
-                Map<String, List<String>> randomMetadata = new HashMap<>(nbMetadata);
+                Map<String, List<String>> randomMetadata = Maps.newMapWithExpectedSize(nbMetadata);
 
                 for (int i = 0; i < nbMetadata; i++) {
                     List<String> values = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -28,7 +29,6 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -108,7 +108,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
     @Override
     protected ClusterHealthResponse createTestInstance() {
         int indicesSize = randomInt(20);
-        Map<String, ClusterIndexHealth> indices = new HashMap<>(indicesSize);
+        Map<String, ClusterIndexHealth> indices = Maps.newMapWithExpectedSize(indicesSize);
         if (ClusterHealthRequest.Level.INDICES.equals(level) || ClusterHealthRequest.Level.SHARDS.equals(level)) {
             for (int i = 0; i < indicesSize; i++) {
                 String indexName = randomAlphaOfLengthBetween(1, 5) + i;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Re
 import org.elasticsearch.cluster.service.ClusterStateUpdateStats;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.http.HttpStats;
@@ -793,7 +794,7 @@ public class NodeStatsTests extends ESTestCase {
                 randomLongBetween(0, maxStatValue)
             );
             List<IngestStats.PipelineStat> ingestPipelineStats = new ArrayList<>(numPipelines);
-            Map<String, List<IngestStats.ProcessorStat>> ingestProcessorStats = new HashMap<>(numPipelines);
+            Map<String, List<IngestStats.ProcessorStat>> ingestProcessorStats = Maps.newMapWithExpectedSize(numPipelines);
             for (int i = 0; i < numPipelines; i++) {
                 String pipelineId = randomAlphaOfLengthBetween(3, 10);
                 ingestPipelineStats.add(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.admin.indices.rollover;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -89,7 +90,7 @@ public class RolloverResponseTests extends AbstractWireSerializingTestCase<Rollo
                 if (response.getConditionStatus().isEmpty()) {
                     results = randomResults(false);
                 } else {
-                    results = new HashMap<>(response.getConditionStatus().size());
+                    results = Maps.newMapWithExpectedSize(response.getConditionStatus().size());
                     List<String> keys = randomSubsetOf(
                         randomIntBetween(1, response.getConditionStatus().size()),
                         response.getConditionStatus().keySet()

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadataTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class ComponentTemplateMetadataTests extends AbstractNamedWriteableTestCa
     @Override
     protected ComponentTemplateMetadata createTestInstance() {
         int count = randomIntBetween(0, 3);
-        Map<String, ComponentTemplate> templateMap = new HashMap<>(count);
+        Map<String, ComponentTemplate> templateMap = Maps.newMapWithExpectedSize(count);
         for (int i = 0; i < count; i++) {
             templateMap.put(randomAlphaOfLength(4), ComponentTemplateTests.randomInstance());
         }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemp
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
@@ -73,7 +74,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         final MetadataCreateIndexService metadataCreateIndexService = getMetadataCreateIndexService();
         final String dataStreamName = "my-data-stream";
         final int aliasCount = randomIntBetween(0, 3);
-        Map<String, AliasMetadata> aliases = new HashMap<>(aliasCount);
+        Map<String, AliasMetadata> aliases = Maps.newMapWithExpectedSize(aliasCount);
         for (int k = 0; k < aliasCount; k++) {
             final AliasMetadata am = randomAlias(null);
             aliases.put(am.alias(), am);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/TemplateUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/TemplateUpgradeServiceTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -36,7 +37,6 @@ import org.junit.Before;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -189,7 +189,7 @@ public class TemplateUpgradeServiceTests extends ESTestCase {
         for (int i = 0; i < deletionsCount; i++) {
             deletions.add("remove_template_" + i);
         }
-        Map<String, BytesReference> additions = new HashMap<>(additionsCount);
+        Map<String, BytesReference> additions = Maps.newMapWithExpectedSize(additionsCount);
         for (int i = 0; i < additionsCount; i++) {
             additions.put("add_template_" + i, new BytesArray("""
                 {"index_patterns" : "*", "order" : %s}

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceStatsTests.java
@@ -11,9 +11,9 @@ package org.elasticsearch.cluster.service;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Recording;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class ClusterApplierRecordingServiceStatsTests extends AbstractWireSerializingTestCase<Stats> {
@@ -26,7 +26,7 @@ public class ClusterApplierRecordingServiceStatsTests extends AbstractWireSerial
     @Override
     protected Stats createTestInstance() {
         int numRecordings = randomInt(256);
-        Map<String, Recording> recordings = new HashMap<>(numRecordings);
+        Map<String, Recording> recordings = Maps.newMapWithExpectedSize(numRecordings);
         for (int i = 0; i < numRecordings; i++) {
             recordings.put(randomAlphaOfLength(16), new Recording(randomNonNegativeLong(), randomNonNegativeLong()));
         }

--- a/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.collect;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
@@ -138,7 +139,7 @@ public class ImmutableOpenMapTests extends ESTestCase {
         ImmutableOpenMap.Builder<Long, String> builder2 = ImmutableOpenMap.builder(map.size());
         map.entrySet().stream().forEach(entry -> builder2.put(entry.getKey(), entry.getValue()));
 
-        Map<Long, String> hMap = new HashMap<>(map.size());
+        Map<Long, String> hMap = Maps.newMapWithExpectedSize(map.size());
         map.entrySet().forEach(entry -> hMap.put(entry.getKey(), entry.getValue()));
 
         ImmutableOpenMap.Builder<Long, String> builder3 = ImmutableOpenMap.builder(map.size());
@@ -240,7 +241,7 @@ public class ImmutableOpenMapTests extends ESTestCase {
     }
 
     private static <KType, VType> Map.Entry<KType, VType> entry(KType key, VType value) {
-        Map<KType, VType> map = new HashMap<>(1);
+        Map<KType, VType> map = Maps.newMapWithExpectedSize(1);
         map.put(key, value);
         return map.entrySet().iterator().next();
     }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -497,7 +498,7 @@ public class BytesStreamsTests extends ESTestCase {
 
     public void testWriteMap() throws IOException {
         final int size = randomIntBetween(0, 100);
-        final Map<String, String> expected = new HashMap<>(randomIntBetween(0, 100));
+        final Map<String, String> expected = Maps.newMapWithExpectedSize(randomIntBetween(0, 100));
         for (int i = 0; i < size; ++i) {
             expected.put(randomAlphaOfLength(2), randomAlphaOfLength(5));
         }
@@ -545,7 +546,7 @@ public class BytesStreamsTests extends ESTestCase {
 
     public void testWriteMapOfLists() throws IOException {
         final int size = randomIntBetween(0, 5);
-        final Map<String, List<String>> expected = new HashMap<>(size);
+        final Map<String, List<String>> expected = Maps.newMapWithExpectedSize(size);
 
         for (int i = 0; i < size; ++i) {
             int listSize = randomIntBetween(0, 5);

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class MapsTests extends ESTestCase {
 
@@ -204,6 +205,22 @@ public class MapsTests extends ESTestCase {
         for (Map.Entry<String, Object> entry : flatten.entrySet()) {
             assertThat(entry.getKey(), entry.getValue(), equalTo(deepGet(entry.getKey(), map)));
         }
+    }
+
+    public void testCapacityIsEnoughForMapToNotBeResized() {
+        for (int i = 0; i < 1000; i++) {
+            int size = randomIntBetween(0, 1_000_000);
+            int capacity = Maps.capacity(size);
+            assertThat(size, lessThanOrEqualTo((int) (capacity * 0.75f)));
+        }
+    }
+
+    public void testCapacityForMaxSize() {
+        assertEquals(Integer.MAX_VALUE, Maps.capacity(Integer.MAX_VALUE));
+    }
+
+    public void testCapacityForZeroSize() {
+        assertEquals(1, Maps.capacity(0));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.PathUtils;
@@ -416,7 +417,7 @@ public class XContentBuilderTests extends ESTestCase {
 
         TestWritableValue(InputStream in) throws IOException {
             final int size = in.read();
-            this.values = new HashMap<>(size);
+            this.values = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 final int keySize = in.read();
                 final String key = new String(in.readNBytes(keySize), StandardCharsets.ISO_8859_1);

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.xcontent.support;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.DeprecationHandler;
@@ -40,7 +41,7 @@ public class XContentHelperTests extends ESTestCase {
     Map<String, Object> getNamedMap(String name, Object... keyValues) {
         Map<String, Object> map = getMap(keyValues);
 
-        Map<String, Object> namedMap = new HashMap<>(1);
+        Map<String, Object> namedMap = Maps.newMapWithExpectedSize(1);
         namedMap.put(name, map);
         return namedMap;
     }

--- a/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestRequest;
@@ -396,7 +397,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
     }
 
     private Map<String, String> getRelevantHeaders(HttpRequest httpRequest) {
-        final Map<String, String> headers = new HashMap<>(4);
+        final Map<String, String> headers = Maps.newMapWithExpectedSize(4);
         final String[] relevantHeaderNames = new String[] { "user-agent", "x-elastic-product-origin", "x-forwarded-for", "x-opaque-id" };
         for (Map.Entry<String, List<String>> header : httpRequest.getHeaders().entrySet()) {
             if (header.getValue().size() > 0) {

--- a/server/src/test/java/org/elasticsearch/index/get/GetResultTests.java
+++ b/server/src/test/java/org/elasticsearch/index/get/GetResultTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
@@ -418,8 +419,8 @@ public class GetResultTests extends ESTestCase {
         boolean isMetaFields
     ) {
         int numFields = isMetaFields ? randomIntBetween(1, 3) : randomIntBetween(2, 10);
-        Map<String, DocumentField> fields = new HashMap<>(numFields);
-        Map<String, DocumentField> expectedFields = new HashMap<>(numFields);
+        Map<String, DocumentField> fields = Maps.newMapWithExpectedSize(numFields);
+        Map<String, DocumentField> expectedFields = Maps.newMapWithExpectedSize(numFields);
         // As we are using this to construct a GetResult object that already contains
         // index, id, version, seqNo, and source fields, we need to exclude them from random fields
         Predicate<String> excludeMetaFieldFilter = field -> field.equals(IndexFieldMapper.NAME)

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.ShardLock;
@@ -946,7 +947,7 @@ public class StoreTests extends ESTestCase {
         Document doc = new Document();
         doc.add(new TextField("id", "1", Field.Store.NO));
         writer.addDocument(doc);
-        Map<String, String> commitData = new HashMap<>(2);
+        Map<String, String> commitData = Maps.newMapWithExpectedSize(2);
         String syncId = "a sync id";
         commitData.put(Engine.SYNC_COMMIT_ID, syncId);
         writer.setLiveCommitData(commitData.entrySet());

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
@@ -1419,7 +1420,7 @@ public class IngestServiceTests extends ESTestCase {
             handler.accept(RandomDocumentPicks.randomIngestDocument(random()), null);
             return null;
         }).when(processor).execute(any(), any());
-        Map<String, Processor.Factory> map = new HashMap<>(2);
+        Map<String, Processor.Factory> map = Maps.newMapWithExpectedSize(2);
         map.put("mock", (factories, tag, description, config) -> processor);
 
         IngestService ingestService = createWithProcessors(map);
@@ -1471,7 +1472,7 @@ public class IngestServiceTests extends ESTestCase {
             handler.accept(null, new RuntimeException("error"));
             return null;
         }).when(processorFailure).execute(any(IngestDocument.class), any());
-        Map<String, Processor.Factory> map = new HashMap<>(2);
+        Map<String, Processor.Factory> map = Maps.newMapWithExpectedSize(2);
         map.put("mock", (factories, tag, description, config) -> processor);
         map.put("failure-mock", (factories, tag, description, config) -> processorFailure);
         IngestService ingestService = createWithProcessors(map);

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESTestCase;
@@ -132,8 +133,8 @@ public class RepositoryDataTests extends ESTestCase {
 
     public void testInitIndices() {
         final int numSnapshots = randomIntBetween(1, 30);
-        final Map<String, SnapshotId> snapshotIds = new HashMap<>(numSnapshots);
-        final Map<String, RepositoryData.SnapshotDetails> snapshotsDetails = new HashMap<>(numSnapshots);
+        final Map<String, SnapshotId> snapshotIds = Maps.newMapWithExpectedSize(numSnapshots);
+        final Map<String, RepositoryData.SnapshotDetails> snapshotsDetails = Maps.newMapWithExpectedSize(numSnapshots);
         for (int i = 0; i < numSnapshots; i++) {
             final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
             snapshotIds.put(snapshotId.getUUID(), snapshotId);
@@ -471,7 +472,7 @@ public class RepositoryDataTests extends ESTestCase {
         final List<SnapshotId> snapshotIds = new ArrayList<>(snapshotIdsMap.values());
         final int totalSnapshots = snapshotIds.size();
         final int numIndices = randomIntBetween(1, 30);
-        final Map<IndexId, List<SnapshotId>> indices = new HashMap<>(numIndices);
+        final Map<IndexId, List<SnapshotId>> indices = Maps.newMapWithExpectedSize(numIndices);
         for (int i = 0; i < numIndices; i++) {
             final IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
             final Set<SnapshotId> indexSnapshots = new LinkedHashSet<>();

--- a/server/src/test/java/org/elasticsearch/search/AbstractSearchTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/AbstractSearchTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.plugins.Plugin;
@@ -87,10 +88,10 @@ public abstract class AbstractSearchTestCase extends ESTestCase {
 
     public static Map<String, Object> randomRuntimeMappings() {
         int count = between(1, 100);
-        Map<String, Object> runtimeFields = new HashMap<>(count);
+        Map<String, Object> runtimeFields = Maps.newMapWithExpectedSize(count);
         while (runtimeFields.size() < count) {
             int size = between(1, 10);
-            Map<String, Object> config = new HashMap<>(size);
+            Map<String, Object> config = Maps.newMapWithExpectedSize(size);
             while (config.size() < size) {
                 config.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.get.GetResultTests;
 import org.elasticsearch.index.shard.ShardId;
@@ -95,7 +96,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         }
         if (randomBoolean()) {
             int size = randomIntBetween(0, 5);
-            Map<String, HighlightField> highlightFields = new HashMap<>(size);
+            Map<String, HighlightField> highlightFields = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 HighlightField testItem = HighlightFieldTests.createTestItem();
                 highlightFields.put(testItem.getName(), testItem);
@@ -116,7 +117,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         if (withOptionalInnerHits) {
             int innerHitsSize = randomIntBetween(0, 3);
             if (innerHitsSize > 0) {
-                Map<String, SearchHits> innerHits = new HashMap<>(innerHitsSize);
+                Map<String, SearchHits> innerHits = Maps.newMapWithExpectedSize(innerHitsSize);
                 for (int i = 0; i < innerHitsSize; i++) {
                     innerHits.put(randomAlphaOfLength(5), SearchHitsTests.createTestItem(xContentType, false, transportSerialization));
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorTests.java
@@ -10,12 +10,12 @@ package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +28,7 @@ public class AdjacencyMatrixAggregatorTests extends AggregatorTestCase {
         int maxFilters = IndexSearcher.getMaxClauseCount();
         int maxFiltersPlusOne = maxFilters + 1;
 
-        Map<String, QueryBuilder> filters = new HashMap<>(maxFilters);
+        Map<String, QueryBuilder> filters = Maps.newMapWithExpectedSize(maxFilters);
         for (int i = 0; i < maxFiltersPlusOne; i++) {
             filters.put("filter" + i, new MatchAllQueryBuilder());
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.adjacency;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -102,7 +103,7 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
             }
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -207,7 +208,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
             }
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.filter;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -94,7 +95,7 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
             }
             default -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.apache.lucene.index.IndexWriter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -128,7 +129,7 @@ public abstract class GeoGridTestCase<B extends InternalGeoGridBucket, T extends
             case 2 -> size = size + between(1, 10);
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -279,7 +280,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.Rounding.DateTimeUnit;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
@@ -196,7 +197,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
             case 4 -> offset += between(1, 20);
             case 5 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -189,7 +190,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
             }
             case 4 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -113,7 +114,7 @@ public class InternalVariableWidthHistogramTests extends InternalMultiBucketAggr
             case 2 -> {
                 emptyBucketInfo = null;
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -133,7 +134,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -130,7 +131,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -110,7 +111,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -125,7 +126,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -104,7 +105,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
                 }
                 case 8 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -139,7 +140,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
                 case 2 -> minDocCount += between(1, 100);
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -64,7 +65,7 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
                 }
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -80,7 +81,7 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
                 case 0 -> name += randomAlphaOfLength(5);
                 case 1 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -104,7 +105,7 @@ public class LongTermsTests extends InternalTermsTestCase {
                 }
                 case 8 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -139,7 +140,7 @@ public class LongTermsTests extends InternalTermsTestCase {
                 case 2 -> minDocCount += between(1, 100);
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
@@ -103,7 +104,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                 }
                 case 8 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -133,7 +134,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                 case 2 -> minDocCount += between(1, 100);
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
@@ -106,7 +107,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                 }
                 case 8 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -136,7 +137,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                 case 2 -> minDocCount += between(1, 100);
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -75,7 +76,7 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
                 }
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -91,7 +92,7 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
                 case 0 -> name += randomAlphaOfLength(5);
                 case 1 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -86,7 +87,7 @@ public class StringTermsTests extends InternalTermsTestCase {
                 }
                 case 8 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
@@ -121,7 +122,7 @@ public class StringTermsTests extends InternalTermsTestCase {
                 case 2 -> minDocCount += between(1, 100);
                 case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AdjacencyMatrixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AdjacencyMatrixTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -24,7 +25,7 @@ public class AdjacencyMatrixTests extends BaseAggregationTestCase<AdjacencyMatri
 
         int size = randomIntBetween(1, 20);
         AdjacencyMatrixAggregationBuilder factory;
-        Map<String, QueryBuilder> filters = new HashMap<>(size);
+        Map<String, QueryBuilder> filters = Maps.newMapWithExpectedSize(size);
         for (String key : randomUnique(() -> randomAlphaOfLengthBetween(1, 20), size)) {
             filters.put(key, QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
@@ -116,7 +117,7 @@ public class InternalAvgTests extends InternalAggregationTestCase<InternalAvg> {
                 break;
             case 3:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import com.carrotsearch.hppc.BitMixer;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.core.Releasables;
@@ -113,7 +114,7 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
             }
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
@@ -210,7 +211,7 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
                 break;
             case 7:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -133,7 +134,7 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
                 break;
             case 8:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
@@ -112,7 +113,7 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
                 break;
             case 3:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class InternalHDRPercentilesRanksTests extends InternalPercentilesRanksTe
             case 3 -> keyed = keyed == false;
             case 4 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.util.Arrays;
@@ -104,7 +105,7 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
             case 3 -> keyed = keyed == false;
             case 4 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMaxTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMaxTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -62,7 +63,7 @@ public class InternalMaxTests extends InternalAggregationTestCase<InternalMax> {
                 break;
             case 2:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -72,7 +73,7 @@ public class InternalMedianAbsoluteDeviationTests extends InternalAggregationTes
             }
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(metadata);
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMinTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMinTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -61,7 +62,7 @@ public class InternalMinTests extends InternalAggregationTestCase<InternalMin> {
                 break;
             case 2:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptEngine;
@@ -242,7 +243,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
             );
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -188,7 +189,7 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
                 break;
             case 5:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalSumTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalSumTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
@@ -99,7 +100,7 @@ public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
                 break;
             case 2:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.util.Arrays;
@@ -87,7 +88,7 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
             case 3 -> keyed = keyed == false;
             case 4 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.util.Arrays;
@@ -85,7 +86,7 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
             case 3 -> keyed = keyed == false;
             case 4 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.SearchHit;
@@ -371,7 +372,7 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
             }
             case 5 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalValueCountTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalValueCountTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -51,7 +52,7 @@ public class InternalValueCountTests extends InternalAggregationTestCase<Interna
                 break;
             case 2:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -80,7 +81,7 @@ public class InternalWeightedAvgTests extends InternalAggregationTestCase<Intern
                 break;
             case 3:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValueTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -79,7 +80,7 @@ public class InternalBucketMetricValueTests extends InternalAggregationTestCase<
                 break;
             case 3:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -74,7 +75,7 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
                 break;
             case 3:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
@@ -206,7 +207,7 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
             }
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -69,7 +70,7 @@ public class InternalSimpleValueTests extends InternalAggregationTestCase<Intern
                 break;
             case 2:
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -47,7 +48,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -664,7 +664,7 @@ public class HighlightBuilderTests extends ESTestCase {
         }
         if (randomBoolean()) {
             int items = randomIntBetween(0, 5);
-            Map<String, Object> options = new HashMap<>(items);
+            Map<String, Object> options = Maps.newMapWithExpectedSize(items);
             for (int i = 0; i < items; i++) {
                 Object value = switch (randomInt(2)) {
                     case 0 -> randomAlphaOfLengthBetween(1, 10);
@@ -733,7 +733,7 @@ public class HighlightBuilderTests extends ESTestCase {
                 break;
             case 15:
                 int items = 6;
-                Map<String, Object> options = new HashMap<>(items);
+                Map<String, Object> options = Maps.newMapWithExpectedSize(items);
                 for (int i = 0; i < items; i++) {
                     options.put(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
                 }

--- a/server/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.profile;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -18,7 +19,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +32,7 @@ public class ProfileResultTests extends AbstractSerializingTestCase<ProfileResul
         String type = randomAlphaOfLengthBetween(5, 10);
         String description = randomAlphaOfLengthBetween(5, 10);
         int breakdownsSize = randomIntBetween(0, 5);
-        Map<String, Long> breakdown = new HashMap<>(breakdownsSize);
+        Map<String, Long> breakdown = Maps.newMapWithExpectedSize(breakdownsSize);
         while (breakdown.size() < breakdownsSize) {
             long value = randomNonNegativeLong();
             if (randomBoolean()) {
@@ -42,7 +42,7 @@ public class ProfileResultTests extends AbstractSerializingTestCase<ProfileResul
             breakdown.put(randomAlphaOfLengthBetween(5, 10), value);
         }
         int debugSize = randomIntBetween(0, 5);
-        Map<String, Object> debug = new HashMap<>(debugSize);
+        Map<String, Object> debug = Maps.newMapWithExpectedSize(debugSize);
         while (debug.size() < debugSize) {
             debug.put(randomAlphaOfLength(5), randomAlphaOfLength(4));
         }

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsBuilderTests.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.search.profile;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +68,7 @@ public class SearchProfileResultsBuilderTests extends ESTestCase {
     }
 
     private static Map<SearchShardTarget, SearchProfileQueryPhaseResult> randomSearchPhaseResults(int size) {
-        Map<SearchShardTarget, SearchProfileQueryPhaseResult> results = new HashMap<>(size);
+        Map<SearchShardTarget, SearchProfileQueryPhaseResult> results = Maps.newMapWithExpectedSize(size);
         while (results.size() < size) {
             results.put(randomTarget(), SearchProfileQueryPhaseResultTests.createTestItem());
         }

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsTests.java
@@ -9,11 +9,11 @@
 package org.elasticsearch.search.profile;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -23,7 +23,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldN
 public class SearchProfileResultsTests extends AbstractSerializingTestCase<SearchProfileResults> {
     public static SearchProfileResults createTestItem() {
         int size = rarely() ? 0 : randomIntBetween(1, 2);
-        Map<String, SearchProfileShardResult> shards = new HashMap<>(size);
+        Map<String, SearchProfileShardResult> shards = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             SearchProfileQueryPhaseResult searchResult = SearchProfileQueryPhaseResultTests.createTestItem();
             ProfileResult fetchResult = randomBoolean() ? null : ProfileResultTests.createTestItem(2);

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.suggest.phrase;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
@@ -102,7 +103,9 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             }
             case 9 -> builder.forceUnigrams(builder.forceUnigrams() == null ? randomBoolean() : builder.forceUnigrams() == false);
             case 10 -> {
-                Map<String, Object> collateParams = builder.collateParams() == null ? new HashMap<>(1) : builder.collateParams();
+                Map<String, Object> collateParams = builder.collateParams() == null
+                    ? Maps.newMapWithExpectedSize(1)
+                    : builder.collateParams();
                 collateParams.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
                 builder.collateParams(collateParams);
             }

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
@@ -28,7 +29,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -134,7 +134,7 @@ public class RestoreServiceTests extends ESTestCase {
         final PlainActionFuture<Void> listener = new PlainActionFuture<>();
 
         final int repositoryCount = between(1, 5);
-        final Map<String, Repository> repositories = new HashMap<>(repositoryCount);
+        final Map<String, Repository> repositories = Maps.newMapWithExpectedSize(repositoryCount);
         final Set<String> pendingRefreshes = new HashSet<>();
         final List<Runnable> finalAssertions = new ArrayList<>();
         while (repositories.size() < repositoryCount) {

--- a/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -203,7 +204,7 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
             case 9:
                 Map<String, String> headers = info.getHeaders();
                 if (headers == null) {
-                    headers = new HashMap<>(1);
+                    headers = Maps.newMapWithExpectedSize(1);
                 } else {
                     headers = new HashMap<>(info.getHeaders());
                 }

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -10,6 +10,7 @@ package org.elasticsearch.script;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.IntervalFilterScript;
 import org.elasticsearch.index.similarity.ScriptedSimilarity.Doc;
 import org.elasticsearch.index.similarity.ScriptedSimilarity.Field;
@@ -68,7 +69,9 @@ public class MockScriptEngine implements ScriptEngine {
         Map<ScriptContext<?>, ContextCompiler> contexts
     ) {
 
-        Map<String, MockDeterministicScript> scriptMap = new HashMap<>(deterministicScripts.size() + nonDeterministicScripts.size());
+        Map<String, MockDeterministicScript> scriptMap = Maps.newMapWithExpectedSize(
+            deterministicScripts.size() + nonDeterministicScripts.size()
+        );
         deterministicScripts.forEach((key, value) -> scriptMap.put(key, MockDeterministicScript.asDeterministic(value)));
         nonDeterministicScripts.forEach((key, value) -> scriptMap.put(key, MockDeterministicScript.asNonDeterministic(value)));
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
@@ -83,7 +84,7 @@ public abstract class InternalSingleBucketAggregationTestCase<T extends Internal
             }
             default -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -85,6 +85,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -155,7 +156,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -1118,13 +1118,13 @@ public abstract class ESIntegTestCase extends ESTestCase {
         if (cluster() != null && cluster().size() > 0) {
             final Client masterClient = client();
             Metadata metadata = masterClient.admin().cluster().prepareState().all().get().getState().metadata();
-            final Map<String, String> serializationParams = new HashMap<>(2);
+            final Map<String, String> serializationParams = Maps.newMapWithExpectedSize(2);
             serializationParams.put("binary", "true");
             serializationParams.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
             final ToXContent.Params serializationFormatParams = new ToXContent.MapParams(serializationParams);
 
             // when comparing XContent output, do not use binary format
-            final Map<String, String> compareParams = new HashMap<>(2);
+            final Map<String, String> compareParams = Maps.newMapWithExpectedSize(2);
             compareParams.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
             final ToXContent.Params compareFormatParams = new ToXContent.MapParams(compareParams);
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -59,6 +59,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -124,7 +125,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -955,7 +955,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     public static <K, V> Map<K, V> randomMap(int minMapSize, int maxMapSize, Supplier<Tuple<K, V>> entryConstructor) {
         final int size = randomIntBetween(minMapSize, maxMapSize);
-        Map<K, V> list = new HashMap<>(size);
+        Map<K, V> list = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             Tuple<K, V> entry = entryConstructor.get();
             list.put(entry.v1(), entry.v2());

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -144,7 +145,7 @@ public class StringStatsAggregator extends MetricsAggregator {
 
         // Convert Map entries: Character -> String and LongArray -> Long
         // Include only characters that have at least one occurrence
-        Map<String, Long> occurrences = new HashMap<>(charOccurrences.size());
+        Map<String, Long> occurrences = Maps.newMapWithExpectedSize(charOccurrences.size());
         for (Map.Entry<Character, LongArray> e : charOccurrences.entrySet()) {
             if (e.getValue().size() > bucket) {
                 long occ = e.getValue().get(bucket);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -84,7 +85,7 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
             case 1 -> state.add(randomDouble());
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -253,7 +254,7 @@ public class InternalMultiTermsTests extends InternalAggregationTestCase<Interna
             case 1 -> order = randomValueOtherThan(order, InternalMultiTermsTests::randomBucketOrder);
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.analytics.rate;
 
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -73,7 +74,7 @@ public class InternalRateTests extends InternalAggregationTestCase<InternalRate>
             case 2 -> divider = randomDouble();
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -97,7 +98,7 @@ public class InternalTTestTests extends InternalAggregationTestCase<InternalTTes
             case 1 -> state = randomState(Long.MAX_VALUE, randomFrom(TTestType.values()), randomIntBetween(1, 2));
             case 2 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -64,6 +64,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.TimeValue;
@@ -1395,7 +1396,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
         final Consumer<Collection<ResourceNotFoundException>> exceptionConsumer
     ) throws Exception {
         final int numberOfPrimaryShards = randomIntBetween(1, 3);
-        final Map<String, String> extraSettingsMap = new HashMap<>(2);
+        final Map<String, String> extraSettingsMap = Maps.newMapWithExpectedSize(2);
         extraSettingsMap.put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), "200ms");
         final String leaderIndexSettings = getIndexSettings(numberOfPrimaryShards, between(0, 1), extraSettingsMap);
         assertAcked(leaderClient().admin().indices().prepareCreate("index1").setSource(leaderIndexSettings, XContentType.JSON));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.collect.CopyOnWriteHashMap;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.TimeValue;
@@ -265,7 +266,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
             .filter(remoteCluster -> autoFollowersCopy.containsKey(remoteCluster) == false)
             .collect(Collectors.toSet());
 
-        Map<String, AutoFollower> newAutoFollowers = new HashMap<>(newRemoteClusters.size());
+        Map<String, AutoFollower> newAutoFollowers = Maps.newMapWithExpectedSize(newRemoteClusters.size());
         for (String remoteCluster : newRemoteClusters) {
             AutoFollower autoFollower = new AutoFollower(
                 remoteCluster,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
@@ -281,8 +282,8 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             Metadata remoteMetadata = response.getState().getMetadata();
 
             Map<String, SnapshotId> copiedSnapshotIds = new HashMap<>();
-            Map<String, RepositoryData.SnapshotDetails> snapshotsDetails = new HashMap<>(copiedSnapshotIds.size());
-            Map<IndexId, List<SnapshotId>> indexSnapshots = new HashMap<>(copiedSnapshotIds.size());
+            Map<String, RepositoryData.SnapshotDetails> snapshotsDetails = Maps.newMapWithExpectedSize(copiedSnapshotIds.size());
+            Map<IndexId, List<SnapshotId>> indexSnapshots = Maps.newMapWithExpectedSize(copiedSnapshotIds.size());
 
             ImmutableOpenMap<String, IndexMetadata> remoteIndices = remoteMetadata.getIndices();
             for (String indexName : remoteMetadata.getConcreteAllIndices()) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -38,9 +39,9 @@ public class AutoFollowMetadataTests extends AbstractSerializingTestCase<AutoFol
     @Override
     protected AutoFollowMetadata createTestInstance() {
         int numEntries = randomIntBetween(0, 32);
-        Map<String, AutoFollowMetadata.AutoFollowPattern> configs = new HashMap<>(numEntries);
-        Map<String, List<String>> followedLeaderIndices = new HashMap<>(numEntries);
-        Map<String, Map<String, String>> headers = new HashMap<>(numEntries);
+        Map<String, AutoFollowMetadata.AutoFollowPattern> configs = Maps.newMapWithExpectedSize(numEntries);
+        Map<String, List<String>> followedLeaderIndices = Maps.newMapWithExpectedSize(numEntries);
+        Map<String, Map<String, String>> headers = Maps.newMapWithExpectedSize(numEntries);
         for (int i = 0; i < numEntries; i++) {
             List<String> leaderPatterns = Arrays.asList(generateRandomStringArray(4, 4, false));
             List<String> leaderExclusionPatterns = Arrays.asList(generateRandomStringArray(4, 4, false));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
@@ -108,7 +109,7 @@ public class CCRInfoTransportActionTests extends ESTestCase {
         metadata.put(regularIndex);
 
         int numAutoFollowPatterns = randomIntBetween(0, 32);
-        Map<String, AutoFollowMetadata.AutoFollowPattern> patterns = new HashMap<>(numAutoFollowPatterns);
+        Map<String, AutoFollowMetadata.AutoFollowPattern> patterns = Maps.newMapWithExpectedSize(numAutoFollowPatterns);
         for (int i = 0; i < numAutoFollowPatterns; i++) {
             AutoFollowMetadata.AutoFollowPattern pattern = new AutoFollowMetadata.AutoFollowPattern(
                 "remote_cluser",

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
@@ -339,7 +340,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
     public void testAutoFollowerWithNoActivePatternsDoesNotStart() {
         final String remoteCluster = randomAlphaOfLength(5);
 
-        final Map<String, AutoFollowPattern> autoFollowPatterns = new HashMap<>(2);
+        final Map<String, AutoFollowPattern> autoFollowPatterns = Maps.newMapWithExpectedSize(2);
         autoFollowPatterns.put(
             "pattern_1",
             new AutoFollowPattern(
@@ -383,11 +384,11 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
             )
         );
 
-        final Map<String, List<String>> followedLeaderIndexUUIDs = new HashMap<>(2);
+        final Map<String, List<String>> followedLeaderIndexUUIDs = Maps.newMapWithExpectedSize(2);
         followedLeaderIndexUUIDs.put("pattern_1", List.of("uuid1", "uuid2"));
         followedLeaderIndexUUIDs.put("pattern_2", Collections.emptyList());
 
-        final Map<String, Map<String, String>> headers = new HashMap<>(2);
+        final Map<String, Map<String, String>> headers = Maps.newMapWithExpectedSize(2);
         headers.put("pattern_1", singletonMap("header", "value"));
         headers.put("pattern_2", emptyMap());
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
@@ -11,13 +11,13 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata.AutoFollowPattern;
 import org.elasticsearch.xpack.core.ccr.action.GetAutoFollowPatternAction;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class GetAutoFollowPatternResponseTests extends AbstractWireSerializingTestCase<GetAutoFollowPatternAction.Response> {
@@ -30,7 +30,7 @@ public class GetAutoFollowPatternResponseTests extends AbstractWireSerializingTe
     @Override
     protected GetAutoFollowPatternAction.Response createTestInstance() {
         int numPatterns = randomIntBetween(1, 8);
-        Map<String, AutoFollowPattern> patterns = new HashMap<>(numPatterns);
+        Map<String, AutoFollowPattern> patterns = Maps.newMapWithExpectedSize(numPatterns);
         for (int i = 0; i < numPatterns; i++) {
             AutoFollowPattern autoFollowPattern = new AutoFollowPattern(
                 "remote",

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.seqno.LocalCheckpointTracker;
@@ -291,7 +292,7 @@ public class ShardFollowNodeTaskRandomTests extends ESTestCase {
         long settingsVersion = startSettingsVersion;
         long aliasesVersion = startAliasesVersion;
         int numResponses = randomIntBetween(16, 256);
-        Map<Long, List<TestResponse>> responses = new HashMap<>(numResponses);
+        Map<Long, List<TestResponse>> responses = Maps.newMapWithExpectedSize(numResponses);
         for (int i = 0; i < numResponses; i++) {
             long nextGlobalCheckPoint = prevGlobalCheckpoint + maxOperationCount;
             if (sometimes()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
@@ -9,6 +9,7 @@ package org.elasticsearch.license;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.protocol.xpack.common.ProtocolUtils;
 import org.elasticsearch.rest.RestStatus;
@@ -17,7 +18,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -65,7 +65,7 @@ public class PostStartBasicResponse extends AcknowledgedResponse implements Stat
         status = in.readEnum(Status.class);
         acknowledgeMessage = in.readOptionalString();
         int size = in.readVInt();
-        Map<String, String[]> acknowledgeMessages = new HashMap<>(size);
+        Map<String, String[]> acknowledgeMessages = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String feature = in.readString();
             int nMessages = in.readVInt();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
@@ -9,11 +9,11 @@ package org.elasticsearch.license;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class PostStartTrialResponse extends ActionResponse {
@@ -57,7 +57,7 @@ public class PostStartTrialResponse extends ActionResponse {
         status = in.readEnum(Status.class);
         acknowledgeMessage = in.readOptionalString();
         int size = in.readVInt();
-        Map<String, String[]> acknowledgeMessages = new HashMap<>(size);
+        Map<String, String[]> acknowledgeMessages = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String feature = in.readString();
             int nMessages = in.readVInt();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.license;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -21,7 +22,6 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +56,7 @@ public class RestGetLicenseAction extends BaseRestHandler {
      */
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final Map<String, String> overrideParams = new HashMap<>(2);
+        final Map<String, String> overrideParams = Maps.newMapWithExpectedSize(2);
         overrideParams.put(License.REST_VIEW_MODE, "true");
         overrideParams.put(License.LICENSE_VERSION_MODE, String.valueOf(License.VERSION_CURRENT));
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.license.License;
@@ -25,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -297,7 +297,7 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
         private final Map<String, FeatureSet> featureSets;
 
         public FeatureSetsInfo(Set<FeatureSet> featureSets) {
-            Map<String, FeatureSet> map = new HashMap<>(featureSets.size());
+            Map<String, FeatureSet> map = Maps.newMapWithExpectedSize(featureSets.size());
             for (FeatureSet featureSet : featureSets) {
                 map.put(featureSet.name, featureSet);
             }
@@ -306,7 +306,7 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
 
         public FeatureSetsInfo(StreamInput in) throws IOException {
             int size = in.readVInt();
-            Map<String, FeatureSet> featureSets = new HashMap<>(size);
+            Map<String, FeatureSet> featureSets = Maps.newMapWithExpectedSize(size);
             for (int i = 0; i < size; i++) {
                 FeatureSet featureSet = new FeatureSet(in);
                 featureSets.put(featureSet.name, featureSet);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
@@ -10,12 +10,12 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.protocol.xpack.common.ProtocolUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,7 +30,7 @@ public class PutLicenseResponse extends AcknowledgedResponse {
         status = LicensesStatus.fromId(in.readVInt());
         acknowledgeHeader = in.readOptionalString();
         int size = in.readVInt();
-        Map<String, String[]> acknowledgeMessages = new HashMap<>(size);
+        Map<String, String[]> acknowledgeMessages = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String feature = in.readString();
             int nMessages = in.readVInt();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -18,7 +19,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,7 +60,7 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
     public ExplainLifecycleResponse(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
-        Map<String, IndexLifecycleExplainResponse> indexResponses = new HashMap<>(size);
+        Map<String, IndexLifecycleExplainResponse> indexResponses = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             IndexLifecycleExplainResponse indexResponse = new IndexLifecycleExplainResponse(in);
             indexResponses.put(indexResponse.getIndex(), indexResponse);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ContextParser;
@@ -23,7 +24,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,7 +42,7 @@ public class Phase implements ToXContentObject, Writeable {
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<Phase, String> PARSER = new ConstructingObjectParser<>("phase", false, (a, name) -> {
         final List<LifecycleAction> lifecycleActions = (List<LifecycleAction>) a[1];
-        Map<String, LifecycleAction> map = new HashMap<>(lifecycleActions.size());
+        Map<String, LifecycleAction> map = Maps.newMapWithExpectedSize(lifecycleActions.size());
         for (LifecycleAction lifecycleAction : lifecycleActions) {
             if (map.put(lifecycleAction.getWriteableName(), lifecycleAction) != null) {
                 throw new IllegalStateException("Duplicate key");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TopClassEntry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TopClassEntry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -20,7 +21,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -98,7 +98,7 @@ public class TopClassEntry implements Writeable, ToXContentObject {
     }
 
     public Map<String, Object> asValueMap() {
-        Map<String, Object> map = new HashMap<>(3, 1.0f);
+        Map<String, Object> map = Maps.newMapWithExpectedSize(3);
         map.put(CLASS_NAME.getPreferredName(), classification);
         map.put(CLASS_PROBABILITY.getPreferredName(), probability);
         map.put(CLASS_SCORE.getPreferredName(), score);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MapHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MapHelper.java
@@ -7,10 +7,10 @@
 package org.elasticsearch.xpack.core.ml.utils;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
@@ -94,8 +94,7 @@ public final class MapHelper {
      * @return A fully collapsed map
      */
     public static Map<String, Object> dotCollapse(Map<String, Object> map, Collection<String> pathsToCollapse) {
-        // default load factor is 0.75 (3/4).
-        Map<String, Object> collapsed = new HashMap<>(((pathsToCollapse.size() * 4) / 3) + 1);
+        Map<String, Object> collapsed = Maps.newMapWithExpectedSize(pathsToCollapse.size());
         for (String path : pathsToCollapse) {
             Object dug = dig(path, map);
             if (dug != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField;
@@ -18,7 +19,6 @@ import org.elasticsearch.xpack.core.security.support.CacheKey;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -286,7 +286,7 @@ public class IndicesAccessControl {
         Set<String> otherIndexes = limitedByIndicesAccessControl.indexPermissions.keySet();
         Set<String> commonIndexes = Sets.intersection(indexes, otherIndexes);
 
-        Map<String, IndexAccessControl> indexPermissionsMap = new HashMap<>(commonIndexes.size());
+        Map<String, IndexAccessControl> indexPermissionsMap = Maps.newMapWithExpectedSize(commonIndexes.size());
         for (String index : commonIndexes) {
             IndexAccessControl indexAccessControl = getIndexPermissions(index);
             IndexAccessControl limitedByIndexAccessControl = limitedByIndicesAccessControl.getIndexPermissions(index);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
@@ -366,9 +367,9 @@ public final class IndicesPermission {
 
         // now... every index that is associated with the request, must be granted
         // by at least one indices permission group
-        final Map<String, Set<FieldPermissions>> fieldPermissionsByIndex = new HashMap<>(totalResourceCount);
-        final Map<String, DocumentLevelPermissions> roleQueriesByIndex = new HashMap<>(totalResourceCount);
-        final Map<String, Boolean> grantedBuilder = new HashMap<>(totalResourceCount);
+        final Map<String, Set<FieldPermissions>> fieldPermissionsByIndex = Maps.newMapWithExpectedSize(totalResourceCount);
+        final Map<String, DocumentLevelPermissions> roleQueriesByIndex = Maps.newMapWithExpectedSize(totalResourceCount);
+        final Map<String, Boolean> grantedBuilder = Maps.newMapWithExpectedSize(totalResourceCount);
 
         final boolean isMappingUpdateAction = isMappingUpdateAction(action);
 
@@ -481,7 +482,7 @@ public final class IndicesPermission {
         }
 
         boolean overallGranted = true;
-        Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions = new HashMap<>(grantedBuilder.size());
+        Map<String, IndicesAccessControl.IndexAccessControl> indexPermissions = Maps.newMapWithExpectedSize(grantedBuilder.size());
         for (Map.Entry<String, Boolean> entry : grantedBuilder.entrySet()) {
             String index = entry.getKey();
             DocumentLevelPermissions permissions = roleQueriesByIndex.get(index);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesActi
 import org.elasticsearch.action.ingest.GetPipelineAction;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.GetStatusAction;
@@ -38,7 +39,6 @@ import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -322,7 +322,7 @@ public class ClusterPrivilegeResolver {
      */
     static SortedMap<String, NamedClusterPrivilege> sortByAccessLevel(Collection<NamedClusterPrivilege> privileges) {
         // How many other privileges does this privilege imply. Those with a higher count are considered to be a higher privilege
-        final Map<String, Long> impliesCount = new HashMap<>(privileges.size());
+        final Map<String, Long> impliesCount = Maps.newMapWithExpectedSize(privileges.size());
         privileges.forEach(
             priv -> impliesCount.put(
                 priv.name(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
@@ -8,11 +8,11 @@ package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -86,7 +86,7 @@ public class Privilege {
      */
     static <T extends Privilege> SortedMap<String, T> sortByAccessLevel(Map<String, T> privileges) {
         // How many other privileges is this privilege a subset of. Those with a higher count are considered to be a lower privilege
-        final Map<String, Long> subsetCount = new HashMap<>(privileges.size());
+        final Map<String, Long> subsetCount = Maps.newMapWithExpectedSize(privileges.size());
         privileges.forEach(
             (name, priv) -> subsetCount.put(
                 name,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.KeyStoreUtil;
 import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.common.ssl.SslKeyConfig;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.env.Environment;
 
 import java.io.IOException;
@@ -30,7 +31,6 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -109,7 +109,7 @@ public class CertParsingUtils {
     private static Map<Certificate, Key> readKeyPairsFromKeystore(KeyStore store, Function<String, char[]> keyPassword)
         throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
         final Enumeration<String> enumeration = store.aliases();
-        final Map<Certificate, Key> map = new HashMap<>(store.size());
+        final Map<Certificate, Key> map = Maps.newMapWithExpectedSize(store.size());
         while (enumeration.hasMoreElements()) {
             final String alias = enumeration.nextElement();
             if (store.isKeyEntry(alias)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.ssl.SslConfiguration;
 import org.elasticsearch.common.ssl.SslDiagnostics;
 import org.elasticsearch.common.ssl.SslKeyConfig;
 import org.elasticsearch.common.ssl.SslTrustConfig;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -534,7 +535,7 @@ public class SSLService {
 
     private static Map<String, SslConfiguration> getSSLConfigurations(Environment env, Settings settings) {
         final Map<String, Settings> sslSettingsMap = getSSLSettingsMap(settings);
-        final Map<String, SslConfiguration> sslConfigurationMap = new HashMap<>(sslSettingsMap.size());
+        final Map<String, SslConfiguration> sslConfigurationMap = Maps.newMapWithExpectedSize(sslSettingsMap.size());
         sslSettingsMap.forEach((key, sslSettings) -> {
             if (key.endsWith(".")) {
                 // Drop trailing '.' so that any exception messages are consistent
@@ -596,7 +597,7 @@ public class SSLService {
      * Parses the settings to load all SslConfiguration objects that will be used.
      */
     Map<SslConfiguration, SSLContextHolder> loadSslConfigurations(Map<String, SslConfiguration> sslConfigurationMap) {
-        final Map<SslConfiguration, SSLContextHolder> sslContextHolders = new HashMap<>(sslConfigurationMap.size());
+        final Map<SslConfiguration, SSLContextHolder> sslContextHolders = Maps.newMapWithExpectedSize(sslConfigurationMap.size());
         sslConfigurationMap.forEach((key, sslConfiguration) -> {
             try {
                 sslContextHolders.computeIfAbsent(sslConfiguration, this::createSslContext);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -60,7 +61,7 @@ public class WatchStatus implements ToXContentObject, Writeable {
         lastChecked = readOptionalDate(in);
         lastMetCondition = readOptionalDate(in);
         int count = in.readInt();
-        Map<String, ActionStatus> actions = new HashMap<>(count);
+        Map<String, ActionStatus> actions = Maps.newMapWithExpectedSize(count);
         for (int i = 0; i < count; i++) {
             actions.put(in.readString(), ActionStatus.readFrom(in));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
@@ -184,7 +185,7 @@ public class ClientHelperTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("foo", "foo");
         headers.put("bar", "bar");
 
@@ -217,7 +218,7 @@ public class ClientHelperTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -118,7 +119,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
      */
     public static LifecyclePolicy randomTimeseriesLifecyclePolicyWithAllPhases(@Nullable String lifecycleName) {
         List<String> phaseNames = TimeseriesLifecycleType.ORDERED_VALID_PHASES;
-        Map<String, Phase> phases = new HashMap<>(phaseNames.size());
+        Map<String, Phase> phases = Maps.newMapWithExpectedSize(phaseNames.size());
         Function<String, Set<String>> validActions = getPhaseToValidActions();
         Function<String, LifecycleAction> randomAction = getNameToActionFunction();
         TimeValue prev = null;
@@ -150,7 +151,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
             // Remove the frozen phase, we'll randomly re-add it later
             .filter(pn -> TimeseriesLifecycleType.FROZEN_PHASE.equals(pn) == false)
             .collect(Collectors.toList());
-        Map<String, Phase> phases = new HashMap<>(phaseNames.size());
+        Map<String, Phase> phases = Maps.newMapWithExpectedSize(phaseNames.size());
         Function<String, Set<String>> validActions = getPhaseToValidActions();
         Function<String, LifecycleAction> randomAction = getNameToActionFunction();
         // as what actions end up in the hot phase influence what actions are allowed in the subsequent phases we'll move the hot phase
@@ -269,7 +270,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
 
     public static LifecyclePolicy randomTestLifecyclePolicy(@Nullable String lifecycleName) {
         int numberPhases = randomInt(5);
-        Map<String, Phase> phases = new HashMap<>(numberPhases);
+        Map<String, Phase> phases = Maps.newMapWithExpectedSize(numberPhases);
         for (int i = 0; i < numberPhases; i++) {
             TimeValue after = TimeValue.parseTimeValue(randomTimeValue(0, 10000, "s", "m", "h", "d"), "test_after");
             Map<String, LifecycleAction> actions = new HashMap<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PolicyStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PolicyStatsTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PhaseStats;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PolicyStats;
@@ -25,7 +26,7 @@ public class PolicyStatsTests extends AbstractWireSerializingTestCase<PolicyStat
 
     public static PolicyStats createRandomInstance() {
         int size = randomIntBetween(0, 10);
-        Map<String, PhaseStats> phaseStats = new HashMap<>(size);
+        Map<String, PhaseStats> phaseStats = Maps.newMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             phaseStats.put(randomAlphaOfLengthBetween(1, 20), PhaseStatsTests.createRandomInstance());
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml.inference.preprocessing;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
@@ -86,7 +87,7 @@ public abstract class PreProcessingTests<T extends PreProcessor> extends Abstrac
 
     Map<String, Object> randomFieldValues() {
         int numFields = randomIntBetween(1, 5);
-        Map<String, Object> fieldValues = new HashMap<>(numFields);
+        Map<String, Object> fieldValues = Maps.newMapWithExpectedSize(numFields);
         for (int k = 0; k < numFields; k++) {
             fieldValues.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModelTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -161,12 +161,9 @@ public class EnsembleInferenceModelTests extends ESTestCase {
         }
 
         // This should handle missing values and take the default_left path
-        featureMap = new HashMap<>(2) {
-            {
-                put("foo", 0.3);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.3);
+        featureMap.put("bar", null);
         expected = Arrays.asList(0.6899744811, 0.3100255188);
         scores = Arrays.asList(0.482982136, 0.0930076556);
         probabilities = ((ClassificationInferenceResults) ensemble.infer(featureMap, new ClassificationConfig(2), Collections.emptyMap()))
@@ -246,12 +243,9 @@ public class EnsembleInferenceModelTests extends ESTestCase {
             )
         );
 
-        featureMap = new HashMap<>(2) {
-            {
-                put("foo", 0.3);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.3);
+        featureMap.put("bar", null);
         assertThat(
             0.0,
             closeTo(
@@ -330,12 +324,9 @@ public class EnsembleInferenceModelTests extends ESTestCase {
             )
         );
 
-        featureMap = new HashMap<>(2) {
-            {
-                put("foo", 0.6);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.6);
+        featureMap.put("bar", null);
         assertThat(
             1.0,
             closeTo(
@@ -424,12 +415,9 @@ public class EnsembleInferenceModelTests extends ESTestCase {
             )
         );
 
-        featureMap = new HashMap<>(2) {
-            {
-                put("foo", 0.3);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.3);
+        featureMap.put("bar", null);
         assertThat(
             1.8,
             closeTo(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -165,12 +165,9 @@ public class TreeInferenceModelTests extends ESTestCase {
         );
 
         // This should handle missing values and take the default_left path
-        featureMap = new HashMap<>(2, 1.0f) {
-            {
-                put("foo", 0.3);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.3);
+        featureMap.put("bar", null);
         assertThat(
             0.1,
             closeTo(
@@ -222,12 +219,9 @@ public class TreeInferenceModelTests extends ESTestCase {
         }
 
         // This should handle missing values and take the default_left path
-        featureMap = new HashMap<>(2) {
-            {
-                put("foo", 0.3);
-                put("bar", null);
-            }
-        };
+        featureMap = Maps.newMapWithExpectedSize(2);
+        featureMap.put("foo", 0.3);
+        featureMap.put("bar", null);
         probabilities = ((ClassificationInferenceResults) tree.infer(featureMap, new ClassificationConfig(2), Collections.emptyMap()))
             .getTopClasses();
         for (int i = 0; i < expectedProbs.size(); i++) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/RollupActionDateHistogramGroupConfigSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/RollupActionDateHistogramGroupConfigSerializingTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.rollup;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -97,7 +98,7 @@ public class RollupActionDateHistogramGroupConfigSerializingTests extends Abstra
 
         // Have to mock fieldcaps because the ctor's aren't public...
         FieldCapabilities fieldCaps = mock(FieldCapabilities.class);
-        Map<String, FieldCapabilities> types = new HashMap<>(2);
+        Map<String, FieldCapabilities> types = Maps.newMapWithExpectedSize(2);
         types.put("date", fieldCaps);
         types.put("keyword", fieldCaps);
         responseMap.put("my_field", types);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfigSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfigSerializingTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -136,7 +137,7 @@ public class DateHistogramGroupConfigSerializingTests extends AbstractSerializin
 
         // Have to mock fieldcaps because the ctor's aren't public...
         FieldCapabilities fieldCaps = mock(FieldCapabilities.class);
-        Map<String, FieldCapabilities> types = new HashMap<>(2);
+        Map<String, FieldCapabilities> types = Maps.newMapWithExpectedSize(2);
         types.put("date", fieldCaps);
         types.put("keyword", fieldCaps);
         responseMap.put("my_field", types);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobTests.java
@@ -8,13 +8,13 @@ package org.elasticsearch.xpack.core.rollup.job;
 
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractDiffableSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class RollupJobTests extends AbstractDiffableSerializationTestCase<RollupJob> {
@@ -41,7 +41,7 @@ public class RollupJobTests extends AbstractDiffableSerializationTestCase<Rollup
 
         Map<String, String> headers = Collections.emptyMap();
         if (randomBoolean()) {
-            headers = new HashMap<>(1);
+            headers = Maps.newMapWithExpectedSize(1);
             headers.put("foo", "bar");
         }
         return new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), headers);
@@ -51,7 +51,7 @@ public class RollupJobTests extends AbstractDiffableSerializationTestCase<Rollup
     protected RollupJob makeTestChanges(RollupJob other) {
         if (randomBoolean()) {
             if (other.getHeaders().isEmpty()) {
-                Map<String, String> headers = new HashMap<>(1);
+                Map<String, String> headers = Maps.newMapWithExpectedSize(1);
                 headers.put("foo", "bar");
                 return new RollupJob(other.getConfig(), headers);
             } else {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -9,11 +9,11 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +23,7 @@ public class PutPrivilegesResponseTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         final int applicationCount = randomInt(3);
-        final Map<String, List<String>> map = new HashMap<>(applicationCount);
+        final Map<String, List<String>> map = Maps.newMapWithExpectedSize(applicationCount);
         for (int i = 0; i < applicationCount; i++) {
             map.put(randomAlphaOfLengthBetween(3, 8), Arrays.asList(generateRandomStringArray(5, 6, false, true)));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadataTests.java
@@ -8,12 +8,12 @@
 package org.elasticsearch.xpack.core.slm;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class SnapshotLifecycleMetadataTests extends AbstractSerializingTestCase<SnapshotLifecycleMetadata> {
@@ -25,7 +25,7 @@ public class SnapshotLifecycleMetadataTests extends AbstractSerializingTestCase<
     @Override
     protected SnapshotLifecycleMetadata createTestInstance() {
         int policyCount = randomIntBetween(0, 3);
-        Map<String, SnapshotLifecyclePolicyMetadata> policies = new HashMap<>(policyCount);
+        Map<String, SnapshotLifecyclePolicyMetadata> policies = Maps.newMapWithExpectedSize(policyCount);
         for (int i = 0; i < policyCount; i++) {
             String id = "policy-" + randomAlphaOfLength(3);
             policies.put(id, SnapshotLifecyclePolicyMetadataTests.createRandomPolicyMetadata(id));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStatsTests.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.xpack.core.slm;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class SnapshotLifecycleStatsTests extends AbstractSerializingTestCase<SnapshotLifecycleStats> {
@@ -33,7 +33,7 @@ public class SnapshotLifecycleStatsTests extends AbstractSerializingTestCase<Sna
 
     public static SnapshotLifecycleStats randomLifecycleStats() {
         int policies = randomIntBetween(0, 5);
-        Map<String, SnapshotLifecycleStats.SnapshotPolicyStats> policyStats = new HashMap<>(policies);
+        Map<String, SnapshotLifecycleStats.SnapshotPolicyStats> policyStats = Maps.newMapWithExpectedSize(policies);
         for (int i = 0; i < policies; i++) {
             String policy = "policy-" + randomAlphaOfLength(4);
             policyStats.put(policy, randomPolicyStats(policy));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -39,7 +40,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -241,7 +241,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
     }
 
     private static Map<String, String> randomHeaders() {
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("key", "value");
 
         return headers;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettingsTests.java
@@ -11,11 +11,11 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.AbstractSerializingTransformTestCase;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,7 +30,7 @@ public class TransformDestIndexSettingsTests extends AbstractSerializingTransfor
         Map<String, Object> mappings = null;
 
         if (randomBoolean()) {
-            mappings = new HashMap<>(size);
+            mappings = Maps.newMapWithExpectedSize(size);
             mappings.put("_meta", singletonMap("_transform", singletonMap("version", Version.CURRENT.toString())));
             for (int i = 0; i < size; i++) {
                 mappings.put(randomAlphaOfLength(10), singletonMap("type", randomAlphaOfLength(10)));

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -14,13 +14,13 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -152,7 +152,7 @@ public class EnrichCache {
 
     private static Object innerDeepCopy(Object value, boolean unmodifiable) {
         if (value instanceof Map<?, ?> mapValue) {
-            Map<Object, Object> copy = new HashMap<>(mapValue.size());
+            Map<Object, Object> copy = Maps.newMapWithExpectedSize(mapValue.size());
             for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
                 copy.put(entry.getKey(), innerDeepCopy(entry.getValue(), unmodifiable));
             }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMetadataTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMetadataTests.java
@@ -7,13 +7,13 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.enrich.EnrichPolicyTests.randomEnrichPolicy;
@@ -38,7 +38,7 @@ public class EnrichMetadataTests extends AbstractSerializingTestCase<EnrichMetad
 
     private static EnrichMetadata randomEnrichMetadata(XContentType xContentType) {
         int numPolicies = randomIntBetween(8, 64);
-        Map<String, EnrichPolicy> policies = new HashMap<>(numPolicies);
+        Map<String, EnrichPolicy> policies = Maps.newMapWithExpectedSize(numPolicies);
         for (int i = 0; i < numPolicies; i++) {
             EnrichPolicy policy = randomEnrichPolicy(xContentType);
             policies.put(randomAlphaOfLength(8), policy);

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -67,7 +67,7 @@ public class DataLoader {
     private static boolean main = false;
 
     private static Map<String, String[]> getReplacementPatterns() {
-        final Map<String, String[]> map = new HashMap<>(1);
+        final Map<String, String[]> map = Maps.newMapWithExpectedSize(1);
         map.put("[runtime_random_keyword_type]", new String[] { "keyword", "wildcard" });
         return map;
     }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -169,7 +170,7 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         Tuple<String, Tuple<String, Boolean>>... resourceActionAccess
     ) {
         final boolean isCompleteMatch = randomBoolean();
-        final Map<String, Map<String, Boolean>> resourcePrivilegeMap = new HashMap<>(resourceActionAccess.length);
+        final Map<String, Map<String, Boolean>> resourcePrivilegeMap = Maps.newMapWithExpectedSize(resourceActionAccess.length);
         for (Tuple<String, Tuple<String, Boolean>> t : resourceActionAccess) {
             final String resource = t.v1();
             final String action = t.v2().v1();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.Metadata.Custom;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractDiffableSerializationTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -46,7 +47,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -60,7 +60,7 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
     @Override
     protected IndexLifecycleMetadata createTestInstance() {
         int numPolicies = randomIntBetween(1, 5);
-        Map<String, LifecyclePolicyMetadata> policies = new HashMap<>(numPolicies);
+        Map<String, LifecyclePolicyMetadata> policies = Maps.newMapWithExpectedSize(numPolicies);
         for (int i = 0; i < numPolicies; i++) {
             LifecyclePolicy policy = randomTimeseriesLifecyclePolicy(randomAlphaOfLength(4) + i);
             policies.put(
@@ -189,7 +189,7 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
         SortedMap<String, LifecyclePolicyMetadata> policies = new TreeMap<>();
         for (int i = 0; i < numPolicies; i++) {
             int numberPhases = randomInt(5);
-            Map<String, Phase> phases = new HashMap<>(numberPhases);
+            Map<String, Phase> phases = Maps.newMapWithExpectedSize(numberPhases);
             for (int j = 0; j < numberPhases; j++) {
                 TimeValue after = TimeValue.parseTimeValue(randomTimeValue(0, 1000000000, "s", "m", "h", "d"), "test_after");
                 Map<String, LifecycleAction> actions = Collections.emptyMap();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -20,7 +21,6 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.mockito.Mockito;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -90,7 +90,7 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("foo", "foo");
         headers.put("bar", "bar");
 
@@ -131,7 +131,7 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         SearchRequest request = new SearchRequest("foo");
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -33,7 +34,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.logstash.Logstash;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -66,7 +66,7 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
                 .setScroll(TimeValue.timeValueMinutes(1L))
                 .execute(ActionListener.wrap(searchResponse -> {
                     final int numHits = Math.toIntExact(searchResponse.getHits().getTotalHits().value);
-                    final Map<String, BytesReference> pipelineSources = new HashMap<>(numHits);
+                    final Map<String, BytesReference> pipelineSources = Maps.newMapWithExpectedSize(numHits);
                     final Consumer<SearchResponse> clearScroll = (response) -> {
                         if (response != null && response.getScrollId() != null) {
                             ClearScrollRequest clearScrollRequest = new ClearScrollRequest();

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponseTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponseTests.java
@@ -10,9 +10,9 @@ package org.elasticsearch.xpack.logstash.action;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class GetPipelineResponseTests extends AbstractWireSerializingTestCase<GetPipelineResponse> {
@@ -25,7 +25,7 @@ public class GetPipelineResponseTests extends AbstractWireSerializingTestCase<Ge
     @Override
     protected GetPipelineResponse createTestInstance() {
         final int numPipelines = randomIntBetween(1, 10);
-        final Map<String, BytesReference> map = new HashMap<>(numPipelines);
+        final Map<String, BytesReference> map = Maps.newMapWithExpectedSize(numPipelines);
         for (int i = 0; i < numPipelines; i++) {
             final String name = randomAlphaOfLengthBetween(2, 10);
             final BytesReference ref = new BytesArray(randomByteArrayOfLength(randomIntBetween(1, 16)));
@@ -36,7 +36,7 @@ public class GetPipelineResponseTests extends AbstractWireSerializingTestCase<Ge
 
     @Override
     protected GetPipelineResponse mutateInstance(GetPipelineResponse instance) {
-        Map<String, BytesReference> map = new HashMap<>(instance.pipelines().size() + 1);
+        Map<String, BytesReference> map = Maps.newMapWithExpectedSize(instance.pipelines().size() + 1);
         map.putAll(instance.pipelines());
         map.put(randomAlphaOfLengthBetween(2, 10), new BytesArray(randomByteArrayOfLength(randomIntBetween(1, 16))));
         return new GetPipelineResponse(map);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.license.XPackLicenseState;
@@ -472,7 +473,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
                 }
             }));
 
-        Map<String, Object> ingestUsage = new HashMap<>(6);
+        Map<String, Object> ingestUsage = Maps.newMapWithExpectedSize(6);
         ingestUsage.put("pipelines", createCountUsageEntry(pipelines.size()));
         ingestUsage.put("num_docs_processed", docCountStats);
         ingestUsage.put("time_ms", timeStats);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
@@ -26,7 +27,6 @@ import org.elasticsearch.xpack.ml.datafeed.delayeddatacheck.DelayedDataDetectorF
 
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -136,7 +136,7 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
             SearchResponse response = client.execute(SearchAction.INSTANCE, searchRequest).actionGet();
             List<? extends Histogram.Bucket> buckets = ((Histogram) response.getAggregations().get(DATE_BUCKETS)).getBuckets();
-            Map<Long, Long> hashMap = new HashMap<>(buckets.size());
+            Map<Long, Long> hashMap = Maps.newMapWithExpectedSize(buckets.size());
             for (Histogram.Bucket bucket : buckets) {
                 long bucketTime = toHistogramKeyToEpoch(bucket.getKey());
                 if (bucketTime < 0) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.ml.extractor;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +40,7 @@ public class ProcessedField {
 
     public Object[] value(SearchHit hit, Function<String, ExtractedField> fieldExtractor) {
         List<String> inputFields = getInputFieldNames();
-        Map<String, Object> inputs = new HashMap<>(inputFields.size(), 1.0f);
+        Map<String, Object> inputs = Maps.newMapWithExpectedSize(inputFields.size());
         for (String field : inputFields) {
             ExtractedField extractedField = fieldExtractor.apply(field);
             if (extractedField == null) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -31,7 +32,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -209,7 +209,7 @@ public class CppLogMessageHandler implements Closeable {
         String copyrightMessage = getCppCopyright(timeout);
         Matcher matcher = Pattern.compile("Version (.+) \\(Build ([^)]+)\\) Copyright ").matcher(copyrightMessage);
         if (matcher.find()) {
-            Map<String, Object> info = new HashMap<>(2);
+            Map<String, Object> info = Maps.newMapWithExpectedSize(2);
             info.put("version", matcher.group(1));
             info.put("build_hash", matcher.group(2));
             return info;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastActionTests.java
@@ -8,13 +8,13 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -76,7 +76,7 @@ public class TransportDeleteForecastActionTests extends ESTestCase {
     }
 
     private static SearchHit createForecastStatsHit(ForecastRequestStats.ForecastRequestStatus status) {
-        Map<String, DocumentField> documentFields = new HashMap<>(2);
+        Map<String, DocumentField> documentFields = Maps.newMapWithExpectedSize(2);
         documentFields.put(
             ForecastRequestStats.FORECAST_ID.getPreferredName(),
             new DocumentField(ForecastRequestStats.FORECAST_ID.getPreferredName(), Collections.singletonList(""))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.IngestMetadata;
@@ -275,7 +276,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
     }
 
     private static ClusterState buildClusterStateWithModelReferences(String... modelId) throws IOException {
-        Map<String, PipelineConfiguration> configurations = new HashMap<>(modelId.length);
+        Map<String, PipelineConfiguration> configurations = Maps.newMapWithExpectedSize(modelId.length);
         for (String id : modelId) {
             configurations.put("pipeline_with_model_" + id + 0, newConfigurationWithInferenceProcessor(id, 0));
             configurations.put("pipeline_with_model_" + id + 1, newConfigurationWithInferenceProcessor(id, 1));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/ParsedKSTest.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.ml.aggs.kstest;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class ParsedKSTest extends ParsedAggregation {
@@ -21,7 +21,7 @@ public class ParsedKSTest extends ParsedAggregation {
     @SuppressWarnings("unchecked")
     public static ParsedKSTest fromXContent(XContentParser parser, final String name) throws IOException {
         Map<String, Object> values = parser.map();
-        Map<String, Double> doubleValues = new HashMap<>(values.size(), 1.0f);
+        Map<String, Double> doubleValues = Maps.newMapWithExpectedSize(values.size());
         for (Alternative alternative : Alternative.values()) {
             Double value = (Double) values.get(alternative.toString());
             if (value != null) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -617,7 +618,7 @@ public class DataExtractorFactoryTests extends ESTestCase {
         );
         RollupJobCaps rollupJobCaps = new RollupJobCaps(rollupJobConfig);
         RollableIndexCaps rollableIndexCaps = new RollableIndexCaps("myIndex_rollup", Collections.singletonList(rollupJobCaps));
-        Map<String, RollableIndexCaps> jobs = new HashMap<>(1);
+        Map<String, RollableIndexCaps> jobs = Maps.newMapWithExpectedSize(1);
         jobs.put("rollupJob1", rollableIndexCaps);
         when(getRollupIndexResponse.getJobs()).thenReturn(jobs);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.dataframe.extractor;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -794,7 +795,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("some_integer", "integer")
             .build();
 
-        Map<String, Long> fieldCardinalities = new HashMap<>(2);
+        Map<String, Long> fieldCardinalities = Maps.newMapWithExpectedSize(2);
         fieldCardinalities.put("some_boolean", 2L);
         fieldCardinalities.put("some_integer", 2L);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
@@ -412,7 +413,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     }
 
     private static ClusterState builderClusterStateWithModelReferences(Version minNodeVersion, String... modelId) throws IOException {
-        Map<String, PipelineConfiguration> configurations = new HashMap<>(modelId.length);
+        Map<String, PipelineConfiguration> configurations = Maps.newMapWithExpectedSize(modelId.length);
         for (String id : modelId) {
             configurations.put(
                 "pipeline_with_model_" + id,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.inference.ingest;
 
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
@@ -325,14 +326,11 @@ public class InferenceProcessorTests extends ESTestCase {
         String modelId = "model";
         Integer topNClasses = randomBoolean() ? null : randomIntBetween(1, 10);
 
-        Map<String, String> fieldMapping = new HashMap<>(5) {
-            {
-                put("value1", "new_value1");
-                put("value2", "new_value2");
-                put("categorical", "new_categorical");
-                put("_ingest._value", "metafield");
-            }
-        };
+        Map<String, String> fieldMapping = Maps.newMapWithExpectedSize(4);
+        fieldMapping.put("value1", "new_value1");
+        fieldMapping.put("value2", "new_value2");
+        fieldMapping.put("categorical", "new_categorical");
+        fieldMapping.put("_ingest._value", "metafield");
 
         InferenceProcessor processor = new InferenceProcessor(
             client,
@@ -345,25 +343,19 @@ public class InferenceProcessorTests extends ESTestCase {
             fieldMapping
         );
 
-        Map<String, Object> source = new HashMap<>(5) {
-            {
-                put("value1", 1);
-                put("categorical", "foo");
-                put("un_touched", "bar");
-            }
-        };
+        Map<String, Object> source = Maps.newMapWithExpectedSize(3);
+        source.put("value1", 1);
+        source.put("categorical", "foo");
+        source.put("un_touched", "bar");
         Map<String, Object> ingestMetadata = new HashMap<>();
         IngestDocument document = new IngestDocument(source, ingestMetadata);
 
-        Map<String, Object> expectedMap = new HashMap<>(7) {
-            {
-                put("new_value1", 1);
-                put("value1", 1);
-                put("categorical", "foo");
-                put("new_categorical", "foo");
-                put("un_touched", "bar");
-            }
-        };
+        Map<String, Object> expectedMap = Maps.newMapWithExpectedSize(5);
+        expectedMap.put("new_value1", 1);
+        expectedMap.put("value1", 1);
+        expectedMap.put("categorical", "foo");
+        expectedMap.put("new_categorical", "foo");
+        expectedMap.put("un_touched", "bar");
         assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expectedMap));
 
         ingestMetadata = Collections.singletonMap("_value", "baz");
@@ -378,13 +370,10 @@ public class InferenceProcessorTests extends ESTestCase {
         String modelId = "model";
         Integer topNClasses = randomBoolean() ? null : randomIntBetween(1, 10);
 
-        Map<String, String> fieldMapping = new HashMap<>(5) {
-            {
-                put("value1.foo", "new_value1");
-                put("value2", "new_value2");
-                put("categorical.bar", "new_categorical");
-            }
-        };
+        Map<String, String> fieldMapping = Maps.newMapWithExpectedSize(3);
+        fieldMapping.put("value1.foo", "new_value1");
+        fieldMapping.put("value2", "new_value2");
+        fieldMapping.put("categorical.bar", "new_categorical");
 
         InferenceProcessor processor = new InferenceProcessor(
             client,
@@ -397,25 +386,19 @@ public class InferenceProcessorTests extends ESTestCase {
             fieldMapping
         );
 
-        Map<String, Object> source = new HashMap<>(5) {
-            {
-                put("value1", Collections.singletonMap("foo", 1));
-                put("categorical.bar", "foo");
-                put("un_touched", "bar");
-            }
-        };
+        Map<String, Object> source = Maps.newMapWithExpectedSize(3);
+        source.put("value1", Collections.singletonMap("foo", 1));
+        source.put("categorical.bar", "foo");
+        source.put("un_touched", "bar");
         Map<String, Object> ingestMetadata = new HashMap<>();
         IngestDocument document = new IngestDocument(source, ingestMetadata);
 
-        Map<String, Object> expectedMap = new HashMap<>(7) {
-            {
-                put("new_value1", 1);
-                put("value1", Collections.singletonMap("foo", 1));
-                put("categorical.bar", "foo");
-                put("new_categorical", "foo");
-                put("un_touched", "bar");
-            }
-        };
+        Map<String, Object> expectedMap = Maps.newMapWithExpectedSize(5);
+        expectedMap.put("new_value1", 1);
+        expectedMap.put("value1", Collections.singletonMap("foo", 1));
+        expectedMap.put("categorical.bar", "foo");
+        expectedMap.put("new_categorical", "foo");
+        expectedMap.put("un_touched", "bar");
         assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expectedMap));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.ingest.IngestMetadata;
@@ -59,7 +60,6 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -768,7 +768,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
     }
 
     private static Metadata.Builder addIngest(Metadata.Builder builder, String... modelId) throws IOException {
-        Map<String, PipelineConfiguration> configurations = new HashMap<>(modelId.length);
+        Map<String, PipelineConfiguration> configurations = Maps.newMapWithExpectedSize(modelId.length);
         for (String id : modelId) {
             configurations.put("pipeline_with_model_" + id, newConfigurationWithInferenceProcessor(id));
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.CheckedFunction;
@@ -26,7 +27,6 @@ import org.elasticsearch.xcontent.XContent;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -107,7 +107,7 @@ public abstract class PublishableHttpResource extends HttpResource {
         super(resourceOwnerName, dirty);
 
         if (masterTimeout != null && TimeValue.MINUS_ONE.equals(masterTimeout) == false) {
-            final Map<String, String> parameters = new HashMap<>(baseParameters.size() + 1);
+            final Map<String, String> parameters = Maps.newMapWithExpectedSize(baseParameters.size() + 1);
 
             parameters.putAll(baseParameters);
             parameters.put("master_timeout", masterTimeout.toString());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -20,13 +20,13 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.BaseCollectorTestCase;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -85,9 +85,9 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
         // Total number of indices
         final int indices = existingIndices + createdIndices + deletedIndices;
 
-        final Map<String, IndexStats> indicesStats = new HashMap<>(indices);
-        final Map<String, IndexMetadata> indicesMetadata = new HashMap<>(indices);
-        final Map<String, IndexRoutingTable> indicesRoutingTable = new HashMap<>(indices);
+        final Map<String, IndexStats> indicesStats = Maps.newMapWithExpectedSize(indices);
+        final Map<String, IndexMetadata> indicesMetadata = Maps.newMapWithExpectedSize(indices);
+        final Map<String, IndexRoutingTable> indicesRoutingTable = Maps.newMapWithExpectedSize(indices);
 
         for (int i = 0; i < indices; i++) {
             final String index = "_index_" + i;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQuery.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ql.querydsl.query;
 
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -16,7 +17,6 @@ import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,7 +80,7 @@ public class NestedQuery extends Query {
             // I already have the field, no rewriting needed
             return this;
         }
-        Map<String, Map.Entry<Boolean, String>> newFields = new HashMap<>(fields.size() + 1);
+        Map<String, Map.Entry<Boolean, String>> newFields = Maps.newMapWithExpectedSize(fields.size() + 1);
         newFields.putAll(fields);
         newFields.put(field, new AbstractMap.SimpleImmutableEntry<>(hasDocValues, format));
         return new NestedQuery(source(), otherPath, unmodifiableMap(newFields), child);

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQueryTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/NestedQueryTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ql.querydsl.query;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -15,7 +16,6 @@ import org.elasticsearch.xpack.ql.util.StringUtils;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -42,7 +42,7 @@ public class NestedQueryTests extends ESTestCase {
 
     private static Map<String, Map.Entry<Boolean, String>> randomFields() {
         int size = between(0, 5);
-        Map<String, Map.Entry<Boolean, String>> fields = new HashMap<>(size);
+        Map<String, Map.Entry<Boolean, String>> fields = Maps.newMapWithExpectedSize(size);
         while (fields.size() < size) {
             fields.put(randomAlphaOfLength(5), new SimpleImmutableEntry<>(randomBoolean(), null));
         }

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
@@ -60,7 +61,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -317,10 +317,10 @@ public final class TestUtils {
 
     public static Map<String, Object> randomRuntimeMappings() {
         int count = between(1, 100);
-        Map<String, Object> runtimeFields = new HashMap<>(count);
+        Map<String, Object> runtimeFields = Maps.newMapWithExpectedSize(count);
         while (runtimeFields.size() < count) {
             int size = between(1, 10);
-            Map<String, Object> config = new HashMap<>(size);
+            Map<String, Object> config = Maps.newMapWithExpectedSize(size);
             while (config.size() < size) {
                 config.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.Tuple;
@@ -706,7 +707,7 @@ public class EncryptedRepository extends BlobStoreRepository {
         @Override
         public Map<String, BlobContainer> children() throws IOException {
             final Map<String, BlobContainer> childEncryptedBlobContainers = delegatedBlobContainer.children();
-            final Map<String, BlobContainer> resultBuilder = new HashMap<>(childEncryptedBlobContainers.size());
+            final Map<String, BlobContainer> resultBuilder = Maps.newMapWithExpectedSize(childEncryptedBlobContainers.size());
             for (Map.Entry<String, BlobContainer> childBlobContainer : childEncryptedBlobContainers.entrySet()) {
                 if (childBlobContainer.getKey().equals(DEK_ROOT_CONTAINER) && path().parts().isEmpty()) {
                     // do not descend into the DEK blob container

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/IndexerUtils.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/IndexerUtils.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
@@ -23,7 +24,6 @@ import org.elasticsearch.xpack.core.rollup.job.RollupIndexerJobStats;
 import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -65,7 +65,7 @@ class IndexerUtils {
             List<Aggregation> metrics = b.getAggregations().asList();
 
             RollupIDGenerator idGenerator = new RollupIDGenerator(jobId);
-            Map<String, Object> doc = new HashMap<>(keys.size() + metrics.size());
+            Map<String, Object> doc = Maps.newMapWithExpectedSize(keys.size() + metrics.size());
 
             processKeys(keys, doc, b.getDocCount(), groupConfig, idGenerator);
             idGenerator.add(jobId);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexService;
@@ -265,7 +266,7 @@ class RollupShardIndexer {
 
     private void indexBucket(BucketKey key, List<FieldMetricsProducer> fieldsMetrics, int docCount) {
         IndexRequestBuilder request = client.prepareIndex(tmpIndex);
-        Map<String, Object> doc = new HashMap<>(2 + key.groupFields.size() + fieldsMetrics.size());
+        Map<String, Object> doc = Maps.newMapWithExpectedSize(2 + key.groupFields.size() + fieldsMetrics.size());
         doc.put(DocCountFieldMapper.NAME, docCount);
         doc.put(timestampField.name(), timestampFormat.format(key.timestamp));
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -76,7 +77,6 @@ import org.elasticsearch.xpack.core.rollup.RollupField;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -167,7 +167,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         InternalFilter filter = mock(InternalFilter.class);
 
         List<InternalAggregation> subaggs = new ArrayList<>(2);
-        Map<String, Object> metadata = new HashMap<>(1);
+        Map<String, Object> metadata = Maps.newMapWithExpectedSize(1);
         metadata.put(RollupField.ROLLUP_META + "." + RollupField.COUNT_FIELD, "foo." + RollupField.COUNT_FIELD);
         InternalSum sum = mock(InternalSum.class);
         when(sum.getValue()).thenReturn(10.0);
@@ -282,7 +282,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         InternalFilter filter = mock(InternalFilter.class);
 
         List<InternalAggregation> subaggs = new ArrayList<>(2);
-        Map<String, Object> metadata = new HashMap<>(1);
+        Map<String, Object> metadata = Maps.newMapWithExpectedSize(1);
         metadata.put(RollupField.ROLLUP_META + "." + RollupField.COUNT_FIELD, "foo." + RollupField.COUNT_FIELD);
         InternalSum sum = mock(InternalSum.class);
         when(sum.getValue()).thenReturn(10.0);
@@ -434,7 +434,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         InternalFilter filter = mock(InternalFilter.class);
 
         List<InternalAggregation> subaggs = new ArrayList<>(2);
-        Map<String, Object> metadata = new HashMap<>(1);
+        Map<String, Object> metadata = Maps.newMapWithExpectedSize(1);
         metadata.put(RollupField.ROLLUP_META + "." + RollupField.COUNT_FIELD, "foo." + RollupField.COUNT_FIELD);
         InternalSum sum = mock(InternalSum.class);
         when(sum.getValue()).thenReturn(10.0);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetJobsActionRequestTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetJobsActionRequestTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
@@ -18,7 +19,6 @@ import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction.Request;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class GetJobsActionRequestTests extends AbstractWireSerializingTestCase<Request> {
@@ -105,7 +105,7 @@ public class GetJobsActionRequestTests extends AbstractWireSerializingTestCase<R
         GetRollupJobsAction.Request request = new GetRollupJobsAction.Request("_all");
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random(), "foo"), Collections.emptyMap());
         RollupJob job2 = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random(), "bar"), Collections.emptyMap());
-        Map<String, PersistentTasksCustomMetadata.PersistentTask<?>> tasks = new HashMap<>(2);
+        Map<String, PersistentTasksCustomMetadata.PersistentTask<?>> tasks = Maps.newMapWithExpectedSize(2);
         tasks.put("foo", new PersistentTasksCustomMetadata.PersistentTask<>("foo", RollupJob.NAME, job, 1, null));
         tasks.put("bar", new PersistentTasksCustomMetadata.PersistentTask<>("bar", RollupJob.NAME, job2, 1, null));
         ClusterState state = ClusterState.builder(new ClusterName("_name"))

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupCapsActionRequestTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupCapsActionRequestTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
@@ -106,7 +107,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
         String indexPattern = randomBoolean() ? randomAlphaOfLength(10) : randomAlphaOfLength(10) + "-*";
 
         int num = randomIntBetween(1, 5);
-        Map<String, Object> jobs = new HashMap<>(num);
+        Map<String, Object> jobs = Maps.newMapWithExpectedSize(num);
         for (int i = 0; i < num; i++) {
             String jobName = randomAlphaOfLength(5);
             jobs.put(jobName, ConfigTestHelpers.randomRollupJobConfig(random(), jobName));
@@ -139,7 +140,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
-            Map<String, Object> jobs = new HashMap<>(num);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(num);
             for (int i = 0; i < num; i++) {
                 String jobName = randomAlphaOfLength(10);
                 String indexName = Integer.toString(indexCounter);
@@ -174,7 +175,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
                 selectedIndexName = indexName;
             }
 
-            Map<String, Object> jobs = new HashMap<>(num);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(num);
             for (int i = 0; i < num; i++) {
                 String jobName = randomAlphaOfLength(5);
                 jobs.put(jobName, ConfigTestHelpers.randomRollupJobConfig(random(), jobName, indexName));
@@ -220,7 +221,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
         String jobName = randomAlphaOfLength(5);
         RollupJobConfig job = ConfigTestHelpers.randomRollupJobConfig(random(), jobName);
 
-        Map<String, Object> metaMap = new HashMap<>(2);
+        Map<String, Object> metaMap = Maps.newMapWithExpectedSize(2);
         metaMap.put("foo", Collections.singletonMap("bar", "baz"));
         metaMap.put(RollupField.ROLLUP_META, Collections.singletonMap(jobName, job));
 
@@ -244,10 +245,10 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
         int numUnrelated = randomIntBetween(0, 10);
         for (int i = 0; i < numUnrelated; i++) {
             int numFields = randomIntBetween(0, 5);
-            Map<String, Object> fields = new HashMap<>(numFields);
+            Map<String, Object> fields = Maps.newMapWithExpectedSize(numFields);
             for (int j = 0; j < numFields; j++) {
                 int numFields2 = randomIntBetween(0, 2);
-                Map<String, String> fields2 = new HashMap<>(numFields2);
+                Map<String, String> fields2 = Maps.newMapWithExpectedSize(numFields2);
                 for (int k = 0; k < numFields; k++) {
                     fields2.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
                 }
@@ -257,7 +258,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
         }
 
         int numJobs = randomIntBetween(1, 5);
-        Map<String, Object> jobs = new HashMap<>(numJobs);
+        Map<String, Object> jobs = Maps.newMapWithExpectedSize(numJobs);
         for (int i = 0; i < numJobs; i++) {
             String name = randomAlphaOfLength(5);
             jobs.put(name, ConfigTestHelpers.randomRollupJobConfig(random(), name));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupIndexCapsActionRequestTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupIndexCapsActionRequestTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
@@ -21,7 +22,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.rollup.action.TransportGetRollupIndexCapsAction.getCapsByRollupIndex;
@@ -54,7 +54,7 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
-            Map<String, Object> jobs = new HashMap<>(num);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(num);
             for (int i = 0; i < num; i++) {
                 String jobName = randomAlphaOfLength(10);
                 String indexName = Integer.toString(indexCounter);
@@ -84,7 +84,7 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
-            Map<String, Object> jobs = new HashMap<>(1);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(1);
             String jobName = randomAlphaOfLength(10);
             String indexName = Integer.toString(indexCounter);
             indexCounter += 1;
@@ -112,7 +112,7 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
-            Map<String, Object> jobs = new HashMap<>(1);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(1);
             String jobName = randomAlphaOfLength(10);
             String indexName = Integer.toString(indexCounter);
             indexCounter += 1;
@@ -142,7 +142,7 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
-            Map<String, Object> jobs = new HashMap<>(1);
+            Map<String, Object> jobs = Maps.newMapWithExpectedSize(1);
             String jobName = randomAlphaOfLength(10);
             String indexName = Integer.toString(indexCounter);
             indexCounter += 1;

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -37,7 +38,6 @@ import org.elasticsearch.xpack.rollup.Rollup;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -242,7 +242,7 @@ public class PutJobStateMachineTests extends ESTestCase {
         ArgumentCaptor<ActionListener> requestCaptor = ArgumentCaptor.forClass(ActionListener.class);
         doAnswer(invocation -> {
             GetMappingsResponse response = mock(GetMappingsResponse.class);
-            Map<String, Object> m = new HashMap<>(2);
+            Map<String, Object> m = Maps.newMapWithExpectedSize(2);
             m.put("random", Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
@@ -278,7 +278,7 @@ public class PutJobStateMachineTests extends ESTestCase {
         ArgumentCaptor<ActionListener> requestCaptor = ArgumentCaptor.forClass(ActionListener.class);
         doAnswer(invocation -> {
             GetMappingsResponse response = mock(GetMappingsResponse.class);
-            Map<String, Object> m = new HashMap<>(2);
+            Map<String, Object> m = Maps.newMapWithExpectedSize(2);
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
@@ -314,7 +314,7 @@ public class PutJobStateMachineTests extends ESTestCase {
         ArgumentCaptor<ActionListener> requestCaptor = ArgumentCaptor.forClass(ActionListener.class);
         doAnswer(invocation -> {
             GetMappingsResponse response = mock(GetMappingsResponse.class);
-            Map<String, Object> m = new HashMap<>(2);
+            Map<String, Object> m = Maps.newMapWithExpectedSize(2);
             m.put(Rollup.ROLLUP_TEMPLATE_VERSION_FIELD, VersionUtils.randomIndexCompatibleVersion(random()));
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
@@ -358,7 +358,7 @@ public class PutJobStateMachineTests extends ESTestCase {
         ArgumentCaptor<ActionListener> requestCaptor = ArgumentCaptor.forClass(ActionListener.class);
         doAnswer(invocation -> {
             GetMappingsResponse response = mock(GetMappingsResponse.class);
-            Map<String, Object> m = new HashMap<>(2);
+            Map<String, Object> m = Maps.newMapWithExpectedSize(2);
             m.put(Rollup.ROLLUP_TEMPLATE_VERSION_FIELD, VersionUtils.randomIndexCompatibleVersion(random()));
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(unrelatedJob.getId(), unrelatedJob));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
@@ -63,7 +64,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -718,7 +718,7 @@ public class SearchActionTests extends ESTestCase {
         InternalFilter filter = mock(InternalFilter.class);
 
         List<InternalAggregation> subaggs = new ArrayList<>(2);
-        Map<String, Object> metadata = new HashMap<>(1);
+        Map<String, Object> metadata = Maps.newMapWithExpectedSize(1);
         metadata.put(RollupField.ROLLUP_META + "." + RollupField.COUNT_FIELD, "foo." + RollupField.COUNT_FIELD);
         InternalSum sum = mock(InternalSum.class);
         when(sum.getValue()).thenReturn(10.0);
@@ -850,7 +850,7 @@ public class SearchActionTests extends ESTestCase {
         InternalFilter filter = mock(InternalFilter.class);
 
         List<InternalAggregation> subaggs = new ArrayList<>(2);
-        Map<String, Object> metadata = new HashMap<>(1);
+        Map<String, Object> metadata = Maps.newMapWithExpectedSize(1);
         metadata.put(RollupField.ROLLUP_META + "." + RollupField.COUNT_FIELD, "foo." + RollupField.COUNT_FIELD);
         InternalSum sum = mock(InternalSum.class);
         when(sum.getValue()).thenReturn(10.0);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelperTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelperTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.rollup.action;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
@@ -14,7 +15,6 @@ import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -79,7 +79,7 @@ public class TransportTaskHelperTests extends ESTestCase {
 
     private Map<Long, Task> getRandomTasks() {
         int num = randomIntBetween(1, 10);
-        Map<Long, Task> tasks = new HashMap<>(num);
+        Map<Long, Task> tasks = Maps.newMapWithExpectedSize(num);
         for (int i = 0; i < num; i++) {
             Long taskId = randomLongBetween(10, Long.MAX_VALUE);
             tasks.put(

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.rollup.config;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
@@ -18,7 +19,6 @@ import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
 
 import java.time.ZoneId;
 import java.time.zone.ZoneRulesException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -126,7 +126,7 @@ public class ConfigTests extends ESTestCase {
     }
 
     public void testNoHeadersInJSON() {
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(2);
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
         RollupJob job = new RollupJob(randomRollupJobConfig(random()), headers);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTaskState;
@@ -39,7 +40,6 @@ import org.junit.Before;
 
 import java.time.Clock;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -681,7 +681,7 @@ public class RollupJobTaskTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void testTriggerWithHeaders() throws Exception {
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), headers);
@@ -786,7 +786,7 @@ public class RollupJobTaskTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void testSaveStateChangesIDScheme() throws Exception {
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        Map<String, String> headers = new HashMap<>(1);
+        Map<String, String> headers = Maps.newMapWithExpectedSize(1);
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), headers);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -406,7 +407,9 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                 ActionListener.runAfter(new ActionListener<>() {
                     @Override
                     public void onResponse(NodesCacheFilesMetadata nodesCacheFilesMetadata) {
-                        final Map<DiscoveryNode, NodeCacheFilesMetadata> res = new HashMap<>(nodesCacheFilesMetadata.getNodesMap().size());
+                        final Map<DiscoveryNode, NodeCacheFilesMetadata> res = Maps.newMapWithExpectedSize(
+                            nodesCacheFilesMetadata.getNodesMap().size()
+                        );
                         for (Map.Entry<String, NodeCacheFilesMetadata> entry : nodesCacheFilesMetadata.getNodesMap().entrySet()) {
                             res.put(nodes.get(entry.getKey()), entry.getValue());
                         }
@@ -421,7 +424,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                     @Override
                     public void onFailure(Exception e) {
                         logger.warn("Failure when trying to fetch existing cache sizes", e);
-                        final Map<DiscoveryNode, NodeCacheFilesMetadata> res = new HashMap<>(dataNodes.length);
+                        final Map<DiscoveryNode, NodeCacheFilesMetadata> res = Maps.newMapWithExpectedSize(dataNodes.length);
                         for (DiscoveryNode dataNode : dataNodes) {
                             res.put(dataNode, new NodeCacheFilesMetadata(dataNode, 0L));
                         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.PathUtils;
@@ -544,7 +545,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 if (randomBoolean()) {
                     writer.forceMerge(1, true);
                 }
-                final Map<String, String> userData = new HashMap<>(2);
+                final Map<String, String> userData = Maps.newMapWithExpectedSize(2);
                 userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, "0");
                 userData.put(Translog.TRANSLOG_UUID_KEY, UUIDs.randomBase64UUID(random()));
                 writer.setLiveCommitData(userData.entrySet());

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.ssl.PemUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.env.Environment;
@@ -64,7 +65,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -493,7 +493,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
     }
 
     private Map<String, String> buildSubstitutions(Environment env, Map<String, String> entries) {
-        final Map<String, String> map = new HashMap<>(entries.size() + 4);
+        final Map<String, String> map = Maps.newMapWithExpectedSize(entries.size() + 4);
         ZonedDateTime now = ZonedDateTime.now().withNano(0);
         map.put("DATE", now.format(DateTimeFormatter.ISO_LOCAL_DATE));
         map.put("TIME", now.format(DateTimeFormatter.ISO_OFFSET_TIME));

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.PemUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -141,7 +142,7 @@ public class CertificateGenerateToolTests extends ESTestCase {
 
     public void testPromptingForInstanceInformation() throws Exception {
         final int numberOfInstances = scaledRandomIntBetween(1, 12);
-        Map<String, Map<String, String>> instanceInput = new HashMap<>(numberOfInstances);
+        Map<String, Map<String, String>> instanceInput = Maps.newMapWithExpectedSize(numberOfInstances);
         for (int i = 0; i < numberOfInstances; i++) {
             final String name;
             while (true) {

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.KeyStoreUtil;
 import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -164,7 +165,7 @@ public class CertificateToolTests extends ESTestCase {
 
     public void testPromptingForInstanceInformation() throws Exception {
         final int numberOfInstances = scaledRandomIntBetween(1, 12);
-        Map<String, Map<String, String>> instanceInput = new HashMap<>(numberOfInstances);
+        Map<String, Map<String, String>> instanceInput = Maps.newMapWithExpectedSize(numberOfInstances);
         for (int i = 0; i < numberOfInstances; i++) {
             final String name;
             while (true) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/core/security/transport/ProfileConfigurations.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/core/security/transport/ProfileConfigurations.java
@@ -8,10 +8,10 @@ package org.elasticsearch.xpack.core.security.transport;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,7 +23,7 @@ public final class ProfileConfigurations {
 
     public static Map<String, SslConfiguration> get(Settings settings, SSLService sslService, SslConfiguration defaultConfiguration) {
         Set<String> profileNames = settings.getGroups("transport.profiles.", true).keySet();
-        Map<String, SslConfiguration> profileConfiguration = new HashMap<>(profileNames.size() + 1);
+        Map<String, SslConfiguration> profileConfiguration = Maps.newMapWithExpectedSize(profileNames.size() + 1);
         for (String profileName : profileNames) {
             if (profileName.equals(TransportSettings.DEFAULT_PROFILE)) {
                 // don't attempt to parse ssl settings from the profile;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.license.XPackLicenseState;
@@ -35,7 +36,6 @@ import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -167,7 +167,7 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
         // If security has been explicitly disabled in the settings, then SSL is also explicitly disabled, and we don't want to report
         // these http/transport settings as they would be misleading (they could report `true` even though they were ignored)
         if (XPackSettings.SECURITY_ENABLED.get(settings)) {
-            Map<String, Object> map = new HashMap<>(2);
+            Map<String, Object> map = Maps.newMapWithExpectedSize(2);
             map.put("http", singletonMap("enabled", HTTP_SSL_ENABLED.get(settings)));
             map.put("transport", singletonMap("enabled", TRANSPORT_SSL_ENABLED.get(settings)));
             return map;
@@ -185,7 +185,7 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
     }
 
     static Map<String, Object> auditUsage(Settings settings) {
-        Map<String, Object> map = new HashMap<>(2);
+        Map<String, Object> map = Maps.newMapWithExpectedSize(2);
         map.put("enabled", XPackSettings.AUDIT_ENABLED.get(settings));
         if (XPackSettings.AUDIT_ENABLED.get(settings)) {
             // the only available output type is "logfile", but the optputs=<list> is to keep compatibility with previous reporting format

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
@@ -432,7 +433,7 @@ public class Realms implements Iterable<Realm> {
     }
 
     private static Map<String, Object> convertToMapOfLists(Map<String, Object> map) {
-        Map<String, Object> converted = new HashMap<>(map.size());
+        Map<String, Object> converted = Maps.newMapWithExpectedSize(map.size());
         for (Entry<String, Object> entry : map.entrySet()) {
             converted.put(entry.getKey(), new ArrayList<>(Collections.singletonList(entry.getValue())));
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -61,6 +61,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.iterable.Iterables;
@@ -2344,7 +2345,7 @@ public final class TokenService {
         if (keyCache.cache.size() <= numKeysToKeep) {
             return getTokenMetadata(); // nothing to do
         }
-        Map<BytesKey, KeyAndCache> map = new HashMap<>(keyCache.cache.size() + 1);
+        Map<BytesKey, KeyAndCache> map = Maps.newMapWithExpectedSize(keyCache.cache.size() + 1);
         KeyAndCache currentKey = keyCache.get(keyCache.currentTokenKeyHash);
         ArrayList<KeyAndCache> entries = new ArrayList<>(keyCache.cache.values());
         Collections.sort(entries, (left, right) -> Long.compare(right.keyAndTimestamp.getTimestamp(), left.keyAndTimestamp.getTimestamp()));
@@ -2382,7 +2383,7 @@ public final class TokenService {
     synchronized void refreshMetadata(TokenMetadata metadata) {
         BytesKey currentUsedKeyHash = new BytesKey(metadata.getCurrentKeyHash());
         byte[] saltArr = new byte[SALT_BYTES];
-        Map<BytesKey, KeyAndCache> map = new HashMap<>(metadata.getKeys().size());
+        Map<BytesKey, KeyAndCache> map = Maps.newMapWithExpectedSize(metadata.getKeys().size());
         long maxTimestamp = createdTimeStamps.get();
         for (KeyAndTimestamp key : metadata.getKeys()) {
             secureRandom.nextBytes(saltArr);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/tool/UsersTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/tool/UsersTool.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -291,7 +292,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
             roles.addAll(Arrays.asList(addRoles));
             roles.removeAll(Arrays.asList(removeRoles));
 
-            Map<String, String[]> userRolesToWrite = new HashMap<>(userRoles.size());
+            Map<String, String[]> userRolesToWrite = Maps.newMapWithExpectedSize(userRoles.size());
             userRolesToWrite.putAll(userRoles);
             if (roles.isEmpty()) {
                 userRolesToWrite.remove(username);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
@@ -120,7 +121,7 @@ public class FileRolesStore implements BiConsumer<Set<String>, ActionListener<Ro
 
     public Map<String, Object> usageStats() {
         final Map<String, RoleDescriptor> localPermissions = permissions;
-        Map<String, Object> usageStats = new HashMap<>(3);
+        Map<String, Object> usageStats = Maps.newMapWithExpectedSize(3);
         usageStats.put("size", localPermissions.size());
 
         boolean dls = false;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -51,7 +52,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -255,7 +255,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
     }
 
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        Map<String, Object> usageStats = new HashMap<>(3);
+        Map<String, Object> usageStats = Maps.newMapWithExpectedSize(3);
         if (securityIndex.isAvailable() == false) {
             usageStats.put("size", 0L);
             usageStats.put("fls", false);
@@ -427,7 +427,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
                 if (dlsEnabled) {
                     unlicensedFeatures.add("dls");
                 }
-                Map<String, Object> transientMap = new HashMap<>(2);
+                Map<String, Object> transientMap = Maps.newMapWithExpectedSize(2);
                 transientMap.put("unlicensed_features", unlicensedFeatures);
                 transientMap.put("enabled", false);
                 return new RoleDescriptor(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -41,7 +42,6 @@ import org.elasticsearch.xpack.security.authz.AuthorizationService;
 import org.elasticsearch.xpack.security.authz.AuthorizationUtils;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.setting;
@@ -194,7 +194,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
         final SslConfiguration sslConfiguration = sslService.getSSLConfiguration(setting("transport.ssl"));
         final Map<String, SslConfiguration> profileConfigurations = ProfileConfigurations.get(settings, sslService, sslConfiguration);
 
-        Map<String, ServerTransportFilter> profileFilters = new HashMap<>(profileConfigurations.size() + 1);
+        Map<String, ServerTransportFilter> profileFilters = Maps.newMapWithExpectedSize(profileConfigurations.size() + 1);
 
         final boolean transportSSLEnabled = XPackSettings.TRANSPORT_SSL_ENABLED.get(settings);
         for (Map.Entry<String, SslConfiguration> entry : profileConfigurations.entrySet()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.xpack.security.Security;
@@ -221,7 +222,7 @@ public class IPFilter {
     }
 
     public Map<String, Object> usageStats() {
-        Map<String, Object> map = new HashMap<>(2);
+        Map<String, Object> map = Maps.newMapWithExpectedSize(2);
         final boolean httpFilterEnabled = isHttpFilterEnabled && (httpAllowFilter.isEmpty() == false || httpDenyFilter.isEmpty() == false);
         final boolean transportFilterEnabled = isIpFilterEnabled
             && (transportAllowFilter.isEmpty() == false || transportDenyFilter.isEmpty() == false);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
@@ -213,7 +214,7 @@ public class SetupPasswordToolTests extends CommandTestCase {
         URL checkUrl = authenticateUrl(url);
         inOrder.verify(httpClient)
             .execute(eq("GET"), eq(checkUrl), eq(ElasticUser.NAME), eq(bootstrapPassword), anyCheckedSupplier(), anyCheckedFunction());
-        Map<String, String> capturedPasswords = new HashMap<>(usersInSetOrder.size());
+        Map<String, String> capturedPasswords = Maps.newMapWithExpectedSize(usersInSetOrder.size());
         for (String user : usersInSetOrder) {
             URL urlWithRoute = passwordUrl(url, user);
             @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoLineMultiValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoLineMultiValuesSource.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.spatial.search.aggregations.support;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -16,12 +17,11 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class GeoLineMultiValuesSource extends MultiValuesSource<ValuesSource> {
     public GeoLineMultiValuesSource(Map<String, ValuesSourceConfig> valuesSourceConfigs) {
-        values = new HashMap<>(valuesSourceConfigs.size());
+        values = Maps.newMapWithExpectedSize(valuesSourceConfigs.size());
         for (Map.Entry<String, ValuesSourceConfig> entry : valuesSourceConfigs.entrySet()) {
             final ValuesSource valuesSource = entry.getValue().getValuesSource();
             if (valuesSource instanceof ValuesSource.Numeric == false && valuesSource instanceof ValuesSource.GeoPoint == false) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Point;
@@ -39,7 +40,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -202,7 +202,7 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("group_id")
             .subAggregation(lineAggregationBuilder);
 
-        Map<String, InternalGeoLine> lines = new HashMap<>(1);
+        Map<String, InternalGeoLine> lines = Maps.newMapWithExpectedSize(1);
         String groupOrd = "0";
         long[] points = new long[numPoints];
         double[] sortValues = new double[numPoints];
@@ -275,9 +275,9 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
             .subAggregation(lineAggregationBuilder);
 
         int numGroups = randomIntBetween(1, 2);
-        Map<String, InternalGeoLine> lines = new HashMap<>(numGroups);
-        Map<Integer, long[]> indexedPoints = new HashMap<>(numGroups);
-        Map<Integer, double[]> indexedSortValues = new HashMap<>(numGroups);
+        Map<String, InternalGeoLine> lines = Maps.newMapWithExpectedSize(numGroups);
+        Map<Integer, long[]> indexedPoints = Maps.newMapWithExpectedSize(numGroups);
+        Map<Integer, double[]> indexedSortValues = Maps.newMapWithExpectedSize(numGroups);
         for (int groupOrd = 0; groupOrd < numGroups; groupOrd++) {
             int numPoints = randomIntBetween(2, 2 * size);
             boolean complete = numPoints <= size;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.spatial.search.aggregations;
 
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
@@ -75,7 +76,7 @@ public class InternalGeoLineTests extends InternalAggregationTestCase<InternalGe
             case 2 -> sortVals[0] = sortVals[0] + 10000;
             case 3 -> {
                 if (metadata == null) {
-                    metadata = new HashMap<>(1);
+                    metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.jdbc;
 
 import org.elasticsearch.SpecialPermission;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.SslConfig;
 import org.elasticsearch.xpack.sql.client.SuppressForbidden;
@@ -19,7 +20,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -275,13 +275,13 @@ public class JdbcConfigurationTests extends ESTestCase {
     }
 
     public void testSSLPropertiesInUrlAndProperties() throws Exception {
-        Map<String, String> urlPropMap = new HashMap<>(4);
+        Map<String, String> urlPropMap = Maps.newMapWithExpectedSize(4);
         urlPropMap.put("ssl", "false");
         urlPropMap.put("ssl.protocol", "SSLv3");
         urlPropMap.put("ssl.keystore.location", "/abc/xyz");
         urlPropMap.put("ssl.keystore.pass", "mypass");
 
-        Map<String, String> propMap = new HashMap<>(4);
+        Map<String, String> propMap = Maps.newMapWithExpectedSize(4);
         propMap.put("ssl.keystore.type", "PKCS12");
         propMap.put("ssl.truststore.location", "/foo/bar");
         propMap.put("ssl.truststore.pass", "anotherpass");
@@ -299,7 +299,7 @@ public class JdbcConfigurationTests extends ESTestCase {
 
     public void testSSLPropertiesOverride() throws Exception {
         Map<String, String> urlPropMap = sslProperties();
-        Map<String, String> propMap = new HashMap<>(8);
+        Map<String, String> propMap = Maps.newMapWithExpectedSize(8);
         propMap.put("ssl", "false");
         propMap.put("ssl.protocol", "TLS");
         propMap.put("ssl.keystore.location", "/xyz");
@@ -360,7 +360,7 @@ public class JdbcConfigurationTests extends ESTestCase {
     }
 
     static Map<String, String> sslProperties() {
-        Map<String, String> sslPropertiesMap = new HashMap<>(8);
+        Map<String, String> sslPropertiesMap = Maps.newMapWithExpectedSize(8);
         // always using "false" so that the SSLContext doesn't actually start verifying the keystore and trustore
         // locations, as we don't have file permissions to access them.
         sslPropertiesMap.put("ssl", "false");

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlSecurityIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.NotEqualMessageBuilder;
@@ -118,7 +119,7 @@ public class RestSqlSecurityIT extends SqlSecurityTestCase {
         @Override
         public void expectDescribe(Map<String, List<String>> columns, String user) throws Exception {
             String mode = randomMode();
-            Map<String, Object> expected = new HashMap<>(3);
+            Map<String, Object> expected = Maps.newMapWithExpectedSize(3);
             expected.put(
                 "columns",
                 Arrays.asList(

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -12,6 +12,7 @@ import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -56,7 +57,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
         boolean enableSource = randomBoolean(); // enable _source at index level
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         createIndexWithFieldTypeAndProperties("text", null, explicitSourceSetting ? indexProps : null);
@@ -85,13 +86,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreAbove = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreAbove) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_above", 10);
             fieldProps.put("keyword_field", fieldProp);
         }
@@ -121,13 +122,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
         boolean enableSource = randomBoolean(); // enable _source at index level
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (randomBoolean()) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("value", value);
             fieldProps.put("constant_keyword_field", fieldProp);
         }
@@ -158,13 +159,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreAbove = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreAbove) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_above", 10);
             fieldProps.put("wildcard_field", fieldProp);
         }
@@ -215,8 +216,8 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (isScaledFloat) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("scaling_factor", 10);            // scaling_factor is required for "scaled_float"
             fieldProps.put(fieldType + "_field", fieldProp);
         }
@@ -288,13 +289,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-number value
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a string instead of a number and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put(fieldName, fieldProp);
@@ -326,7 +327,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean(); // enable _source at index level
         boolean asString = randomBoolean();              // pass true or false as string "true" or "false
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         createIndexWithFieldTypeAndProperties("boolean", null, explicitSourceSetting ? indexProps : null);
@@ -361,13 +362,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-IP and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put("ip_field", fieldProp);
@@ -400,13 +401,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-geo-point and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put("geo_point_field", fieldProp);
@@ -438,13 +439,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-geo-shape and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put("geo_shape_field", fieldProp);
@@ -479,13 +480,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-geo-point and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put("shape_field", fieldProp);
@@ -620,13 +621,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "text_field.keyword_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreAbove) {
-            subFieldsProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            subFieldsProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_above", 10);
             subFieldsProps.put(subFieldName, fieldProp);
         }
@@ -667,8 +668,8 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String function = randomFrom("FIRST", "LAST");
         String query = "select keyword_field from test group by keyword_field order by " + function + "(date)";
 
-        Map<String, Map<String, Object>> fieldProps = new HashMap<>(1);
-        Map<String, Object> fieldProp = new HashMap<>(1);
+        Map<String, Map<String, Object>> fieldProps = Maps.newMapWithExpectedSize(1);
+        Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
         fieldProp.put("ignore_above", 10);
         fieldProps.put("keyword_field", fieldProp);
 
@@ -703,13 +704,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "text_field.integer_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreMalformed) {
-            subFieldsProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            subFieldsProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a string instead of a number and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             subFieldsProps.put(subFieldName, fieldProp);
@@ -762,13 +763,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "text_field.ip_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreMalformed) {
-            subFieldsProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            subFieldsProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-IP value instead of an IP and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             subFieldsProps.put(subFieldName, fieldProp);
@@ -822,13 +823,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "integer_field." + (isKeyword ? "keyword_subfield" : "text_subfield");
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a string instead of a number and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put(fieldName, fieldProp);
@@ -892,13 +893,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "ip_field." + (isKeyword ? "keyword_subfield" : "text_subfield");
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             // on purpose use a non-IP instead of an ip and check for null when querying the field's value
             fieldProp.put("ignore_malformed", true);
             fieldProps.put(fieldName, fieldProp);
@@ -959,20 +960,20 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "integer_field.byte_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (rootIgnoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_malformed", true);
             fieldProps.put(fieldName, fieldProp);
         }
         Map<String, Map<String, Object>> subFieldProps = null;
         if (subFieldIgnoreMalformed) {
-            subFieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            subFieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_malformed", true);
             subFieldProps.put(subFieldName, fieldProp);
         }
@@ -1028,20 +1029,20 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String subFieldName = "byte_field.integer_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
 
-        Map<String, Object> indexProps = new HashMap<>(1);
+        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
         indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (rootIgnoreMalformed) {
-            fieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            fieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_malformed", true);
             fieldProps.put(fieldName, fieldProp);
         }
         Map<String, Map<String, Object>> subFieldProps = null;
         if (subFieldIgnoreMalformed) {
-            subFieldProps = new HashMap<>(1);
-            Map<String, Object> fieldProp = new HashMap<>(1);
+            subFieldProps = Maps.newMapWithExpectedSize(1);
+            Map<String, Object> fieldProp = Maps.newMapWithExpectedSize(1);
             fieldProp.put("ignore_malformed", true);
             subFieldProps.put(subFieldName, fieldProp);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.execution.search;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -71,7 +72,7 @@ class SearchHitRowSet extends ResultRowSet<HitExtractor> {
 
             sz = 0;
             for (SearchHit hit : hits) {
-                Map<String, SearchHit[]> innerHitsPerPath = new HashMap<>(innerHits.size());
+                Map<String, SearchHit[]> innerHitsPerPath = Maps.newMapWithExpectedSize(innerHits.size());
                 for (String ih : innerHits) {
                     SearchHit[] sh = getAllInnerHits(hit, ih);
                     innerHitsPerPath.put(ih, sh);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.analysis.index;
 
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
@@ -331,7 +332,7 @@ public class IndexResolverTests extends ESTestCase {
 
         // each index will have one field with different name than all others
         for (int i = 0; i < indicesCount; i++) {
-            Map<String, EsField> mapping = new HashMap<>(1);
+            Map<String, EsField> mapping = Maps.newMapWithExpectedSize(1);
             String fieldName = "field" + (i + 1);
             mapping.put(fieldName, new KeywordEsField(fieldName));
             expectedIndices[i] = new EsIndex("index" + (i + 1), mapping);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.execution.search.extractor;
 
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
@@ -24,7 +25,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -172,7 +172,7 @@ public class FieldHitExtractorTests extends AbstractSqlWireSerializingTestCase<F
         String fieldName = randomAlphaOfLength(5);
         FieldHitExtractor fe = new FieldHitExtractor(fieldName, randomBoolean() ? GEO_SHAPE : SHAPE, UTC, false);
 
-        Map<String, Object> map = new HashMap<>(2);
+        Map<String, Object> map = Maps.newMapWithExpectedSize(2);
         map.put("coordinates", asList(1d, 2d));
         map.put("type", "Point");
         DocumentField field = new DocumentField(fieldName, singletonList(map));
@@ -185,10 +185,10 @@ public class FieldHitExtractorTests extends AbstractSqlWireSerializingTestCase<F
         String fieldName = randomAlphaOfLength(5);
         FieldHitExtractor fe = new FieldHitExtractor(fieldName, randomBoolean() ? GEO_SHAPE : SHAPE, UTC, false);
 
-        Map<String, Object> map1 = new HashMap<>(2);
+        Map<String, Object> map1 = Maps.newMapWithExpectedSize(2);
         map1.put("coordinates", asList(1d, 2d));
         map1.put("type", "Point");
-        Map<String, Object> map2 = new HashMap<>(2);
+        Map<String, Object> map2 = Maps.newMapWithExpectedSize(2);
         map2.put("coordinates", asList(3d, 4d));
         map2.put("type", "Point");
         DocumentField field = new DocumentField(fieldName, asList(map1, map2));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.Murmur3HashFunction;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexingOperationListener;
@@ -41,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -331,7 +331,7 @@ final class WatcherIndexingListener implements IndexingOperationListener, Cluste
      *   data.put(ShardId(".watch", 0), new Tuple(1, 4))
      */
     Map<ShardId, ShardAllocationConfiguration> getLocalShardAllocationIds(List<ShardRouting> localShards, IndexRoutingTable routingTable) {
-        Map<ShardId, ShardAllocationConfiguration> data = new HashMap<>(localShards.size());
+        Map<ShardId, ShardAllocationConfiguration> data = Maps.newMapWithExpectedSize(localShards.size());
 
         for (ShardRouting shardRouting : localShards) {
             ShardId shardId = shardRouting.shardId();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.routing.Preference;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
@@ -50,7 +51,6 @@ import org.elasticsearch.xpack.watcher.watch.WatchStoreUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -346,7 +346,7 @@ public class WatcherService {
                 return Collections.emptyList();
             }
 
-            Map<Integer, List<String>> sortedShards = new HashMap<>(localShards.size());
+            Map<Integer, List<String>> sortedShards = Maps.newMapWithExpectedSize(localShards.size());
             for (ShardRouting localShardRouting : localShards) {
                 List<String> sortedAllocationIds = watchIndexShardRoutings.stream()
                     .filter(sr -> localShardRouting.getId() == sr.getId())

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -51,6 +51,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.core.internal.io.Streams;
@@ -71,7 +72,6 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -268,7 +268,7 @@ public class HttpClient implements Closeable {
         try (CloseableHttpResponse response = SocketAccess.doPrivileged(() -> client.execute(httpHost, internalRequest, localContext))) {
             // headers
             Header[] headers = response.getAllHeaders();
-            Map<String, String[]> responseHeaders = new HashMap<>(headers.length);
+            Map<String, String[]> responseHeaders = Maps.newMapWithExpectedSize(headers.length);
             for (Header header : headers) {
                 if (responseHeaders.containsKey(header.getName())) {
                     String[] old = responseHeaders.get(header.getName());

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
@@ -28,7 +29,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,7 +59,7 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
     @Override
     public synchronized void start(Collection<Watch> jobs) {
         long startTime = clock.millis();
-        Map<String, ActiveSchedule> startingSchedules = new HashMap<>(jobs.size());
+        Map<String, ActiveSchedule> startingSchedules = Maps.newMapWithExpectedSize(jobs.size());
         for (Watch job : jobs) {
             if (job.trigger()instanceof ScheduleTrigger trigger) {
                 startingSchedules.put(job.id(), new ActiveSchedule(job.id(), trigger.getSchedule(), startTime));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -450,7 +451,7 @@ public class EmailActionTests extends ESTestCase {
         String attachmentId = "my_attachment";
 
         // setup mock response
-        Map<String, String[]> headers = new HashMap<>(1);
+        Map<String, String[]> headers = Maps.newMapWithExpectedSize(1);
         headers.put(HttpHeaders.Names.CONTENT_TYPE, new String[] { "plain/text" });
         String content = "My wonderful text";
         HttpResponse mockResponse = new HttpResponse(200, content, headers);
@@ -539,7 +540,7 @@ public class EmailActionTests extends ESTestCase {
         HttpClient httpClient = mock(HttpClient.class);
 
         // setup mock response, second one is an error
-        Map<String, String[]> headers = new HashMap<>(1);
+        Map<String, String[]> headers = Maps.newMapWithExpectedSize(1);
         headers.put(HttpHeaders.Names.CONTENT_TYPE, new String[] { "plain/text" });
         when(httpClient.execute(any(HttpRequest.class))).thenReturn(new HttpResponse(200, "body", headers))
             .thenReturn(new HttpResponse(403));
@@ -623,7 +624,7 @@ public class EmailActionTests extends ESTestCase {
 
         String attachmentType = randomFrom("http", "data", null);
         if ("http".equals(attachmentType)) {
-            Map<String, String[]> headers = new HashMap<>(1);
+            Map<String, String[]> headers = Maps.newMapWithExpectedSize(1);
             headers.put(HttpHeaders.Names.CONTENT_TYPE, new String[] { "plain/text" });
             String content = "My wonderful text";
             HttpResponse mockResponse = new HttpResponse(200, content, headers);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.watcher.condition;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -24,7 +25,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -124,7 +124,7 @@ public class ArrayCompareConditionTests extends ESTestCase {
         }
         List<Object> values = new ArrayList<>(numberOfValues);
         for (int i = 0; i < numberOfValues; i++) {
-            Map<String, Object> map = new HashMap<>(1);
+            Map<String, Object> map = Maps.newMapWithExpectedSize(1);
             map.put("doc_count", docCounts.get(i));
             values.add(map);
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/http/HttpInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/http/HttpInputTests.java
@@ -11,6 +11,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -279,7 +280,7 @@ public class HttpInputTests extends ESTestCase {
         HttpInput httpInput = new HttpInput(template, HttpContentType.TEXT, null);
         ExecutableHttpInput input = new ExecutableHttpInput(httpInput, httpClient, templateEngine);
 
-        Map<String, String[]> headers = new HashMap<>(1);
+        Map<String, String[]> headers = Maps.newMapWithExpectedSize(1);
         String contentType = randomFrom(
             "application/json",
             "application/json;charset=utf-8",

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -545,7 +546,7 @@ public class ReportingAttachmentParserTests extends ESTestCase {
         String reportId = randomAlphaOfLength(5);
         Map<String, String[]> headers = new HashMap<>();
         headers.put("Content-Type", new String[] { randomContentType });
-        Map<String, String> customWarnings = new HashMap<>(WARNINGS.size());
+        Map<String, String> customWarnings = Maps.newMapWithExpectedSize(WARNINGS.size());
         WARNINGS.keySet().forEach((k) -> {
             final String warning = randomAlphaOfLength(20);
             customWarnings.put(k, warning);
@@ -583,7 +584,7 @@ public class ReportingAttachmentParserTests extends ESTestCase {
         String reportId = randomAlphaOfLength(5);
         Map<String, String[]> headers = new HashMap<>();
         headers.put("Content-Type", new String[] { randomContentType });
-        Map<String, String> customWarnings = new HashMap<>(WARNINGS.size());
+        Map<String, String> customWarnings = Maps.newMapWithExpectedSize(WARNINGS.size());
         WARNINGS.keySet().forEach((k) -> {
             // add a parameter
             final String warning = randomAlphaOfLength(20) + " %s";
@@ -627,7 +628,7 @@ public class ReportingAttachmentParserTests extends ESTestCase {
         String reportId = randomAlphaOfLength(5);
         Map<String, String[]> headers = new HashMap<>();
         headers.put("Content-Type", new String[] { randomContentType });
-        Map<String, String> customWarnings = new HashMap<>(WARNINGS.size());
+        Map<String, String> customWarnings = Maps.newMapWithExpectedSize(WARNINGS.size());
         WARNINGS.keySet().forEach((k) -> {
             final String warning = randomAlphaOfLength(20);
             customWarnings.put(k, warning);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.searchable_snapshots.MountSnapshotRequest.Storag
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.indices.ShardLimitValidator;
 import org.elasticsearch.repositories.fs.FsRepository;
@@ -25,7 +26,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -367,7 +367,7 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
         final Map<String, Object> nodes = (Map<String, Object>) extractValue(responseAsMap(response), "nodes");
         assertNotNull("Nodes info is null", nodes);
-        final Map<String, Version> nodesVersions = new HashMap<>(nodes.size());
+        final Map<String, Version> nodesVersions = Maps.newMapWithExpectedSize(nodes.size());
         for (Map.Entry<String, Object> node : nodes.entrySet()) {
             nodesVersions.put(node.getKey(), Version.fromString((String) extractValue((Map<?, ?>) node.getValue(), "version")));
         }


### PR DESCRIPTION
Backports #82670 to 8.0

----

The HashMap(int) constructor doesn't accept the size, but rather the capacity of the map. Unfortunately, the HashMap requires N/0.75 capacity to hold N elements. So, if we call `new HashMap(N)` to hold N elements, the map will be too small and need to be resized/rehashed
midway. We add a new method `Maps.newMapWithExpectedSize` which calculates the correct capacity
for the specified expected size

See:

* https://stackoverflow.com/questions/52671362/why-does-hashmap-resize-again-when-specifying-a-precise-capacity
* https://stackoverflow.com/questions/30220820/difference-between-new-hashmapint-and-guava-maps-newhashmapwithexpectedsizein
* https://bugs.openjdk.java.net/browse/JDK-8186958