### PR TITLE
Speed up MappingStats Computation on Coordinating Node

### DIFF
--- a/docs/changelog/82830.yaml
+++ b/docs/changelog/82830.yaml
@@ -1,0 +1,5 @@
+pr: 82830
+summary: Speed up `MappingStats` Computation on Coordinating Node
+area: Stats
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -29,6 +29,7 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -276,7 +277,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
             }""").get();
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getIndicesStats().getMappings().getFieldTypeStats().size(), equalTo(3));
-        Set<FieldStats> stats = response.getIndicesStats().getMappings().getFieldTypeStats();
+        List<FieldStats> stats = response.getIndicesStats().getMappings().getFieldTypeStats();
         for (FieldStats stat : stats) {
             if (stat.getName().equals("integer")) {
                 assertThat(stat.getCount(), greaterThanOrEqualTo(1));

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldScriptStats.java
@@ -68,14 +68,14 @@ public final class FieldScriptStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
-    void update(int chars, long lines, int sourceUsages, int docUsages) {
+    void update(int chars, long lines, int sourceUsages, int docUsages, int count) {
         this.maxChars = Math.max(this.maxChars, chars);
-        this.totalChars += chars;
+        this.totalChars += (long) chars * count;
         this.maxLines = Math.max(this.maxLines, lines);
-        this.totalLines += lines;
-        this.totalSourceUsages += sourceUsages;
+        this.totalLines += lines * count;
+        this.totalSourceUsages += (long) sourceUsages * count;
         this.maxSourceUsages = Math.max(this.maxSourceUsages, sourceUsages);
-        this.totalDocUsages += docUsages;
+        this.totalDocUsages += (long) docUsages * count;
         this.maxDocUsages = Math.max(this.maxDocUsages, docUsages);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -949,7 +949,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return builder;
     }
 
-    Map<String, MappingMetadata> getMappingsByHash() {
+    public Map<String, MappingMetadata> getMappingsByHash() {
         return mappingsByHash;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,73 +30,70 @@ import java.util.List;
 
 public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingStats> {
 
-    public void testToXContent() {
-        Settings settings = Settings.builder()
-            .put("index.number_of_replicas", 0)
-            .put("index.number_of_shards", 1)
-            .put("index.version.created", Version.CURRENT)
-            .build();
-        Script script1 = new Script("doc['field'] + doc.field + params._source.field");
-        Script script2 = new Script("doc['field']");
-        Script script3 = new Script("params._source.field + params._source.field \n + params._source.field");
-        Script script4 = new Script("params._source.field");
-        String mapping = """
-            {
-                "runtime": {
-                    "keyword1": {
-                        "type": "keyword",
-                        "script": %s
-                    },
-                    "keyword2": {
-                        "type": "keyword"
-                    },
-                    "object.keyword3": {
-                        "type": "keyword",
-                        "script": %s
-                    },
-                    "long": {
-                        "type": "long",
-                        "script": %s
-                    },
-                    "long2": {
-                        "type": "long",
-                        "script": %s
+    private static final Settings SINGLE_SHARD_NO_REPLICAS = Settings.builder()
+        .put("index.number_of_replicas", 0)
+        .put("index.number_of_shards", 1)
+        .put("index.version.created", Version.CURRENT)
+        .build();
+
+    public static final String MAPPING_TEMPLATE = """
+        {
+            "runtime": {
+                "keyword1": {
+                    "type": "keyword",
+                    "script": %s
+                },
+                "keyword2": {
+                    "type": "keyword"
+                },
+                "object.keyword3": {
+                    "type": "keyword",
+                    "script": %s
+                },
+                "long": {
+                    "type": "long",
+                    "script": %s
+                },
+                "long2": {
+                    "type": "long",
+                    "script": %s
+                }
+            },
+            "properties": {
+                "object": {
+                    "type": "object",
+                    "properties": {
+                        "keyword3": {
+                            "type": "keyword"
+                        }
                     }
                 },
-                "properties": {
-                    "object": {
-                        "type": "object",
-                        "properties": {
-                            "keyword3": {
-                                "type": "keyword"
-                            }
-                        }
-                    },
-                    "long3": {
-                        "type": "long",
-                        "script": %s
-                    },
-                    "long4": {
-                        "type": "long",
-                        "script": %s
-                    },
-                    "keyword3": {
-                        "type": "keyword",
-                        "script": %s
-                    }
+                "long3": {
+                    "type": "long",
+                    "script": %s
+                },
+                "long4": {
+                    "type": "long",
+                    "script": %s
+                },
+                "keyword3": {
+                    "type": "keyword",
+                    "script": %s
                 }
-            }""".formatted(
-            Strings.toString(script1),
-            Strings.toString(script2),
-            Strings.toString(script3),
-            Strings.toString(script4),
-            Strings.toString(script3),
-            Strings.toString(script4),
-            Strings.toString(script1)
-        );
-        IndexMetadata meta = IndexMetadata.builder("index").settings(settings).putMapping(mapping).build();
-        IndexMetadata meta2 = IndexMetadata.builder("index2").settings(settings).putMapping(mapping).build();
+            }
+        }""";
+
+    private static final String SCRIPT_1 = scriptAsJSON("doc['field'] + doc.field + params._source.field");
+    private static final String SCRIPT_2 = scriptAsJSON("doc['field']");
+    private static final String SCRIPT_3 = scriptAsJSON("params._source.field + params._source.field \n + params._source.field");
+    private static final String SCRIPT_4 = scriptAsJSON("params._source.field");
+
+    public void testToXContent() {
+        String mapping = MAPPING_TEMPLATE.formatted(SCRIPT_1, SCRIPT_2, SCRIPT_3, SCRIPT_4, SCRIPT_3, SCRIPT_4, SCRIPT_1);
+        IndexMetadata meta = IndexMetadata.builder("index").settings(SINGLE_SHARD_NO_REPLICAS).putMapping(mapping).build();
+        IndexMetadata meta2 = IndexMetadata.builder("index2").settings(SINGLE_SHARD_NO_REPLICAS).putMapping(mapping).build();
         Metadata metadata = Metadata.builder().put(meta, false).put(meta2, false).build();
+        assertThat(metadata.getMappingsByHash(), Matchers.aMapWithSize(1));
         MappingStats mappingStats = MappingStats.of(metadata, () -> {});
         assertEquals("""
             {
@@ -184,6 +182,109 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
             }""", Strings.toString(mappingStats, true, true));
     }
 
+    public void testToXContentWithSomeSharedMappings() {
+        IndexMetadata meta = IndexMetadata.builder("index")
+            .settings(SINGLE_SHARD_NO_REPLICAS)
+            .putMapping(MAPPING_TEMPLATE.formatted(SCRIPT_1, SCRIPT_2, SCRIPT_3, SCRIPT_4, SCRIPT_3, SCRIPT_4, SCRIPT_1))
+            .build();
+        // make mappings that are slightly different because we shuffled 2 scripts between fields
+        final String mappingString2 = MAPPING_TEMPLATE.formatted(SCRIPT_1, SCRIPT_2, SCRIPT_3, SCRIPT_4, SCRIPT_4, SCRIPT_3, SCRIPT_1);
+        IndexMetadata meta2 = IndexMetadata.builder("index2").settings(SINGLE_SHARD_NO_REPLICAS).putMapping(mappingString2).build();
+        IndexMetadata meta3 = IndexMetadata.builder("index3").settings(SINGLE_SHARD_NO_REPLICAS).putMapping(mappingString2).build();
+        Metadata metadata = Metadata.builder().put(meta, false).put(meta2, false).put(meta3, false).build();
+        assertThat(metadata.getMappingsByHash(), Matchers.aMapWithSize(2));
+        MappingStats mappingStats = MappingStats.of(metadata, () -> {});
+        assertEquals("""
+            {
+              "mappings" : {
+                "field_types" : [
+                  {
+                    "name" : "keyword",
+                    "count" : 6,
+                    "index_count" : 3,
+                    "script_count" : 3,
+                    "lang" : [
+                      "painless"
+                    ],
+                    "lines_max" : 1,
+                    "lines_total" : 3,
+                    "chars_max" : 47,
+                    "chars_total" : 141,
+                    "source_max" : 1,
+                    "source_total" : 3,
+                    "doc_max" : 2,
+                    "doc_total" : 6
+                  },
+                  {
+                    "name" : "long",
+                    "count" : 6,
+                    "index_count" : 3,
+                    "script_count" : 6,
+                    "lang" : [
+                      "painless"
+                    ],
+                    "lines_max" : 2,
+                    "lines_total" : 9,
+                    "chars_max" : 68,
+                    "chars_total" : 264,
+                    "source_max" : 3,
+                    "source_total" : 12,
+                    "doc_max" : 0,
+                    "doc_total" : 0
+                  },
+                  {
+                    "name" : "object",
+                    "count" : 3,
+                    "index_count" : 3,
+                    "script_count" : 0
+                  }
+                ],
+                "runtime_field_types" : [
+                  {
+                    "name" : "keyword",
+                    "count" : 9,
+                    "index_count" : 3,
+                    "scriptless_count" : 3,
+                    "shadowed_count" : 3,
+                    "lang" : [
+                      "painless"
+                    ],
+                    "lines_max" : 1,
+                    "lines_total" : 6,
+                    "chars_max" : 47,
+                    "chars_total" : 177,
+                    "source_max" : 1,
+                    "source_total" : 3,
+                    "doc_max" : 2,
+                    "doc_total" : 9
+                  },
+                  {
+                    "name" : "long",
+                    "count" : 6,
+                    "index_count" : 3,
+                    "scriptless_count" : 0,
+                    "shadowed_count" : 0,
+                    "lang" : [
+                      "painless"
+                    ],
+                    "lines_max" : 2,
+                    "lines_total" : 9,
+                    "chars_max" : 68,
+                    "chars_total" : 264,
+                    "source_max" : 3,
+                    "source_total" : 12,
+                    "doc_max" : 0,
+                    "doc_total" : 0
+                  }
+                ]
+              }
+            }""", Strings.toString(mappingStats, true, true));
+    }
+
+    private static String scriptAsJSON(String script) {
+        return Strings.toString(new Script(script));
+    }
+
     @Override
     protected Reader<MappingStats> instanceReader() {
         return MappingStats::new;
@@ -219,6 +320,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                 randomIntBetween(1, 100),
                 randomLongBetween(100, 1000),
                 randomIntBetween(1, 10),
+                randomIntBetween(1, 10),
                 randomIntBetween(1, 10)
             );
         }
@@ -236,6 +338,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
             stats.fieldScriptStats.update(
                 randomIntBetween(1, 100),
                 randomLongBetween(100, 1000),
+                randomIntBetween(1, 10),
                 randomIntBetween(1, 10),
                 randomIntBetween(1, 10)
             );
@@ -285,7 +388,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         FieldStats expectedStats = new FieldStats("long");
         expectedStats.count = 1;
         expectedStats.indexCount = 1;
-        assertEquals(Collections.singleton(expectedStats), mappingStats.getFieldTypeStats());
+        assertEquals(Collections.singletonList(expectedStats), mappingStats.getFieldTypeStats());
     }
 
     public void testIgnoreSystemIndices() {
@@ -299,7 +402,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo").settings(settings).putMapping(mapping).system(true);
         Metadata metadata = new Metadata.Builder().put(indexMetadata).build();
         MappingStats mappingStats = MappingStats.of(metadata, () -> {});
-        assertEquals(Collections.emptySet(), mappingStats.getFieldTypeStats());
+        assertEquals(Collections.emptyList(), mappingStats.getFieldTypeStats());
     }
 
     public void testChecksForCancellation() {
@@ -308,7 +411,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
             .build();
-        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo").settings(settings);
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo").settings(settings).putMapping("{}");
         Metadata metadata = new Metadata.Builder().put(indexMetadata).build();
         expectThrows(
             TaskCancelledException.class,


### PR DESCRIPTION
We can exploit the mapping deduplication logic to save deserializing the
same mapping repeatedly here. This should fix extremely long running
computations when the cache needs to be refreshed for these stats
in the common case of many duplicate mappings in a cluster.
Also, removed some confusing and needless set creation in the constructor here.

We could go even further here probably and merge the logic for analysis and mapping stats parsing into one, but it doesn't matter much. With this fix the time to get a response in a 10k indices cluster with many repeated but very large (Beats) mappings (as you would expect them to be in the real world) goes from ~10s down to sub-second in the uncached case.
This removes a very long running task from the management pool and also ensures we don't burn endless CPU responding to monitoring in clusters that go through frequent metadata updates and thus won't see all that much benefit from the caching in `TransportClusterStatsAction`.

relates #77466 