### PR TITLE
[7.17] Fix `PutPrivilegesResponse` serialization test  (#82894)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,7 +35,16 @@ public class PutPrivilegesResponseTests extends ESTestCase {
         output.flush();
         final PutPrivilegesResponse copy = new PutPrivilegesResponse(output.bytes().streamInput());
         assertThat(copy.created(), equalTo(original.created()));
-        assertThat(Strings.toString(copy), equalTo(Strings.toString(original)));
+        assertJsonEquals(Strings.toString(copy), Strings.toString(original));
+    }
+
+    private void assertJsonEquals(String actual, String expected) throws IOException {
+        try (
+            var actualParser = createParser(JsonXContent.jsonXContent, actual);
+            var expectedParser = createParser(JsonXContent.jsonXContent, expected)
+        ) {
+            assertThat(actualParser.mapOrdered(), equalTo(expectedParser.mapOrdered()));
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -40,8 +40,8 @@ public class PutPrivilegesResponseTests extends ESTestCase {
 
     private void assertJsonEquals(String actual, String expected) throws IOException {
         try (
-            var actualParser = createParser(JsonXContent.jsonXContent, actual);
-            var expectedParser = createParser(JsonXContent.jsonXContent, expected)
+            XContentParser actualParser = createParser(JsonXContent.jsonXContent, actual);
+            XContentParser expectedParser = createParser(JsonXContent.jsonXContent, expected)
         ) {
             assertThat(actualParser.mapOrdered(), equalTo(expectedParser.mapOrdered()));
         }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix `PutPrivilegesResponse` serialization test  (#82894)