### PR TITLE
Remove duplicate security vulnerability section from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Question
     url: https://discuss.elastic.co/c/elasticsearch
     about: Ask (and answer) questions here.
-  - name: Security Vulnerability
-    url: https://www.elastic.co/community/security
-    about: Send security vulnerability reports to security@elastic.co.


### PR DESCRIPTION
The Elasticsearch project has a security policy set on it, which causes
a "Report a security vulnerability" section in the new issue template
with a link to the security policy. This commit removes the older link
to sending an email to the security list, since it is confusing whether
a user should look at the policy (which references the security email)
or directly click the fake "Open" button.