### PR TITLE
[7.17] [DOCS] Fix typo (#82988)

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -103,7 +103,7 @@ clusters].
 [[self-managed-repo-types]]
 ==== Self-managed repository types
 
-If you run the {es} on your own hardware, you can use the following built-in
+If you run {es} on your own hardware, you can use the following built-in
 snapshot repository types:
 
 * <<snapshots-filesystem-repository,Shared file system>>


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Fix typo (#82988)