### PR TITLE
Fix duplicated allow lists upon script engine creation

### DIFF
--- a/docs/changelog/82820.yaml
+++ b/docs/changelog/82820.yaml
@@ -2,4 +2,5 @@ pr: 82820
 summary: Fix duplicated allow lists upon script engine creation
 area: Infra/Scripting
 type: bug
-issues: []
+issues:
+ - 82778

--- a/docs/changelog/82820.yaml
+++ b/docs/changelog/82820.yaml
@@ -2,4 +2,4 @@ pr: 82820
 summary: Fix duplicated allow lists upon script engine creation
 area: Infra/Scripting
 type: bug
-issues: [82778]
+issues: []

--- a/docs/changelog/82820.yaml
+++ b/docs/changelog/82820.yaml
@@ -2,4 +2,4 @@ pr: 82820
 summary: Fix duplicated allow lists upon script engine creation
 area: Infra/Scripting
 type: bug
-issues: []
+issues: [82778]

--- a/docs/changelog/82820.yaml
+++ b/docs/changelog/82820.yaml
@@ -1,0 +1,5 @@
+pr: 82820
+summary: Fix duplicated allow lists upon script engine creation
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -119,11 +119,12 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin, Extens
         Map<ScriptContext<?>, List<Whitelist>> contextsWithWhitelists = new HashMap<>();
         for (ScriptContext<?> context : contexts) {
             // we might have a context that only uses the base whitelists, so would not have been filled in by reloadSPI
-            List<Whitelist> contextWhitelists = new ArrayList<>(BASE_WHITELISTS);
-            if (whitelists.get(context) != null) {
-                contextWhitelists.addAll(whitelists.get(context));
+            List<Whitelist> mergedWhitelists = new ArrayList<>(BASE_WHITELISTS);
+            List<Whitelist> contextWhitelists = whitelists.get(context);
+            if (contextWhitelists != null) {
+                mergedWhitelists.addAll(contextWhitelists);
             }
-            contextsWithWhitelists.put(context, contextWhitelists);
+            contextsWithWhitelists.put(context, mergedWhitelists);
         }
         painlessScriptEngine.set(new PainlessScriptEngine(settings, contextsWithWhitelists));
         return painlessScriptEngine.get();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -119,11 +119,9 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin, Extens
         Map<ScriptContext<?>, List<Whitelist>> contextsWithWhitelists = new HashMap<>();
         for (ScriptContext<?> context : contexts) {
             // we might have a context that only uses the base whitelists, so would not have been filled in by reloadSPI
-            List<Whitelist> contextWhitelists = whitelists.get(context);
-            if (contextWhitelists == null) {
-                contextWhitelists = new ArrayList<>(BASE_WHITELISTS);
-            } else {
-                contextWhitelists.addAll(BASE_WHITELISTS);
+            List<Whitelist> contextWhitelists = new ArrayList<>(BASE_WHITELISTS);
+            if (whitelists.get(context) != null) {
+                contextWhitelists.addAll(whitelists.get(context));
             }
             contextsWithWhitelists.put(context, contextWhitelists);
         }


### PR DESCRIPTION
This fixes a bug where base allow lists were added to the merged context allow lists more than once in cases where `getScriptEngine` was called multiple times on the `PainlessPlugin`. 

Closes #82778