### PR TITLE
[8.0] Add rollover to watcher history ILM policy (#82603)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -570,6 +570,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             "ilm-history-ilm-policy",
             "slm-history-ilm-policy",
             "watch-history-ilm-policy",
+            "watch-history-ilm-policy-16",
             "ml-size-based-ilm-policy",
             "logs",
             "metrics",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
@@ -21,8 +21,9 @@ public final class WatcherIndexTemplateRegistryField {
     // version 13: add `allow_auto_create` setting
     // version 14: move watch history to data stream
     // version 15: remove watches and triggered watches, these are now system indices
+    // version 16: change watch history ILM policy
     // Note: if you change this, also inform the kibana team around the watcher-ui
-    public static final int INDEX_TEMPLATE_VERSION = 14;
+    public static final int INDEX_TEMPLATE_VERSION = 16;
     public static final String HISTORY_TEMPLATE_NAME = ".watch-history-" + INDEX_TEMPLATE_VERSION;
     public static final String HISTORY_TEMPLATE_NAME_NO_ILM = ".watch-history-no-ilm-" + INDEX_TEMPLATE_VERSION;
     public static final String[] TEMPLATE_NAMES = new String[] { HISTORY_TEMPLATE_NAME };

--- a/x-pack/plugin/core/src/main/resources/watch-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/watch-history-ilm-policy.json
@@ -1,7 +1,15 @@
 {
   "phases": {
+    "hot": {
+      "actions": {
+        "rollover": {
+          "max_age": "3d",
+          "max_primary_shard_size": "50gb"
+        }
+      }
+    },
     "delete": {
-      "min_age": "7d",
+      "min_age": "4d",
       "actions": {
         "delete": {}
       }

--- a/x-pack/plugin/core/src/main/resources/watch-history.json
+++ b/x-pack/plugin/core/src/main/resources/watch-history.json
@@ -9,7 +9,7 @@
       "index.number_of_shards": 1,
       "index.number_of_replicas": 0,
       "index.auto_expand_replicas": "0-1",
-      "index.lifecycle.name": "watch-history-ilm-policy",
+      "index.lifecycle.name": "watch-history-ilm-policy-16",
       "index.hidden": true,
       "index.format": 6
     },

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -40,7 +40,7 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
     );
 
     public static final LifecyclePolicyConfig POLICY_WATCH_HISTORY = new LifecyclePolicyConfig(
-        "watch-history-ilm-policy",
+        "watch-history-ilm-policy-16",
         "/watch-history-ilm-policy.json"
     );
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -140,7 +140,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             .filter(r -> r.name().equals(WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME))
             .findFirst()
             .orElseThrow(() -> new AssertionError("expected the watch history template to be put"));
-        assertThat(req.indexTemplate().template().settings().get("index.lifecycle.name"), equalTo("watch-history-ilm-policy"));
+        assertThat(req.indexTemplate().template().settings().get("index.lifecycle.name"), equalTo("watch-history-ilm-policy-16"));
     }
 
     public void testThatNonExistingTemplatesAreAddedEvenWithILMUsageDisabled() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleType;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
 import org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField;
@@ -110,7 +111,8 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
                     new ParseField(TimeseriesLifecycleType.TYPE),
                     (p) -> TimeseriesLifecycleType.INSTANCE
                 ),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DeleteAction.NAME), DeleteAction::parse)
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DeleteAction.NAME), DeleteAction::parse),
+                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME), RolloverAction::parse)
             )
         );
         xContentRegistry = new NamedXContentRegistry(entries);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add rollover to watcher history ILM policy (#82603)