### PR TITLE
[8.0] Add support for HTTP Proxies for the GCS repository (#82737)

### DIFF
--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -191,6 +191,16 @@ are marked as `Secure`.
     can be specified explicitly. For example, it can be used to switch between projects when the
     same credentials are usable for both the production and the development projects.
 
+`proxy.host`::
+    The host name of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.port`::
+    The port of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.type`::
+    The proxy type for the client. Supported values are `direct`, `http`, and `socks`.
+    The default value is `direct` (no proxy).
+
 [[repository-gcs-repository]]
 ==== Repository Settings
 

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
@@ -140,6 +141,11 @@ public class GoogleCloudStorageService {
                 SecurityUtils.loadKeyStore(certTrustStore, keyStoreStream, "notasecret");
             }
             builder.trustCertificates(certTrustStore);
+            Proxy proxy = gcsClientSettings.getProxy();
+            if (proxy != null) {
+                builder.setProxy(proxy);
+                notifyProxyIsSet(proxy);
+            }
             return builder.build();
         });
 
@@ -272,4 +278,7 @@ public class GoogleCloudStorageService {
         }
         return Math.toIntExact(timeout.getMillis());
     }
+
+    // used for unit testing
+    void notifyProxyIsSet(Proxy proxy) {}
 }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
@@ -17,6 +17,9 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -34,6 +37,9 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSetting
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CREDENTIALS_FILE_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.ENDPOINT_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROJECT_ID_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_HOST_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_PORT_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_TYPE_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.getClientSettings;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.loadCredential;
@@ -94,9 +100,33 @@ public class GoogleCloudStorageClientSettingsTests extends ESTestCase {
             CONNECT_TIMEOUT_SETTING.getDefault(Settings.EMPTY),
             READ_TIMEOUT_SETTING.getDefault(Settings.EMPTY),
             APPLICATION_NAME_SETTING.getDefault(Settings.EMPTY),
-            new URI("")
+            new URI(""),
+            PROXY_TYPE_SETTING.getDefault(Settings.EMPTY),
+            PROXY_HOST_SETTING.getDefault(Settings.EMPTY),
+            PROXY_PORT_SETTING.getDefault(Settings.EMPTY)
         );
         assertEquals(credential.getProjectId(), googleCloudStorageClientSettings.getProjectId());
+    }
+
+    public void testLoadsProxySettings() throws Exception {
+        final String clientName = randomAlphaOfLength(5);
+        final ServiceAccountCredentials credential = randomCredential(clientName).v1();
+        final GoogleCloudStorageClientSettings googleCloudStorageClientSettings = new GoogleCloudStorageClientSettings(
+            credential,
+            ENDPOINT_SETTING.getDefault(Settings.EMPTY),
+            PROJECT_ID_SETTING.getDefault(Settings.EMPTY),
+            CONNECT_TIMEOUT_SETTING.getDefault(Settings.EMPTY),
+            READ_TIMEOUT_SETTING.getDefault(Settings.EMPTY),
+            APPLICATION_NAME_SETTING.getDefault(Settings.EMPTY),
+            new URI(""),
+            Proxy.Type.HTTP,
+            "192.168.15.1",
+            8080
+        );
+        assertEquals(
+            new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getByName("192.168.15.1"), 8080)),
+            googleCloudStorageClientSettings.getProxy()
+        );
     }
 
     /** Generates a given number of GoogleCloudStorageClientSettings along with the Settings to build them from **/
@@ -192,7 +222,10 @@ public class GoogleCloudStorageClientSettingsTests extends ESTestCase {
             connectTimeout,
             readTimeout,
             applicationName,
-            new URI("")
+            new URI(""),
+            PROXY_TYPE_SETTING.getDefault(Settings.EMPTY),
+            PROXY_HOST_SETTING.getDefault(Settings.EMPTY),
+            PROXY_PORT_SETTING.getDefault(Settings.EMPTY)
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add support for HTTP Proxies for the GCS repository (#82737)