### PR TITLE
[DOCS] Fix links to anomaly detection docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -24,7 +24,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 This API deletes a filter. If an {anomaly-job} references the filter, you cannot
 delete the filter. You must update or delete the job before you can delete the
 filter. For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Custom rules].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-rules[Custom rules].
 
 [[ml-delete-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -33,7 +33,7 @@ one or more forecasts before they expire.
 NOTE: When you delete a job, its associated forecasts are deleted.
 
 For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Forecasting the future].
+{ml-docs}/ml-ad-forecast.html[Forecasting the future].
 
 [[ml-delete-forecast-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -23,7 +23,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 
 You can create a forecast job based on an {anomaly-job} to extrapolate future 
 behavior. Refer to
-{ml-docs}/ml-ad-finding-anomalies.html[Forecasting the future]
+{ml-docs}/ml-ad-forecast.html[Forecasting the future]
 and 
 {ml-docs}/ml-limitations.html#ml-forecast-limitations[Forecast limitations] to 
 learn more.

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -24,7 +24,7 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-get-calendar-event-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -24,7 +24,7 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-get-calendar-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -24,7 +24,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 You can get a single filter or all filters. For more information, see 
-{ml-docs}/ml-ad-finding-anomalies.html[Custom rules].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-rules[Custom rules].
 
 [[ml-get-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -22,7 +22,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 This API accepts a list of
-{ml-docs}/ml-ad-finding-anomalies.html[scheduled events], each
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[scheduled events], each
 of which must have a start time, end time, and description.
 
 [[ml-post-calendar-event-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -22,7 +22,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-put-calendar-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -24,7 +24,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 A filter contains a list of strings. It can be used by one or more jobs.
 Specifically, filters are referenced in the `custom_rules` property of detector
 configuration objects. For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Custom rules].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-rules[Custom rules].
 
 [[ml-put-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -176,7 +176,7 @@ If the {anomaly-job} uses a {dfeed} with
 {ml-docs}/ml-configuring-aggregation.html[aggregations], this value must also be
 divisible by the interval of the date histogram aggregation. The default value
 is `5m`. For more information, see
-{ml-docs}/ml-ad-finding-anomalies.html[Bucket span].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-bucket-span[Bucket span].
 end::bucket-span[]
 
 tag::bucket-span-results[]
@@ -418,7 +418,7 @@ of the most recent snapshot for this job. Valid values range from `0` to
 `model_snapshot_retention_days`. For new jobs, the default value is `1`. For
 jobs created before version 7.8.0, the default value matches
 `model_snapshot_retention_days`. For more information, refer to
-{ml-docs}/ml-ad-finding-anomalies.html[Model snapshots].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-model-snapshots[Model snapshots].
 end::daily-model-snapshot-retention-after-days[]
 
 tag::data-description[]
@@ -1419,7 +1419,7 @@ snapshots for this job. It specifies the maximum period of time (in days) that
 snapshots are retained. This period is relative to the timestamp of the most
 recent snapshot for this job. The default value is `10`, which means snapshots
 ten days older than the newest snapshot are deleted. For more information, refer
-to {ml-docs}/ml-ad-finding-anomalies.html[Model snapshots].
+to {ml-docs}/ml-ad-run-jobs.html#ml-ad-model-snapshots[Model snapshots].
 end::model-snapshot-retention-days[]
 
 tag::model-timestamp[]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -379,19 +379,19 @@ See <<commands>>.
 === Calendar resources
 
 See <<ml-get-calendar>> and
-{ml-docs}/ml-ad-finding-anomalies.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[Calendars and scheduled events].
 
 [role="exclude",id="ml-filter-resource"]
 === Filter resources
 
 See <<ml-get-filter>> and
-{ml-docs}/ml-ad-finding-anomalies.html[Machine learning custom rules].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-rules[Machine learning custom rules].
 
 [role="exclude",id="ml-event-resource"]
 === Scheduled event resources
 
 See <<ml-get-calendar-event>> and
-{ml-docs}/ml-ad-finding-anomalies.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-calendars[Calendars and scheduled events].
 
 [role="exclude",id="index-apis"]
 === Index APIs


### PR DESCRIPTION
Relates to elastic/stack-docs#1739

This page reverts the changes in https://github.com/elastic/elasticsearch/pull/82774, such that the links target the new pages in the Machine Learning guide.