### PR TITLE
[8.0] Upgrade documentation for xpack.monitoring.history.duration (#82295)

### DIFF
--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -907,3 +907,29 @@ will continue to use that configured value.
 Any node that did not have an explicitly configured password hashing algorithm in
 {es} 6.x or {es} 7.x would have failed to start.
 ====
+
+//tag::notable-breaking-changes[]
+.The `xpack.monitoring.history.duration` will not delete indices created by metricbeat or elastic agent
+[%collapsible]
+====
+*Details* +
+
+Prior to 8.0, Elasticsearch would internally handle removal of all monitoring indices according to the
+`xpack.monitoring.history.duration` setting.
+
+When using metricbeat or elastic agent >= 8.0 to collect monitoring data, indices are managed via an ILM policy. If the setting is present, the policy will be created using the `xpack.monitoring.history.duration` as an initial retention period.
+
+If you need to customize retention settings for monitoring data collected with metricbeat, please update the `.monitoring-8-ilm-policy` ILM policy directly.
+
+The `xpack.monitoring.history.duration` setting will only apply to monitoring indices written using (legacy) internal
+collection, not indices created by metricbeat or agent.
+
+*Impact* +
+After upgrading, insure that the `.monitoring-8-ilm-policy` ILM policy aligns with your desired retention settings.
+
+If you only use
+metricbeat or agent to collect monitoring data, you can also remove any custom `xpack.monitoring.history.duration`
+settings.
+
+====
+// end::notable-breaking-changes[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Upgrade documentation for xpack.monitoring.history.duration (#82295)