### PR TITLE
[DOCS] Add note that write indices are not replicated

### DIFF
--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -197,7 +197,8 @@ indices reject writes in all configurations.
 
 NOTE: Although changes to aliases on the leader index are replicated to follower
 indices, write indices are ignored. Follower indices can't accept direct writes,
-so any indices where `is_write_index` is `true` are not replicated.
+so if any follower indices have `is_write_index` set to `true`, that value is
+forced to `false`.
 
 For example, you index a document named `doc_1` in Datacenter A, which
 replicates to Datacenter B. If a client connects to Datacenter B and attempts

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -197,7 +197,7 @@ indices reject writes in all configurations.
 
 NOTE: Although changes to aliases on the leader index are replicated to follower
 indices, write indices are ignored. Follower indices can't accept direct writes,
-so if any follower indices have `is_write_index` set to `true`, that value is
+so if any leader aliases have `is_write_index` set to `true`, that value is
 forced to `false`.
 
 For example, you index a document named `doc_1` in Datacenter A, which

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -195,6 +195,10 @@ You can't manually modify a follower index's mappings or aliases. To make
 changes, you must update the leader index. Because they are read-only, follower
 indices reject writes in all configurations. 
 
+NOTE: Although changes to aliases on the leader index are replicated to follower
+indices, write indices are ignored. Follower indices can't accept direct writes,
+so any indices where `is_write_index` is `true` are not replicated.
+
 For example, you index a document named `doc_1` in Datacenter A, which
 replicates to Datacenter B. If a client connects to Datacenter B and attempts
 to update `doc_1`, the request fails. To update `doc_1`, the client must


### PR DESCRIPTION
Adds a note to the CCR docs that write indices are ignored when indices are replicated from a leader to a follower.

Preview link: https://elasticsearch_82997.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/xpack-ccr.html#ccr-update-leader-index

Closes #82679