### PR TITLE
Remove version_type "internal" from rest api specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -60,7 +60,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -66,7 +66,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -69,7 +69,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -65,7 +65,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -69,7 +69,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -65,7 +65,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -80,7 +80,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -87,7 +87,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -93,7 +93,6 @@
       "version_type":{
         "type":"enum",
         "options":[
-          "internal",
           "external",
           "external_gte"
         ],

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
@@ -277,10 +277,8 @@ public class ClientYamlSuiteRestApiTests extends ESTestCase {
               "version_type":{
                 "type":"enum",
                 "options":[
-                  "internal",
                   "external",
-                  "external_gte",
-                  "force"
+                  "external_gte"
                 ],
                 "description":"Specific version type"
               },


### PR DESCRIPTION
This commit removes the version_type `"internal"` from the rest api specs.
Support for internal versioning for optimistic concurrency control was
removed in elastic/elasticsearch#38254.

Since this removes values from rest api specs, it will affect any artifact that is generated from specs, for example, clients.

Other observations
- `VersionType` enum still has an `INTERNAL` value, which might be needed for bwc?
- `SetProcessorTests` randomly selects a version type which includes `"internal"` - this should probably also be removed.
- `IngestServiceTests` randomly selects a version type which includes `"internal"` and `"external_gt"` - these should probably also be removed.
