### PR TITLE
Mute problematic DateUtilsTests.testTimezoneIds Pacific/Niue on all JDK releases

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -49,14 +49,12 @@ public class DateUtilsTests extends ESTestCase {
         )
     );
 
-    private static final boolean isAtLeastJava18 = JavaVersion.current().compareTo(JavaVersion.parse("18")) >= 0;
-
     // A temporary list of zones and JDKs, where Joda and the JDK timezone data are out of sync, until either Joda or the JDK
     // are updated, see https://github.com/elastic/elasticsearch/issues/82356
     private static final Set<String> IGNORE_IDS = new HashSet<>(Arrays.asList("Pacific/Niue"));
 
     private static boolean maybeIgnore(String jodaId) {
-        if (IGNORE_IDS.contains(jodaId) && isAtLeastJava18) {
+        if (IGNORE_IDS.contains(jodaId)) {
             return true;
         }
         return false;

--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.common.time;
 
 import org.apache.logging.log4j.Level;
-import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 


### PR DESCRIPTION
Remove the JDK version condition that determines if a particular 
problematic time zone test scenario should be skipped. The updated TZ
data is now in all recent shipping JDK releases, so the scenario fails
consistently on all recent JDKs (not just JDK 18 EA as was previously
the case).

More details in #82356, but this change effectively amounts to muting
the specific test scenario, until further action is taken.