### PR TITLE
Remove nebula extra configuration plugin

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -220,7 +220,6 @@ dependencies {
   api 'commons-codec:commons-codec:1.11'
   api 'org.apache.commons:commons-compress:1.19'
   api 'org.apache.ant:ant:1.10.8'
-  api 'com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0'
   api 'com.netflix.nebula:gradle-info-plugin:11.1.0'
   api 'org.apache.rat:apache-rat:0.11'
   api "net.java.dev.jna:jna:${versions.getProperty('jna')}"

--- a/modules/legacy-geo/build.gradle
+++ b/modules/legacy-geo/build.gradle
@@ -9,7 +9,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-cluster-test'
-apply plugin: 'nebula.optional-base'
 
 esplugin {
   description 'Placeholder plugin for geospatial features in ES'
@@ -18,8 +17,8 @@ esplugin {
 
 dependencies {
   api "org.apache.lucene:lucene-spatial-extras:${versions.lucene}"
-  api "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}", optional
-  api "org.locationtech.jts:jts-core:${versions.jts}", optional
+  api "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
+  api "org.locationtech.jts:jts-core:${versions.jts}"
   testImplementation project(":test:framework")
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -9,7 +9,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.build'
-apply plugin: 'nebula.optional-base'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
@@ -59,7 +58,7 @@ dependencies {
 
   // logging
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-  api "org.apache.logging.log4j:log4j-core:${versions.log4j}", optional
+  api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
   api "net.java.dev.jna:jna:${versions.jna}"
 


### PR DESCRIPTION
This was used to mark dependencies as optional. Within
Gradle those deps are handled as usual and optional is only
added to the according pom file. When packaging our distro those
modules are added anyhow including the optional dependencies

The initial motiviation to remove the plugin was it is incompatible
with the gradle configuration cache