### PR TITLE
Port fix to ccs-rolling-upgrade-remote-cluster

### DIFF
--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -53,11 +53,17 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     }
   }
 
-  tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
+  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     dependsOn "processTestResources"
     mustRunAfter("precommit")
     doFirst {
       localCluster.get().nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oldClusterTest"
+    doFirst {
       remoteCluster.get().nextNodeToNextVersion()
     }
   }


### PR DESCRIPTION
This is a forward port of the 8.0 fix introduced in this commit:

[2b300496eb82f8e9d9226a85b8f3f5073edcc3a9](https://github.com/elastic/elasticsearch/commit/2b300496eb82f8e9d9226a85b8f3f5073edcc3a9)