### PR TITLE
Fixes permissions within pre-defined "viewer" and "editor" roles for security solutions 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -40,11 +40,26 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>> {
+    /** "Security Solutions" only legacy signals index */
     public static final String ALERTS_LEGACY_INDEX = ".siem-signals*";
+
+    /** Alerts, Rules, Cases (RAC) index used by multiple solutions */
     public static final String ALERTS_BACKING_INDEX = ".internal.alerts*";
+
+    /** Alerts, Rules, Cases (RAC) index used by multiple solutions */
     public static final String ALERTS_INDEX_ALIAS = ".alerts*";
+
+    /** Alerts, Rules, Cases (RAC) preview index used by multiple solutions */
     public static final String PREVIEW_ALERTS_INDEX_ALIAS = ".preview.alerts*";
+
+    /** Alerts, Rules, Cases (RAC) preview index used by multiple solutions */
     public static final String PREVIEW_ALERTS_BACKING_INDEX_ALIAS = ".internal.preview.alerts*";
+
+    /** "Security Solutions" only lists index for value lists for detections */
+    public static final String LISTS_INDEX = ".lists-*";
+
+    /** "Security Solutions" only lists index for value list items for detections */
+    public static final String LISTS_ITEMS_INDEX = ".items-*";
 
     public static final RoleDescriptor SUPERUSER_ROLE_DESCRIPTOR = new RoleDescriptor(
         "superuser",
@@ -544,7 +559,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // Security
-                RoleDescriptor.IndicesPrivileges.builder().indices(".siem-signals-*").privileges("read", "view_index_metadata").build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(ReservedRolesStore.ALERTS_LEGACY_INDEX, ReservedRolesStore.LISTS_INDEX, ReservedRolesStore.LISTS_ITEMS_INDEX)
+                    .privileges("read", "view_index_metadata")
+                    .build(),
                 // Alerts-as-data
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(ReservedRolesStore.ALERTS_INDEX_ALIAS, ReservedRolesStore.PREVIEW_ALERTS_INDEX_ALIAS)
@@ -580,7 +598,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .build(),
                 // Security
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".siem-signals-*", ".lists-*", ".items-*")
+                    .indices(ReservedRolesStore.ALERTS_LEGACY_INDEX, ReservedRolesStore.LISTS_INDEX, ReservedRolesStore.LISTS_ITEMS_INDEX)
                     .privileges("read", "view_index_metadata", "write", "maintenance")
                     .build(),
                 // Alerts-as-data
@@ -591,7 +609,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         ReservedRolesStore.PREVIEW_ALERTS_BACKING_INDEX_ALIAS,
                         ReservedRolesStore.PREVIEW_ALERTS_INDEX_ALIAS
                     )
-                    .privileges("read", "view_index_metadata", "write")
+                    .privileges("read", "view_index_metadata", "write", "maintenance")
                     .build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {
                 RoleDescriptor.ApplicationResourcePrivileges.builder()
@@ -691,6 +709,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Legacy "Alerts as data" used in Security Solution.
                 // Kibana user creates these indices; reads / writes to them.
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_LEGACY_INDEX).privileges("all").build(),
+                // Used in Security Solution for value lists.
+                // Kibana user creates these indices; reads / writes to them.
+                RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.LISTS_INDEX).privileges("all").build(),
+                // Used in Security Solution for value lists.
+                // Kibana user creates these indices; reads / writes to them.
+                RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.LISTS_ITEMS_INDEX).privileges("all").build(),
                 // "Alerts as data" internal backing indices used in Security Solution, Observability, etc.
                 // Kibana system user creates these indices; reads / writes to them via the aliases (see below).
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_BACKING_INDEX).privileges("all").build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -711,10 +711,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_LEGACY_INDEX).privileges("all").build(),
                 // Used in Security Solution for value lists.
                 // Kibana user creates these indices; reads / writes to them.
-                RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.LISTS_INDEX).privileges("all").build(),
-                // Used in Security Solution for value lists.
-                // Kibana user creates these indices; reads / writes to them.
-                RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.LISTS_ITEMS_INDEX).privileges("all").build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(ReservedRolesStore.LISTS_INDEX, ReservedRolesStore.LISTS_ITEMS_INDEX)
+                    .privileges("all")
+                    .build(),
                 // "Alerts as data" internal backing indices used in Security Solution, Observability, etc.
                 // Kibana system user creates these indices; reads / writes to them via the aliases (see below).
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_BACKING_INDEX).privileges("all").build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -466,7 +466,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ReservedRolesStore.ALERTS_BACKING_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.PREVIEW_ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13)),
-            ReservedRolesStore.PREVIEW_ALERTS_BACKING_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13))
+            ReservedRolesStore.PREVIEW_ALERTS_BACKING_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13)),
+            ReservedRolesStore.LISTS_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
+            ReservedRolesStore.LISTS_ITEMS_INDEX + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
 
         // read-only index access, including cross cluster
@@ -2270,6 +2272,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, ".siem-signals-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".alerts-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".preview.alerts-" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".lists-" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".items-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5) + "-transaction-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "logs-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "auditbeat-" + randomIntBetween(0, 5));
@@ -2332,10 +2336,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".lists-" + randomIntBetween(0, 5));
         assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".items-" + randomIntBetween(0, 5));
         assertReadWriteDocsButNotDeleteIndexAllowed(role, "observability-annotations");
-        assertReadWriteDocsButNotDeleteIndexAllowed(role, ".alerts-" + randomIntBetween(0, 5));
-        assertReadWriteDocsButNotDeleteIndexAllowed(role, ".internal.alerts-" + randomIntBetween(0, 5));
-        assertReadWriteDocsButNotDeleteIndexAllowed(role, ".preview.alerts-" + randomIntBetween(0, 5));
-        assertReadWriteDocsButNotDeleteIndexAllowed(role, ".internal.preview.alerts-" + randomIntBetween(0, 5));
+        assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".alerts-" + randomIntBetween(0, 5));
+        assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".internal.alerts-" + randomIntBetween(0, 5));
+        assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".preview.alerts-" + randomIntBetween(0, 5));
+        assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(role, ".internal.preview.alerts-" + randomIntBetween(0, 5));
 
         assertNoAccessAllowed(role, RestrictedIndicesNames.RESTRICTED_NAMES);
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));


### PR DESCRIPTION
##Summary

See Kibana issue here from testing that brought up the bugs and details:
https://github.com/elastic/kibana/issues/123413

Elasticsearch has built-in `editor` and `viewer` roles that grant access to all features in Kibana. This PR touches up and fixes permission issues found from "viewer" and "editor".

* This adds permissions for the `.lists*` and `.items*` indexes when using `editor` role and `kibana_system` role that are missing.
* This adds the `maintenance` role needed for index refreshes to the alerting indexes.
* This changes some strings for the same constants used in the file to be consistent with permissions across these indexes.
* This adds tests
* This adds some docs to the code.


**Manual testing (for curious Kibana devs)**
* See [testing](https://github.com/elastic/elasticsearch/blob/master/TESTING.asciidoc) and the main [README here](https://github.com/elastic/elasticsearch) to help get setup as you go through the steps below
* Install gradle and opendjk. I installed them through brew.
* Run `gradle wrapper` to create the wrapper
* Start elasticsearch through `./gradlew run -Drun.license_type=trial`
* Edit your `kibana.dev.yml` and `auditbeat.yml` file(s) to use the `elastic-admin` to first log into the system and start Kibana as well as run auditbeat.
* Start auditbeat.
* Add two users. 1 user should have the role of `viewer` and the other `editor`
* Go to "Security -> Detections" and create a rule that has KQL such as "\*:\*" to generate alerts as the user with the role "editor"
* Ensure you don't get permission warnings about the user.
* Log out and log in as the user with "viewer" role.
* Check to ensure that user can access read-only mode on the detections and that the banner now says it has read permissions and is only missing write permissions.
