### PR TITLE
[8.0] [DOCS] Remove unused tag from rolling restart docs (#82967)

### DIFF
--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -20,7 +20,7 @@ time, so the service remains uninterrupted.
 include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
-// tag::stop_indexing[]
+
 . *Stop indexing and perform a flush.*
 +
 --
@@ -31,7 +31,7 @@ Performing a <<indices-flush, flush>> speeds up shard recovery.
 POST /_flush
 --------------------------------------------------
 --
-// end::stop_indexing[]
+
 //tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -21,6 +21,7 @@ include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
 
+
 . *Stop indexing and perform a flush.*
 +
 --
@@ -173,7 +174,17 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
-include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
++
+--
+While you can continue indexing during the rolling restart, shard recovery
+can be faster if you temporarily stop non-essential indexing and perform a
+<<indices-flush, flush>>.
+
+[source,console]
+--------------------------------------------------
+POST /_flush
+--------------------------------------------------
+--
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_ml]
 +


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove unused tag from rolling restart docs (#82967)