### PR TITLE
[7.16] [DOCS] Remove `compress` param from example snippets (#82994)

### DIFF
--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -21,8 +21,7 @@ PUT _snapshot/my_fs_backup
 {
   "type": "fs",
   "settings": {
-    "location": "/mount/backups/my_fs_backup_location",
-    "compress": true
+    "location": "/mount/backups/my_fs_backup_location"
   }
 }
 ----
@@ -39,8 +38,7 @@ PUT _snapshot/my_fs_backup
 {
   "type": "fs",
   "settings": {
-    "location": "my_fs_backup_location",       <1>
-    "compress": true
+    "location": "my_fs_backup_location"        <1>
   }
 }
 ----
@@ -97,8 +95,7 @@ PUT _snapshot/my_fs_backup
 {
   "type": "fs",
   "settings": {
-    "location": "E:\\Mount\\Backups\\My_fs_backup_location",
-    "compress": true
+    "location": "E:\\Mount\\Backups\\My_fs_backup_location"
   }
 }
 ----
@@ -112,8 +109,7 @@ PUT _snapshot/my_fs_backup
 {
   "type": "fs",
   "settings": {
-    "location": "My_fs_backup_location",       <1>
-    "compress": true
+    "location": "My_fs_backup_location"        <1>
   }
 }
 ----


### PR DESCRIPTION
This is an automatic backport of pull request #82994 to 7.16.

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information