### PR TITLE
Bind to non-localhost for transport in some cases

### DIFF
--- a/docs/changelog/82973.yaml
+++ b/docs/changelog/82973.yaml
@@ -1,0 +1,5 @@
+pr: 82973
+summary: Bind to non-localhost for transport in some cases
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -802,7 +802,8 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                         bw.newLine();
                         bw.write("# Connections are encrypted and mutually authenticated");
                         bw.newLine();
-                        if (false == shouldBindTransportToNonLocalhost(transportAddresses, NetworkUtils.getAllAddresses())) {
+                        if (inEnrollmentMode
+                            && false == shouldBindTransportToNonLocalhost(transportAddresses, NetworkUtils.getAllAddresses())) {
                             bw.write("#");
                         }
                         bw.write(TransportSettings.HOST.getKey() + ": " + hostSettingValue(NetworkUtils.getAllAddresses()));

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
@@ -32,8 +32,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.anyRemoteHostNodeAddress;
 import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.removePreviousAutoconfiguration;
-import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.shouldOnlyBindTransportToLocalhost;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -213,41 +213,41 @@ public class AutoConfigureNodeTests extends ESTestCase {
         }
     }
 
-    public void testShouldBindTransportToNonLocalhost() throws Exception {
+    public void testAnyRemoteHostNodeAddress() throws Exception {
         List<String> remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300");
         InetAddress[] localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] {
             InetAddress.getByName("192.168.0.1"),
             InetAddress.getByName("127.0.0.1"),
             InetAddress.getByName("10.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300", "10.0.0.1:9301");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(false));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("[::1]"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.2.3") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("1.2.3.4:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("[::1]"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of();
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
+        assertThat(anyRemoteHostNodeAddress(remoteAddresses, localAddresses), equalTo(false));
     }
 
     private boolean checkGeneralNameSan(X509Certificate certificate, String generalName, int generalNameTag) throws Exception {

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
@@ -244,6 +244,10 @@ public class AutoConfigureNodeTests extends ESTestCase {
         remoteAddresses = List.of("1.2.3.4:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("[::1]"), InetAddress.getByName("127.0.0.1") };
         assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+
+        remoteAddresses = List.of();
+        localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
+        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
     }
 
     private boolean checkGeneralNameSan(X509Certificate certificate, String generalName, int generalNameTag) throws Exception {

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.removePreviousAutoconfiguration;
-import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.shouldBindTransportToNonLocalhost;
+import static org.elasticsearch.xpack.security.cli.AutoConfigureNode.shouldOnlyBindTransportToLocalhost;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -216,38 +216,38 @@ public class AutoConfigureNodeTests extends ESTestCase {
     public void testShouldBindTransportToNonLocalhost() throws Exception {
         List<String> remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300");
         InetAddress[] localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] {
             InetAddress.getByName("192.168.0.1"),
             InetAddress.getByName("127.0.0.1"),
             InetAddress.getByName("10.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("192.168.0.1:9300", "127.0.0.1:9300", "[::1]:9300", "10.0.0.1:9301");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(true));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(false));
 
         remoteAddresses = List.of("127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("[::1]"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("127.0.0.1:9300", "[::1]:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.2.3") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of("1.2.3.4:9300");
         localAddresses = new InetAddress[] { InetAddress.getByName("[::1]"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
 
         remoteAddresses = List.of();
         localAddresses = new InetAddress[] { InetAddress.getByName("192.168.0.1"), InetAddress.getByName("127.0.0.1") };
-        assertThat(shouldBindTransportToNonLocalhost(remoteAddresses, localAddresses), equalTo(false));
+        assertThat(shouldOnlyBindTransportToLocalhost(true, remoteAddresses, localAddresses), equalTo(true));
     }
 
     private boolean checkGeneralNameSan(X509Certificate certificate, String generalName, int generalNameTag) throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/InitialNodeSecurityAutoConfiguration.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/InitialNodeSecurityAutoConfiguration.java
@@ -254,7 +254,7 @@ public class InitialNodeSecurityAutoConfiguration {
         } else if (false == Strings.isEmpty(elasticPassword)) {
             builder.append(
                 infoBullet
-                    + " Password for the "
+                    + "  Password for the "
                     + boldOnANSI
                     + "elastic"
                     + boldOffANSI
@@ -271,7 +271,7 @@ public class InitialNodeSecurityAutoConfiguration {
         builder.append(System.lineSeparator());
 
         if (null != caCertFingerprint) {
-            builder.append(infoBullet + " HTTP CA certificate SHA-256 fingerprint:");
+            builder.append(infoBullet + "  HTTP CA certificate SHA-256 fingerprint:");
             builder.append(System.lineSeparator());
             builder.append("  " + boldOnANSI + caCertFingerprint + boldOffANSI);
         }
@@ -279,7 +279,7 @@ public class InitialNodeSecurityAutoConfiguration {
         builder.append(System.lineSeparator());
 
         if (null != kibanaEnrollmentToken) {
-            builder.append(infoBullet + " Configure Kibana to use this cluster:");
+            builder.append(infoBullet + "  Configure Kibana to use this cluster:");
             builder.append(System.lineSeparator());
             builder.append(bullet + " Run Kibana and click the configuration link in the terminal when Kibana starts.");
             builder.append(System.lineSeparator());
@@ -325,7 +325,7 @@ public class InitialNodeSecurityAutoConfiguration {
                     + ", using the enrollment token that you generated."
             );
         } else if (Strings.isEmpty(nodeEnrollmentToken)) {
-            builder.append(infoBullet + " Configure other nodes to join this cluster:");
+            builder.append(infoBullet + "  Configure other nodes to join this cluster:");
             builder.append(System.lineSeparator());
             builder.append(bullet + " On this node:");
             builder.append(System.lineSeparator());


### PR DESCRIPTION
When enrolling a new node to an existing cluster, we sometimes need to
bind transport to non-localhost addresse. If the other nodes of the
cluster are on different hosts than this node, then the default
configuration of binding transport layer to localhost will prevent this
node to join the cluster even after "successful" enrollment.
We check the non-localhost transport addresses that we receive during
enrollment and if any of these are not in the list of non-localhost IP
addresses that we gather from all interfaces of the current host, we
assume that at least some other node in the cluster runs on another host.
- If we don't find any non localhost addresses on all interfaces of the
current host, we don't attempt to bind to non localhost addresses as this
would result on an error on startup.
- If the transport layer addresses we found out in enrollment are all
localhost, we cannot be sure where we are still on the same host, but we
assume that as it is safer to do so and do not bind to non localhost for
this node either.