### PR TITLE
[8.0] [DOCS] Fix typo (extra +) (#82823)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -177,7 +177,7 @@ docker run -e ENROLLMENT_TOKEN="<token>" --name es02 --net elastic -it {docker-i
 ----
 
 endif::[]
-+
+
 {es} is now configured to join the existing cluster.
 --
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix typo (extra +) (#82823)