### PR TITLE
TSDB:time series bounds added max and min value checks

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -477,6 +477,8 @@ public final class IndexSettings {
     public static final Setting<Instant> TIME_SERIES_START_TIME = Setting.dateSetting(
         "index.time_series.start_time",
         Instant.ofEpochMilli(0),
+        Instant.ofEpochMilli(0),
+        Instant.ofEpochMilli(DateUtils.MAX_MILLIS_BEFORE_9999),
         v -> {},
         Property.IndexScope,
         Property.Final
@@ -487,6 +489,8 @@ public final class IndexSettings {
      */
     public static final Setting<Instant> TIME_SERIES_END_TIME = Setting.dateSetting(
         "index.time_series.end_time",
+        Instant.ofEpochMilli(DateUtils.MAX_MILLIS_BEFORE_9999),
+        Instant.ofEpochMilli(0),
         Instant.ofEpochMilli(DateUtils.MAX_MILLIS_BEFORE_9999),
         new Setting.Validator<>() {
             @Override

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1439,7 +1439,10 @@ public class SettingTests extends ESTestCase {
 
         assertThat(dateSetting.get(Settings.EMPTY).toEpochMilli(), equalTo(300L));
         assertThat(dateSetting.get(Settings.builder().put("date.setting", 200L).build()).toEpochMilli(), equalTo(200L));
-        assertThat(dateSetting.get(Settings.builder().put("date.setting", Instant.ofEpochMilli(200).toString()).build()).toEpochMilli(), equalTo(200L));
+        assertThat(
+            dateSetting.get(Settings.builder().put("date.setting", Instant.ofEpochMilli(200).toString()).build()).toEpochMilli(),
+            equalTo(200L)
+        );
         assertThat(dateSetting.get(Settings.builder().put("date.setting", 100L).build()).toEpochMilli(), equalTo(100L));
         assertThat(dateSetting.get(Settings.builder().put("date.setting", 500L).build()).toEpochMilli(), equalTo(500L));
 

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -190,14 +190,24 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
         final Settings settings = getSettings("foo", "1969-01-01T00:00:00Z", "9999-12-31T23:59:59.999Z");
         IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
-        assertThat(e.getMessage(), Matchers.containsString("Failed to parse value [1969-01-01T00:00:00Z] for setting [index.time_series.start_time] must be >= 1970-01-01T00:00:00Z"));
+        assertThat(
+            e.getMessage(),
+            Matchers.containsString(
+                "Failed to parse value [1969-01-01T00:00:00Z] for setting [index.time_series.start_time] must be >= 1970-01-01T00:00:00Z"
+            )
+        );
     }
 
     public void testEndTimeOutOfBound() {
         final Settings settings = getSettings("foo", "1970-01-01T00:00:00Z", "253402300800000");
         IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
-        assertThat(e.getMessage(), Matchers.containsString("Failed to parse value [+10000-01-01T00:00:00Z] for setting [index.time_series.end_time] must be <= 9999-12-31T23:59:59.999Z"));
+        assertThat(
+            e.getMessage(),
+            Matchers.containsString(
+                "Failed to parse value [+10000-01-01T00:00:00Z] for setting [index.time_series.end_time] must be <= 9999-12-31T23:59:59.999Z"
+            )
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -205,7 +205,8 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
         assertThat(
             e.getMessage(),
             Matchers.containsString(
-                "Failed to parse value [+10000-01-01T00:00:00Z] for setting [index.time_series.end_time] must be <= 9999-12-31T23:59:59.999Z"
+                "Failed to parse value [+10000-01-01T00:00:00Z] for "
+                    + "setting [index.time_series.end_time] must be <= 9999-12-31T23:59:59.999Z"
             )
         );
     }


### PR DESCRIPTION
dateSetting add the max and min value check.
if not set max and min value check, start_time can set to a negative value, and end_time can set to a very large value than the strict_date_optional_time bound.
I prefer add the max and min value check to avoid bad date.
