### PR TITLE
[7.16] [DOCS] Update security deprecation message in migration guide (#82816)

### DIFF
--- a/docs/reference/migration/migrate_7_14.asciidoc
+++ b/docs/reference/migration/migrate_7_14.asciidoc
@@ -145,15 +145,28 @@ Discontinue use of the `type` parameter in `geo_bounding_box` queries.
 
 [discrete]
 [[implicitly-disabled-security]]
-.The default behavior of disabling security on basic and trial licenses is deprecated
+.Having security disabled by default on basic and trial licenses is deprecated.
 [%collapsible]
 ====
 *Details* +
-Currently, security features are disabled when operating on a basic or trial
-license when `xpack.security.enabled` has not been explicitly set to `true`.
-This behavior is now deprecated. In version 8.0.0, security features will be
-enabled by default for all licenses, unless explicitly disabled (by setting
-`xpack.security.enabled` to `false`).
+{es} security features are disabled by default when operating on a basic or
+trial license if `xpack.security.enabled` is not set to `true`. In {es} 8.0.0,
+security features will be enabled by default for all licenses unless you
+explicitly disable security by setting `xpack.security.enabled` to `false`
+(not recommended).
+
+Before migrating to {es} 8.0.0, you must explicitly set a value for
+`xpack.security.enabled` or {es} will fail to start. If you have already
+enabled security features by explicitly setting `xpack.security.enabled` to
+`true`, your configuration will be respected in 8.0.0.
+
+Otherwise, on every node in your cluster, enable {es} security features by
+setting `xpack.security.enabled` to `true` in `elasticsearch.yml`. You then 
+configure security for the transport layer on each node, which requires 
+generating a certificate authority (if you don't have one), creating node
+security certificates, and configuring internode communication. Refer to
+<<security-basic-setup,set up basic security for the {stack}>> for steps on
+configuring security.
 ====
 
 [[reserved-prefixed-realm-names]]


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Update security deprecation message in migration guide (#82816)