### PR TITLE
[8.0] Fix getBuildPluginFile for examples and thirdparty build (#82730)

### DIFF
--- a/build-tools-internal/src/main/resources/roles.yml
+++ b/build-tools-internal/src/main/resources/roles.yml
@@ -1,7 +1,0 @@
-_root:
-    cluster: [ "ALL" ]
-    indices:
-        - names: [ "*" ]
-          allow_restricted_indices: true
-          privileges: [ "ALL" ]
-    run_as: [ "*" ]

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -17,6 +17,7 @@ import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
@@ -51,6 +52,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     private final String path;
     private final String clusterName;
     private final NamedDomainObjectContainer<ElasticsearchNode> nodes;
+    private final FileOperations fileOperations;
     private final File workingDirBase;
     private final LinkedHashMap<String, Predicate<TestClusterConfiguration>> waitConditions = new LinkedHashMap<>();
     private final Project project;
@@ -69,6 +71,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         FileSystemOperations fileSystemOperations,
         ArchiveOperations archiveOperations,
         ExecOperations execOperations,
+        FileOperations fileOperations,
         File workingDirBase,
         Provider<File> runtimeJava
     ) {
@@ -79,6 +82,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         this.fileSystemOperations = fileSystemOperations;
         this.archiveOperations = archiveOperations;
         this.execOperations = execOperations;
+        this.fileOperations = fileOperations;
         this.workingDirBase = workingDirBase;
         this.runtimeJava = runtimeJava;
         this.nodes = project.container(ElasticsearchNode.class);
@@ -92,6 +96,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                 fileSystemOperations,
                 archiveOperations,
                 execOperations,
+                fileOperations,
                 workingDirBase,
                 runtimeJava
             )
@@ -124,6 +129,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                     fileSystemOperations,
                     archiveOperations,
                     execOperations,
+                    fileOperations,
                     workingDirBase,
                     runtimeJava
                 )

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -38,6 +38,7 @@ import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
@@ -59,6 +60,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.LineNumberReader;
 import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -126,6 +128,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final FileSystemOperations fileSystemOperations;
     private final ArchiveOperations archiveOperations;
     private final ExecOperations execOperations;
+    private final FileOperations fileOperations;
     private final AtomicBoolean configurationFrozen = new AtomicBoolean(false);
     private final Path workingDir;
 
@@ -180,6 +183,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         FileSystemOperations fileSystemOperations,
         ArchiveOperations archiveOperations,
         ExecOperations execOperations,
+        FileOperations fileOperations,
         File workingDirBase,
         Provider<File> runtimeJava
     ) {
@@ -191,6 +195,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         this.fileSystemOperations = fileSystemOperations;
         this.archiveOperations = archiveOperations;
         this.execOperations = execOperations;
+        this.fileOperations = fileOperations;
         this.runtimeJava = runtimeJava;
         workingDir = workingDirBase.toPath().resolve(safeName(name)).toAbsolutePath();
         confPathRepo = workingDir.resolve("repo");
@@ -759,7 +764,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private File getBuildPluginFile(String name) {
-        return project.getRootProject().file("build-tools/src/main/resources/" + name);
+        URL resource = getClass().getResource(name);
+        return fileOperations.getResources().getText().fromUri(resource).asFile();
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -57,6 +58,11 @@ public class TestClustersPlugin implements Plugin<Project> {
 
     @Inject
     protected ExecOperations getExecOperations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected FileOperations getFileOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -116,6 +122,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 getFileSystemOperations(),
                 getArchiveOperations(),
                 getExecOperations(),
+                getFileOperations(),
                 new File(project.getBuildDir(), "testclusters"),
                 runtimeJavaProvider
             );


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix getBuildPluginFile for examples and thirdparty build (#82730)