### PR TITLE
[ML] Fix ZeroShotClassificationConfig update mixing fields

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
@@ -152,7 +152,7 @@ public class ZeroShotClassificationConfigUpdate extends NlpConfigUpdate implemen
     }
 
     boolean isNoop(ZeroShotClassificationConfig originalConfig) {
-        return (labels == null || labels.equals(originalConfig.getClassificationLabels()))
+        return (labels == null || labels.equals(originalConfig.getLabels()))
             && (isMultiLabel == null || isMultiLabel.equals(originalConfig.isMultiLabel()))
             && (resultsField == null || resultsField.equals(originalConfig.getResultsField()))
             && super.isNoop();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
@@ -178,6 +178,30 @@ public class ZeroShotClassificationConfigUpdateTests extends InferenceConfigItem
 
     public void testIsNoop() {
         assertTrue(new ZeroShotClassificationConfigUpdate.Builder().build().isNoop(ZeroShotClassificationConfigTests.createRandom()));
+
+        var originalConfig = new ZeroShotClassificationConfig(
+            List.of("contradiction", "neutral", "entailment"),
+            randomBoolean() ? null : VocabularyConfigTests.createRandom(),
+            randomBoolean() ? null : BertTokenizationTests.createRandom(),
+            randomAlphaOfLength(10),
+            randomBoolean(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLength(8)
+        );
+
+        var update = new ZeroShotClassificationConfigUpdate.Builder().setLabels(List.of("glad", "sad", "mad")).build();
+        assertFalse(update.isNoop(originalConfig));
+
+        originalConfig = new ZeroShotClassificationConfig(
+            List.of("contradiction", "neutral", "entailment"),
+            randomBoolean() ? null : VocabularyConfigTests.createRandom(),
+            randomBoolean() ? null : BertTokenizationTests.createRandom(),
+            randomAlphaOfLength(10),
+            randomBoolean(),
+            List.of("glad", "sad", "mad"),
+            randomBoolean() ? null : randomAlphaOfLength(8)
+        );
+        assertTrue(update.isNoop(originalConfig));
     }
 
     public static ZeroShotClassificationConfigUpdate createRandom() {


### PR DESCRIPTION
When checking if the update can be skipped the `labels` and `classification_labels` fields were accidentally mixed up.

This is a minor bug which in all cases prevents an small optimisation except the one case where `labels` are exactly the same as `classification_labels`:

```
POST _ml/trained_models/model-x/deployment/_infer
{
  "docs": [
    {
      "text_field": "This is a very happy person"
    }
  ],
  "inference_config": {
    "zero_shot_classification": {
      "labels": [
        "ENTAILMENT",
        "NEUTRAL",
        "CONTRADICTION"
      ]
    }
  }
}
```

Would return the confusing error because the update is not applied:

```zero_shot_classification requires non-empty [labels]``` 

