### PR TITLE
Fix Broken Assertion in SnapshotsInProgress

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -902,7 +902,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
          * @return a new instance with updated index ids or this instance if unchanged
          */
         public Entry withUpdatedIndexIds(Map<IndexId, IndexId> updates) {
-            assert isClone() == false : "only snapshots can be reassigned to updated IndexId values";
+            if (isClone()) {
+                assert indices.values().stream().noneMatch(updates::containsKey)
+                    : "clone index ids can not be updated but saw tried to update " + updates + " on " + this;
+                return this;
+            }
             Map<String, IndexId> updatedIndices = null;
             for (IndexId existingIndexId : indices.values()) {
                 final IndexId updatedIndexId = updates.get(existingIndexId);


### PR DESCRIPTION
Follow-up to #82912. We may loop over clones here as well
if both clones and snapshots are queued after a delete.
Accounting for that by making this method work with clones.

non-issue because this hasn't been released