### PR TITLE
[DOCS] Fix formatting in cat transforms API

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -916,9 +916,11 @@ pattern (for example, `"my-index-*"`), an array of indices (for example,
 `["my-index-000001", "my-index-000002"]`), or an array of index patterns (for
 example, `["my-index-*", "my-other-index-*"]`. For remote indices use the syntax
 `"remote_name:index_name"`.
-
++
+--
 NOTE: If any indices are in remote clusters then the master node and at least
 one transform node must have the `remote_cluster_client` node role.
+--
 end::source-index-transforms[]
 
 tag::source-query-transforms[]


### PR DESCRIPTION
This PR fixes the nesting of parameters in [cat transforms](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html), in particular:

![image](https://user-images.githubusercontent.com/26471269/150449034-4498295d-d1e5-4f18-9f22-16d17ccf4c2f.png)
