### PR TITLE
Identify other node in SameShardAllocDec message

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -94,7 +94,7 @@ public class SameShardAllocationDecider extends AllocationDecider {
                 // check if its on the same host as the one we want to allocate to
                 assert Strings.hasLength(checkNode.getHostAddress()) : checkNode;
                 if (checkNode.getHostAddress().equals(node.node().getHostAddress())) {
-                    return allocation.debugDecision() ? debugNoAlreadyAllocatedToHost(node, allocation) : Decision.NO;
+                    return allocation.debugDecision() ? debugNoAlreadyAllocatedToHost(node, checkNode, allocation) : Decision.NO;
                 }
             }
         }
@@ -106,15 +106,16 @@ public class SameShardAllocationDecider extends AllocationDecider {
         return canAllocate(shardRouting, node, allocation);
     }
 
-    private static Decision debugNoAlreadyAllocatedToHost(RoutingNode node, RoutingAllocation allocation) {
+    private static Decision debugNoAlreadyAllocatedToHost(RoutingNode newNode, DiscoveryNode existingNode, RoutingAllocation allocation) {
         return allocation.decision(
             Decision.NO,
             NAME,
-            "can not allocate to this node [%s], a copy of this shard is already allocated to another node "
-                + "at the same host address [%s], and [%s] is [true] which "
-                + "forbids more than one node on this host from holding a copy of this shard",
-            node.nodeId(),
-            node.node().getHostAddress(),
+            """
+                cannot allocate to node [%s] because a copy of this shard is already allocated to node [%s] with the same host \
+                address [%s] and [%s] is [true] which forbids more than one node on each host from holding a copy of this shard""",
+            newNode.nodeId(),
+            existingNode.getId(),
+            newNode.node().getHostAddress(),
             CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey()
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterInfo;
@@ -47,7 +45,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SameShardRoutingTests extends ESAllocationTestCase {
-    private final Logger logger = LogManager.getLogger(SameShardRoutingTests.class);
 
     public void testSameHost() {
         AllocationService strategy = createAllocationService(
@@ -213,6 +210,11 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
                 .findFirst()
                 .orElseThrow(AssertionError::new);
 
+            final RoutingNode otherNode = StreamSupport.stream(clusterState.getRoutingNodes().spliterator(), false)
+                .filter(node -> node != emptyNode)
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
             final RoutingAllocation routingAllocation = new RoutingAllocation(
                 new AllocationDeciders(singletonList(decider)),
                 clusterState.getRoutingNodes(),
@@ -230,11 +232,12 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
                 decision.getExplanation(),
                 equalTo(
                     """
-                        can not allocate to this node [%s], a copy of this shard is already allocated to another node at \
-                        the same host address [%s], and [%s] is [true] which forbids more than one node on this host from \
-                        holding a copy of this shard\
+                        cannot allocate to this node [%s] because a copy of this shard is already allocated to node [%s] with the same \
+                        host address [%s] and [%s] is [true] which forbids more than one node on this host from holding a copy of this \
+                        shard\
                         """.formatted(
                         emptyNode.nodeId(),
+                        otherNode.nodeId(),
                         host1,
                         SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey()
                     )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -232,9 +232,8 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
                 decision.getExplanation(),
                 equalTo(
                     """
-                        cannot allocate to this node [%s] because a copy of this shard is already allocated to node [%s] with the same \
-                        host address [%s] and [%s] is [true] which forbids more than one node on this host from holding a copy of this \
-                        shard\
+                        cannot allocate to node [%s] because a copy of this shard is already allocated to node [%s] with the same host \
+                        address [%s] and [%s] is [true] which forbids more than one node on each host from holding a copy of this shard\
                         """.formatted(
                         emptyNode.nodeId(),
                         otherNode.nodeId(),


### PR DESCRIPTION
In #80767 we discovered that the explanation message from the
`SameShardAllocationDecider` names the target node but not the other
node that blocks the allocation. This commit enhances the explanation
message to identify both nodes.