### PR TITLE
[8.0] Fix bug where field is not returned if it has the same prefix as a nested field (#82922)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -87,7 +87,9 @@ public class FieldFetcher {
                 if (nestedParentPaths.isEmpty() == false) {
                     // try to find the shortest nested parent path for this field
                     for (String nestedFieldPath : nestedParentPaths) {
-                        if (field.startsWith(nestedFieldPath)) {
+                        if (field.startsWith(nestedFieldPath)
+                            && field.length() > nestedFieldPath.length()
+                            && field.charAt(nestedFieldPath.length()) == '.') {
                             nestedParentPath = nestedFieldPath;
                             break;
                         }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -1002,6 +1002,33 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertThat(fields.get("date_field").getValues().get(1), equalTo("12"));
     }
 
+    public void testNestedPrefix() throws IOException {
+        String mapping = """
+            {
+              "_doc": {
+                "properties" : {
+                  "foo" : {
+                    "type" : "nested",
+                    "properties" : {
+                      "nested_field" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "foo_bar" : {
+                    "type" : "double"
+                  }
+                }
+              }
+            }
+            """;
+        MapperService mapperService = createMapperService(mapping);
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("foo_bar", 3.1).endObject();
+        // the field should be returned
+        Map<String, DocumentField> fields = fetchFields(mapperService, source, "foo_bar");
+        assertThat(fields.get("foo_bar").getValues().size(), equalTo(1));
+    }
+
     /**
      * Field patterns retrieved with "include_unmapped" use an automaton with a maximal allowed size internally.
      * This test checks we have a bound in place to avoid misuse of this with exceptionally large field patterns


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix bug where field is not returned if it has the same prefix as a nested field (#82922)