### PR TITLE
Fix `PutPrivilegesResponse` serialization test 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Response when adding one or more application privileges to the security index.
@@ -45,7 +44,7 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject().field("created", new TreeMap<>(created)).endObject();
+        builder.startObject().field("created", created).endObject();
         return builder;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Response when adding one or more application privileges to the security index.
@@ -44,7 +45,7 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject().field("created", created).endObject();
+        builder.startObject().field("created", new TreeMap<>(created)).endObject();
         return builder;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,7 +35,16 @@ public class PutPrivilegesResponseTests extends ESTestCase {
         output.flush();
         final PutPrivilegesResponse copy = new PutPrivilegesResponse(output.bytes().streamInput());
         assertThat(copy.created(), equalTo(original.created()));
-        assertThat(Strings.toString(copy), equalTo(Strings.toString(original)));
+        assertJsonEquals(Strings.toString(copy), Strings.toString(original));
+    }
+
+    private void assertJsonEquals(String actual, String expected) throws IOException {
+        try (
+            var actualParser = createParser(JsonXContent.jsonXContent, actual);
+            var expectedParser = createParser(JsonXContent.jsonXContent, expected)
+        ) {
+            assertThat(actualParser.mapOrdered(), equalTo(expectedParser.mapOrdered()));
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class PutPrivilegesResponseTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82831")
     public void testSerialization() throws IOException {
         final int applicationCount = randomInt(3);
         final Map<String, List<String>> map = Maps.newMapWithExpectedSize(applicationCount);


### PR DESCRIPTION
Assert JSONs not as strings, but as maps, so we don't depend on the order of the fields in the JSON object. 

Fixes #82831
