### PR TITLE
[DOCS] Remove duplicate link to update dfanalytics jobs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
@@ -12,4 +12,3 @@ You can use the following APIs to perform {ml} {dfanalytics} activities.
 * <<get-dfanalytics-stats,Get {dfanalytics-jobs} statistics>>
 * <<start-dfanalytics,Start {dfanalytics-jobs}>>
 * <<stop-dfanalytics,Stop {dfanalytics-jobs}>>
-* <<update-dfanalytics,Update {dfanalytics-jobs}>>


### PR DESCRIPTION
The link to the documentation for updating data frame analytics jobs was duplicated at the bottom of this list.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->