### PR TITLE
TSDB: Fix time series bounds default value error

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
@@ -139,8 +139,8 @@ no partitioning:
                 time_series:
                   start_time: 2021-04-28T00:00:00Z
                   end_time: 2021-04-29T00:00:00Z
-                shards: 5
                 routing_partition_size: 2
+                number_of_shards: 4
 
 ---
 routing_path required:
@@ -197,6 +197,27 @@ routing required:
             mappings:
               _routing:
                 required: true
+
+---
+empty routing_path:
+  - skip:
+      version: " - 8.0.99"
+      reason: introduced in 8.1.0
+
+  - do:
+      catch: /\[index.mode=time_series\] index.routing_path can not be empty/
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: []
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+              number_of_shards: 5
+
 ---
 set start_time and end_time:
   - skip:
@@ -476,6 +497,39 @@ check end_time boundary with data_nano:
 
   - do:
       catch: /time series index @timestamp value \[2021-09-26T03:09:52.123456789Z\] must be smaller than 2021-09-26T03:09:52Z/
+      index:
+        index: test_index
+        body: {
+          "@timestamp": "2021-09-26T03:09:52.123456789Z",
+          "metricset": "pod"
+        }
+
+
+---
+check time_series default time bound value:
+  - skip:
+      version: " - 8.0.99"
+      reason: introduced in 8.1.0
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [metricset]
+              time_series:
+                start_time: 1970-01-01T00:00:00Z
+                end_time: 9999-12-31T23:59:59.999Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date_nanos
+              metricset:
+                type: keyword
+                time_series_dimension: true
+
+  - do:
       index:
         index: test_index
         body: {

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -85,6 +85,10 @@ public enum IndexMode {
             settingRequiresTimeSeries(settings, IndexMetadata.INDEX_ROUTING_PATH);
             settingRequiresTimeSeries(settings, IndexSettings.TIME_SERIES_START_TIME);
             settingRequiresTimeSeries(settings, IndexSettings.TIME_SERIES_END_TIME);
+
+            if (IndexMetadata.INDEX_ROUTING_PATH.get(settings).isEmpty()) {
+                throw new IllegalArgumentException(tsdbMode() + " " + IndexMetadata.INDEX_ROUTING_PATH.getKey() + " can not be empty");
+            }
         }
 
         private void settingRequiresTimeSeries(Settings settings, Setting<?> setting) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -518,20 +518,7 @@ public final class IndexSettings {
         IndexMode.class,
         "index.mode",
         IndexMode.STANDARD,
-        new Setting.Validator<IndexMode>() {
-            @Override
-            public void validate(IndexMode value) {}
-
-            @Override
-            public void validate(IndexMode value, Map<Setting<?>, Object> settings) {
-                value.validateWithOtherSettings(settings);
-            }
-
-            @Override
-            public Iterator<Setting<?>> settings() {
-                return IndexMode.VALIDATE_WITH_SETTINGS.iterator();
-            }
-        },
+        v -> {},
         Property.IndexScope,
         Property.Final
     );
@@ -702,6 +689,7 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
+        mode.validateWithOtherSettings(settings);
         this.timestampBounds = TIME_SERIES_START_TIME.exists(settings) ? new TimestampBounds(scopedSettings) : null;
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -21,6 +21,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
 
 import static org.elasticsearch.index.IndexSettings.TIME_SERIES_END_TIME;
@@ -73,6 +74,13 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] requires [index.routing_path]"));
     }
 
+    public void testWithEmptyRoutingPath() {
+        Settings s = getSettings("");
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        assertThat(e.getMessage(), equalTo("[index.mode=time_series] index.routing_path can not be empty"));
+    }
+
     public void testWithoutStartTime() {
         final Settings settings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
@@ -96,12 +104,12 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
         assertThat(e.getMessage(), Matchers.containsString("[index.mode=time_series] requires [index.time_series.end_time]"));
     }
 
-    public void testTimeSeriesTimeSetDefaultValue() {
+    public void testSetDefaultTimeRangeValue() {
         final Settings settings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
-            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "")
-            .put(TIME_SERIES_START_TIME.getKey(), "1970-01-01T00:00:00Z")
-            .put(TIME_SERIES_END_TIME.getKey(), "9999-12-31T23:59:59.999Z")
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "foo")
+            .put(TIME_SERIES_START_TIME.getKey(), Instant.ofEpochMilli(0).toString())
+            .put(TIME_SERIES_END_TIME.getKey(), Instant.ofEpochMilli(DateUtils.MAX_MILLIS_BEFORE_9999).toString())
             .build();
         IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
         IndexSettings indexSettings = new IndexSettings(metadata, Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -10,16 +10,21 @@ package org.elasticsearch.index;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.script.StringFieldScript.LeafFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static org.elasticsearch.index.IndexSettings.TIME_SERIES_END_TIME;
+import static org.elasticsearch.index.IndexSettings.TIME_SERIES_START_TIME;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TimeSeriesModeTests extends MapperServiceTestCase {
@@ -30,33 +35,78 @@ public class TimeSeriesModeTests extends MapperServiceTestCase {
     }
 
     public void testPartitioned() {
-        Settings s = Settings.builder().put(getSettings()).put(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING.getKey(), 2).build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        Settings s = Settings.builder()
+            .put(getSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+            .put(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING.getKey(), 2)
+            .build();
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.routing_partition_size]"));
     }
 
     public void testSortField() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "a").build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.field]"));
     }
 
     public void testSortMode() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey(), "_last").build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.missing]"));
     }
 
     public void testSortOrder() {
         Settings s = Settings.builder().put(getSettings()).put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), "desc").build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.order]"));
     }
 
     public void testWithoutRoutingPath() {
         Settings s = Settings.builder().put(IndexSettings.MODE.getKey(), "time_series").build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", s);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
         assertThat(e.getMessage(), equalTo("[index.mode=time_series] requires [index.routing_path]"));
+    }
+
+    public void testWithoutStartTime() {
+        final Settings settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "foo")
+            .build();
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        assertThat(e.getMessage(), Matchers.containsString("[index.mode=time_series] requires [index.time_series.start_time]"));
+    }
+
+    public void testWithoutEndTime() {
+        final Settings settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "foo")
+            .put(TIME_SERIES_START_TIME.getKey(), "1970-01-01T00:00:00Z")
+            .build();
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new IndexSettings(metadata, Settings.EMPTY));
+        assertThat(e.getMessage(), Matchers.containsString("[index.mode=time_series] requires [index.time_series.end_time]"));
+    }
+
+    public void testTimeSeriesTimeSetDefaultValue() {
+        final Settings settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "")
+            .put(TIME_SERIES_START_TIME.getKey(), "1970-01-01T00:00:00Z")
+            .put(TIME_SERIES_END_TIME.getKey(), "9999-12-31T23:59:59.999Z")
+            .build();
+        IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", settings);
+        IndexSettings indexSettings = new IndexSettings(metadata, Settings.EMPTY);
+        assertThat(indexSettings.getTimestampBounds().startTime(), CoreMatchers.equalTo(0L));
+        assertThat(indexSettings.getTimestampBounds().endTime(), CoreMatchers.equalTo(DateUtils.MAX_MILLIS_BEFORE_9999));
     }
 
     public void testRequiredRouting() {


### PR DESCRIPTION
The index.mode validation is use the setting's validator mechanism.
```
    public static final Setting<IndexMode> MODE = Setting.enumSetting(
        IndexMode.class,
        "index.mode",
        IndexMode.STANDARD,
        new Setting.Validator<IndexMode>() {
            @Override
            public void validate(IndexMode value) {}

            @Override
            public void validate(IndexMode value, Map<Setting<?>, Object> settings) {
                value.validateWithOtherSettings(settings);
            }

            @Override
            public Iterator<Setting<?>> settings() {
                return IndexMode.VALIDATE_WITH_SETTINGS.iterator();
            }
        },
        Property.IndexScope,
        Property.Final
    );
```
The `settings` method will init the settings that are not configured in the setting builder and the not configured settings are use the default value, so if set the setting to default value is the same with not put it in the builder.

```
        private void settingRequiresTimeSeries(Map<Setting<?>, Object> settings, Setting<?> setting) {
            if (Objects.equals(setting.getDefault(Settings.EMPTY), settings.get(setting))) {
                 throw new IllegalArgumentException("[" + IndexSettings.MODE.getKey() + "=time_series] requires [" + setting.getKey() + "]");
             }
         }
```

This method check the setting if configured, but if set the default value, it also meet the equals check.
To solve the problem, I move the validator from the setting validator mechanism to explicitly called in IndexSettings constructor.

And this change will modify the validation of empty routing_path, so I add it in the TIME_SERIES mode's `validateWithOtherSettings`

it fixed the bug of https://github.com/elastic/elasticsearch/issues/82832 