### PR TITLE
Update the signature of the `submitStateUpdateTask` across the codebase.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -156,7 +156,7 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                 }
             }, finalListener::onFailure);
             CreateIndexTask clusterTask = new CreateIndexTask(request, listener, indexNameRef);
-            clusterService.submitStateUpdateTask("auto create [" + request.index() + "]", clusterTask, clusterTask, executor, clusterTask);
+            clusterService.submitStateUpdateTask("auto create [" + request.index() + "]", clusterTask, clusterTask, executor);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -181,7 +181,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     String source = "rollover_index source [" + trialRolloverIndexName + "] to target [" + trialRolloverIndexName + "]";
                     RolloverTask rolloverTask = new RolloverTask(rolloverRequest, statsResponse, trialRolloverResponse, listener);
                     ClusterStateTaskConfig config = ClusterStateTaskConfig.build(Priority.NORMAL, rolloverRequest.masterNodeTimeout());
-                    clusterService.submitStateUpdateTask(source, rolloverTask, config, rolloverTaskExecutor, rolloverTask);
+                    clusterService.submitStateUpdateTask(source, rolloverTask, config, rolloverTaskExecutor);
                 } else {
                     // conditions not met
                     listener.onResponse(trialRolloverResponse);

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -115,10 +115,6 @@ public interface ClusterStateTaskExecutor<T> {
             public ClusterTasksResult<T> build(ClusterState resultingState) {
                 return new ClusterTasksResult<>(resultingState, executionResults);
             }
-
-            ClusterTasksResult<T> build(ClusterTasksResult<T> result, ClusterState previousState) {
-                return new ClusterTasksResult<>(result.resultingState == null ? previousState : result.resultingState, executionResults);
-            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
@@ -52,8 +52,7 @@ public abstract class LocalMasterServiceTask implements ClusterStateTaskListener
                     LocalMasterServiceTask.this.execute(currentState);
                     return ClusterTasksResult.<LocalMasterServiceTask>builder().successes(tasks).build(currentState);
                 }
-            },
-            this
+            }
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -300,8 +300,7 @@ public class ShardStateAction {
                 TASK_SOURCE,
                 update,
                 ClusterStateTaskConfig.build(Priority.HIGH),
-                shardFailedClusterStateTaskExecutor,
-                update
+                shardFailedClusterStateTaskExecutor
             );
         }
     }
@@ -622,8 +621,7 @@ public class ShardStateAction {
                 "shard-started " + request,
                 update,
                 ClusterStateTaskConfig.build(Priority.URGENT),
-                shardStartedClusterStateTaskExecutor,
-                update
+                shardStartedClusterStateTaskExecutor
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -308,8 +308,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     "node-left",
                     task,
                     ClusterStateTaskConfig.build(Priority.IMMEDIATE),
-                    nodeRemovalExecutor,
-                    task
+                    nodeRemovalExecutor
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -48,14 +48,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -456,18 +454,17 @@ public class JoinHelper {
             assert closed == false : "CandidateJoinAccumulator closed";
             closed = true;
             if (newMode == Mode.LEADER) {
-                final Map<JoinTaskExecutor.Task, ClusterStateTaskListener> pendingAsTasks = new LinkedHashMap<>();
-                final Consumer<JoinTaskExecutor.Task> pendingTaskAdder = task -> pendingAsTasks.put(task, task);
+                final List<JoinTaskExecutor.Task> pendingAsTasks = new ArrayList<>();
                 joinRequestAccumulator.forEach(
-                    (node, listener) -> pendingTaskAdder.accept(
+                    (node, listener) -> pendingAsTasks.add(
                         new JoinTaskExecutor.Task(node, joinReasonService.getJoinReason(node, Mode.CANDIDATE), listener)
                     )
                 );
 
                 final String stateUpdateSource = "elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
 
-                pendingTaskAdder.accept(JoinTaskExecutor.newBecomeMasterTask());
-                pendingTaskAdder.accept(JoinTaskExecutor.newFinishElectionTask());
+                pendingAsTasks.add(JoinTaskExecutor.newBecomeMasterTask());
+                pendingAsTasks.add(JoinTaskExecutor.newFinishElectionTask());
                 joinTaskExecutor = joinTaskExecutorGenerator.get();
                 masterService.submitStateUpdateTasks(
                     stateUpdateSource,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -403,7 +403,7 @@ public class JoinHelper {
                 joinListener
             );
             assert joinTaskExecutor != null;
-            masterService.submitStateUpdateTask("node-join", task, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor, task);
+            masterService.submitStateUpdateTask("node-join", task, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -253,8 +253,7 @@ public class MetadataMappingService {
             "put-mapping " + Strings.arrayToCommaDelimitedString(request.indices()),
             task,
             ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
-            putMappingExecutor,
-            task
+            putMappingExecutor
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -223,7 +223,7 @@ public class ClusterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, ClusterStateTaskListener, ClusterStateTaskConfig, ClusterStateTaskExecutor)}.
+     * Submits a cluster state update task
      * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
      * @param executor   the executor to use for the submitted task.

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -223,8 +223,7 @@ public class ClusterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, Object, ClusterStateTaskConfig,
-     * ClusterStateTaskExecutor, ClusterStateTaskListener)}.
+     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, ClusterStateTaskListener, ClusterStateTaskConfig, ClusterStateTaskExecutor)}.
      * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
      * @param executor   the executor to use for the submitted task.
@@ -234,7 +233,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         T updateTask,
         ClusterStateTaskExecutor<T> executor
     ) {
-        submitStateUpdateTask(source, updateTask, updateTask, executor, updateTask);
+        submitStateUpdateTask(source, updateTask, updateTask, executor);
     }
 
     /**
@@ -246,24 +245,21 @@ public class ClusterService extends AbstractLifecycleComponent {
      * tasks will all be executed on the executor in a single batch
      *
      * @param source   the source of the cluster state update task
-     * @param task     the state needed for the cluster state update task
+     * @param task     the state and the callback needed for the cluster state update task
      * @param config   the cluster state update task configuration
      * @param executor the cluster state update task executor; tasks
      *                 that share the same executor will be executed
      *                 batches on this executor
-     * @param listener callback after the cluster state update task
-     *                 completes
      * @param <T>      the type of the cluster state update task state
      *
      */
-    public <T> void submitStateUpdateTask(
+    public <T extends ClusterStateTaskListener> void submitStateUpdateTask(
         String source,
         T task,
         ClusterStateTaskConfig config,
-        ClusterStateTaskExecutor<T> executor,
-        ClusterStateTaskListener listener
+        ClusterStateTaskExecutor<T> executor
     ) {
-        masterService.submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
+        masterService.submitStateUpdateTasks(source, Collections.singletonMap(task, task), config, executor);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.Collections;
+import java.util.List;
 
 public class ClusterService extends AbstractLifecycleComponent {
     private final MasterService masterService;
@@ -259,7 +259,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         ClusterStateTaskConfig config,
         ClusterStateTaskExecutor<T> executor
     ) {
-        masterService.submitStateUpdateTasks(source, Collections.singletonMap(task, task), config, executor);
+        masterService.submitStateUpdateTasks(source, List.of(task), config, executor);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -426,7 +426,7 @@ public class MasterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, ClusterStateTaskListener, ClusterStateTaskConfig, ClusterStateTaskExecutor)}, submitted updates will not be batched.
+     * Submits a cluster state update task
      * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
      * @param executor

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -426,9 +426,8 @@ public class MasterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, Object, ClusterStateTaskConfig,
-     * ClusterStateTaskExecutor, ClusterStateTaskListener)}, submitted updates will not be batched.
-     *  @param source     the source of the cluster state update task
+     * Submits a cluster state update task; unlike {@link #submitStateUpdateTask(String, ClusterStateTaskListener, ClusterStateTaskConfig, ClusterStateTaskExecutor)}, submitted updates will not be batched.
+     * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
      * @param executor
      *
@@ -438,7 +437,7 @@ public class MasterService extends AbstractLifecycleComponent {
         T updateTask,
         ClusterStateTaskExecutor<T> executor
     ) {
-        submitStateUpdateTask(source, updateTask, updateTask, executor, updateTask);
+        submitStateUpdateTask(source, updateTask, updateTask, executor);
     }
 
     /**
@@ -450,24 +449,21 @@ public class MasterService extends AbstractLifecycleComponent {
      * tasks will all be executed on the executor in a single batch
      *
      * @param source   the source of the cluster state update task
-     * @param task     the state needed for the cluster state update task
+     * @param task     the state and the callback needed for the cluster state update task
      * @param config   the cluster state update task configuration
      * @param executor the cluster state update task executor; tasks
      *                 that share the same executor will be executed
      *                 batches on this executor
-     * @param listener callback after the cluster state update task
-     *                 completes
      * @param <T>      the type of the cluster state update task state
      *
      */
-    public <T> void submitStateUpdateTask(
+    public <T extends ClusterStateTaskListener> void submitStateUpdateTask(
         String source,
         T task,
         ClusterStateTaskConfig config,
-        ClusterStateTaskExecutor<T> executor,
-        ClusterStateTaskListener listener
+        ClusterStateTaskExecutor<T> executor
     ) {
-        submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
+        submitStateUpdateTasks(source, Collections.singletonMap(task, task), config, executor);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -3402,8 +3402,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             "update snapshot state",
             update,
             ClusterStateTaskConfig.build(Priority.NORMAL),
-            SHARD_STATE_EXECUTOR,
-            update
+            SHARD_STATE_EXECUTOR
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -65,11 +65,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -604,17 +602,16 @@ public class MasterServiceTests extends ESTestCase {
                             var executor = assignment.v1();
                             submittedTasks.addAndGet(tasks.size());
                             if (tasks.size() == 1) {
-                                var update = tasks.iterator().next();
                                 masterService.submitStateUpdateTask(
                                     threadName,
-                                    update,
+                                    tasks.iterator().next(),
                                     ClusterStateTaskConfig.build(randomFrom(Priority.values())),
                                     executor
                                 );
                             } else {
                                 masterService.submitStateUpdateTasks(
                                     threadName,
-                                    tasks.stream().collect(toMap(Function.<Task>identity(), Function.<ClusterStateTaskListener>identity())),
+                                    tasks,
                                     ClusterStateTaskConfig.build(randomFrom(Priority.values())),
                                     executor
                                 );

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -275,11 +275,14 @@ public class MasterServiceTests extends ESTestCase {
                 "testClusterStateTaskListenerThrowingExceptionIsOkay",
                 update,
                 ClusterStateTaskConfig.build(Priority.NORMAL),
-                new ClusterStateTaskExecutor<Object>() {
+                new ClusterStateTaskExecutor<>() {
                     @Override
-                    public ClusterTasksResult<Object> execute(ClusterState currentState, List<Object> tasks) {
+                    public ClusterTasksResult<ClusterStateTaskListener> execute(
+                        ClusterState currentState,
+                        List<ClusterStateTaskListener> tasks
+                    ) {
                         ClusterState newClusterState = ClusterState.builder(currentState).build();
-                        return ClusterTasksResult.builder().successes(tasks).build(newClusterState);
+                        return ClusterTasksResult.<ClusterStateTaskListener>builder().successes(tasks).build(newClusterState);
                     }
 
                     @Override
@@ -287,8 +290,7 @@ public class MasterServiceTests extends ESTestCase {
                         published.set(true);
                         latch.countDown();
                     }
-                },
-                update
+                }
             );
 
             latch.await();
@@ -607,8 +609,7 @@ public class MasterServiceTests extends ESTestCase {
                                     threadName,
                                     update,
                                     ClusterStateTaskConfig.build(randomFrom(Priority.values())),
-                                    executor,
-                                    update
+                                    executor
                                 );
                             } else {
                                 masterService.submitStateUpdateTasks(
@@ -685,8 +686,7 @@ public class MasterServiceTests extends ESTestCase {
                 (currentState, tasks) -> {
                     ClusterState newClusterState = ClusterState.builder(currentState).build();
                     return ClusterTasksResult.<ClusterStateTaskListener>builder().successes(tasks).build(newClusterState);
-                },
-                update
+                }
             );
 
             latch.await();

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -684,7 +684,7 @@ class IndexLifecycleRunner {
                 busyIndices.remove(dedupKey);
                 assert removed : "tried to unregister unknown task [" + task + "]";
             }));
-            clusterService.submitStateUpdateTask(source, task, ILM_TASK_CONFIG, ILM_TASK_EXECUTOR, task);
+            clusterService.submitStateUpdateTask(source, task, ILM_TASK_CONFIG, ILM_TASK_EXECUTOR);
         } else {
             logger.trace("skipped redundant execution of [{}]", source);
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -175,7 +175,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
 
-        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(anyString(), any(), any(), any(), any());
+        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(anyString(), any(), any(), any());
     }
 
     public void testRunPolicyErrorStep() {
@@ -656,8 +656,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                     ilm-execute-cluster-state-steps [{"phase":"phase","action":"action","name":"cluster_state_action_step"} => null]"""),
                 Mockito.argThat(taskMatcher),
                 eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
-                any(),
-                Mockito.argThat(taskMatcher)
+                any()
             );
         Mockito.verifyNoMoreInteractions(clusterService);
     }
@@ -684,8 +683,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                     ilm-execute-cluster-state-steps [{"phase":"phase","action":"action","name":"cluster_state_action_step"} => null]"""),
                 Mockito.argThat(taskMatcher),
                 eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
-                any(),
-                Mockito.argThat(taskMatcher)
+                any()
             );
         Mockito.verifyNoMoreInteractions(clusterService);
     }
@@ -766,8 +764,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 Mockito.eq("ilm-set-step-info {policy [cluster_state_action_policy], index [my_index], currentStep [null]}"),
                 Mockito.argThat(taskMatcher),
                 eq(IndexLifecycleRunner.ILM_TASK_CONFIG),
-                any(),
-                Mockito.argThat(taskMatcher)
+                any()
             );
         Mockito.verifyNoMoreInteractions(clusterService);
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -338,7 +338,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             ranPolicy.set(true);
             throw new AssertionError("invalid invocation");
-        }).when(clusterService).submitStateUpdateTask(anyString(), any(), eq(IndexLifecycleRunner.ILM_TASK_CONFIG), any(), any());
+        }).when(clusterService).submitStateUpdateTask(anyString(), any(), eq(IndexLifecycleRunner.ILM_TASK_CONFIG), any());
 
         doAnswer(invocationOnMock -> {
             OperationModeUpdateTask task = (OperationModeUpdateTask) invocationOnMock.getArguments()[1];


### PR DESCRIPTION
This change updates `submitStateUpdateTask` signature to enforce task implements 
ClusterStateTaskListener and remove extra listener argument. This reduces the 
number of arguments and simplifies the call sites as all tasks are listeners already.

Related to: #82644 