### PR TITLE
[7.16] [DOCS] Fix formatting in cat transforms API (#82899)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -929,9 +929,11 @@ pattern (for example, `"my-index-*"`), an array of indices (for example,
 `["my-index-000001", "my-index-000002"]`), or an array of index patterns (for
 example, `["my-index-*", "my-other-index-*"]`. For remote indices use the syntax
 `"remote_name:index_name"`.
-
++
+--
 NOTE: If any indices are in remote clusters then the master node and at least
 one transform node must have the `remote_cluster_client` node role.
+--
 end::source-index-transforms[]
 
 tag::source-query-transforms[]


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Fix formatting in cat transforms API (#82899)