### PR TITLE
Make IndexNameExpressionResolver more Static

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -205,7 +205,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
         );
 
         assertThat(
-            indexNameExpressionResolver.resolveSearchRoutingAllIndices(state.metadata(), "0,1,2,tw , ltw , lw"),
+            IndexNameExpressionResolver.resolveSearchRoutingAllIndices(state.metadata(), "0,1,2,tw , ltw , lw"),
             equalTo(
                 newMap(
                     "test1",

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
 import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.node.Node;
@@ -685,7 +684,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
     public void testSnapshotWithDateMath() {
         final String repo = "repo";
 
-        final IndexNameExpressionResolver nameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
         final String snapshotName = "<snapshot-{now/d}>";
 
         logger.info("-->  creating repository");
@@ -695,11 +693,11 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .setSettings(Settings.builder().put("location", randomRepoPath()).put("compress", randomBoolean()))
         );
 
-        final String expression1 = nameExpressionResolver.resolveDateMathExpression(snapshotName);
+        final String expression1 = IndexNameExpressionResolver.resolveDateMathExpression(snapshotName);
         logger.info("-->  creating date math snapshot");
         createFullSnapshot(repo, snapshotName);
         // snapshot could be taken before or after a day rollover
-        final String expression2 = nameExpressionResolver.resolveDateMathExpression(snapshotName);
+        final String expression2 = IndexNameExpressionResolver.resolveDateMathExpression(snapshotName);
 
         SnapshotsStatusResponse response = clusterAdmin().prepareSnapshotStatus(repo)
             .setSnapshots(Sets.newHashSet(expression1, expression2).toArray(Strings.EMPTY_ARRAY))

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -204,7 +204,7 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                 switch (action.actionType()) {
                     case ADD:
                         for (String alias : concreteAliases(action, state.metadata(), index.getName())) {
-                            String resolvedName = this.indexNameExpressionResolver.resolveDateMathExpression(alias, now);
+                            String resolvedName = IndexNameExpressionResolver.resolveDateMathExpression(alias, now);
                             finalActions.add(
                                 new AliasAction.Add(
                                     index.getName(),

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -212,7 +212,7 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     indexNameRef.set(clusterState.metadata().dataStreams().get(request.index()).getIndices().get(0).getName());
                     return clusterState;
                 } else {
-                    String indexName = indexNameExpressionResolver.resolveDateMathExpression(request.index());
+                    String indexName = IndexNameExpressionResolver.resolveDateMathExpression(request.index());
                     indexNameRef.set(indexName);
                     if (isSystemIndex) {
                         if (indexName.equals(request.index()) == false) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -90,7 +90,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
         }
 
         final long resolvedAt = System.currentTimeMillis();
-        final String indexName = indexNameExpressionResolver.resolveDateMathExpression(request.index(), resolvedAt);
+        final String indexName = IndexNameExpressionResolver.resolveDateMathExpression(request.index(), resolvedAt);
 
         final SystemIndexDescriptor mainDescriptor = systemIndices.findMatchingDescriptor(indexName);
         final boolean isSystemIndex = mainDescriptor != null;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -61,7 +61,6 @@ public class MetadataRolloverService {
     private final ThreadPool threadPool;
     private final MetadataCreateIndexService createIndexService;
     private final MetadataIndexAliasesService indexAliasesService;
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final SystemIndices systemIndices;
 
     @Inject
@@ -69,13 +68,11 @@ public class MetadataRolloverService {
         ThreadPool threadPool,
         MetadataCreateIndexService createIndexService,
         MetadataIndexAliasesService indexAliasesService,
-        IndexNameExpressionResolver indexNameExpressionResolver,
         SystemIndices systemIndices
     ) {
         this.threadPool = threadPool;
         this.createIndexService = createIndexService;
         this.indexAliasesService = indexAliasesService;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.systemIndices = systemIndices;
     }
 
@@ -183,10 +180,8 @@ public class MetadataRolloverService {
         final String sourceProvidedName = writeIndex.getSettings()
             .get(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, writeIndex.getIndex().getName());
         final String sourceIndexName = writeIndex.getIndex().getName();
-        final String unresolvedName = (newIndexName != null)
-            ? newIndexName
-            : generateRolloverIndexName(sourceProvidedName, indexNameExpressionResolver);
-        final String rolloverIndexName = indexNameExpressionResolver.resolveDateMathExpression(unresolvedName);
+        final String unresolvedName = (newIndexName != null) ? newIndexName : generateRolloverIndexName(sourceProvidedName);
+        final String rolloverIndexName = IndexNameExpressionResolver.resolveDateMathExpression(unresolvedName);
         return new NameResolution(sourceIndexName, unresolvedName, rolloverIndexName);
     }
 
@@ -313,8 +308,8 @@ public class MetadataRolloverService {
         return new RolloverResult(newWriteIndexName, originalWriteIndex.getName(), newState);
     }
 
-    static String generateRolloverIndexName(String sourceIndexName, IndexNameExpressionResolver indexNameExpressionResolver) {
-        String resolvedName = indexNameExpressionResolver.resolveDateMathExpression(sourceIndexName);
+    static String generateRolloverIndexName(String sourceIndexName) {
+        String resolvedName = IndexNameExpressionResolver.resolveDateMathExpression(sourceIndexName);
         final boolean isDateMath = sourceIndexName.equals(resolvedName) == false;
         if (INDEX_NAME_PATTERN.matcher(resolvedName).matches()) {
             int numberIndex = sourceIndexName.lastIndexOf("-");

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -116,8 +116,8 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
     ) {
 
         // there is no need to fetch docs stats for split but we keep it simple and do it anyway for simplicity of the code
-        final String sourceIndex = indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getSourceIndex());
-        final String targetIndex = indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getTargetIndexRequest().index());
+        final String sourceIndex = IndexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getSourceIndex());
+        final String targetIndex = IndexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getTargetIndexRequest().index());
 
         final IndexMetadata sourceMetadata = state.metadata().index(sourceIndex);
         if (sourceMetadata == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
@@ -76,7 +76,7 @@ public class IndexAbstractionResolver {
             }
 
             // we always need to check for date math expressions
-            final String dateMathName = indexNameExpressionResolver.resolveDateMathExpression(indexAbstraction);
+            final String dateMathName = IndexNameExpressionResolver.resolveDateMathExpression(indexAbstraction);
             if (dateMathName != indexAbstraction) {
                 assert dateMathName.equals(indexAbstraction) == false;
                 if (replaceWildcards && Regex.isSimpleMatchPattern(dateMathName)) {

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -863,11 +863,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     }
 
     public Function<String, String> dateMathExpressionResolverAt() {
-        return expression -> expressionResolver.resolveDateMathExpression(expression, System.currentTimeMillis());
+        return expression -> IndexNameExpressionResolver.resolveDateMathExpression(expression, System.currentTimeMillis());
     }
 
     public Function<String, String> dateMathExpressionResolverAt(long instant) {
-        return expression -> expressionResolver.resolveDateMathExpression(expression, instant);
+        return expression -> IndexNameExpressionResolver.resolveDateMathExpression(expression, instant);
     }
 
     public interface ShardStoreDeleter {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -88,8 +88,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     public static final String INGEST_ORIGIN = "ingest";
 
     private static final Logger logger = LogManager.getLogger(IngestService.class);
-    private static final IndexNameExpressionResolver.DateMathExpressionResolver DATE_MATH_EXPRESSION_RESOLVER =
-        new IndexNameExpressionResolver.DateMathExpressionResolver();
 
     private final ClusterService clusterService;
     private final ScriptService scriptService;
@@ -264,7 +262,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     }
 
     private static String resolveIndexName(final String unresolvedIndexName, final long epochMillis) {
-        List<String> resolvedNames = DATE_MATH_EXPRESSION_RESOLVER.resolve(
+        List<String> resolvedNames = IndexNameExpressionResolver.DateMathExpressionResolver.resolve(
             new IndexNameExpressionResolver.ResolverContext(epochMillis),
             List.of(unresolvedIndexName)
         );

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -241,7 +241,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      */
     public void createSnapshot(final CreateSnapshotRequest request, final ActionListener<Snapshot> listener) {
         final String repositoryName = request.repository();
-        final String snapshotName = indexNameExpressionResolver.resolveDateMathExpression(request.snapshot());
+        final String snapshotName = IndexNameExpressionResolver.resolveDateMathExpression(request.snapshot());
         validate(repositoryName, snapshotName);
         // TODO: create snapshot UUID in CreateSnapshotRequest and make this operation idempotent to cleanly deal with transport layer
         // retries
@@ -455,7 +455,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             listener.onFailure(new RepositoryException(repositoryName, "cannot create snapshot in a readonly repository"));
             return;
         }
-        final String snapshotName = indexNameExpressionResolver.resolveDateMathExpression(request.target());
+        final String snapshotName = IndexNameExpressionResolver.resolveDateMathExpression(request.target());
         validate(repositoryName, snapshotName);
         // TODO: create snapshot UUID in CloneSnapshotRequest and make this operation idempotent to cleanly deal with transport layer
         // retries

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -60,7 +60,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
@@ -68,7 +67,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class MetadataRolloverServiceTests extends ESTestCase {
 
@@ -282,29 +280,17 @@ public class MetadataRolloverServiceTests extends ESTestCase {
     public void testGenerateRolloverIndexName() {
         String invalidIndexName = randomAlphaOfLength(10) + "A";
         IndexNameExpressionResolver indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> MetadataRolloverService.generateRolloverIndexName(invalidIndexName, indexNameExpressionResolver)
-        );
+        expectThrows(IllegalArgumentException.class, () -> MetadataRolloverService.generateRolloverIndexName(invalidIndexName));
         int num = randomIntBetween(0, 100);
         final String indexPrefix = randomAlphaOfLength(10);
         String indexEndingInNumbers = indexPrefix + "-" + num;
         assertThat(
-            MetadataRolloverService.generateRolloverIndexName(indexEndingInNumbers, indexNameExpressionResolver),
+            MetadataRolloverService.generateRolloverIndexName(indexEndingInNumbers),
             equalTo(indexPrefix + "-" + String.format(Locale.ROOT, "%06d", num + 1))
         );
-        assertThat(
-            MetadataRolloverService.generateRolloverIndexName("index-name-1", indexNameExpressionResolver),
-            equalTo("index-name-000002")
-        );
-        assertThat(
-            MetadataRolloverService.generateRolloverIndexName("index-name-2", indexNameExpressionResolver),
-            equalTo("index-name-000003")
-        );
-        assertEquals(
-            "<index-name-{now/d}-000002>",
-            MetadataRolloverService.generateRolloverIndexName("<index-name-{now/d}-1>", indexNameExpressionResolver)
-        );
+        assertThat(MetadataRolloverService.generateRolloverIndexName("index-name-1"), equalTo("index-name-000002"));
+        assertThat(MetadataRolloverService.generateRolloverIndexName("index-name-2"), equalTo("index-name-000003"));
+        assertEquals("<index-name-{now/d}-000002>", MetadataRolloverService.generateRolloverIndexName("<index-name-{now/d}-1>"));
     }
 
     public void testCreateIndexRequest() {
@@ -703,13 +689,10 @@ public class MetadataRolloverServiceTests extends ESTestCase {
 
         MetadataCreateIndexService createIndexService = mock(MetadataCreateIndexService.class);
         MetadataIndexAliasesService metadataIndexAliasesService = mock(MetadataIndexAliasesService.class);
-        IndexNameExpressionResolver mockIndexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
-        when(mockIndexNameExpressionResolver.resolveDateMathExpression(any())).then(returnsFirstArg());
         MetadataRolloverService rolloverService = new MetadataRolloverService(
             null,
             createIndexService,
             metadataIndexAliasesService,
-            mockIndexNameExpressionResolver,
             EmptySystemIndices.INSTANCE
         );
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -227,7 +227,6 @@ public class TransportRolloverActionTests extends ESTestCase {
         final ThreadPool mockThreadPool = mock(ThreadPool.class);
         final MetadataCreateIndexService mockCreateIndexService = mock(MetadataCreateIndexService.class);
         final IndexNameExpressionResolver mockIndexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
-        when(mockIndexNameExpressionResolver.resolveDateMathExpression(any())).thenReturn("logs-index-000003");
         final ActionFilters mockActionFilters = mock(ActionFilters.class);
         final MetadataIndexAliasesService mdIndexAliasesService = mock(MetadataIndexAliasesService.class);
 
@@ -271,7 +270,6 @@ public class TransportRolloverActionTests extends ESTestCase {
             mockThreadPool,
             mockCreateIndexService,
             mdIndexAliasesService,
-            mockIndexNameExpressionResolver,
             EmptySystemIndices.INSTANCE
         );
         final TransportRolloverAction transportRolloverAction = new TransportRolloverAction(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1415,65 +1415,6 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(IndexNameExpressionResolver.isExplicitAllPattern(Arrays.asList("*")), equalTo(false));
     }
 
-    public void testIsPatternMatchingAllIndicesExplicitList() throws Exception {
-        // even though it does identify all indices, it's not a pattern but just an explicit list of them
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(concreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, concreteIndices, concreteIndices), equalTo(false));
-    }
-
-    public void testIsPatternMatchingAllIndicesOnlyWildcard() throws Exception {
-        String[] indicesOrAliases = new String[] { "*" };
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(concreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(true));
-    }
-
-    public void testIsPatternMatchingAllIndicesMatchingTrailingWildcard() throws Exception {
-        String[] indicesOrAliases = new String[] { "index*" };
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(concreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(true));
-    }
-
-    public void testIsPatternMatchingAllIndicesNonMatchingTrailingWildcard() throws Exception {
-        String[] indicesOrAliases = new String[] { "index*" };
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        String[] allConcreteIndices = new String[] { "index1", "index2", "index3", "a", "b" };
-        Metadata metadata = metadataBuilder(allConcreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(false));
-    }
-
-    public void testIsPatternMatchingAllIndicesMatchingSingleExclusion() throws Exception {
-        String[] indicesOrAliases = new String[] { "-index1", "index1" };
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(concreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(true));
-    }
-
-    public void testIsPatternMatchingAllIndicesNonMatchingSingleExclusion() throws Exception {
-        String[] indicesOrAliases = new String[] { "-index1" };
-        String[] concreteIndices = new String[] { "index2", "index3" };
-        String[] allConcreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(allConcreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(false));
-    }
-
-    public void testIsPatternMatchingAllIndicesMatchingTrailingWildcardAndExclusion() throws Exception {
-        String[] indicesOrAliases = new String[] { "index*", "-index1", "index1" };
-        String[] concreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(concreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(true));
-    }
-
-    public void testIsPatternMatchingAllIndicesNonMatchingTrailingWildcardAndExclusion() throws Exception {
-        String[] indicesOrAliases = new String[] { "index*", "-index1" };
-        String[] concreteIndices = new String[] { "index2", "index3" };
-        String[] allConcreteIndices = new String[] { "index1", "index2", "index3" };
-        Metadata metadata = metadataBuilder(allConcreteIndices);
-        assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metadata, indicesOrAliases, concreteIndices), equalTo(false));
-    }
-
     public void testIndexOptionsFailClosedIndicesAndAliases() {
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(
@@ -2912,7 +2853,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
     public void testMathExpressionSupport() {
         Instant instant = LocalDate.of(2021, 01, 11).atStartOfDay().toInstant(ZoneOffset.UTC);
-        String resolved = this.indexNameExpressionResolver.resolveDateMathExpression("<a-name-{now/M{yyyy-MM}}>", instant.toEpochMilli());
+        String resolved = IndexNameExpressionResolver.resolveDateMathExpression("<a-name-{now/M{yyyy-MM}}>", instant.toEpochMilli());
 
         assertEquals(resolved, "a-name-2021-01");
     }
@@ -2921,7 +2862,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         Instant instant = LocalDate.of(2020, 12, 2).atStartOfDay().toInstant(ZoneOffset.UTC);
         final String indexName = "<older-date-{now/M{yyyy-MM}}>";
-        String resolved = this.indexNameExpressionResolver.resolveDateMathExpression(indexName, instant.toEpochMilli());
+        String resolved = IndexNameExpressionResolver.resolveDateMathExpression(indexName, instant.toEpochMilli());
 
         assertEquals(resolved, "older-date-2020-12");
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexModule;
@@ -109,11 +108,9 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
     private CreateIndexClusterStateUpdateRequest request;
     private SearchExecutionContext searchExecutionContext;
-    private IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Before
     public void setupCreateIndexRequestAndAliasValidator() {
-        indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY), EmptySystemIndices.INSTANCE);
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
         Settings indexSettings = Settings.builder()
             .put(SETTING_VERSION_CREATED, Version.CURRENT)
@@ -741,7 +738,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 Metadata.builder().build(),
                 xContentRegistry(),
                 searchExecutionContext,
-                indexNameExpressionResolver::resolveDateMathExpression,
+                IndexNameExpressionResolver::resolveDateMathExpression,
                 m -> false
             )
         );
@@ -759,7 +756,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Metadata.builder().build(),
             xContentRegistry(),
             searchExecutionContext,
-            indexNameExpressionResolver::resolveDateMathExpression,
+            IndexNameExpressionResolver::resolveDateMathExpression,
             m -> false
         );
 
@@ -793,7 +790,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Metadata.builder().build(),
             xContentRegistry(),
             searchExecutionContext,
-            indexNameExpressionResolver::resolveDateMathExpression,
+            IndexNameExpressionResolver::resolveDateMathExpression,
             m -> false
         );
 
@@ -889,7 +886,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Metadata.builder().build(),
             xContentRegistry(),
             searchExecutionContext,
-            indexNameExpressionResolver::resolveDateMathExpression,
+            IndexNameExpressionResolver::resolveDateMathExpression,
             m -> false
         );
 
@@ -930,7 +927,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Metadata.builder().build(),
             xContentRegistry(),
             searchExecutionContext,
-            indexNameExpressionResolver::resolveDateMathExpression,
+            IndexNameExpressionResolver::resolveDateMathExpression,
             m -> false
         );
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -40,37 +40,60 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("testYYY"))
             .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
             state,
             IndicesOptions.lenientExpandOpen(),
             SystemIndexAccessLevel.NONE
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testXXX"))), equalTo(newHashSet("testXXX")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "testYYY"))), equalTo(newHashSet("testXXX", "testYYY")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "ku*"))), equalTo(newHashSet("testXXX", "kuku")));
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("test*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("testXXX"))),
+            equalTo(newHashSet("testXXX"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "testYYY"))),
+            equalTo(newHashSet("testXXX", "testYYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "ku*"))),
+            equalTo(newHashSet("testXXX", "kuku"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("test*"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))), equalTo(newHashSet("testXXX", "testXYY")));
         assertThat(
-            newHashSet(resolver.resolve(context, Arrays.asList("testX*", "kuku"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("testX*"))),
+            equalTo(newHashSet("testXXX", "testXYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testX*", "kuku"))),
             equalTo(newHashSet("testXXX", "testXYY", "kuku"))
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("*"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY", "kuku"))
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Arrays.asList("*", "-kuku"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("*", "-kuku"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
         );
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "testYYY"))), equalTo(newHashSet("testXXX", "testYYY")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "-testXXX"))), equalTo(newHashSet("testXXX", "-testXXX")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "testY*"))), equalTo(newHashSet("testXXX", "testYYY")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "-testX*"))), equalTo(newHashSet("testXXX")));
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "testYYY"))),
+            equalTo(newHashSet("testXXX", "testYYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "-testXXX"))),
+            equalTo(newHashSet("testXXX", "-testXXX"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "testY*"))),
+            equalTo(newHashSet("testXXX", "testYYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testXXX", "-testX*"))),
+            equalTo(newHashSet("testXXX"))
+        );
     }
 
     public void testConvertWildcardsTests() {
@@ -80,7 +103,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("testYYY").putAlias(AliasMetadata.builder("alias3")))
             .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
             state,
@@ -88,17 +110,23 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Arrays.asList("testYY*", "alias*"))),
-            equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
-        );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("-kuku"))), equalTo(newHashSet("-kuku")));
-        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("test*", "-testYYY"))), equalTo(newHashSet("testXXX", "testXYY")));
-        assertThat(
-            newHashSet(resolver.resolve(context, Arrays.asList("testX*", "testYYY"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testYY*", "alias*"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Arrays.asList("testYYY", "testX*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("-kuku"))),
+            equalTo(newHashSet("-kuku"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("test*", "-testYYY"))),
+            equalTo(newHashSet("testXXX", "testXYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testX*", "testYYY"))),
+            equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Arrays.asList("testYYY", "testX*"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
         );
     }
@@ -112,7 +140,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("testYYX").state(IndexMetadata.State.CLOSE))
             .put(indexBuilder("kuku").state(IndexMetadata.State.OPEN));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
             state,
@@ -120,7 +147,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("testX*"))),
             equalTo(newHashSet("testXXX", "testXXY", "testXYY"))
         );
         context = new IndexNameExpressionResolver.Context(
@@ -128,13 +155,19 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             IndicesOptions.fromOptions(true, true, false, true),
             SystemIndexAccessLevel.NONE
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))), equalTo(newHashSet("testXYY")));
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("testX*"))),
+            equalTo(newHashSet("testXYY"))
+        );
         context = new IndexNameExpressionResolver.Context(
             state,
             IndicesOptions.fromOptions(true, true, true, false),
             SystemIndexAccessLevel.NONE
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))), equalTo(newHashSet("testXXX", "testXXY")));
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("testX*"))),
+            equalTo(newHashSet("testXXX", "testXXY"))
+        );
     }
 
     // issue #13334
@@ -148,7 +181,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("kukuYYY"));
 
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
             state,
@@ -156,17 +188,30 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("test*X*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("test*X*"))),
             equalTo(newHashSet("testXXX", "testXXY", "testXYY"))
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("test*X*Y"))), equalTo(newHashSet("testXXY", "testXYY")));
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("kuku*Y*"))), equalTo(newHashSet("kukuYYY")));
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("*Y*"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("test*X*Y"))),
+            equalTo(newHashSet("testXXY", "testXYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("kuku*Y*"))),
+            equalTo(newHashSet("kukuYYY"))
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("*Y*"))),
             equalTo(newHashSet("testXXY", "testXYY", "testYYY", "kukuYYY"))
         );
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("test*Y*X"))).size(), equalTo(0));
-        assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("*Y*X"))).size(), equalTo(0));
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("test*Y*X")))
+                .size(),
+            equalTo(0)
+        );
+        assertThat(
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("*Y*X"))).size(),
+            equalTo(0)
+        );
     }
 
     public void testAll() {
@@ -175,7 +220,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("testXYY"))
             .put(indexBuilder("testYYY"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
             state,
@@ -183,7 +227,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(resolver.resolve(context, Collections.singletonList("_all"))),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolve(context, Collections.singletonList("_all"))),
             equalTo(newHashSet("testXXX", "testXYY", "testYYY"))
         );
     }
@@ -195,7 +239,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("foo_index").state(State.OPEN).putAlias(AliasMetadata.builder("foo_alias")))
             .put(indexBuilder("bar_index").state(State.OPEN).putAlias(AliasMetadata.builder("foo_alias")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
         // when ignoreAliases option is not set, WildcardExpressionResolver resolves the provided
         // expressions against the defined indices and aliases
         IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(
@@ -229,44 +272,71 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         );
 
         {
-            List<String> indices = resolver.resolve(indicesAndAliasesContext, Collections.singletonList("foo_a*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAndAliasesContext,
+                Collections.singletonList("foo_a*")
+            );
             assertThat(indices, containsInAnyOrder("foo_index", "bar_index"));
         }
         {
-            List<String> indices = resolver.resolve(skipAliasesLenientContext, Collections.singletonList("foo_a*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                skipAliasesLenientContext,
+                Collections.singletonList("foo_a*")
+            );
             assertEquals(0, indices.size());
         }
         {
             IndexNotFoundException infe = expectThrows(
                 IndexNotFoundException.class,
-                () -> resolver.resolve(skipAliasesStrictContext, Collections.singletonList("foo_a*"))
+                () -> IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                    skipAliasesStrictContext,
+                    Collections.singletonList("foo_a*")
+                )
             );
             assertEquals("foo_a*", infe.getIndex().getName());
         }
         {
-            List<String> indices = resolver.resolve(indicesAndAliasesContext, Collections.singletonList("foo*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAndAliasesContext,
+                Collections.singletonList("foo*")
+            );
             assertThat(indices, containsInAnyOrder("foo_foo", "foo_index", "bar_index"));
         }
         {
-            List<String> indices = resolver.resolve(skipAliasesLenientContext, Collections.singletonList("foo*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                skipAliasesLenientContext,
+                Collections.singletonList("foo*")
+            );
             assertThat(indices, containsInAnyOrder("foo_foo", "foo_index"));
         }
         {
-            List<String> indices = resolver.resolve(skipAliasesStrictContext, Collections.singletonList("foo*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                skipAliasesStrictContext,
+                Collections.singletonList("foo*")
+            );
             assertThat(indices, containsInAnyOrder("foo_foo", "foo_index"));
         }
         {
-            List<String> indices = resolver.resolve(indicesAndAliasesContext, Collections.singletonList("foo_alias"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAndAliasesContext,
+                Collections.singletonList("foo_alias")
+            );
             assertThat(indices, containsInAnyOrder("foo_alias"));
         }
         {
-            List<String> indices = resolver.resolve(skipAliasesLenientContext, Collections.singletonList("foo_alias"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                skipAliasesLenientContext,
+                Collections.singletonList("foo_alias")
+            );
             assertThat(indices, containsInAnyOrder("foo_alias"));
         }
         {
             IllegalArgumentException iae = expectThrows(
                 IllegalArgumentException.class,
-                () -> resolver.resolve(skipAliasesStrictContext, Collections.singletonList("foo_alias"))
+                () -> IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                    skipAliasesStrictContext,
+                    Collections.singletonList("foo_alias")
+                )
             );
             assertEquals(
                 "The provided expression [foo_alias] matches an alias, " + "specify the corresponding concrete indices instead.",
@@ -298,8 +368,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
 
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
-        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
-
         {
             IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(
                 randomBoolean(),
@@ -318,11 +386,17 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             // data streams are not included but expression matches the data stream
-            List<String> indices = resolver.resolve(indicesAndAliasesContext, Collections.singletonList("foo_*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAndAliasesContext,
+                Collections.singletonList("foo_*")
+            );
             assertThat(indices, containsInAnyOrder("foo_index", "foo_foo", "bar_index"));
 
             // data streams are not included and expression doesn't match the data steram
-            indices = resolver.resolve(indicesAndAliasesContext, Collections.singletonList("bar_*"));
+            indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAndAliasesContext,
+                Collections.singletonList("bar_*")
+            );
             assertThat(indices, containsInAnyOrder("bar_bar", "bar_index"));
         }
 
@@ -349,7 +423,10 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             // data stream's corresponding backing indices are resolved
-            List<String> indices = resolver.resolve(indicesAliasesAndDataStreamsContext, Collections.singletonList("foo_*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAliasesAndDataStreamsContext,
+                Collections.singletonList("foo_*")
+            );
             assertThat(
                 indices,
                 containsInAnyOrder(
@@ -362,7 +439,10 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             // include all wildcard adds the data stream's backing indices
-            indices = resolver.resolve(indicesAliasesAndDataStreamsContext, Collections.singletonList("*"));
+            indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAliasesAndDataStreamsContext,
+                Collections.singletonList("*")
+            );
             assertThat(
                 indices,
                 containsInAnyOrder(
@@ -400,7 +480,10 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             // data stream's corresponding backing indices are resolved
-            List<String> indices = resolver.resolve(indicesAliasesDataStreamsAndHiddenIndices, Collections.singletonList("foo_*"));
+            List<String> indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAliasesDataStreamsAndHiddenIndices,
+                Collections.singletonList("foo_*")
+            );
             assertThat(
                 indices,
                 containsInAnyOrder(
@@ -413,7 +496,10 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             // include all wildcard adds the data stream's backing indices
-            indices = resolver.resolve(indicesAliasesDataStreamsAndHiddenIndices, Collections.singletonList("*"));
+            indices = IndexNameExpressionResolver.WildcardExpressionResolver.resolve(
+                indicesAliasesDataStreamsAndHiddenIndices,
+                Collections.singletonList("*")
+            );
             assertThat(
                 indices,
                 containsInAnyOrder(

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -67,7 +67,6 @@ import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomMap;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -424,8 +423,6 @@ public final class DataStreamTestHelper {
             mappingLookup = MappingLookup.fromMappers(mapping, List.of(dtfm, dateFieldMapper), List.of(), List.of());
         }
         IndicesService indicesService = mockIndicesServices(mappingLookup);
-        IndexNameExpressionResolver mockIndexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
-        when(mockIndexNameExpressionResolver.resolveDateMathExpression(any())).then(returnsFirstArg());
 
         ShardLimitValidator shardLimitValidator = new ShardLimitValidator(Settings.EMPTY, clusterService);
         MetadataCreateIndexService createIndexService = new MetadataCreateIndexService(
@@ -443,13 +440,7 @@ public final class DataStreamTestHelper {
             new IndexSettingProviders(providers)
         );
         MetadataIndexAliasesService indexAliasesService = new MetadataIndexAliasesService(clusterService, indicesService, null, registry);
-        return new MetadataRolloverService(
-            testThreadPool,
-            createIndexService,
-            indexAliasesService,
-            mockIndexNameExpressionResolver,
-            EmptySystemIndices.INSTANCE
-        );
+        return new MetadataRolloverService(testThreadPool, createIndexService, indexAliasesService, EmptySystemIndices.INSTANCE);
     }
 
     private static MetadataFieldMapper getDataStreamTimestampFieldMapper() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -39,9 +39,6 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
 
     private static final Logger logger = LogManager.getLogger(GenerateSnapshotNameStep.class);
 
-    private static final IndexNameExpressionResolver.DateMathExpressionResolver DATE_MATH_RESOLVER =
-        new IndexNameExpressionResolver.DateMathExpressionResolver();
-
     private final String snapshotRepository;
 
     public GenerateSnapshotNameStep(StepKey key, StepKey nextStepKey, String snapshotRepository) {
@@ -143,7 +140,7 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
     }
 
     public static String generateSnapshotName(String name, IndexNameExpressionResolver.Context context) {
-        List<String> candidates = DATE_MATH_RESOLVER.resolve(context, Collections.singletonList(name));
+        List<String> candidates = IndexNameExpressionResolver.DateMathExpressionResolver.resolve(context, Collections.singletonList(name));
         if (candidates.size() != 1) {
             throw new IllegalStateException("resolving snapshot name " + name + " generated more than one candidate: " + candidates);
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
@@ -17,9 +17,9 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.Requests;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 
@@ -59,7 +59,7 @@ public class DateMathExpressionIntegTests extends SecurityIntegTestCase {
 
     public void testDateMathExpressionsCanBeAuthorized() throws Exception {
         final String expression = "<datemath-{now/M}>";
-        final String expectedIndexName = TestIndexNameExpressionResolver.newInstance().resolveDateMathExpression(expression);
+        final String expectedIndexName = IndexNameExpressionResolver.resolveDateMathExpression(expression);
         final boolean refeshOnOperation = randomBoolean();
         Client client = client().filterWithHeader(Collections.singletonMap("Authorization", basicAuthHeaderValue("user1", USERS_PASSWD)));
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -177,7 +177,7 @@ class IndicesAndAliasesResolver {
         // shard level requests.
         final List<String> localIndices = new ArrayList<>(indices.length);
         for (String name : indices) {
-            localIndices.add(nameExpressionResolver.resolveDateMathExpression(name));
+            localIndices.add(IndexNameExpressionResolver.resolveDateMathExpression(name));
         }
         return new ResolvedIndices(localIndices, List.of());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -122,7 +122,6 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     private CompositeRolesStore rolesStore;
     private Metadata metadata;
     private IndicesAndAliasesResolver defaultIndicesResolver;
-    private IndexNameExpressionResolver indexNameExpressionResolver;
     private Map<String, RoleDescriptor> roleMap;
     private String todaySuffix;
     private String tomorrowSuffix;
@@ -137,7 +136,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             .put("cluster.remote.other_remote.seeds", "127.0.0.1:" + randomIntBetween(9351, 9399))
             .build();
 
-        indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
+        IndexNameExpressionResolver indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
 
         DateFormatter dateFormatter = DateFormatter.forPattern("uuuu.MM.dd");
         Instant now = Instant.now(Clock.systemUTC());
@@ -168,7 +167,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             .put(indexBuilder("bar").settings(settings))
             .put(indexBuilder("bar-closed").state(State.CLOSE).settings(settings))
             .put(indexBuilder("bar2").settings(settings))
-            .put(indexBuilder(indexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>")).settings(settings))
+            .put(indexBuilder(IndexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>")).settings(settings))
             .put(indexBuilder("-index10").settings(settings))
             .put(indexBuilder("-index11").settings(settings))
             .put(indexBuilder("-index20").settings(settings))
@@ -1618,7 +1617,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     public void testResolveDateMathExpression() {
         // make the user authorized
         final String pattern = randomBoolean() ? "<datetime-{now/M}>" : "<datetime-{now/M}*>";
-        String dateTimeIndex = indexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>");
+        String dateTimeIndex = IndexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>");
         String[] authorizedIndices = new String[] { "bar", "bar-closed", "foofoobar", "foofoo", "missing", "foofoo-closed", dateTimeIndex };
         roleMap.put(
             "role",
@@ -1677,7 +1676,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             "foofoo",
             "missing",
             "foofoo-closed",
-            indexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>") };
+            IndexNameExpressionResolver.resolveDateMathExpression("<datetime-{now/M}>") };
         roleMap.put(
             "role",
             new RoleDescriptor(


### PR DESCRIPTION
Lots of things can be made static here. I found these while investigating
some index-math related issues and think making more things static here
that are stateless+static in practice makes the code much easier to follow
and might also offer a slight performance gain in expression resolving.

Note for reviewer: The test changes are removed mocking seem inconsequential to me, but maybe I'm missing something?