### PR TITLE
[7.17] [DOCS] Remove unused tag from rolling restart docs (#82967)

### DIFF
--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -21,7 +21,6 @@ include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
 
-// tag::stop_indexing[]
 . *Stop indexing and perform a flush.*
 +
 --
@@ -30,7 +29,6 @@ recovery.
 
 include::{es-repo-dir}/upgrade/synced-flush.asciidoc[]
 --
-// end::stop_indexing[]
 
 //tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
@@ -173,7 +171,17 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
-include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
++
+--
+While you can continue indexing during the rolling restart, shard recovery
+can be faster if you temporarily stop non-essential indexing and perform a
+<<indices-flush, flush>>.
+
+[source,console]
+--------------------------------------------------
+POST /_flush
+--------------------------------------------------
+--
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_ml]
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -21,6 +21,7 @@ include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
 
+// tag::stop_indexing[]
 . *Stop indexing and perform a flush.*
 +
 --
@@ -29,6 +30,7 @@ recovery.
 
 include::{es-repo-dir}/upgrade/synced-flush.asciidoc[]
 --
+// end::stop_indexing[]
 
 //tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -20,8 +20,8 @@ time, so the service remains uninterrupted.
 include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
-// tag::stop_indexing[]
-. *Stop indexing and perform a synced flush.*
+
+. *Stop indexing and perform a flush.*
 +
 --
 Performing a <<indices-synced-flush-api, synced-flush>> speeds up shard
@@ -29,7 +29,7 @@ recovery.
 
 include::{es-repo-dir}/upgrade/synced-flush.asciidoc[]
 --
-// end::stop_indexing[]
+
 //tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Remove unused tag from rolling restart docs (#82967)