### PR TITLE
Ignore dynamic settings specified by deprecation.skip_deprecated_settings in node deprecation checks

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -213,7 +213,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     private final Version oldestIndexVersion;
 
-    private Metadata(
+    protected Metadata(
         String clusterUUID,
         boolean clusterUUIDCommitted,
         long version,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -213,7 +213,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     private final Version oldestIndexVersion;
 
-    protected Metadata(
+    private Metadata(
         String clusterUUID,
         boolean clusterUUIDCommitted,
         long version,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -126,7 +126,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     private static final class FilteredClusterState extends ClusterState {
         private final Metadata filteredMetadata;
 
-        public FilteredClusterState(ClusterState state, List<String> skipTheseDeprecations) {
+        FilteredClusterState(ClusterState state, List<String> skipTheseDeprecations) {
             super(state.version(), state.stateUUID(), state);
             this.filteredMetadata = new FilteredMetadata(super.metadata(), skipTheseDeprecations);
         }
@@ -138,7 +138,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     }
 
     private static final class FilteredMetadata extends Metadata {
-        public FilteredMetadata(Metadata originalMetadata, List<String> skipTheseDeprecations) {
+        FilteredMetadata(Metadata originalMetadata, List<String> skipTheseDeprecations) {
             super(
                 originalMetadata.clusterUUID(),
                 originalMetadata.clusterUUIDCommitted(),

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -79,8 +79,8 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
             ClusterState,
             XPackLicenseState,
             DeprecationIssue> nodeSettingCheck = (settings, p, clusterState1, l) -> {
-            visibleNodeSettings.set(settings);
-            visibleClusterStateMetadataSettings.set(clusterState1.getMetadata().settings());
+                visibleNodeSettings.set(settings);
+                visibleClusterStateMetadataSettings.set(clusterState1.getMetadata().settings());
                 return null;
             };
         java.util.List<
@@ -123,8 +123,10 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         Assert.assertNotNull(visibleNodeSettings.get());
         Assert.assertEquals(expectedSettings, visibleNodeSettings.get());
         Assert.assertNotNull(visibleClusterStateMetadataSettings.get());
-        Assert.assertEquals(Settings.builder().put("some.bad.dynamic.property", "someValue1").build(),
-            visibleClusterStateMetadataSettings.get());
+        Assert.assertEquals(
+            Settings.builder().put("some.bad.dynamic.property", "someValue1").build(),
+            visibleClusterStateMetadataSettings.get()
+        );
     }
 
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DiffableStringMap;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -47,11 +47,8 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         Settings dynamicSettings = settingsBuilder.build();
         ThreadPool threadPool = null;
         final XPackLicenseState licenseState = null;
-        Metadata metadata = Mockito.mock(Metadata.class);
-        Mockito.when(metadata.hashesOfConsistentSettings()).thenReturn(DiffableStringMap.EMPTY);
-        Mockito.when(metadata.settings()).thenReturn(dynamicSettings);
-        ClusterState clusterState = Mockito.mock(ClusterState.class);
-        Mockito.when(clusterState.metadata()).thenReturn(metadata);
+        Metadata metadata = Metadata.builder().transientSettings(dynamicSettings).build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
         ClusterService clusterService = Mockito.mock(ClusterService.class);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
         ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, Set.of(DeprecationChecks.SKIP_DEPRECATIONS_SETTING));

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.deprecation;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DiffableStringMap;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -44,6 +45,7 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         ThreadPool threadPool = null;
         final XPackLicenseState licenseState = null;
         Metadata metadata = Mockito.mock(Metadata.class);
+        Mockito.when(metadata.hashesOfConsistentSettings()).thenReturn(DiffableStringMap.EMPTY);
         ClusterState clusterState = Mockito.mock(ClusterState.class);
         Mockito.when(clusterState.metadata()).thenReturn(metadata);
         ClusterService clusterService = Mockito.mock(ClusterService.class);
@@ -113,4 +115,5 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         Assert.assertNotNull(visibleSettings.get());
         Assert.assertEquals(expectedSettings, visibleSettings.get());
     }
+
 }


### PR DESCRIPTION
This commit makes it so that the NodeDeprecationChecks part of the deprecation info API will ignore settings
specified by deprecation.skip_deprecated_settings, even if those settings are dynamically set.
Closes #82889