### PR TITLE
Migrate to Java 16 records (part 3)

### DIFF
--- a/modules/ingest-common/src/internalClusterTest/java/org/elasticsearch/ingest/common/IngestRestartIT.java
+++ b/modules/ingest-common/src/internalClusterTest/java/org/elasticsearch/ingest/common/IngestRestartIT.java
@@ -99,7 +99,7 @@ public class IngestRestartIT extends ESIntegTestCase {
         for (int k = 0; k < nodeCount; k++) {
             List<IngestStats.ProcessorStat> stats = r.getNodes().get(k).getIngestStats().getProcessorStats().get(pipelineId);
             for (IngestStats.ProcessorStat st : stats) {
-                assertThat(st.getStats().getIngestCurrent(), greaterThanOrEqualTo(0L));
+                assertThat(st.stats().getIngestCurrent(), greaterThanOrEqualTo(0L));
             }
         }
     }

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/CircleBuilder.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/CircleBuilder.java
@@ -97,7 +97,7 @@ public class CircleBuilder extends ShapeBuilder<Circle, org.elasticsearch.geomet
      * @return this
      */
     public CircleBuilder radius(Distance radius) {
-        return radius(radius.value, radius.unit);
+        return radius(radius.value(), radius.unit());
     }
 
     /**

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -280,7 +280,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
                 ft.setTreeLevels(treeLevels.get());
             }
             if (precision.get() != null) {
-                ft.setPrecisionInMeters(precision.get().value);
+                ft.setPrecisionInMeters(precision.get().value());
             }
             if (pointsOnly.get() != null) {
                 ft.setPointsOnly(pointsOnly.get());

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
@@ -105,12 +105,12 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchAnalyzer().name()));
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
             b.field("search_quote_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchQuoteAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchQuoteAnalyzer().name()));
 
     }
 
@@ -712,7 +712,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         assertThat(fieldType.shingleFields.length, equalTo(maxShingleSize - 1));
         NamedAnalyzer indexAnalyzer = mapper.indexAnalyzers().get(fieldType.name());
-        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().searchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
         }
         int shingleSize = 2;
@@ -734,7 +734,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         ShingleFieldType fieldType = mapper.fieldType();
         assertThat(fieldType.shingleSize, equalTo(shingleSize));
 
-        for (NamedAnalyzer analyzer : asList(indexAnalyzers.get(fieldType.name()), fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+        for (NamedAnalyzer analyzer : asList(indexAnalyzers.get(fieldType.name()), fieldType.getTextSearchInfo().searchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
             if (shingleSize > 1) {
                 final SearchAsYouTypeAnalyzer wrappedAnalyzer = (SearchAsYouTypeAnalyzer) analyzer.analyzer();
@@ -755,13 +755,13 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     ) {
         PrefixFieldType fieldType = mapper.fieldType();
         NamedAnalyzer indexAnalyzer = indexAnalyzers.get(fieldType.name());
-        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().searchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
         }
 
         final SearchAsYouTypeAnalyzer wrappedIndexAnalyzer = (SearchAsYouTypeAnalyzer) indexAnalyzer.analyzer();
         final SearchAsYouTypeAnalyzer wrappedSearchAnalyzer = (SearchAsYouTypeAnalyzer) fieldType.getTextSearchInfo()
-            .getSearchAnalyzer()
+            .searchAnalyzer()
             .analyzer();
         for (SearchAsYouTypeAnalyzer analyzer : asList(wrappedIndexAnalyzer, wrappedSearchAnalyzer)) {
             assertThat(analyzer.shingleSize(), equalTo(shingleSize));

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -355,13 +355,13 @@ public abstract class AbstractAsyncBulkByScrollAction<
             return;
         }
         if (    // If any of the shards failed that should abort the request.
-        (response.getFailures().size() > 0)
+        (response.failures().size() > 0)
             // Timeouts aren't shard failures but we still need to pass them back to the user.
-            || response.isTimedOut()) {
-            refreshAndFinish(emptyList(), response.getFailures(), response.isTimedOut());
+            || response.timedOut()) {
+            refreshAndFinish(emptyList(), response.failures(), response.timedOut());
             return;
         }
-        long total = response.getTotalHits();
+        long total = response.totalHits();
         if (mainRequest.getMaxDocs() > 0) {
             total = min(total, mainRequest.getMaxDocs());
         }
@@ -972,7 +972,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
 
         ScrollConsumableHitsResponse(ScrollableHitSource.AsyncResponse asyncResponse) {
             this.asyncResponse = asyncResponse;
-            this.hits = asyncResponse.response().getHits();
+            this.hits = asyncResponse.response().hits();
         }
 
         ScrollableHitSource.Response response() {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSource.java
@@ -89,9 +89,9 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
     }
 
     private void onStartResponse(RejectAwareActionListener<Response> searchListener, Response response) {
-        if (Strings.hasLength(response.getScrollId()) && response.getHits().isEmpty()) {
-            logger.debug("First response looks like a scan response. Jumping right to the second. scroll=[{}]", response.getScrollId());
-            doStartNextScroll(response.getScrollId(), timeValueMillis(0), searchListener);
+        if (Strings.hasLength(response.scrollId()) && response.hits().isEmpty()) {
+            logger.debug("First response looks like a scan response. Jumping right to the second. scroll=[{}]", response.scrollId());
+            doStartNextScroll(response.scrollId(), timeValueMillis(0), searchListener);
         } else {
             searchListener.onResponse(response);
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -122,7 +122,7 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
             ScrollableHitSource.AsyncResponse asyncResponse = responses.poll(10, TimeUnit.SECONDS);
             assertNotNull(asyncResponse);
             assertEquals(responses.size(), 0);
-            assertSameHits(asyncResponse.response().getHits(), searchResponse.getHits().getHits());
+            assertSameHits(asyncResponse.response().hits(), searchResponse.getHits().getHits());
             asyncResponse.done(TimeValue.ZERO);
 
             for (int retry = 0; retry < randomIntBetween(minFailures, maxFailures); ++retry) {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -149,15 +149,15 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testParseStartOk() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("start_ok.json").doStart(wrapAsListener(r -> {
-            assertFalse(r.isTimedOut());
-            assertEquals(FAKE_SCROLL_ID, r.getScrollId());
-            assertEquals(4, r.getTotalHits());
-            assertThat(r.getFailures(), empty());
-            assertThat(r.getHits(), hasSize(1));
-            assertEquals("test", r.getHits().get(0).getIndex());
-            assertEquals("AVToMiC250DjIiBO3yJ_", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test2\"}", r.getHits().get(0).getSource().utf8ToString());
-            assertNull(r.getHits().get(0).getRouting());
+            assertFalse(r.timedOut());
+            assertEquals(FAKE_SCROLL_ID, r.scrollId());
+            assertEquals(4, r.totalHits());
+            assertThat(r.failures(), empty());
+            assertThat(r.hits(), hasSize(1));
+            assertEquals("test", r.hits().get(0).getIndex());
+            assertEquals("AVToMiC250DjIiBO3yJ_", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test2\"}", r.hits().get(0).getSource().utf8ToString());
+            assertNull(r.hits().get(0).getRouting());
             called.set(true);
         }));
         assertTrue(called.get());
@@ -166,15 +166,15 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testParseScrollOk() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("scroll_ok.json").doStartNextScroll("", timeValueMillis(0), wrapAsListener(r -> {
-            assertFalse(r.isTimedOut());
-            assertEquals(FAKE_SCROLL_ID, r.getScrollId());
-            assertEquals(4, r.getTotalHits());
-            assertThat(r.getFailures(), empty());
-            assertThat(r.getHits(), hasSize(1));
-            assertEquals("test", r.getHits().get(0).getIndex());
-            assertEquals("AVToMiDL50DjIiBO3yKA", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test3\"}", r.getHits().get(0).getSource().utf8ToString());
-            assertNull(r.getHits().get(0).getRouting());
+            assertFalse(r.timedOut());
+            assertEquals(FAKE_SCROLL_ID, r.scrollId());
+            assertEquals(4, r.totalHits());
+            assertThat(r.failures(), empty());
+            assertThat(r.hits(), hasSize(1));
+            assertEquals("test", r.hits().get(0).getIndex());
+            assertEquals("AVToMiDL50DjIiBO3yKA", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test3\"}", r.hits().get(0).getSource().utf8ToString());
+            assertNull(r.hits().get(0).getRouting());
             called.set(true);
         }));
         assertTrue(called.get());
@@ -186,9 +186,9 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testParseScrollFullyLoaded() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("scroll_fully_loaded.json").doStartNextScroll("", timeValueMillis(0), wrapAsListener(r -> {
-            assertEquals("AVToMiDL50DjIiBO3yKA", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test3\"}", r.getHits().get(0).getSource().utf8ToString());
-            assertEquals("testrouting", r.getHits().get(0).getRouting());
+            assertEquals("AVToMiDL50DjIiBO3yKA", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test3\"}", r.hits().get(0).getSource().utf8ToString());
+            assertEquals("testrouting", r.hits().get(0).getRouting());
             called.set(true);
         }));
         assertTrue(called.get());
@@ -200,9 +200,9 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testParseScrollFullyLoadedFrom1_7() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("scroll_fully_loaded_1_7.json").doStartNextScroll("", timeValueMillis(0), wrapAsListener(r -> {
-            assertEquals("AVToMiDL50DjIiBO3yKA", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test3\"}", r.getHits().get(0).getSource().utf8ToString());
-            assertEquals("testrouting", r.getHits().get(0).getRouting());
+            assertEquals("AVToMiDL50DjIiBO3yKA", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test3\"}", r.hits().get(0).getSource().utf8ToString());
+            assertEquals("testrouting", r.hits().get(0).getRouting());
             called.set(true);
         }));
         assertTrue(called.get());
@@ -215,15 +215,15 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testScanJumpStart() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("start_scan.json", "scroll_ok.json").doStart(wrapAsListener(r -> {
-            assertFalse(r.isTimedOut());
-            assertEquals(FAKE_SCROLL_ID, r.getScrollId());
-            assertEquals(4, r.getTotalHits());
-            assertThat(r.getFailures(), empty());
-            assertThat(r.getHits(), hasSize(1));
-            assertEquals("test", r.getHits().get(0).getIndex());
-            assertEquals("AVToMiDL50DjIiBO3yKA", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test3\"}", r.getHits().get(0).getSource().utf8ToString());
-            assertNull(r.getHits().get(0).getRouting());
+            assertFalse(r.timedOut());
+            assertEquals(FAKE_SCROLL_ID, r.scrollId());
+            assertEquals(4, r.totalHits());
+            assertThat(r.failures(), empty());
+            assertThat(r.hits(), hasSize(1));
+            assertEquals("test", r.hits().get(0).getIndex());
+            assertEquals("AVToMiDL50DjIiBO3yKA", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test3\"}", r.hits().get(0).getSource().utf8ToString());
+            assertNull(r.hits().get(0).getRouting());
             called.set(true);
         }));
         assertTrue(called.get());
@@ -234,25 +234,25 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         AtomicBoolean called = new AtomicBoolean();
         // Handling a scroll rejection is the same as handling a search rejection so we reuse the verification code
         Consumer<Response> checkResponse = r -> {
-            assertFalse(r.isTimedOut());
-            assertEquals(FAKE_SCROLL_ID, r.getScrollId());
-            assertEquals(4, r.getTotalHits());
-            assertThat(r.getFailures(), hasSize(1));
-            assertEquals("test", r.getFailures().get(0).getIndex());
-            assertEquals((Integer) 0, r.getFailures().get(0).getShardId());
-            assertEquals("87A7NvevQxSrEwMbtRCecg", r.getFailures().get(0).getNodeId());
-            assertThat(r.getFailures().get(0).getReason(), instanceOf(EsRejectedExecutionException.class));
+            assertFalse(r.timedOut());
+            assertEquals(FAKE_SCROLL_ID, r.scrollId());
+            assertEquals(4, r.totalHits());
+            assertThat(r.failures(), hasSize(1));
+            assertEquals("test", r.failures().get(0).getIndex());
+            assertEquals((Integer) 0, r.failures().get(0).getShardId());
+            assertEquals("87A7NvevQxSrEwMbtRCecg", r.failures().get(0).getNodeId());
+            assertThat(r.failures().get(0).getReason(), instanceOf(EsRejectedExecutionException.class));
             assertEquals(
                 "rejected execution of org.elasticsearch.transport.TransportService$5@52d06af2 on "
                     + "EsThreadPoolExecutor[search, queue capacity = 1000, org.elasticsearch.common.util.concurrent."
                     + "EsThreadPoolExecutor@778ea553[Running, pool size = 7, active threads = 7, queued tasks = 1000, "
                     + "completed tasks = 4182]]",
-                r.getFailures().get(0).getReason().getMessage()
+                r.failures().get(0).getReason().getMessage()
             );
-            assertThat(r.getHits(), hasSize(1));
-            assertEquals("test", r.getHits().get(0).getIndex());
-            assertEquals("AVToMiC250DjIiBO3yJ_", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test1\"}", r.getHits().get(0).getSource().utf8ToString());
+            assertThat(r.hits(), hasSize(1));
+            assertEquals("test", r.hits().get(0).getIndex());
+            assertEquals("AVToMiC250DjIiBO3yJ_", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test1\"}", r.hits().get(0).getSource().utf8ToString());
             called.set(true);
         };
         sourceWithMockedRemoteCall("rejection.json").doStart(wrapAsListener(checkResponse));
@@ -267,22 +267,22 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         AtomicBoolean called = new AtomicBoolean();
         // Handling a scroll rejection is the same as handling a search rejection so we reuse the verification code
         Consumer<Response> checkResponse = r -> {
-            assertFalse(r.isTimedOut());
-            assertEquals(FAKE_SCROLL_ID, r.getScrollId());
-            assertEquals(10000, r.getTotalHits());
-            assertThat(r.getFailures(), hasSize(1));
-            assertEquals(null, r.getFailures().get(0).getIndex());
-            assertEquals(null, r.getFailures().get(0).getShardId());
-            assertEquals(null, r.getFailures().get(0).getNodeId());
-            assertThat(r.getFailures().get(0).getReason(), instanceOf(RuntimeException.class));
+            assertFalse(r.timedOut());
+            assertEquals(FAKE_SCROLL_ID, r.scrollId());
+            assertEquals(10000, r.totalHits());
+            assertThat(r.failures(), hasSize(1));
+            assertEquals(null, r.failures().get(0).getIndex());
+            assertEquals(null, r.failures().get(0).getShardId());
+            assertEquals(null, r.failures().get(0).getNodeId());
+            assertThat(r.failures().get(0).getReason(), instanceOf(RuntimeException.class));
             assertEquals(
                 "Unknown remote exception with reason=[SearchContextMissingException[No search context found for id [82]]]",
-                r.getFailures().get(0).getReason().getMessage()
+                r.failures().get(0).getReason().getMessage()
             );
-            assertThat(r.getHits(), hasSize(1));
-            assertEquals("test", r.getHits().get(0).getIndex());
-            assertEquals("10000", r.getHits().get(0).getId());
-            assertEquals("{\"test\":\"test10000\"}", r.getHits().get(0).getSource().utf8ToString());
+            assertThat(r.hits(), hasSize(1));
+            assertEquals("test", r.hits().get(0).getIndex());
+            assertEquals("10000", r.hits().get(0).getId());
+            assertEquals("{\"test\":\"test10000\"}", r.hits().get(0).getSource().utf8ToString());
             called.set(true);
         };
         sourceWithMockedRemoteCall("failure_with_status.json").doStart(wrapAsListener(checkResponse));
@@ -299,12 +299,12 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     public void testParseRequestFailure() throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         Consumer<Response> checkResponse = r -> {
-            assertFalse(r.isTimedOut());
-            assertNull(r.getScrollId());
-            assertEquals(0, r.getTotalHits());
-            assertThat(r.getFailures(), hasSize(1));
-            assertThat(r.getFailures().get(0).getReason(), instanceOf(ParsingException.class));
-            ParsingException failure = (ParsingException) r.getFailures().get(0).getReason();
+            assertFalse(r.timedOut());
+            assertNull(r.scrollId());
+            assertEquals(0, r.totalHits());
+            assertThat(r.failures(), hasSize(1));
+            assertThat(r.failures().get(0).getReason(), instanceOf(ParsingException.class));
+            ParsingException failure = (ParsingException) r.failures().get(0).getReason();
             assertEquals("Unknown key for a VALUE_STRING in [invalid].", failure.getMessage());
             assertEquals(2, failure.getLineNumber());
             assertEquals(14, failure.getColumnNumber());
@@ -322,14 +322,14 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         sourceWithMockedRemoteCall("fail:rejection.json", "start_ok.json", "fail:rejection.json", "scroll_ok.json").start();
         ScrollableHitSource.AsyncResponse response = responseQueue.poll();
         assertNotNull(response);
-        assertThat(response.response().getFailures(), empty());
+        assertThat(response.response().failures(), empty());
         assertTrue(responseQueue.isEmpty());
         assertEquals(1, retries);
         retries = 0;
         response.done(timeValueMillis(0));
         response = responseQueue.poll();
         assertNotNull(response);
-        assertThat(response.response().getFailures(), empty());
+        assertThat(response.response().failures(), empty());
         assertTrue(responseQueue.isEmpty());
         assertEquals(1, retries);
     }
@@ -349,7 +349,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         sourceWithMockedRemoteCall(searchOKPaths).start();
         ScrollableHitSource.AsyncResponse response = responseQueue.poll();
         assertNotNull(response);
-        assertThat(response.response().getFailures(), empty());
+        assertThat(response.response().failures(), empty());
         assertTrue(responseQueue.isEmpty());
 
         response.done(timeValueMillis(0));

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -54,7 +54,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
     public void testExecuteSingleUploadBlobSizeTooLarge() {
         final long blobSize = ByteSizeUnit.GB.toBytes(randomIntBetween(6, 10));
         final S3BlobStore blobStore = mock(S3BlobStore.class);
-        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final S3BlobContainer blobContainer = new S3BlobContainer(new BlobPath(List.of()), blobStore);
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -67,7 +67,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
         final S3BlobStore blobStore = mock(S3BlobStore.class);
         when(blobStore.bufferSizeInBytes()).thenReturn(ByteSizeUnit.MB.toBytes(1));
 
-        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final S3BlobContainer blobContainer = new S3BlobContainer(new BlobPath(List.of()), blobStore);
         final String blobName = randomAlphaOfLengthBetween(1, 10);
 
         final IllegalArgumentException e = expectThrows(
@@ -131,7 +131,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
     public void testExecuteMultipartUploadBlobSizeTooLarge() {
         final long blobSize = ByteSizeUnit.TB.toBytes(randomIntBetween(6, 10));
         final S3BlobStore blobStore = mock(S3BlobStore.class);
-        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final S3BlobContainer blobContainer = new S3BlobContainer(new BlobPath(List.of()), blobStore);
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -143,7 +143,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
     public void testExecuteMultipartUploadBlobSizeTooSmall() {
         final long blobSize = ByteSizeUnit.MB.toBytes(randomIntBetween(1, 4));
         final S3BlobStore blobStore = mock(S3BlobStore.class);
-        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final S3BlobContainer blobContainer = new S3BlobContainer(new BlobPath(List.of()), blobStore);
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,

--- a/plugins/mapper-annotated-text/src/internalClusterTest/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/internalClusterTest/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -79,12 +79,12 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchAnalyzer().name()));
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
             b.field("search_quote_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchQuoteAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchQuoteAnalyzer().name()));
 
         checker.registerConflictCheck("store", b -> b.field("store", true));
         checker.registerConflictCheck("index_options", b -> b.field("index_options", "docs"));

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextHighlighterTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextHighlighterTests.java
@@ -149,7 +149,7 @@ public class AnnotatedTextHighlighterTests extends ESTestCase {
                 final Snippet[] snippets = highlighter.highlightField(getOnlyLeafReader(reader), topDocs.scoreDocs[0].doc, () -> rawValue);
                 assertEquals(expectedPassages.length, snippets.length);
                 for (int i = 0; i < snippets.length; i++) {
-                    assertEquals(expectedPassages[i], snippets[i].getText());
+                    assertEquals(expectedPassages[i], snippets[i].text());
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -102,8 +102,8 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
                 assertThat(getTranslogStats().getUncommittedOperations(), equalTo(0));
                 Map<String, String> userData = new HashMap<>(getLastCommittedSegmentInfos().userData);
                 SequenceNumbers.CommitInfo commitInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userData.entrySet());
-                assertThat(commitInfo.localCheckpoint, equalTo(getLastSyncedGlobalCheckpoint()));
-                assertThat(commitInfo.maxSeqNo, equalTo(getLastSyncedGlobalCheckpoint()));
+                assertThat(commitInfo.localCheckpoint(), equalTo(getLastSyncedGlobalCheckpoint()));
+                assertThat(commitInfo.maxSeqNo(), equalTo(getLastSyncedGlobalCheckpoint()));
                 userData.put(Engine.SYNC_COMMIT_ID, syncId);
                 indexWriter.setLiveCommitData(userData.entrySet());
                 indexWriter.commit();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -164,7 +164,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             Translog.Location lastWriteLocation = tlog.getLastWriteLocation();
             try {
                 // the lastWriteLocaltion has a Integer.MAX_VALUE size so we have to create a new one
-                return tlog.ensureSynced(new Translog.Location(lastWriteLocation.generation, lastWriteLocation.translogLocation, 0));
+                return tlog.ensureSynced(new Translog.Location(lastWriteLocation.generation(), lastWriteLocation.translogLocation(), 0));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -412,7 +412,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             logger.info(
                 "--> translog stats [{}] gen [{}] commit_stats [{}] flush_stats [{}/{}]",
                 Strings.toString(translogStats),
-                translog.getGeneration().translogFileGeneration,
+                translog.getGeneration().translogFileGeneration(),
                 commitStats.getUserData(),
                 flushStats.getPeriodic(),
                 flushStats.getTotal()
@@ -451,7 +451,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             );
             final Translog.Location location = result.getTranslogLocation();
             shard.afterWriteOperation();
-            if (location.translogLocation + location.size > generationThreshold) {
+            if (location.translogLocation() + location.size() > generationThreshold) {
                 // wait until the roll completes
                 assertBusy(() -> assertFalse(shard.shouldRollTranslogGeneration()));
                 rolls++;

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1050,7 +1050,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         try (Engine.IndexCommitRef safeCommitRef = shard.acquireSafeIndexCommit()) {
             localCheckpointOfSafeCommit = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(
                 safeCommitRef.getIndexCommit().getUserData().entrySet()
-            ).localCheckpoint;
+            ).localCheckpoint();
         }
         final long maxSeqNo = shard.seqNoStats().getMaxSeqNo();
         shard.failShard("test", new IOException("simulated"));
@@ -1063,8 +1063,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         SequenceNumbers.CommitInfo commitInfoAfterLocalRecovery = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(
             startRecoveryRequest.metadataSnapshot().getCommitUserData().entrySet()
         );
-        assertThat(commitInfoAfterLocalRecovery.localCheckpoint, equalTo(lastSyncedGlobalCheckpoint));
-        assertThat(commitInfoAfterLocalRecovery.maxSeqNo, equalTo(lastSyncedGlobalCheckpoint));
+        assertThat(commitInfoAfterLocalRecovery.localCheckpoint(), equalTo(lastSyncedGlobalCheckpoint));
+        assertThat(commitInfoAfterLocalRecovery.maxSeqNo(), equalTo(lastSyncedGlobalCheckpoint));
         assertThat(startRecoveryRequest.startingSeqNo(), equalTo(lastSyncedGlobalCheckpoint + 1));
         ensureGreen(indexName);
         assertThat((long) localRecoveredOps.get(), equalTo(lastSyncedGlobalCheckpoint - localCheckpointOfSafeCommit));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
@@ -72,7 +72,7 @@ public class SnapshotShardsServiceIT extends AbstractSnapshotIntegTestCase {
             List<IndexShardSnapshotStatus.Stage> stages = snapshotShardsService.currentSnapshotShards(snapshot)
                 .values()
                 .stream()
-                .map(status -> status.asCopy().getStage())
+                .map(status -> status.asCopy().stage())
                 .collect(Collectors.toList());
             assertThat(stages, hasSize(shards));
             assertThat(stages, everyItem(equalTo(IndexShardSnapshotStatus.Stage.DONE)));

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -542,11 +542,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         if (details == null) {
             return -1;
         }
-        final long startTime = details.getStartTimeMillis();
+        final long startTime = details.startTimeMillis();
         if (startTime == -1) {
             return -1;
         }
-        final long endTime = details.getEndTimeMillis();
+        final long endTime = details.endTimeMillis();
         if (endTime == -1) {
             return -1;
         }
@@ -555,7 +555,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
 
     private static long getStartTime(SnapshotId snapshotId, RepositoryData repositoryData) {
         final RepositoryData.SnapshotDetails details = repositoryData.getSnapshotDetails(snapshotId);
-        return details == null ? -1 : details.getStartTimeMillis();
+        return details == null ? -1 : details.startTimeMillis();
     }
 
     private static int indexCount(SnapshotId snapshotId, RepositoryData repositoryData) {
@@ -754,11 +754,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             return new SnapshotPredicates(((snapshotId, repositoryData) -> {
                 final RepositoryData.SnapshotDetails details = repositoryData.getSnapshotDetails(snapshotId);
                 final String policy;
-                if (details == null || (details.getSlmPolicy() == null)) {
+                if (details == null || (details.slmPolicy() == null)) {
                     // no SLM policy recorded
                     return true;
                 } else {
-                    final String policyFound = details.getSlmPolicy();
+                    final String policyFound = details.slmPolicy();
                     // empty string means that snapshot was not created by an SLM policy
                     policy = policyFound.isEmpty() ? null : policyFound;
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -60,25 +60,25 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
 
     SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus.Copy indexShardStatus, String nodeId) {
         super(shardId);
-        stage = switch (indexShardStatus.getStage()) {
+        stage = switch (indexShardStatus.stage()) {
             case INIT -> SnapshotIndexShardStage.INIT;
             case STARTED -> SnapshotIndexShardStage.STARTED;
             case FINALIZE -> SnapshotIndexShardStage.FINALIZE;
             case DONE -> SnapshotIndexShardStage.DONE;
             case FAILURE -> SnapshotIndexShardStage.FAILURE;
-            default -> throw new IllegalArgumentException("Unknown stage type " + indexShardStatus.getStage());
+            default -> throw new IllegalArgumentException("Unknown stage type " + indexShardStatus.stage());
         };
         this.stats = new SnapshotStats(
-            indexShardStatus.getStartTime(),
-            indexShardStatus.getTotalTime(),
-            indexShardStatus.getIncrementalFileCount(),
-            indexShardStatus.getTotalFileCount(),
-            indexShardStatus.getProcessedFileCount(),
-            indexShardStatus.getIncrementalSize(),
-            indexShardStatus.getTotalSize(),
-            indexShardStatus.getProcessedSize()
+            indexShardStatus.startTime(),
+            indexShardStatus.totalTime(),
+            indexShardStatus.incrementalFileCount(),
+            indexShardStatus.totalFileCount(),
+            indexShardStatus.processedFileCount(),
+            indexShardStatus.incrementalSize(),
+            indexShardStatus.totalSize(),
+            indexShardStatus.processedSize()
         );
-        this.failure = indexShardStatus.getFailure();
+        this.failure = indexShardStatus.failure();
         this.nodeId = nodeId;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -105,7 +105,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
                     final ShardId shardId = shardEntry.getKey();
 
                     final IndexShardSnapshotStatus.Copy lastSnapshotStatus = shardEntry.getValue().asCopy();
-                    final IndexShardSnapshotStatus.Stage stage = lastSnapshotStatus.getStage();
+                    final IndexShardSnapshotStatus.Stage stage = lastSnapshotStatus.stage();
 
                     String shardNodeId = null;
                     if (stage != IndexShardSnapshotStatus.Stage.DONE && stage != IndexShardSnapshotStatus.Stage.FAILURE) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -728,8 +728,8 @@ public class ClusterStatsNodes implements ToXContentFragment {
                         .entrySet()) {
                         pipelineIds.add(processorStats.getKey());
                         for (org.elasticsearch.ingest.IngestStats.ProcessorStat stat : processorStats.getValue()) {
-                            stats.compute(stat.getType(), (k, v) -> {
-                                org.elasticsearch.ingest.IngestStats.Stats nodeIngestStats = stat.getStats();
+                            stats.compute(stat.type(), (k, v) -> {
+                                org.elasticsearch.ingest.IngestStats.Stats nodeIngestStats = stat.stats();
                                 if (v == null) {
                                     return new long[] {
                                         nodeIngestStats.getIngestCount(),

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -113,7 +113,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
             }
             context.parsedQuery(context.getSearchExecutionContext().toQuery(request.query()));
             context.preProcess();
-            int topLevelDocId = result.docIdAndVersion().docId + result.docIdAndVersion().docBase;
+            int topLevelDocId = result.docIdAndVersion().docId() + result.docIdAndVersion().docBase();
             Explanation explanation = context.searcher().explain(context.rewrittenQuery(), topLevelDocId);
             for (RescoreContext ctx : context.rescore()) {
                 Rescorer rescorer = ctx.rescorer();

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -553,16 +553,16 @@ public class MasterService extends AbstractLifecycleComponent {
      */
     public List<PendingClusterTask> pendingTasks() {
         return Arrays.stream(threadPoolExecutor.getPending()).map(pending -> {
-            assert pending.task instanceof SourcePrioritizedRunnable
+            assert pending.task() instanceof SourcePrioritizedRunnable
                 : "thread pool executor should only use SourcePrioritizedRunnable instances but found: "
-                    + pending.task.getClass().getName();
-            SourcePrioritizedRunnable task = (SourcePrioritizedRunnable) pending.task;
+                    + pending.task().getClass().getName();
+            SourcePrioritizedRunnable task = (SourcePrioritizedRunnable) pending.task();
             return new PendingClusterTask(
-                pending.insertionOrder,
-                pending.priority,
+                pending.insertionOrder(),
+                pending.priority(),
                 new Text(task.source()),
                 task.getAgeInMillis(),
-                pending.executing
+                pending.executing()
             );
         }).collect(Collectors.toList());
     }

--- a/server/src/main/java/org/elasticsearch/common/Explicit.java
+++ b/server/src/main/java/org/elasticsearch/common/Explicit.java
@@ -8,64 +8,23 @@
 
 package org.elasticsearch.common;
 
-import java.util.Objects;
-
 /**
  * Holds a value that is either:
  * a) set implicitly e.g. through some default value
  * b) set explicitly e.g. from a user selection
- *
+ * <p>
  * When merging conflicting configuration settings such as
  * field mapping settings it is preferable to preserve an explicit
  * choice rather than a choice made only made implicitly by defaults.
- *
  */
-public class Explicit<T> {
+public record Explicit<T> (T value, boolean explicit) {
 
     public static final Explicit<Boolean> EXPLICIT_TRUE = new Explicit<>(true, true);
     public static final Explicit<Boolean> EXPLICIT_FALSE = new Explicit<>(false, true);
     public static final Explicit<Boolean> IMPLICIT_TRUE = new Explicit<>(true, false);
     public static final Explicit<Boolean> IMPLICIT_FALSE = new Explicit<>(false, false);
 
-    private final T value;
-    private final boolean explicit;
-
     public static Explicit<Boolean> explicitBoolean(boolean value) {
         return value ? EXPLICIT_TRUE : EXPLICIT_FALSE;
-    }
-
-    /**
-     * Create a value with an indication if this was an explicit choice
-     * @param value a setting value
-     * @param explicit true if the value passed is a conscious decision, false if using some kind of default
-     */
-    public Explicit(T value, boolean explicit) {
-        this.value = value;
-        this.explicit = explicit;
-    }
-
-    public T value() {
-        return this.value;
-    }
-
-    /**
-     *
-     * @return true if the value passed is a conscious decision, false if using some kind of default
-     */
-    public boolean explicit() {
-        return this.explicit;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Explicit<?> explicit1 = (Explicit<?>) o;
-        return explicit == explicit1.explicit && Objects.equals(value, explicit1.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(value, explicit);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -1417,16 +1417,7 @@ public abstract class Rounding implements Writeable {
     /**
      * Implementation of {@link Prepared} using pre-calculated "round down" points.
      */
-    private static class ArrayRounding implements Prepared {
-        private final long[] values;
-        private final int max;
-        private final Prepared delegate;
-
-        private ArrayRounding(long[] values, int max, Prepared delegate) {
-            this.values = values;
-            this.max = max;
-            this.delegate = delegate;
-        }
+    private record ArrayRounding(long[] values, int max, Prepared delegate) implements Prepared {
 
         @Override
         public long round(long utcMillis) {

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -13,22 +13,15 @@ import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * The list of paths where a blob can reside.  The contents of the paths are dependent upon the implementation of {@link BlobContainer}.
  */
-public class BlobPath {
+public record BlobPath(List<String> paths) {
 
     public static final BlobPath EMPTY = new BlobPath(Collections.emptyList());
 
     private static final String SEPARATOR = "/";
-
-    private final List<String> paths;
-
-    private BlobPath(List<String> paths) {
-        this.paths = paths;
-    }
 
     public List<String> parts() {
         return paths;
@@ -59,27 +52,5 @@ public class BlobPath {
             case 1 -> EMPTY;
             default -> new BlobPath(List.copyOf(paths.subList(0, size - 1)));
         };
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for (String path : paths) {
-            sb.append('[').append(path).append(']');
-        }
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BlobPath other = (BlobPath) o;
-        return paths.equals(other.paths);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(paths);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/DeleteResult.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/DeleteResult.java
@@ -11,25 +11,9 @@ package org.elasticsearch.common.blobstore;
 /**
  * The result of deleting multiple blobs from a {@link BlobStore}.
  */
-public final class DeleteResult {
+public record DeleteResult(long blobsDeleted, long bytesDeleted) {
 
     public static final DeleteResult ZERO = new DeleteResult(0, 0);
-
-    private final long blobsDeleted;
-    private final long bytesDeleted;
-
-    public DeleteResult(long blobsDeleted, long bytesDeleted) {
-        this.blobsDeleted = blobsDeleted;
-        this.bytesDeleted = bytesDeleted;
-    }
-
-    public long blobsDeleted() {
-        return blobsDeleted;
-    }
-
-    public long bytesDeleted() {
-        return bytesDeleted;
-    }
 
     public DeleteResult add(DeleteResult other) {
         return new DeleteResult(blobsDeleted + other.blobsDeleted(), bytesDeleted + other.bytesDeleted());

--- a/server/src/main/java/org/elasticsearch/common/blobstore/support/PlainBlobMetadata.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/support/PlainBlobMetadata.java
@@ -10,29 +10,4 @@ package org.elasticsearch.common.blobstore.support;
 
 import org.elasticsearch.common.blobstore.BlobMetadata;
 
-public class PlainBlobMetadata implements BlobMetadata {
-
-    private final String name;
-
-    private final long length;
-
-    public PlainBlobMetadata(String name, long length) {
-        this.name = name;
-        this.length = length;
-    }
-
-    @Override
-    public String name() {
-        return this.name;
-    }
-
-    @Override
-    public long length() {
-        return this.length;
-    }
-
-    @Override
-    public String toString() {
-        return "name [" + name + "], length [" + length + "]";
-    }
-}
+public record PlainBlobMetadata(String name, long length) implements BlobMetadata {}

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -240,14 +240,5 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
         this.limitAndOverhead = new LimitAndOverhead(limit, overhead);
     }
 
-    private static class LimitAndOverhead {
-
-        private final long limit;
-        private final double overhead;
-
-        LimitAndOverhead(long limit, double overhead) {
-            this.limit = limit;
-            this.overhead = overhead;
-        }
-    }
+    private record LimitAndOverhead(long limit, double overhead) {}
 }

--- a/server/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -710,29 +710,7 @@ public class Cache<K, V> {
         return new CacheStats(this.hits.sum(), misses.sum(), evictions.sum());
     }
 
-    public static class CacheStats {
-        private final long hits;
-        private final long misses;
-        private final long evictions;
-
-        public CacheStats(long hits, long misses, long evictions) {
-            this.hits = hits;
-            this.misses = misses;
-            this.evictions = evictions;
-        }
-
-        public long getHits() {
-            return hits;
-        }
-
-        public long getMisses() {
-            return misses;
-        }
-
-        public long getEvictions() {
-            return evictions;
-        }
-    }
+    public record CacheStats(long hits, long misses, long evictions) {}
 
     private void promote(Entry<K, V> entry, long now) {
         boolean promoted = true;

--- a/server/src/main/java/org/elasticsearch/common/cache/RemovalNotification.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/RemovalNotification.java
@@ -8,32 +8,10 @@
 
 package org.elasticsearch.common.cache;
 
-public class RemovalNotification<K, V> {
+public record RemovalNotification<K, V> (K key, V value, org.elasticsearch.common.cache.RemovalNotification.RemovalReason removalReason) {
     public enum RemovalReason {
         REPLACED,
         INVALIDATED,
         EVICTED
-    }
-
-    private final K key;
-    private final V value;
-    private final RemovalReason removalReason;
-
-    public RemovalNotification(K key, V value, RemovalReason removalReason) {
-        this.key = key;
-        this.value = value;
-        this.removalReason = removalReason;
-    }
-
-    public K getKey() {
-        return key;
-    }
-
-    public V getValue() {
-        return value;
-    }
-
-    public RemovalReason getRemovalReason() {
-        return removalReason;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -409,7 +409,7 @@ public final class GeoJson {
                 }
                 verifyNulls(type, geometries, orientation, null);
                 Point point = coordinates.asPoint();
-                yield new Circle(point.getX(), point.getY(), point.getZ(), radius.convert(DistanceUnit.METERS).value);
+                yield new Circle(point.getX(), point.getY(), point.getZ(), radius.convert(DistanceUnit.METERS).value());
             }
             case POINT -> {
                 verifyNulls(type, geometries, orientation, radius);

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
@@ -79,37 +79,15 @@ public final class VersionsAndSeqNoResolver {
 
     private VersionsAndSeqNoResolver() {}
 
-    /** Wraps an {@link LeafReaderContext}, a doc ID <b>relative to the context doc base</b> and a version. */
-    public static class DocIdAndVersion {
-        public final int docId;
-        public final long version;
-        public final long seqNo;
-        public final long primaryTerm;
-        public final LeafReader reader;
-        public final int docBase;
+    /**
+     * Wraps an {@link LeafReaderContext}, a doc ID <b>relative to the context doc base</b> and a version.
+     */
+    public record DocIdAndVersion(int docId, long version, long seqNo, long primaryTerm, LeafReader reader, int docBase) {}
 
-        public DocIdAndVersion(int docId, long version, long seqNo, long primaryTerm, LeafReader reader, int docBase) {
-            this.docId = docId;
-            this.version = version;
-            this.seqNo = seqNo;
-            this.primaryTerm = primaryTerm;
-            this.reader = reader;
-            this.docBase = docBase;
-        }
-    }
-
-    /** Wraps an {@link LeafReaderContext}, a doc ID <b>relative to the context doc base</b> and a seqNo. */
-    public static class DocIdAndSeqNo {
-        public final int docId;
-        public final long seqNo;
-        public final LeafReaderContext context;
-
-        DocIdAndSeqNo(int docId, long seqNo, LeafReaderContext context) {
-            this.docId = docId;
-            this.seqNo = seqNo;
-            this.context = context;
-        }
-    }
+    /**
+     * Wraps an {@link LeafReaderContext}, a doc ID <b>relative to the context doc base</b> and a seqNo.
+     */
+    public record DocIdAndSeqNo(int docId, long seqNo, LeafReaderContext context) {}
 
     /**
      * Load the internal doc ID and version for the uid from the reader, returning<ul>

--- a/server/src/main/java/org/elasticsearch/common/transport/PortsRange.java
+++ b/server/src/main/java/org/elasticsearch/common/transport/PortsRange.java
@@ -12,13 +12,7 @@ import com.carrotsearch.hppc.IntArrayList;
 
 import java.util.StringTokenizer;
 
-public class PortsRange {
-
-    private final String portRange;
-
-    public PortsRange(String portRange) {
-        this.portRange = portRange;
-    }
+public record PortsRange(String portRange) {
 
     public String getPortRangeString() {
         return portRange;
@@ -67,10 +61,5 @@ public class PortsRange {
 
     public interface PortCallback {
         boolean onPortNumber(int portNumber);
-    }
-
-    @Override
-    public String toString() {
-        return "PortsRange{" + "portRange='" + portRange + '\'' + '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -202,15 +202,7 @@ public enum DistanceUnit implements Writeable {
     /**
      * This class implements a value+unit tuple.
      */
-    public static class Distance implements Comparable<Distance> {
-        public final double value;
-        public final DistanceUnit unit;
-
-        public Distance(double value, DistanceUnit unit) {
-            super();
-            this.value = value;
-            this.unit = unit;
-        }
+    public record Distance(double value, DistanceUnit unit) implements Comparable<Distance> {
 
         /**
          * Converts a {@link Distance} value given in a specific {@link DistanceUnit} into
@@ -225,22 +217,6 @@ public enum DistanceUnit implements Writeable {
             } else {
                 return new Distance(DistanceUnit.convert(value, this.unit, unit), unit);
             }
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            } else if (obj instanceof Distance other) {
-                return DistanceUnit.convert(value, unit, other.unit) == other.value;
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return Double.valueOf(value * unit.meters).hashCode();
         }
 
         @Override
@@ -267,9 +243,9 @@ public enum DistanceUnit implements Writeable {
         /**
          * Parse a {@link Distance} from a given String
          *
-         * @param distance String defining a {@link Distance}
+         * @param distance    String defining a {@link Distance}
          * @param defaultUnit {@link DistanceUnit} to be assumed
-         *          if not unit is provided in the first argument
+         *                    if not unit is provided in the first argument
          * @return parsed {@link Distance}
          */
         private static Distance parseDistance(String distance, DistanceUnit defaultUnit) {

--- a/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
@@ -13,12 +13,7 @@ import org.elasticsearch.ElasticsearchParseException;
 /**
  * Utility class to represent ratio and percentage values between 0 and 100
  */
-public class RatioValue {
-    private final double percent;
-
-    public RatioValue(double percent) {
-        this.percent = percent;
-    }
+public record RatioValue(double percent) {
 
     public double getAsRatio() {
         return this.percent / 100.0;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -183,19 +183,7 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         return new PrioritizedFutureTask<T>((PrioritizedCallable<T>) callable, insertionOrder.incrementAndGet());
     }
 
-    public static class Pending {
-        public final Object task;
-        public final Priority priority;
-        public final long insertionOrder;
-        public final boolean executing;
-
-        public Pending(Object task, Priority priority, long insertionOrder, boolean executing) {
-            this.task = task;
-            this.priority = priority;
-            this.insertionOrder = insertionOrder;
-            this.executing = executing;
-        }
-    }
+    public record Pending(Object task, Priority priority, long insertionOrder, boolean executing) {}
 
     private final class TieBreakingPrioritizedRunnable extends PrioritizedRunnable implements WrappedRunnable {
 

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -337,7 +337,7 @@ public abstract class PeerFinder {
 
         @Nullable
         DiscoveryNode getDiscoveryNode() {
-            return Optional.ofNullable(probeConnectionResult.get()).map(ProbeConnectionResult::getDiscoveryNode).orElse(null);
+            return Optional.ofNullable(probeConnectionResult.get()).map(ProbeConnectionResult::discoveryNode).orElse(null);
         }
 
         private boolean isActive() {
@@ -381,7 +381,7 @@ public abstract class PeerFinder {
                 @Override
                 public void onResponse(ProbeConnectionResult connectResult) {
                     assert holdsLock() == false : "PeerFinder mutex is held in error";
-                    final DiscoveryNode remoteNode = connectResult.getDiscoveryNode();
+                    final DiscoveryNode remoteNode = connectResult.discoveryNode();
                     assert remoteNode.isMasterNode() : remoteNode + " is not master-eligible";
                     assert remoteNode.equals(getLocalNode()) == false : remoteNode + " is the local node";
                     boolean retainConnection = false;

--- a/server/src/main/java/org/elasticsearch/discovery/ProbeConnectionResult.java
+++ b/server/src/main/java/org/elasticsearch/discovery/ProbeConnectionResult.java
@@ -15,27 +15,10 @@ import org.elasticsearch.core.Releasable;
  * The result of a "probe" connection to a transport address, if it successfully discovered a valid node and established a full connection
  * with it.
  */
-public class ProbeConnectionResult implements Releasable {
-
-    private final DiscoveryNode discoveryNode;
-    private final Releasable releasable;
-
-    public ProbeConnectionResult(DiscoveryNode discoveryNode, Releasable releasable) {
-        this.discoveryNode = discoveryNode;
-        this.releasable = releasable;
-    }
-
-    public DiscoveryNode getDiscoveryNode() {
-        return discoveryNode;
-    }
+public record ProbeConnectionResult(DiscoveryNode discoveryNode, Releasable releasable) implements Releasable {
 
     @Override
     public void close() {
         releasable.close();
-    }
-
-    @Override
-    public String toString() {
-        return "ProbeConnectionResult{" + discoveryNode + "}";
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -345,17 +345,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
      * The result of a fetch operation. Make sure to first check {@link #hasData()} before
      * fetching the actual data.
      */
-    public static class FetchResult<T extends BaseNodeResponse> {
-
-        private final ShardId shardId;
-        private final Map<DiscoveryNode, T> data;
-        private final Set<String> ignoreNodes;
-
-        public FetchResult(ShardId shardId, Map<DiscoveryNode, T> data, Set<String> ignoreNodes) {
-            this.shardId = shardId;
-            this.data = data;
-            this.ignoreNodes = ignoreNodes;
-        }
+    public record FetchResult<T extends BaseNodeResponse> (ShardId shardId, Map<DiscoveryNode, T> data, Set<String> ignoreNodes) {
 
         /**
          * Does the result actually contain data? If not, then there are on going fetch

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -156,19 +156,19 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
                             ),
                             exception
                         );
-                        String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
+                        String allocationId = shardStateMetadata.allocationId() != null ? shardStateMetadata.allocationId().getId() : null;
                         return new NodeGatewayStartedShards(
                             clusterService.localNode(),
                             allocationId,
-                            shardStateMetadata.primary,
+                            shardStateMetadata.primary(),
                             exception
                         );
                     }
                 }
 
                 logger.debug("{} shard state info found: [{}]", shardId, shardStateMetadata);
-                String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
-                return new NodeGatewayStartedShards(clusterService.localNode(), allocationId, shardStateMetadata.primary);
+                String allocationId = shardStateMetadata.allocationId() != null ? shardStateMetadata.allocationId().getId() : null;
+                return new NodeGatewayStartedShards(clusterService.localNode(), allocationId, shardStateMetadata.primary());
             }
             logger.trace("{} no local shard info found", shardId);
             return new NodeGatewayStartedShards(clusterService.localNode(), null, false);

--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -156,11 +156,11 @@ public final class BitsetFilterCache extends AbstractIndexComponent
 
     @Override
     public void onRemoval(RemovalNotification<IndexReader.CacheKey, Cache<Query, Value>> notification) {
-        if (notification.getKey() == null) {
+        if (notification.key() == null) {
             return;
         }
 
-        Cache<Query, Value> valueCache = notification.getValue();
+        Cache<Query, Value> valueCache = notification.value();
         if (valueCache == null) {
             return;
         }
@@ -171,15 +171,8 @@ public final class BitsetFilterCache extends AbstractIndexComponent
         }
     }
 
-    public static final class Value {
+    public record Value(BitSet bitset, ShardId shardId) {
 
-        final BitSet bitset;
-        final ShardId shardId;
-
-        public Value(BitSet bitset, ShardId shardId) {
-            this.bitset = bitset;
-            this.shardId = shardId;
-        }
     }
 
     final class QueryWrapperBitSetProducer implements BitSetProducer {

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -558,24 +558,24 @@ public abstract class Engine implements Closeable {
         }
 
         if (docIdAndVersion != null) {
-            if (get.versionType().isVersionConflictForReads(docIdAndVersion.version, get.version())) {
+            if (get.versionType().isVersionConflictForReads(docIdAndVersion.version(), get.version())) {
                 Releasables.close(searcher);
                 throw new VersionConflictEngineException(
                     shardId,
                     get.id(),
-                    get.versionType().explainConflictForReads(docIdAndVersion.version, get.version())
+                    get.versionType().explainConflictForReads(docIdAndVersion.version(), get.version())
                 );
             }
             if (get.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
-                && (get.getIfSeqNo() != docIdAndVersion.seqNo || get.getIfPrimaryTerm() != docIdAndVersion.primaryTerm)) {
+                && (get.getIfSeqNo() != docIdAndVersion.seqNo() || get.getIfPrimaryTerm() != docIdAndVersion.primaryTerm())) {
                 Releasables.close(searcher);
                 throw new VersionConflictEngineException(
                     shardId,
                     get.id(),
                     get.getIfSeqNo(),
                     get.getIfPrimaryTerm(),
-                    docIdAndVersion.seqNo,
-                    docIdAndVersion.primaryTerm
+                    docIdAndVersion.seqNo(),
+                    docIdAndVersion.primaryTerm()
                 );
             }
         }
@@ -1684,7 +1684,7 @@ public abstract class Engine implements Closeable {
         }
 
         public GetResult(Engine.Searcher searcher, DocIdAndVersion docIdAndVersion) {
-            this(true, docIdAndVersion.version, docIdAndVersion, searcher);
+            this(true, docIdAndVersion.version(), docIdAndVersion, searcher);
         }
 
         public boolean exists() {

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -239,8 +239,8 @@ public class ReadOnlyEngine extends Engine {
 
     private static SeqNoStats buildSeqNoStats(EngineConfig config, SegmentInfos infos) {
         final SequenceNumbers.CommitInfo seqNoStats = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(infos.userData.entrySet());
-        long maxSeqNo = seqNoStats.maxSeqNo;
-        long localCheckpoint = seqNoStats.localCheckpoint;
+        long maxSeqNo = seqNoStats.maxSeqNo();
+        long localCheckpoint = seqNoStats.localCheckpoint();
         return new SeqNoStats(maxSeqNo, localCheckpoint, config.getGlobalCheckpointSupplier().getAsLong());
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/SafeCommitInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SafeCommitInfo.java
@@ -12,15 +12,7 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 /**
  * Information about the safe commit, for making decisions about recoveries.
  */
-public class SafeCommitInfo {
-
-    public final long localCheckpoint;
-    public final int docCount;
-
-    public SafeCommitInfo(long localCheckpoint, int docCount) {
-        this.localCheckpoint = localCheckpoint;
-        this.docCount = docCount;
-    }
+public record SafeCommitInfo(long localCheckpoint, int docCount) {
 
     public static final SafeCommitInfo EMPTY = new SafeCommitInfo(SequenceNumbers.NO_OPS_PERFORMED, 0);
 }

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -227,7 +227,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         FieldsVisitor fieldVisitor = buildFieldsVisitors(storedFields, fetchSourceContext);
         if (fieldVisitor != null) {
             try {
-                docIdAndVersion.reader.document(docIdAndVersion.docId, fieldVisitor);
+                docIdAndVersion.reader().document(docIdAndVersion.docId(), fieldVisitor);
             } catch (IOException e) {
                 throw new ElasticsearchException("Failed to get id [" + id + "]", e);
             }
@@ -271,8 +271,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         return new GetResult(
             shardId.getIndexName(),
             id,
-            get.docIdAndVersion().seqNo,
-            get.docIdAndVersion().primaryTerm,
+            get.docIdAndVersion().seqNo(),
+            get.docIdAndVersion().primaryTerm(),
             get.version(),
             get.exists(),
             source,

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -274,7 +274,7 @@ public class CompletionFieldMapper extends FieldMapper {
          */
         public CompletionQuery prefixQuery(Object value) {
             return new PrefixCompletionQuery(
-                getTextSearchInfo().getSearchAnalyzer().analyzer(),
+                getTextSearchInfo().searchAnalyzer().analyzer(),
                 new Term(name(), indexedValueForSearch(value))
             );
         }
@@ -299,7 +299,7 @@ public class CompletionFieldMapper extends FieldMapper {
             boolean unicodeAware
         ) {
             return new FuzzyCompletionQuery(
-                getTextSearchInfo().getSearchAnalyzer().analyzer(),
+                getTextSearchInfo().searchAnalyzer().analyzer(),
                 new Term(name(), indexedValueForSearch(value)),
                 null,
                 fuzziness.asDistance(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -493,7 +493,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         @Override
         protected BytesRef indexedValueForSearch(Object value) {
-            if (getTextSearchInfo().getSearchAnalyzer() == Lucene.KEYWORD_ANALYZER) {
+            if (getTextSearchInfo().searchAnalyzer() == Lucene.KEYWORD_ANALYZER) {
                 // keyword analyzer with the default attribute source which encodes terms using UTF8
                 // in that case we skip normalization, which may be slow if there many terms need to
                 // parse (eg. large terms query) since Analyzer.normalize involves things like creating
@@ -508,7 +508,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (value instanceof BytesRef) {
                 value = ((BytesRef) value).utf8ToString();
             }
-            return getTextSearchInfo().getSearchAnalyzer().normalize(name(), value.toString());
+            return getTextSearchInfo().searchAnalyzer().normalize(name(), value.toString());
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -116,9 +116,9 @@ public class ParsedDocument {
     }
 
     public void updateSeqID(long sequenceNumber, long primaryTerm) {
-        this.seqID.seqNo.setLongValue(sequenceNumber);
-        this.seqID.seqNoDocValue.setLongValue(sequenceNumber);
-        this.seqID.primaryTerm.setLongValue(primaryTerm);
+        this.seqID.seqNo().setLongValue(sequenceNumber);
+        this.seqID.seqNoDocValue().setLongValue(sequenceNumber);
+        this.seqID.primaryTerm().setLongValue(primaryTerm);
     }
 
     public String routing() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -49,21 +49,12 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
      * A sequence ID, which is made up of a sequence number (both the searchable
      * and doc_value version of the field) and the primary term.
      */
-    public static class SequenceIDFields {
+    public record SequenceIDFields(Field seqNo, Field seqNoDocValue, Field primaryTerm, Field tombstoneField) {
 
-        public final Field seqNo;
-        public final Field seqNoDocValue;
-        public final Field primaryTerm;
-        public final Field tombstoneField;
-
-        private SequenceIDFields(Field seqNo, Field seqNoDocValue, Field primaryTerm, Field tombstoneField) {
+        public SequenceIDFields {
             Objects.requireNonNull(seqNo, "sequence number field cannot be null");
             Objects.requireNonNull(seqNoDocValue, "sequence number dv field cannot be null");
             Objects.requireNonNull(primaryTerm, "primary term field cannot be null");
-            this.seqNo = seqNo;
-            this.seqNoDocValue = seqNoDocValue;
-            this.primaryTerm = primaryTerm;
-            this.tombstoneField = tombstoneField;
         }
 
         public void addFields(LuceneDocument document) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -157,8 +157,8 @@ public abstract class StringFieldType extends TermBasedFieldType {
         }
 
         Term term;
-        if (getTextSearchInfo().getSearchAnalyzer() != null && shouldNormalize) {
-            value = normalizeWildcardPattern(name(), value, getTextSearchInfo().getSearchAnalyzer());
+        if (getTextSearchInfo().searchAnalyzer() != null && shouldNormalize) {
+            value = normalizeWildcardPattern(name(), value, getTextSearchInfo().searchAnalyzer());
             term = new Term(name(), value);
         } else {
             term = new Term(name(), indexedValueForSearch(value));

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -602,17 +602,7 @@ public class TextFieldMapper extends FieldMapper {
         }
     }
 
-    private static final class SubFieldInfo {
-
-        private final Analyzer analyzer;
-        private final FieldType fieldType;
-        private final String field;
-
-        SubFieldInfo(String field, FieldType fieldType, Analyzer analyzer) {
-            this.fieldType = fieldType;
-            this.analyzer = analyzer;
-            this.field = field;
-        }
+    private record SubFieldInfo(String field, FieldType fieldType, Analyzer analyzer) {
 
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
@@ -51,7 +51,7 @@ public final class TextParams {
             this.searchAnalyzer = Parameter.analyzerParam(
                 "search_analyzer",
                 true,
-                m -> m.fieldType().getTextSearchInfo().getSearchAnalyzer(),
+                m -> m.fieldType().getTextSearchInfo().searchAnalyzer(),
                 () -> {
                     if (indexAnalyzer.isConfigured() == false) {
                         NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME);
@@ -67,7 +67,7 @@ public final class TextParams {
             this.searchQuoteAnalyzer = Parameter.analyzerParam(
                 "search_quote_analyzer",
                 true,
-                m -> m.fieldType().getTextSearchInfo().getSearchQuoteAnalyzer(),
+                m -> m.fieldType().getTextSearchInfo().searchQuoteAnalyzer(),
                 () -> {
                     if (searchAnalyzer.isConfigured() == false && indexAnalyzer.isConfigured() == false) {
                         NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextSearchInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextSearchInfo.java
@@ -21,9 +21,15 @@ import java.util.Objects;
 /**
  * Encapsulates information about how to perform text searches over a field
  */
-public class TextSearchInfo {
+public record TextSearchInfo(
+    FieldType luceneFieldType,
+    SimilarityProvider similarity,
+    NamedAnalyzer searchAnalyzer,
+    NamedAnalyzer searchQuoteAnalyzer
+) {
 
     private static final FieldType SIMPLE_MATCH_ONLY_FIELD_TYPE = new FieldType();
+
     static {
         SIMPLE_MATCH_ONLY_FIELD_TYPE.setTokenized(false);
         SIMPLE_MATCH_ONLY_FIELD_TYPE.setOmitNorms(true);
@@ -79,42 +85,9 @@ public class TextSearchInfo {
         FORBIDDEN_ANALYZER
     );
 
-    private final FieldType luceneFieldType;
-    private final SimilarityProvider similarity;
-    private final NamedAnalyzer searchAnalyzer;
-    private final NamedAnalyzer searchQuoteAnalyzer;
-
-    /**
-     * Create a new TextSearchInfo
-     *
-     * @param luceneFieldType       the lucene {@link FieldType} of the field to be searched
-     * @param similarity            defines which Similarity to use when searching.  If set to {@code null}
-     *                              then the default Similarity will be used.
-     * @param searchAnalyzer        the search-time analyzer to use.  May not be {@code null}
-     * @param searchQuoteAnalyzer   the search-time analyzer to use for phrase searches.  May not be {@code null}
-     */
-    public TextSearchInfo(
-        FieldType luceneFieldType,
-        SimilarityProvider similarity,
-        NamedAnalyzer searchAnalyzer,
-        NamedAnalyzer searchQuoteAnalyzer
-    ) {
-        this.luceneFieldType = luceneFieldType;
-        this.similarity = similarity;
-        this.searchAnalyzer = Objects.requireNonNull(searchAnalyzer);
-        this.searchQuoteAnalyzer = Objects.requireNonNull(searchQuoteAnalyzer);
-    }
-
-    public SimilarityProvider getSimilarity() {
-        return similarity;
-    }
-
-    public NamedAnalyzer getSearchAnalyzer() {
-        return searchAnalyzer;
-    }
-
-    public NamedAnalyzer getSearchQuoteAnalyzer() {
-        return searchQuoteAnalyzer;
+    public TextSearchInfo {
+        Objects.requireNonNull(searchAnalyzer);
+        Objects.requireNonNull(searchQuoteAnalyzer);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -308,7 +308,7 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
             float boost = entry.getValue() == null ? 1.0f : entry.getValue();
             fieldsAndBoosts.add(new FieldAndBoost(fieldType, boost));
 
-            Analyzer analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+            Analyzer analyzer = fieldType.getTextSearchInfo().searchAnalyzer();
             if (sharedAnalyzer != null && analyzer.equals(sharedAnalyzer) == false) {
                 throw new IllegalArgumentException("All fields in [" + NAME + "] query must have the same search analyzer");
             }
@@ -337,7 +337,7 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
         for (Map.Entry<String, Float> entry : fields.entrySet()) {
             String name = entry.getKey();
             MappedFieldType fieldType = context.getFieldType(name);
-            if (fieldType != null && fieldType.getTextSearchInfo().getSimilarity() != null) {
+            if (fieldType != null && fieldType.getTextSearchInfo().similarity() != null) {
                 throw new IllegalArgumentException("[" + NAME + "] queries cannot be used with per-field similarities");
             }
         }
@@ -348,13 +348,9 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
         }
     }
 
-    private static final class FieldAndBoost {
-        final MappedFieldType fieldType;
-        final float boost;
-
-        FieldAndBoost(MappedFieldType fieldType, float boost) {
-            this.fieldType = Objects.requireNonNull(fieldType);
-            this.boost = boost;
+    private record FieldAndBoost(MappedFieldType fieldType, float boost) {
+        FieldAndBoost {
+            Objects.requireNonNull(fieldType);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -155,7 +155,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                 assert fieldType != null;
             }
             if (analyzer == null) {
-                analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+                analyzer = fieldType.getTextSearchInfo().searchAnalyzer();
             }
             IntervalsSource source = intervals(fieldType, query, maxGaps, ordered, analyzer, context);
             if (useField != null) {
@@ -541,7 +541,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                 assert fieldType != null;
             }
             if (analyzer == null) {
-                analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+                analyzer = fieldType.getTextSearchInfo().searchAnalyzer();
             }
             final BytesRef prefixTerm = analyzer.normalize(fieldType.name(), prefix);
             IntervalsSource source = fieldType.prefixIntervals(prefixTerm, context);
@@ -659,7 +659,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                 assert fieldType != null;
             }
             if (analyzer == null) {
-                analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+                analyzer = fieldType.getTextSearchInfo().searchAnalyzer();
             }
             BytesRef normalizedPattern = analyzer.normalize(fieldType.name(), pattern);
             IntervalsSource source = fieldType.wildcardIntervals(normalizedPattern, context);
@@ -786,7 +786,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                 assert fieldType != null;
             }
             if (analyzer == null) {
-                analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+                analyzer = fieldType.getTextSearchInfo().searchAnalyzer();
             }
             // Fuzzy queries only work with unicode content so it's legal to call utf8ToString here.
             String normalizedTerm = analyzer.normalize(fieldType.name(), term).utf8ToString();

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -175,7 +175,7 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         }
         MappedFieldType mft = context.getFieldType(fieldName);
         if (mft != null) {
-            return mft.getTextSearchInfo().getSearchAnalyzer();
+            return mft.getTextSearchInfo().searchAnalyzer();
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -379,7 +379,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         }
         MappedFieldType mft = context.getFieldType(fieldName);
         if (mft != null) {
-            return mft.getTextSearchInfo().getSearchAnalyzer();
+            return mft.getTextSearchInfo().searchAnalyzer();
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
@@ -91,8 +91,8 @@ public abstract class ScrollableHitSource {
     }
 
     private void onResponse(Response response) {
-        logger.trace("scroll returned [{}] documents with a scroll id of [{}]", response.getHits().size(), response.getScrollId());
-        setScroll(response.getScrollId());
+        logger.trace("scroll returned [{}] documents with a scroll id of [{}]", response.hits().size(), response.scrollId());
+        setScroll(response.scrollId());
         onResponse.accept(new AsyncResponse() {
             private AtomicBoolean alreadyDone = new AtomicBoolean();
 
@@ -172,56 +172,18 @@ public abstract class ScrollableHitSource {
     /**
      * Response from each scroll batch.
      */
-    public static class Response {
-        private final boolean timedOut;
-        private final List<SearchFailure> failures;
-        private final long totalHits;
-        private final List<? extends Hit> hits;
-        private final String scrollId;
-
-        public Response(boolean timedOut, List<SearchFailure> failures, long totalHits, List<? extends Hit> hits, String scrollId) {
-            this.timedOut = timedOut;
-            this.failures = failures;
-            this.totalHits = totalHits;
-            this.hits = hits;
-            this.scrollId = scrollId;
-        }
-
-        /**
-         * Did this batch time out?
-         */
-        public boolean isTimedOut() {
-            return timedOut;
-        }
-
-        /**
-         * Where there any search failures?
-         */
-        public final List<SearchFailure> getFailures() {
-            return failures;
-        }
-
-        /**
-         * What were the total number of documents matching the search?
-         */
-        public long getTotalHits() {
-            return totalHits;
-        }
-
-        /**
-         * The documents returned in this batch.
-         */
-        public List<? extends Hit> getHits() {
-            return hits;
-        }
-
-        /**
-         * The scroll id used to fetch the next set of documents.
-         */
-        public String getScrollId() {
-            return scrollId;
-        }
-    }
+    public record Response(
+        // Did this batch time out?
+        boolean timedOut,
+        // Where there any search failures
+        List<SearchFailure> failures,
+        // What were the total number of documents matching the search?
+        long totalHits,
+        // The documents returned in this batch
+        List<? extends Hit> hits,
+        // The scroll id used to fetch the next set of documents
+        String scrollId
+    ) {}
 
     /**
      * A document returned as part of the response. Think of it like {@link SearchHit} but with all the things reindex needs in convenient

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
@@ -247,7 +247,7 @@ public class MatchQueryParser {
         TextSearchInfo tsi = fieldType.getTextSearchInfo();
         assert tsi != TextSearchInfo.NONE;
         if (analyzer == null) {
-            return quoted ? tsi.getSearchQuoteAnalyzer() : tsi.getSearchAnalyzer();
+            return quoted ? tsi.searchQuoteAnalyzer() : tsi.searchAnalyzer();
         } else {
             return analyzer;
         }

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
@@ -308,13 +308,9 @@ public class MultiMatchQueryParser extends MatchQueryParser {
         }
     }
 
-    static final class FieldAndBoost {
-        final MappedFieldType fieldType;
-        final float boost;
-
-        FieldAndBoost(MappedFieldType fieldType, float boost) {
-            this.fieldType = Objects.requireNonNull(fieldType);
-            this.boost = boost;
+    record FieldAndBoost(MappedFieldType fieldType, float boost) {
+        FieldAndBoost {
+            Objects.requireNonNull(fieldType);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -425,7 +425,7 @@ public class QueryStringQueryParser extends QueryParser {
             return newUnmappedFieldQuery(field);
         }
         try {
-            Analyzer normalizer = forceAnalyzer == null ? currentFieldType.getTextSearchInfo().getSearchAnalyzer() : forceAnalyzer;
+            Analyzer normalizer = forceAnalyzer == null ? currentFieldType.getTextSearchInfo().searchAnalyzer() : forceAnalyzer;
             BytesRef part1Binary = part1 == null ? null : normalizer.normalize(field, part1);
             BytesRef part2Binary = part2 == null ? null : normalizer.normalize(field, part2);
             Query rangeQuery = currentFieldType.rangeQuery(
@@ -482,7 +482,7 @@ public class QueryStringQueryParser extends QueryParser {
             return newUnmappedFieldQuery(field);
         }
         try {
-            Analyzer normalizer = forceAnalyzer == null ? currentFieldType.getTextSearchInfo().getSearchAnalyzer() : forceAnalyzer;
+            Analyzer normalizer = forceAnalyzer == null ? currentFieldType.getTextSearchInfo().searchAnalyzer() : forceAnalyzer;
             BytesRef term = termStr == null ? null : normalizer.normalize(field, termStr);
             return currentFieldType.fuzzyQuery(
                 term,
@@ -538,7 +538,7 @@ public class QueryStringQueryParser extends QueryParser {
             if (currentFieldType == null || currentFieldType.getTextSearchInfo() == TextSearchInfo.NONE) {
                 return newUnmappedFieldQuery(field);
             }
-            setAnalyzer(forceAnalyzer == null ? currentFieldType.getTextSearchInfo().getSearchAnalyzer() : forceAnalyzer);
+            setAnalyzer(forceAnalyzer == null ? currentFieldType.getTextSearchInfo().searchAnalyzer() : forceAnalyzer);
             Query query = null;
             if (currentFieldType.getTextSearchInfo().isTokenized() == false) {
                 query = currentFieldType.prefixQuery(termStr, getMultiTermRewriteMethod(), context);

--- a/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
@@ -79,7 +79,7 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
         if (getAnalyzer() != null) {
             return analyzer;
         }
-        return ft.getTextSearchInfo().getSearchAnalyzer();
+        return ft.getTextSearchInfo().searchAnalyzer();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -281,7 +281,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
 
     private long getMinimumReasonableRetainedSeqNo() {
         final SafeCommitInfo safeCommitInfo = safeCommitInfoSupplier.get();
-        return safeCommitInfo.localCheckpoint + 1 - Math.round(Math.ceil(safeCommitInfo.docCount * fileBasedRecoveryThreshold));
+        return safeCommitInfo.localCheckpoint() + 1 - Math.round(Math.ceil(safeCommitInfo.docCount() * fileBasedRecoveryThreshold));
         // NB safeCommitInfo.docCount is a very low-level count of the docs in the index, and in particular if this shard contains nested
         // docs then safeCommitInfo.docCount counts every child doc separately from the parent doc. However every part of a nested document
         // has the same seqno, so we may be overestimating the cost of a file-based recovery when compared to an ops-based recovery and

--- a/server/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
@@ -103,18 +103,5 @@ public class SequenceNumbers {
         }
     }
 
-    public static final class CommitInfo {
-        public final long maxSeqNo;
-        public final long localCheckpoint;
-
-        public CommitInfo(long maxSeqNo, long localCheckpoint) {
-            this.maxSeqNo = maxSeqNo;
-            this.localCheckpoint = localCheckpoint;
-        }
-
-        @Override
-        public String toString() {
-            return "CommitInfo{" + "maxSeqNo=" + maxSeqNo + ", localCheckpoint=" + localCheckpoint + '}';
-        }
-    }
+    public record CommitInfo(long maxSeqNo, long localCheckpoint) {}
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1686,8 +1686,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 logger.trace("skip local recovery as no safe commit found");
                 return UNASSIGNED_SEQ_NO;
             }
-            assert safeCommit.get().localCheckpoint <= globalCheckpoint : safeCommit.get().localCheckpoint + " > " + globalCheckpoint;
-            if (safeCommit.get().localCheckpoint == globalCheckpoint) {
+            assert safeCommit.get().localCheckpoint() <= globalCheckpoint : safeCommit.get().localCheckpoint() + " > " + globalCheckpoint;
+            if (safeCommit.get().localCheckpoint() == globalCheckpoint) {
                 logger.trace(
                     "skip local recovery as the safe commit is up to date; safe commit {} global checkpoint {}",
                     safeCommit.get(),
@@ -1704,7 +1704,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     globalCheckpoint
                 );
                 recoveryState.getTranslog().totalLocal(0);
-                return safeCommit.get().localCheckpoint + 1;
+                return safeCommit.get().localCheckpoint() + 1;
             }
             try {
                 final Engine.TranslogRecoveryRunner translogRecoveryRunner = (engine, snapshot) -> {
@@ -1734,7 +1734,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // we need to find the safe commit again as we should have created a new one during the local recovery
             final Optional<SequenceNumbers.CommitInfo> newSafeCommit = store.findSafeIndexCommit(globalCheckpoint);
             assert newSafeCommit.isPresent() : "no safe commit found after local recovery";
-            return newSafeCommit.get().localCheckpoint + 1;
+            return newSafeCommit.get().localCheckpoint() + 1;
         } catch (Exception e) {
             logger.debug(
                 new ParameterizedMessage(
@@ -3728,18 +3728,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      *
      * @see IndexShard#addShardFailureCallback(Consumer)
      */
-    public static final class ShardFailure {
-        public final ShardRouting routing;
-        public final String reason;
-        @Nullable
-        public final Exception cause;
-
-        public ShardFailure(ShardRouting routing, String reason, @Nullable Exception cause) {
-            this.routing = routing;
-            this.reason = reason;
-            this.cause = cause;
-        }
-    }
+    public record ShardFailure(ShardRouting routing, String reason, @Nullable Exception cause) {}
 
     EngineFactory getEngineFactory() {
         return engineFactory;

--- a/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -408,7 +408,7 @@ public class RemoveCorruptedShardDataCommand extends ElasticsearchNodeCommand {
                 // We can only safely do it because we will generate a new history uuid this shard.
                 final SequenceNumbers.CommitInfo commitInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userData.entrySet());
                 // Also advances the local checkpoint of the last commit to its max_seqno.
-                userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(commitInfo.maxSeqNo));
+                userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(commitInfo.maxSeqNo()));
             }
 
             // commit the new history id
@@ -437,11 +437,11 @@ public class RemoveCorruptedShardDataCommand extends ElasticsearchNodeCommand {
 
         final AllocationId newAllocationId = AllocationId.newInitializing();
 
-        terminal.println("Changing allocation id " + shardStateMetadata.allocationId.getId() + " to " + newAllocationId.getId());
+        terminal.println("Changing allocation id " + shardStateMetadata.allocationId().getId() + " to " + newAllocationId.getId());
 
         final ShardStateMetadata newShardStateMetadata = new ShardStateMetadata(
-            shardStateMetadata.primary,
-            shardStateMetadata.indexUUID,
+            shardStateMetadata.primary(),
+            shardStateMetadata.indexUUID(),
             newAllocationId
         );
 

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -131,7 +131,7 @@ public final class ShardPath {
             // EMPTY is safe here because we never call namedObject
             ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
             if (load != null) {
-                if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
+                if (load.indexUUID().equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID()) == false) {
                     logger.warn(
                         "{} found shard on path: [{}] with a different index UUID - this "
                             + "shard seems to be leftover from a different index with the same name. "
@@ -142,7 +142,7 @@ public final class ShardPath {
                     throw new IllegalStateException(
                         shardId
                             + " index UUID in shard state was: "
-                            + load.indexUUID
+                            + load.indexUUID()
                             + " expected: "
                             + indexUUID
                             + " on shard path: "
@@ -190,7 +190,7 @@ public final class ShardPath {
             // EMPTY is safe here because we never call namedObject
             ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
             if (load != null) {
-                if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
+                if (load.indexUUID().equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID()) == false) {
                     logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
                     assert Files.isDirectory(path) : path + " is not a directory";
                     NodeEnvironment.acquireFSLockForPaths(indexSettings, path);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
@@ -19,62 +19,16 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Objects;
 
-public final class ShardStateMetadata {
+public record ShardStateMetadata(boolean primary, String indexUUID, @Nullable AllocationId allocationId) {
 
     private static final String SHARD_STATE_FILE_PREFIX = "state-";
     private static final String PRIMARY_KEY = "primary";
     private static final String INDEX_UUID_KEY = "index_uuid";
     private static final String ALLOCATION_ID_KEY = "allocation_id";
 
-    public final String indexUUID;
-    public final boolean primary;
-    @Nullable
-    public final AllocationId allocationId; // can be null if we read from legacy format (see fromXContent and MultiDataPathUpgrader)
-
-    public ShardStateMetadata(boolean primary, String indexUUID, AllocationId allocationId) {
+    public ShardStateMetadata {
         assert indexUUID != null;
-        this.primary = primary;
-        this.indexUUID = indexUUID;
-        this.allocationId = allocationId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ShardStateMetadata that = (ShardStateMetadata) o;
-
-        if (primary != that.primary) {
-            return false;
-        }
-        if (indexUUID.equals(that.indexUUID) == false) {
-            return false;
-        }
-        if (Objects.equals(allocationId, that.allocationId) == false) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = indexUUID.hashCode();
-        result = 31 * result + (allocationId != null ? allocationId.hashCode() : 0);
-        result = 31 * result + (primary ? 1 : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "primary [" + primary + "], allocation [" + allocationId + "]";
     }
 
     public static final MetadataStateFormat<ShardStateMetadata> FORMAT = new MetadataStateFormat<ShardStateMetadata>(

--- a/server/src/main/java/org/elasticsearch/index/similarity/ScriptedSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/ScriptedSimilarity.java
@@ -138,13 +138,7 @@ public final class ScriptedSimilarity extends Similarity {
     }
 
     /** Scoring factors that come from the query. */
-    public static class Query {
-        private final float boost;
-
-        private Query(float boost) {
-            this.boost = boost;
-        }
-
+    public record Query(float boost) {
         /** The boost of the query. It should typically be incorporated into the score as a multiplicative factor. */
         public float getBoost() {
             return boost;
@@ -152,16 +146,7 @@ public final class ScriptedSimilarity extends Similarity {
     }
 
     /** Statistics that are specific to a given field. */
-    public static class Field {
-        private final long docCount;
-        private final long sumDocFreq;
-        private final long sumTotalTermFreq;
-
-        private Field(long docCount, long sumDocFreq, long sumTotalTermFreq) {
-            this.docCount = docCount;
-            this.sumDocFreq = sumDocFreq;
-            this.sumTotalTermFreq = sumTotalTermFreq;
-        }
+    public record Field(long docCount, long sumDocFreq, long sumTotalTermFreq) {
 
         /** Return the number of documents that have a value for this field. */
         public long getDocCount() {
@@ -182,14 +167,7 @@ public final class ScriptedSimilarity extends Similarity {
     }
 
     /** Statistics that are specific to a given term. */
-    public static class Term {
-        private final long docFreq;
-        private final long totalTermFreq;
-
-        private Term(long docFreq, long totalTermFreq) {
-            this.docFreq = docFreq;
-            this.totalTermFreq = totalTermFreq;
-        }
+    public record Term(long docFreq, long totalTermFreq) {
 
         /** Return the number of documents that contain this term in the index. */
         public long getDocFreq() {

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -15,22 +15,7 @@ import java.util.Objects;
 /**
  * Wrapper around a {@link Similarity} and its name.
  */
-public final class SimilarityProvider {
-
-    private final String name;
-    private final Similarity similarity;
-
-    public SimilarityProvider(String name, Similarity similarity) {
-        this.name = name;
-        this.similarity = similarity;
-    }
-
-    /**
-     * Return the name of this {@link Similarity}.
-     */
-    public String name() {
-        return name;
-    }
+public record SimilarityProvider(String name, Similarity similarity) {
 
     /**
      * Return the wrapped {@link Similarity}.

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -159,8 +159,8 @@ public final class SimilarityService {
         @Override
         public Similarity get(String name) {
             MappedFieldType fieldType = fieldTypeLookup.apply(name);
-            return (fieldType != null && fieldType.getTextSearchInfo().getSimilarity() != null)
-                ? fieldType.getTextSearchInfo().getSimilarity().get()
+            return (fieldType != null && fieldType.getTextSearchInfo().similarity() != null)
+                ? fieldType.getTextSearchInfo().similarity().get()
                 : defaultSimilarity;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -240,117 +240,17 @@ public class IndexShardSnapshotStatus {
     /**
      * Returns an immutable state of {@link IndexShardSnapshotStatus} at a given point in time.
      */
-    public static class Copy {
-
-        private final Stage stage;
-        private final long startTime;
-        private final long totalTime;
-        private final int incrementalFileCount;
-        private final int totalFileCount;
-        private final int processedFileCount;
-        private final long totalSize;
-        private final long processedSize;
-        private final long incrementalSize;
-        private final long indexVersion;
-        private final String failure;
-
-        public Copy(
-            final Stage stage,
-            final long startTime,
-            final long totalTime,
-            final int incrementalFileCount,
-            final int totalFileCount,
-            final int processedFileCount,
-            final long incrementalSize,
-            final long totalSize,
-            final long processedSize,
-            final long indexVersion,
-            final String failure
-        ) {
-            this.stage = stage;
-            this.startTime = startTime;
-            this.totalTime = totalTime;
-            this.incrementalFileCount = incrementalFileCount;
-            this.totalFileCount = totalFileCount;
-            this.processedFileCount = processedFileCount;
-            this.totalSize = totalSize;
-            this.processedSize = processedSize;
-            this.incrementalSize = incrementalSize;
-            this.indexVersion = indexVersion;
-            this.failure = failure;
-        }
-
-        public Stage getStage() {
-            return stage;
-        }
-
-        public long getStartTime() {
-            return startTime;
-        }
-
-        public long getTotalTime() {
-            return totalTime;
-        }
-
-        public int getIncrementalFileCount() {
-            return incrementalFileCount;
-        }
-
-        public int getTotalFileCount() {
-            return totalFileCount;
-        }
-
-        public int getProcessedFileCount() {
-            return processedFileCount;
-        }
-
-        public long getIncrementalSize() {
-            return incrementalSize;
-        }
-
-        public long getTotalSize() {
-            return totalSize;
-        }
-
-        public long getProcessedSize() {
-            return processedSize;
-        }
-
-        public long getIndexVersion() {
-            return indexVersion;
-        }
-
-        public String getFailure() {
-            return failure;
-        }
-
-        @Override
-        public String toString() {
-            return "index shard snapshot status ("
-                + "stage="
-                + stage
-                + ", startTime="
-                + startTime
-                + ", totalTime="
-                + totalTime
-                + ", incrementalFileCount="
-                + incrementalFileCount
-                + ", totalFileCount="
-                + totalFileCount
-                + ", processedFileCount="
-                + processedFileCount
-                + ", incrementalSize="
-                + incrementalSize
-                + ", totalSize="
-                + totalSize
-                + ", processedSize="
-                + processedSize
-                + ", indexVersion="
-                + indexVersion
-                + ", failure='"
-                + failure
-                + '\''
-                + ')';
-        }
-    }
+    public record Copy(
+        Stage stage,
+        long startTime,
+        long totalTime,
+        int incrementalFileCount,
+        int totalFileCount,
+        int processedFileCount,
+        long incrementalSize,
+        long totalSize,
+        long processedSize,
+        long indexVersion,
+        String failure
+    ) {}
 }

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -94,7 +94,7 @@ public class TermVectorsService {
             /* or from an existing document */
             else if (docIdAndVersion != null) {
                 // fields with stored term vectors
-                termVectorsByField = docIdAndVersion.reader.getTermVectors(docIdAndVersion.docId);
+                termVectorsByField = docIdAndVersion.reader().getTermVectors(docIdAndVersion.docId());
                 Set<String> selectedFields = request.selectedFields();
                 // generate tvs for fields where analyzer is overridden
                 if (selectedFields == null && request.perFieldAnalyzer() != null) {
@@ -104,7 +104,7 @@ public class TermVectorsService {
                 if (selectedFields != null) {
                     termVectorsByField = addGeneratedTermVectors(indexShard, get, termVectorsByField, request, selectedFields);
                 }
-                termVectorsResponse.setDocVersion(docIdAndVersion.version);
+                termVectorsResponse.setDocVersion(docIdAndVersion.version());
                 termVectorsResponse.setExists(true);
             }
             /* no term vectors generated or found */

--- a/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
@@ -149,8 +149,8 @@ public abstract class BaseTranslogReader implements Comparable<BaseTranslogReade
      * Reads a single operation from the given location.
      */
     Translog.Operation read(Translog.Location location) throws IOException {
-        assert location.generation == this.generation : "generation mismatch expected: " + generation + " got: " + location.generation;
-        ByteBuffer buffer = ByteBuffer.allocate(location.size);
-        return read(checksummedStream(buffer, location.translogLocation, location.size, null));
+        assert location.generation() == this.generation : "generation mismatch expected: " + generation + " got: " + location.generation();
+        ByteBuffer buffer = ByteBuffer.allocate(location.size());
+        return read(checksummedStream(buffer, location.translogLocation(), location.size(), null));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
@@ -30,16 +30,16 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 
-final class Checkpoint {
-
-    final long offset;
-    final int numOps;
-    final long generation;
-    final long minSeqNo;
-    final long maxSeqNo;
-    final long globalCheckpoint;
-    final long minTranslogGeneration;
-    final long trimmedAboveSeqNo;
+record Checkpoint(
+    long offset,
+    int numOps,
+    long generation,
+    long minSeqNo,
+    long maxSeqNo,
+    long globalCheckpoint,
+    long minTranslogGeneration,
+    long trimmedAboveSeqNo
+) {
 
     private static final int VERSION_LUCENE_8 = 3;      // int values written in BE format
     private static final int CURRENT_VERSION = 4;
@@ -69,28 +69,11 @@ final class Checkpoint {
      * @param trimmedAboveSeqNo     all operations with seq# above trimmedAboveSeqNo should be ignored and not read from the
      *                              corresponding translog file. {@link SequenceNumbers#UNASSIGNED_SEQ_NO} is used to disable trimming.
      */
-    Checkpoint(
-        long offset,
-        int numOps,
-        long generation,
-        long minSeqNo,
-        long maxSeqNo,
-        long globalCheckpoint,
-        long minTranslogGeneration,
-        long trimmedAboveSeqNo
-    ) {
+    Checkpoint {
         assert minSeqNo <= maxSeqNo : "minSeqNo [" + minSeqNo + "] is higher than maxSeqNo [" + maxSeqNo + "]";
         assert trimmedAboveSeqNo <= maxSeqNo : "trimmedAboveSeqNo [" + trimmedAboveSeqNo + "] is higher than maxSeqNo [" + maxSeqNo + "]";
         assert minTranslogGeneration <= generation
             : "minTranslogGen [" + minTranslogGeneration + "] is higher than generation [" + generation + "]";
-        this.offset = offset;
-        this.numOps = numOps;
-        this.generation = generation;
-        this.minSeqNo = minSeqNo;
-        this.maxSeqNo = maxSeqNo;
-        this.globalCheckpoint = globalCheckpoint;
-        this.minTranslogGeneration = minTranslogGeneration;
-        this.trimmedAboveSeqNo = trimmedAboveSeqNo;
     }
 
     private void write(DataOutput out) throws IOException {
@@ -141,28 +124,6 @@ final class Checkpoint {
         final long minTranslogGeneration = in.readLong();
         final long trimmedAboveSeqNo = in.readLong();
         return new Checkpoint(offset, numOps, generation, minSeqNo, maxSeqNo, globalCheckpoint, minTranslogGeneration, trimmedAboveSeqNo);
-    }
-
-    @Override
-    public String toString() {
-        return "Checkpoint{"
-            + "offset="
-            + offset
-            + ", numOps="
-            + numOps
-            + ", generation="
-            + generation
-            + ", minSeqNo="
-            + minSeqNo
-            + ", maxSeqNo="
-            + maxSeqNo
-            + ", globalCheckpoint="
-            + globalCheckpoint
-            + ", minTranslogGeneration="
-            + minTranslogGeneration
-            + ", trimmedAboveSeqNo="
-            + trimmedAboveSeqNo
-            + '}';
     }
 
     public static Checkpoint read(Path path) throws IOException {
@@ -229,34 +190,6 @@ final class Checkpoint {
                 : "checkpoint files have to be smaller than 512 bytes for atomic writes; size: " + indexOutput.getFilePointer();
         }
         return byteOutputStream.toByteArray();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Checkpoint that = (Checkpoint) o;
-
-        if (offset != that.offset) return false;
-        if (numOps != that.numOps) return false;
-        if (generation != that.generation) return false;
-        if (minSeqNo != that.minSeqNo) return false;
-        if (maxSeqNo != that.maxSeqNo) return false;
-        if (globalCheckpoint != that.globalCheckpoint) return false;
-        return trimmedAboveSeqNo == that.trimmedAboveSeqNo;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Long.hashCode(offset);
-        result = 31 * result + numOps;
-        result = 31 * result + Long.hashCode(generation);
-        result = 31 * result + Long.hashCode(minSeqNo);
-        result = 31 * result + Long.hashCode(maxSeqNo);
-        result = 31 * result + Long.hashCode(globalCheckpoint);
-        result = 31 * result + Long.hashCode(trimmedAboveSeqNo);
-        return result;
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
@@ -42,9 +42,9 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
      * @param header     the header of the translog file
      */
     TranslogReader(final Checkpoint checkpoint, final FileChannel channel, final Path path, final TranslogHeader header) {
-        super(checkpoint.generation, channel, path, header);
-        this.length = checkpoint.offset;
-        this.totalOperations = checkpoint.numOps;
+        super(checkpoint.generation(), channel, path, header);
+        this.length = checkpoint.offset();
+        this.totalOperations = checkpoint.numOps();
         this.checkpoint = checkpoint;
     }
 
@@ -72,17 +72,17 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
             Closeable toCloseOnFailure = channel;
             final TranslogReader newReader;
             try {
-                if (aboveSeqNo < checkpoint.trimmedAboveSeqNo
-                    || aboveSeqNo < checkpoint.maxSeqNo && checkpoint.trimmedAboveSeqNo == SequenceNumbers.UNASSIGNED_SEQ_NO) {
-                    final Path checkpointFile = path.getParent().resolve(getCommitCheckpointFileName(checkpoint.generation));
+                if (aboveSeqNo < checkpoint.trimmedAboveSeqNo()
+                    || aboveSeqNo < checkpoint.maxSeqNo() && checkpoint.trimmedAboveSeqNo() == SequenceNumbers.UNASSIGNED_SEQ_NO) {
+                    final Path checkpointFile = path.getParent().resolve(getCommitCheckpointFileName(checkpoint.generation()));
                     final Checkpoint newCheckpoint = new Checkpoint(
-                        checkpoint.offset,
-                        checkpoint.numOps,
-                        checkpoint.generation,
-                        checkpoint.minSeqNo,
-                        checkpoint.maxSeqNo,
-                        checkpoint.globalCheckpoint,
-                        checkpoint.minTranslogGeneration,
+                        checkpoint.offset(),
+                        checkpoint.numOps(),
+                        checkpoint.generation(),
+                        checkpoint.minSeqNo(),
+                        checkpoint.maxSeqNo(),
+                        checkpoint.globalCheckpoint(),
+                        checkpoint.minTranslogGeneration(),
                         aboveSeqNo
                     );
                     Checkpoint.write(channelFactory, checkpointFile, newCheckpoint, StandardOpenOption.WRITE);

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
@@ -57,7 +57,8 @@ final class TranslogSnapshot extends BaseTranslogReader {
     public Translog.Operation next() throws IOException {
         while (readOperations < totalOperations) {
             final Translog.Operation operation = readOperation();
-            if (operation.seqNo() <= checkpoint.trimmedAboveSeqNo || checkpoint.trimmedAboveSeqNo == SequenceNumbers.UNASSIGNED_SEQ_NO) {
+            if (operation.seqNo() <= checkpoint.trimmedAboveSeqNo()
+                || checkpoint.trimmedAboveSeqNo() == SequenceNumbers.UNASSIGNED_SEQ_NO) {
                 return operation;
             }
             skippedOperations++;

--- a/server/src/main/java/org/elasticsearch/indices/AbstractIndexShardCacheEntity.java
+++ b/server/src/main/java/org/elasticsearch/indices/AbstractIndexShardCacheEntity.java
@@ -41,9 +41,9 @@ abstract class AbstractIndexShardCacheEntity implements IndicesRequestCache.Cach
     @Override
     public final void onRemoval(RemovalNotification<IndicesRequestCache.Key, BytesReference> notification) {
         stats().onRemoval(
-            notification.getKey(),
-            notification.getValue(),
-            notification.getRemovalReason() == RemovalNotification.RemovalReason.EVICTED
+            notification.key(),
+            notification.value(),
+            notification.removalReason() == RemovalNotification.RemovalReason.EVICTED
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -107,7 +107,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
 
     @Override
     public void onRemoval(RemovalNotification<Key, BytesReference> notification) {
-        notification.getKey().entity.onRemoval(notification);
+        notification.key().entity.onRemoval(notification);
     }
 
     BytesReference getOrCompute(

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -303,17 +303,5 @@ public class SystemIndexManager implements ClusterStateListener {
         }
     }
 
-    static class State {
-        final IndexMetadata.State indexState;
-        final ClusterHealthStatus indexHealth;
-        final boolean isIndexUpToDate;
-        final boolean mappingUpToDate;
-
-        State(IndexMetadata.State indexState, ClusterHealthStatus indexHealth, boolean isIndexUpToDate, boolean mappingUpToDate) {
-            this.indexState = indexState;
-            this.indexHealth = indexHealth;
-            this.isIndexUpToDate = isIndexUpToDate;
-            this.mappingUpToDate = mappingUpToDate;
-        }
-    }
+    record State(IndexMetadata.State indexState, ClusterHealthStatus indexHealth, boolean isIndexUpToDate, boolean mappingUpToDate) {}
 }

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -332,19 +332,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         );
     }
 
-    static class MemoryUsage {
-        final long baseUsage;
-        final long totalUsage;
-        final long transientChildUsage;
-        final long permanentChildUsage;
-
-        MemoryUsage(final long baseUsage, final long totalUsage, final long transientChildUsage, final long permanentChildUsage) {
-            this.baseUsage = baseUsage;
-            this.totalUsage = totalUsage;
-            this.transientChildUsage = transientChildUsage;
-            this.permanentChildUsage = permanentChildUsage;
-        }
-    }
+    record MemoryUsage(long baseUsage, long totalUsage, long transientChildUsage, long permanentChildUsage) {}
 
     private MemoryUsage memoryUsed(long newBytesReserved) {
         long transientUsage = 0;

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -809,14 +809,14 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private class FailedShardHandler implements Consumer<IndexShard.ShardFailure> {
         @Override
         public void accept(final IndexShard.ShardFailure shardFailure) {
-            final ShardRouting shardRouting = shardFailure.routing;
+            final ShardRouting shardRouting = shardFailure.routing();
             threadPool.generic().execute(() -> {
                 synchronized (IndicesClusterStateService.this) {
                     failAndRemoveShard(
                         shardRouting,
                         true,
-                        "shard failure, reason [" + shardFailure.reason + "]",
-                        shardFailure.cause,
+                        "shard failure, reason [" + shardFailure.reason() + "]",
+                        shardFailure.cause(),
                         clusterService.state()
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -75,16 +75,16 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
     @Override
     public void onRemoval(RemovalNotification<Key, Accountable> notification) {
-        Key key = notification.getKey();
+        Key key = notification.key();
         assert key != null && key.listeners != null;
         IndexFieldCache indexCache = key.indexCache;
-        final Accountable value = notification.getValue();
+        final Accountable value = notification.value();
         for (IndexFieldDataCache.Listener listener : key.listeners) {
             try {
                 listener.onRemoval(
                     key.shardId,
                     indexCache.fieldName,
-                    notification.getRemovalReason() == RemovalNotification.RemovalReason.EVICTED,
+                    notification.removalReason() == RemovalNotification.RemovalReason.EVICTED,
                     value.ramBytesUsed()
                 );
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiChunkTransfer.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiChunkTransfer.java
@@ -190,17 +190,7 @@ public abstract class MultiChunkTransfer<Source, Request extends MultiChunkTrans
 
     protected abstract void handleError(Source resource, Exception e) throws Exception;
 
-    private static class FileChunkResponseItem<Source> {
-        final long requestSeqId;
-        final Source source;
-        final Exception failure;
-
-        FileChunkResponseItem(long requestSeqId, Source source, Exception failure) {
-            this.requestSeqId = requestSeqId;
-            this.source = source;
-            this.failure = failure;
-        }
-    }
+    private record FileChunkResponseItem<Source> (long requestSeqId, Source source, Exception failure) {}
 
     public interface ChunkRequest {
         /**

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -236,13 +236,10 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
         store.renameTempFilesSafe(tempFileNames);
     }
 
-    private static final class FileChunk implements Releasable {
-        final StoreFileMetadata md;
-        final ReleasableBytesReference content;
-        final long position;
-        final boolean lastChunk;
-
-        FileChunk(StoreFileMetadata md, ReleasableBytesReference content, long position, boolean lastChunk) {
+    private record FileChunk(StoreFileMetadata md, ReleasableBytesReference content, long position, boolean lastChunk)
+        implements
+            Releasable {
+        private FileChunk(StoreFileMetadata md, ReleasableBytesReference content, long position, boolean lastChunk) {
             this.md = md;
             this.content = content.retain();
             this.position = position;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySnapshotFileRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySnapshotFileRequest.java
@@ -45,7 +45,7 @@ public class RecoverySnapshotFileRequest extends RecoveryTransportRequest {
         this.shardId = new ShardId(in);
         this.repository = in.readString();
         this.indexId = new IndexId(in);
-        this.fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(in);
+        this.fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardRecoveryPlan.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardRecoveryPlan.java
@@ -127,26 +127,11 @@ public class ShardRecoveryPlan {
         );
     }
 
-    public static class SnapshotFilesToRecover implements Iterable<BlobStoreIndexShardSnapshot.FileInfo> {
+    public record SnapshotFilesToRecover(IndexId indexId, String repository, List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles)
+        implements
+            Iterable<BlobStoreIndexShardSnapshot.FileInfo> {
+
         public static final SnapshotFilesToRecover EMPTY = new SnapshotFilesToRecover(null, null, emptyList());
-
-        private final IndexId indexId;
-        private final String repository;
-        private final List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles;
-
-        public SnapshotFilesToRecover(IndexId indexId, String repository, List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles) {
-            this.indexId = indexId;
-            this.repository = repository;
-            this.snapshotFiles = snapshotFiles;
-        }
-
-        public IndexId getIndexId() {
-            return indexId;
-        }
-
-        public String getRepository() {
-            return repository;
-        }
 
         public int size() {
             return snapshotFiles.size();
@@ -154,10 +139,6 @@ public class ShardRecoveryPlan {
 
         public boolean isEmpty() {
             return snapshotFiles.isEmpty();
-        }
-
-        public List<BlobStoreIndexShardSnapshot.FileInfo> getSnapshotFiles() {
-            return snapshotFiles;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshot.java
@@ -51,7 +51,7 @@ public class ShardSnapshot {
 
     public boolean hasDifferentPhysicalFiles(Store.MetadataSnapshot sourceSnapshot) {
         Store.RecoveryDiff recoveryDiff = metadataSnapshot.recoveryDiff(sourceSnapshot);
-        return recoveryDiff.different.isEmpty() == false || recoveryDiff.missing.isEmpty() == false;
+        return recoveryDiff.different().isEmpty() == false || recoveryDiff.missing().isEmpty() == false;
     }
 
     public String getRepository() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/SourceOnlyRecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/SourceOnlyRecoveryPlannerService.java
@@ -36,11 +36,11 @@ public class SourceOnlyRecoveryPlannerService implements RecoveryPlannerService 
     ) {
         ActionListener.completeWith(listener, () -> {
             Store.RecoveryDiff recoveryDiff = sourceMetadata.recoveryDiff(targetMetadata);
-            List<StoreFileMetadata> filesMissingInTarget = concatLists(recoveryDiff.missing, recoveryDiff.different);
+            List<StoreFileMetadata> filesMissingInTarget = concatLists(recoveryDiff.missing(), recoveryDiff.different());
             return new ShardRecoveryPlan(
                 ShardRecoveryPlan.SnapshotFilesToRecover.EMPTY,
                 filesMissingInTarget,
-                recoveryDiff.identical,
+                recoveryDiff.identical(),
                 startingSeqNo,
                 translogOps,
                 sourceMetadata

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1071,14 +1071,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return new Pipeline(id, description, null, null, new CompoundProcessor(failureProcessor));
     }
 
-    static class PipelineHolder {
+    record PipelineHolder(PipelineConfiguration configuration, Pipeline pipeline) {
 
-        final PipelineConfiguration configuration;
-        final Pipeline pipeline;
-
-        PipelineHolder(PipelineConfiguration configuration, Pipeline pipeline) {
-            this.configuration = Objects.requireNonNull(configuration);
-            this.pipeline = Objects.requireNonNull(pipeline);
+        PipelineHolder {
+            Objects.requireNonNull(configuration);
+            Objects.requireNonNull(pipeline);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -71,17 +71,17 @@ public class IngestStats implements Writeable, ToXContentFragment {
         totalStats.writeTo(out);
         out.writeVInt(pipelineStats.size());
         for (PipelineStat pipelineStat : pipelineStats) {
-            out.writeString(pipelineStat.getPipelineId());
-            pipelineStat.getStats().writeTo(out);
-            List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.getPipelineId());
+            out.writeString(pipelineStat.pipelineId());
+            pipelineStat.stats().writeTo(out);
+            List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.pipelineId());
             if (processorStatsForPipeline == null) {
                 out.writeVInt(0);
             } else {
                 out.writeVInt(processorStatsForPipeline.size());
                 for (ProcessorStat processorStat : processorStatsForPipeline) {
-                    out.writeString(processorStat.getName());
-                    out.writeString(processorStat.getType());
-                    processorStat.getStats().writeTo(out);
+                    out.writeString(processorStat.name());
+                    out.writeString(processorStat.type());
+                    processorStat.stats().writeTo(out);
                 }
             }
         }
@@ -95,17 +95,17 @@ public class IngestStats implements Writeable, ToXContentFragment {
         builder.endObject();
         builder.startObject("pipelines");
         for (PipelineStat pipelineStat : pipelineStats) {
-            builder.startObject(pipelineStat.getPipelineId());
-            pipelineStat.getStats().toXContent(builder, params);
-            List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.getPipelineId());
+            builder.startObject(pipelineStat.pipelineId());
+            pipelineStat.stats().toXContent(builder, params);
+            List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.pipelineId());
             builder.startArray("processors");
             if (processorStatsForPipeline != null) {
                 for (ProcessorStat processorStat : processorStatsForPipeline) {
                     builder.startObject();
-                    builder.startObject(processorStat.getName());
-                    builder.field("type", processorStat.getType());
+                    builder.startObject(processorStat.name());
+                    builder.field("type", processorStat.type());
                     builder.startObject("stats");
-                    processorStat.getStats().toXContent(builder, params);
+                    processorStat.stats().toXContent(builder, params);
                     builder.endObject();
                     builder.endObject();
                     builder.endObject();
@@ -264,74 +264,10 @@ public class IngestStats implements Writeable, ToXContentFragment {
     /**
      * Container for pipeline stats.
      */
-    public static class PipelineStat {
-        private final String pipelineId;
-        private final Stats stats;
-
-        public PipelineStat(String pipelineId, Stats stats) {
-            this.pipelineId = pipelineId;
-            this.stats = stats;
-        }
-
-        public String getPipelineId() {
-            return pipelineId;
-        }
-
-        public Stats getStats() {
-            return stats;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            IngestStats.PipelineStat that = (IngestStats.PipelineStat) o;
-            return Objects.equals(pipelineId, that.pipelineId) && Objects.equals(stats, that.stats);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(pipelineId, stats);
-        }
-    }
+    public record PipelineStat(String pipelineId, Stats stats) {}
 
     /**
      * Container for processor stats.
      */
-    public static class ProcessorStat {
-        private final String name;
-        private final String type;
-        private final Stats stats;
-
-        public ProcessorStat(String name, String type, Stats stats) {
-            this.name = name;
-            this.type = type;
-            this.stats = stats;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public Stats getStats() {
-            return stats;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            IngestStats.ProcessorStat that = (IngestStats.ProcessorStat) o;
-            return Objects.equals(name, that.name) && Objects.equals(type, that.type) && Objects.equals(stats, that.stats);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(name, type, stats);
-        }
-    }
+    public record ProcessorStat(String name, String type, Stats stats) {}
 }

--- a/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
@@ -15,11 +15,9 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.TemplateScript;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.script.Script.DEFAULT_TEMPLATE_LANG;
 
@@ -79,13 +77,7 @@ public interface ValueSource {
         }
     }
 
-    final class MapValue implements ValueSource {
-
-        private final Map<ValueSource, ValueSource> map;
-
-        MapValue(Map<ValueSource, ValueSource> map) {
-            this.map = map;
-        }
+    record MapValue(Map<ValueSource, ValueSource> map) implements ValueSource {
 
         @Override
         public Object copyAndResolve(Map<String, Object> model) {
@@ -95,30 +87,9 @@ public interface ValueSource {
             }
             return copy;
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            MapValue mapValue = (MapValue) o;
-            return map.equals(mapValue.map);
-
-        }
-
-        @Override
-        public int hashCode() {
-            return map.hashCode();
-        }
     }
 
-    final class ListValue implements ValueSource {
-
-        private final List<ValueSource> values;
-
-        ListValue(List<ValueSource> values) {
-            this.values = values;
-        }
+    record ListValue(List<ValueSource> values) implements ValueSource {
 
         @Override
         public Object copyAndResolve(Map<String, Object> model) {
@@ -128,105 +99,30 @@ public interface ValueSource {
             }
             return copy;
         }
+    }
+
+    record ObjectValue(Object value) implements ValueSource {
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            ListValue listValue = (ListValue) o;
-            return values.equals(listValue.values);
-
-        }
-
-        @Override
-        public int hashCode() {
-            return values.hashCode();
+        public Object copyAndResolve(Map<String, Object> model) {
+            return value;
         }
     }
 
-    final class ObjectValue implements ValueSource {
-
-        private final Object value;
-
-        ObjectValue(Object value) {
-            this.value = value;
-        }
+    record ByteValue(byte[] value) implements ValueSource {
 
         @Override
         public Object copyAndResolve(Map<String, Object> model) {
             return value;
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            ObjectValue objectValue = (ObjectValue) o;
-            return Objects.equals(value, objectValue.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(value);
-        }
     }
 
-    final class ByteValue implements ValueSource {
-
-        private final byte[] value;
-
-        ByteValue(byte[] value) {
-            this.value = value;
-        }
-
-        @Override
-        public Object copyAndResolve(Map<String, Object> model) {
-            return value;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            ByteValue objectValue = (ByteValue) o;
-            return Arrays.equals(value, objectValue.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Arrays.hashCode(value);
-        }
-
-    }
-
-    final class TemplatedValue implements ValueSource {
-
-        private final TemplateScript.Factory template;
-
-        TemplatedValue(TemplateScript.Factory template) {
-            this.template = template;
-        }
+    record TemplatedValue(TemplateScript.Factory template) implements ValueSource {
 
         @Override
         public Object copyAndResolve(Map<String, Object> model) {
             return template.newInstance(model).execute();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            TemplatedValue templatedValue = (TemplatedValue) o;
-            return Objects.equals(template, templatedValue.template);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(template);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/Snippet.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/Snippet.java
@@ -14,27 +14,4 @@ package org.elasticsearch.lucene.search.uhighlight;
  * Every snippet contains its formatted text and its score.
  * The score is needed in case we want to sort snippets by score, they get sorted by position in the text by default.
  */
-public class Snippet {
-
-    private final String text;
-    private final float score;
-    private final boolean isHighlighted;
-
-    public Snippet(String text, float score, boolean isHighlighted) {
-        this.text = text;
-        this.score = score;
-        this.isHighlighted = isHighlighted;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public float getScore() {
-        return score;
-    }
-
-    public boolean isHighlighted() {
-        return isHighlighted;
-    }
-}
+public record Snippet(String text, float score, boolean isHighlighted) {}

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -74,46 +74,9 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
         Property.NodeScope
     );
 
-    static class GcOverheadThreshold {
-        final int warnThreshold;
-        final int infoThreshold;
-        final int debugThreshold;
+    record GcOverheadThreshold(int warnThreshold, int infoThreshold, int debugThreshold) {}
 
-        GcOverheadThreshold(final int warnThreshold, final int infoThreshold, final int debugThreshold) {
-            this.warnThreshold = warnThreshold;
-            this.infoThreshold = infoThreshold;
-            this.debugThreshold = debugThreshold;
-        }
-    }
-
-    static class GcThreshold {
-        public final String name;
-        public final long warnThreshold;
-        public final long infoThreshold;
-        public final long debugThreshold;
-
-        GcThreshold(String name, long warnThreshold, long infoThreshold, long debugThreshold) {
-            this.name = name;
-            this.warnThreshold = warnThreshold;
-            this.infoThreshold = infoThreshold;
-            this.debugThreshold = debugThreshold;
-        }
-
-        @Override
-        public String toString() {
-            return "GcThreshold{"
-                + "name='"
-                + name
-                + '\''
-                + ", warnThreshold="
-                + warnThreshold
-                + ", infoThreshold="
-                + infoThreshold
-                + ", debugThreshold="
-                + debugThreshold
-                + '}';
-        }
-    }
+    record GcThreshold(String name, long warnThreshold, long infoThreshold, long debugThreshold) {}
 
     public JvmGcMonitorService(Settings settings, ThreadPool threadPool) {
         this.threadPool = threadPool;
@@ -379,33 +342,15 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
             WARN
         }
 
-        static class SlowGcEvent {
-
-            final GarbageCollector currentGc;
-            final long collectionCount;
-            final TimeValue collectionTime;
-            final long elapsed;
-            final JvmStats lastJvmStats;
-            final JvmStats currentJvmStats;
-            final ByteSizeValue maxHeapUsed;
-
-            SlowGcEvent(
-                final GarbageCollector currentGc,
-                final long collectionCount,
-                final TimeValue collectionTime,
-                final long elapsed,
-                final JvmStats lastJvmStats,
-                final JvmStats currentJvmStats,
-                final ByteSizeValue maxHeapUsed
-            ) {
-                this.currentGc = currentGc;
-                this.collectionCount = collectionCount;
-                this.collectionTime = collectionTime;
-                this.elapsed = elapsed;
-                this.lastJvmStats = lastJvmStats;
-                this.currentJvmStats = currentJvmStats;
-                this.maxHeapUsed = maxHeapUsed;
-            }
+        record SlowGcEvent(
+            GarbageCollector currentGc,
+            long collectionCount,
+            TimeValue collectionTime,
+            long elapsed,
+            JvmStats lastJvmStats,
+            JvmStats currentJvmStats,
+            ByteSizeValue maxHeapUsed
+        ) {
 
         }
 

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -328,8 +328,8 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         PersistentTasksExecutor<Params> persistentTasksExecutor = registry.getPersistentTaskExecutorSafe(taskName);
 
         AssignmentDecision decision = enableDecider.canAssign();
-        if (decision.getType() == AssignmentDecision.Type.NO) {
-            return unassignedAssignment("persistent task [" + taskName + "] cannot be assigned [" + decision.getReason() + "]");
+        if (decision.type() == AssignmentDecision.Type.NO) {
+            return unassignedAssignment("persistent task [" + taskName + "] cannot be assigned [" + decision.reason() + "]");
         }
 
         // Filter all nodes that are marked as shutting down, because we do not

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -250,11 +250,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         return ClusterState.builder(clusterState).metadata(metadataBuilder).build();
     }
 
-    public static class Assignment {
-        @Nullable
-        private final String executorNode;
-        private final String explanation;
-
+    public record Assignment(@Nullable String executorNode, String explanation) {
         public Assignment(String executorNode, String explanation) {
             this.executorNode = executorNode;
             assert explanation != null;
@@ -270,27 +266,10 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             return explanation;
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Assignment that = (Assignment) o;
-            return Objects.equals(executorNode, that.executorNode) && Objects.equals(explanation, that.explanation);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(executorNode, explanation);
-        }
-
         public boolean isAssigned() {
             return executorNode != null;
         }
 
-        @Override
-        public String toString() {
-            return "node: [" + executorNode + "], explanation: [" + explanation + "]";
-        }
     }
 
     public static final Assignment INITIAL_ASSIGNMENT = new Assignment(null, "waiting for initial assignment");

--- a/server/src/main/java/org/elasticsearch/persistent/decider/AssignmentDecision.java
+++ b/server/src/main/java/org/elasticsearch/persistent/decider/AssignmentDecision.java
@@ -16,24 +16,13 @@ import java.util.Objects;
  *
  * @see EnableAssignmentDecider
  */
-public final class AssignmentDecision {
+public record AssignmentDecision(org.elasticsearch.persistent.decider.AssignmentDecision.Type type, String reason) {
 
     public static final AssignmentDecision YES = new AssignmentDecision(Type.YES, "");
 
-    private final Type type;
-    private final String reason;
-
-    public AssignmentDecision(final Type type, final String reason) {
-        this.type = Objects.requireNonNull(type);
-        this.reason = Objects.requireNonNull(reason);
-    }
-
-    public Type getType() {
-        return type;
-    }
-
-    public String getReason() {
-        return reason;
+    public AssignmentDecision {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(reason);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 public class IndexSnapshotsService {
     private static final Comparator<Tuple<SnapshotId, RepositoryData.SnapshotDetails>> START_TIME_COMPARATOR = Comparator.<
-        Tuple<SnapshotId, RepositoryData.SnapshotDetails>>comparingLong(pair -> pair.v2().getStartTimeMillis()).thenComparing(Tuple::v1);
+        Tuple<SnapshotId, RepositoryData.SnapshotDetails>>comparingLong(pair -> pair.v2().startTimeMillis()).thenComparing(Tuple::v1);
 
     private final RepositoriesService repositoriesService;
 
@@ -71,8 +71,8 @@ public class IndexSnapshotsService {
 
             final Optional<SnapshotId> latestSnapshotId = indexSnapshots.stream()
                 .map(snapshotId -> Tuple.tuple(snapshotId, repositoryData.getSnapshotDetails(snapshotId)))
-                .filter(s -> s.v2().getSnapshotState() != null && s.v2().getSnapshotState() == SnapshotState.SUCCESS)
-                .filter(s -> s.v2().getStartTimeMillis() != -1 && s.v2().getEndTimeMillis() != -1)
+                .filter(s -> s.v2().snapshotState() != null && s.v2().snapshotState() == SnapshotState.SUCCESS)
+                .filter(s -> s.v2().startTimeMillis() != -1 && s.v2().endTimeMillis() != -1)
                 .max(START_TIME_COMPARATOR)
                 .map(Tuple::v1);
 
@@ -127,26 +127,13 @@ public class IndexSnapshotsService {
         return repositories.get(repositoryName);
     }
 
-    private static class FetchShardSnapshotContext {
-        private final Repository repository;
-        private final RepositoryData repositoryData;
-        private final IndexId indexId;
-        private final ShardId shardId;
-        private final SnapshotInfo snapshotInfo;
-
-        FetchShardSnapshotContext(
-            Repository repository,
-            RepositoryData repositoryData,
-            IndexId indexId,
-            ShardId shardId,
-            SnapshotInfo snapshotInfo
-        ) {
-            this.repository = repository;
-            this.repositoryData = repositoryData;
-            this.indexId = indexId;
-            this.shardId = shardId;
-            this.snapshotInfo = snapshotInfo;
-        }
+    private record FetchShardSnapshotContext(
+        Repository repository,
+        RepositoryData repositoryData,
+        IndexId indexId,
+        ShardId shardId,
+        SnapshotInfo snapshotInfo
+    ) {
 
         private String getIndexMetadataId() throws IOException {
             final IndexMetaDataGenerations indexMetaDataGenerations = repositoryData.indexMetaDataGenerations();

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesStatsArchive.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesStatsArchive.java
@@ -95,14 +95,7 @@ public final class RepositoriesStatsArchive {
             );
     }
 
-    private static class ArchiveEntry {
-        private final RepositoryStatsSnapshot repositoryStatsSnapshot;
-        private final long createdAtMillis;
-
-        private ArchiveEntry(RepositoryStatsSnapshot repositoryStatsSnapshot, long createdAtMillis) {
-            this.repositoryStatsSnapshot = repositoryStatsSnapshot;
-            this.createdAtMillis = createdAtMillis;
-        }
+    private record ArchiveEntry(RepositoryStatsSnapshot repositoryStatsSnapshot, long createdAtMillis) {
 
         private long ageInMillis(LongSupplier relativeTimeInMillis) {
             return Math.max(0, relativeTimeInMillis.getAsLong() - createdAtMillis);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2728,7 +2728,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         indexIncrementalFileCount++;
                         indexIncrementalSize += md.length();
                         // create a new FileInfo
-                        BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+                        BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
                             (needsWrite ? UPLOADED_DATA_BLOB_PREFIX : VIRTUAL_DATA_BLOB_PREFIX) + UUIDs.randomBase64UUID(),
                             md,
                             chunkSize()
@@ -2857,12 +2857,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 logger.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);
                 final BlobStoreIndexShardSnapshot blobStoreIndexShardSnapshot = new BlobStoreIndexShardSnapshot(
                     snapshotId.getName(),
-                    lastSnapshotStatus.getIndexVersion(),
+                    lastSnapshotStatus.indexVersion(),
                     indexCommitPointFiles,
-                    lastSnapshotStatus.getStartTime(),
-                    threadPool.absoluteTimeInMillis() - lastSnapshotStatus.getStartTime(),
-                    lastSnapshotStatus.getIncrementalFileCount(),
-                    lastSnapshotStatus.getIncrementalSize()
+                    lastSnapshotStatus.startTime(),
+                    threadPool.absoluteTimeInMillis() - lastSnapshotStatus.startTime(),
+                    lastSnapshotStatus.incrementalFileCount(),
+                    lastSnapshotStatus.incrementalSize()
                 );
                 try {
                     final String snapshotUUID = snapshotId.getUUID();
@@ -3518,25 +3518,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     /**
      * The result of removing a snapshot from a shard folder in the repository.
      */
-    private static final class ShardSnapshotMetaDeleteResult {
-
-        // Index that the snapshot was removed from
-        private final IndexId indexId;
-
-        // Shard id that the snapshot was removed from
-        private final int shardId;
-
-        // Id of the new index-${uuid} blob that does not include the snapshot any more
-        private final ShardGeneration newGeneration;
-
-        // Blob names in the shard directory that have become unreferenced in the new shard generation
-        private final Collection<String> blobsToDelete;
-
-        ShardSnapshotMetaDeleteResult(IndexId indexId, int shardId, ShardGeneration newGeneration, Collection<String> blobsToDelete) {
-            this.indexId = indexId;
-            this.shardId = shardId;
-            this.newGeneration = newGeneration;
-            this.blobsToDelete = blobsToDelete;
-        }
-    }
+    private record ShardSnapshotMetaDeleteResult(
+        IndexId indexId, // Index that the snapshot was removed from
+        int shardId, // Shard id that the snapshot was removed from
+        ShardGeneration newGeneration, // Id of the new index-${uuid} blob that does not include the snapshot any more
+        Collection<String> blobsToDelete // Blob names in the shard directory that have become unreferenced in the new shard generation
+    ) {}
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -112,7 +112,7 @@ public abstract class FileRestoreContext {
                 }
 
                 final Store.RecoveryDiff diff = sourceMetadata.recoveryDiff(recoveryTargetMetadata);
-                for (StoreFileMetadata md : diff.identical) {
+                for (StoreFileMetadata md : diff.identical()) {
                     BlobStoreIndexShardSnapshot.FileInfo fileInfo = fileInfos.get(md.name());
                     recoveryState.getIndex().addFileDetail(fileInfo.physicalName(), fileInfo.length(), true);
                     if (logger.isTraceEnabled()) {
@@ -216,6 +216,6 @@ public abstract class FileRestoreContext {
 
     @SuppressWarnings("unchecked")
     private static Iterable<StoreFileMetadata> concat(Store.RecoveryDiff diff) {
-        return Iterables.concat(diff.different, diff.missing);
+        return Iterables.concat(diff.different(), diff.missing());
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -195,7 +195,7 @@ public class ScriptCache {
         @Override
         public void onRemoval(RemovalNotification<CacheKey, Object> notification) {
             if (logger.isDebugEnabled()) {
-                logger.debug("removed [{}] from cache, reason: [{}]", notification.getValue(), notification.getRemovalReason());
+                logger.debug("removed [{}] from cache, reason: [{}]", notification.value(), notification.removalReason());
             }
             scriptMetrics.onCacheEviction();
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -83,7 +83,7 @@ public class UnifiedHighlighter implements Highlighter {
         }
         List<Snippet> snippets = new ArrayList<>(fieldSnippets.length);
         for (Snippet fieldSnippet : fieldSnippets) {
-            if (Strings.hasText(fieldSnippet.getText())) {
+            if (Strings.hasText(fieldSnippet.text())) {
                 snippets.add(fieldSnippet);
             }
         }
@@ -93,12 +93,12 @@ public class UnifiedHighlighter implements Highlighter {
 
         if (field.fieldOptions().scoreOrdered()) {
             // let's sort the snippets by score if needed
-            CollectionUtil.introSort(snippets, (o1, o2) -> Double.compare(o2.getScore(), o1.getScore()));
+            CollectionUtil.introSort(snippets, (o1, o2) -> Double.compare(o2.score(), o1.score()));
         }
 
         String[] fragments = new String[snippets.size()];
         for (int i = 0; i < fragments.length; i++) {
-            fragments[i] = snippets.get(i).getText();
+            fragments[i] = snippets.get(i).text();
         }
 
         return new HighlightField(fieldContext.fieldName, Text.convertFromStringArray(fragments));

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -293,7 +293,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
         }
         MappedFieldType fieldType = context.getFieldType(field);
         if (analyzer == null) {
-            suggestionContext.setAnalyzer(fieldType.getTextSearchInfo().getSearchAnalyzer());
+            suggestionContext.setAnalyzer(fieldType.getTextSearchInfo().searchAnalyzer());
         } else {
             Analyzer luceneAnalyzer = context.getIndexAnalyzers().get(analyzer);
             if (luceneAnalyzer == null) {

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -216,7 +216,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
                 snapshotShard.snapshot().getSnapshotId(),
                 snapshotShard.index(),
                 snapshotShard.shardId()
-            ).asCopy().getTotalSize();
+            ).asCopy().totalSize();
 
             logger.debug("snapshot shard size for {}: {} bytes", snapshotShard, snapshotShardSize);
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -397,8 +397,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     public static String getShardStateId(IndexShard indexShard, IndexCommit snapshotIndexCommit) throws IOException {
         final Map<String, String> userCommitData = snapshotIndexCommit.getUserData();
         final SequenceNumbers.CommitInfo seqNumInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userCommitData.entrySet());
-        final long maxSeqNo = seqNumInfo.maxSeqNo;
-        if (maxSeqNo != seqNumInfo.localCheckpoint || maxSeqNo != indexShard.getLastSyncedGlobalCheckpoint()) {
+        final long maxSeqNo = seqNumInfo.maxSeqNo();
+        if (maxSeqNo != seqNumInfo.localCheckpoint() || maxSeqNo != indexShard.getLastSyncedGlobalCheckpoint()) {
             return null;
         }
         return userCommitData.get(Engine.HISTORY_UUID_KEY)
@@ -422,7 +422,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         ShardSnapshotStatus masterShard = masterShards.get(shardId);
                         if (masterShard != null && masterShard.state().completed() == false) {
                             final IndexShardSnapshotStatus.Copy indexShardSnapshotStatus = localShard.getValue().asCopy();
-                            final Stage stage = indexShardSnapshotStatus.getStage();
+                            final Stage stage = indexShardSnapshotStatus.stage();
                             // Master knows about the shard and thinks it has not completed
                             if (stage == Stage.DONE) {
                                 // but we think the shard is done - we need to make new master know that the shard is done
@@ -445,7 +445,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                 notifyFailedSnapshotShard(
                                     snapshot.snapshot(),
                                     shardId,
-                                    indexShardSnapshotStatus.getFailure(),
+                                    indexShardSnapshotStatus.failure(),
                                     localShard.getValue().generation()
                                 );
                             }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -434,33 +434,30 @@ public class NodeStatsTests extends ESTestCase {
                     assertEquals(totalStats.getIngestTimeInMillis(), deserializedIngestStats.getTotalStats().getIngestTimeInMillis());
                     assertEquals(ingestStats.getPipelineStats().size(), deserializedIngestStats.getPipelineStats().size());
                     for (IngestStats.PipelineStat pipelineStat : ingestStats.getPipelineStats()) {
-                        String pipelineId = pipelineStat.getPipelineId();
+                        String pipelineId = pipelineStat.pipelineId();
                         IngestStats.Stats deserializedPipelineStats = getPipelineStats(
                             deserializedIngestStats.getPipelineStats(),
                             pipelineId
                         );
-                        assertEquals(pipelineStat.getStats().getIngestFailedCount(), deserializedPipelineStats.getIngestFailedCount());
-                        assertEquals(pipelineStat.getStats().getIngestTimeInMillis(), deserializedPipelineStats.getIngestTimeInMillis());
-                        assertEquals(pipelineStat.getStats().getIngestCurrent(), deserializedPipelineStats.getIngestCurrent());
-                        assertEquals(pipelineStat.getStats().getIngestCount(), deserializedPipelineStats.getIngestCount());
+                        assertEquals(pipelineStat.stats().getIngestFailedCount(), deserializedPipelineStats.getIngestFailedCount());
+                        assertEquals(pipelineStat.stats().getIngestTimeInMillis(), deserializedPipelineStats.getIngestTimeInMillis());
+                        assertEquals(pipelineStat.stats().getIngestCurrent(), deserializedPipelineStats.getIngestCurrent());
+                        assertEquals(pipelineStat.stats().getIngestCount(), deserializedPipelineStats.getIngestCount());
                         List<IngestStats.ProcessorStat> processorStats = ingestStats.getProcessorStats().get(pipelineId);
                         // intentionally validating identical order
                         Iterator<IngestStats.ProcessorStat> it = deserializedIngestStats.getProcessorStats().get(pipelineId).iterator();
                         for (IngestStats.ProcessorStat processorStat : processorStats) {
                             IngestStats.ProcessorStat deserializedProcessorStat = it.next();
                             assertEquals(
-                                processorStat.getStats().getIngestFailedCount(),
-                                deserializedProcessorStat.getStats().getIngestFailedCount()
+                                processorStat.stats().getIngestFailedCount(),
+                                deserializedProcessorStat.stats().getIngestFailedCount()
                             );
                             assertEquals(
-                                processorStat.getStats().getIngestTimeInMillis(),
-                                deserializedProcessorStat.getStats().getIngestTimeInMillis()
+                                processorStat.stats().getIngestTimeInMillis(),
+                                deserializedProcessorStat.stats().getIngestTimeInMillis()
                             );
-                            assertEquals(
-                                processorStat.getStats().getIngestCurrent(),
-                                deserializedProcessorStat.getStats().getIngestCurrent()
-                            );
-                            assertEquals(processorStat.getStats().getIngestCount(), deserializedProcessorStat.getStats().getIngestCount());
+                            assertEquals(processorStat.stats().getIngestCurrent(), deserializedProcessorStat.stats().getIngestCurrent());
+                            assertEquals(processorStat.stats().getIngestCount(), deserializedProcessorStat.stats().getIngestCount());
                         }
                         assertFalse(it.hasNext());
                     }
@@ -920,6 +917,6 @@ public class NodeStatsTests extends ESTestCase {
     }
 
     private IngestStats.Stats getPipelineStats(List<IngestStats.PipelineStat> pipelineStats, String id) {
-        return pipelineStats.stream().filter(p1 -> p1.getPipelineId().equals(id)).findFirst().map(p2 -> p2.getStats()).orElse(null);
+        return pipelineStats.stream().filter(p1 -> p1.pipelineId().equals(id)).findFirst().map(p2 -> p2.stats()).orElse(null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -63,18 +63,18 @@ public class ClusterStatsNodesTests extends ESTestCase {
         SortedMap<String, long[]> processorStats = new TreeMap<>();
         nodeStats.getIngestStats().getProcessorStats().values().forEach(stats -> {
             stats.forEach(stat -> {
-                processorStats.compute(stat.getType(), (key, value) -> {
+                processorStats.compute(stat.type(), (key, value) -> {
                     if (value == null) {
                         return new long[] {
-                            stat.getStats().getIngestCount(),
-                            stat.getStats().getIngestFailedCount(),
-                            stat.getStats().getIngestCurrent(),
-                            stat.getStats().getIngestTimeInMillis() };
+                            stat.stats().getIngestCount(),
+                            stat.stats().getIngestFailedCount(),
+                            stat.stats().getIngestCurrent(),
+                            stat.stats().getIngestTimeInMillis() };
                     } else {
-                        value[0] += stat.getStats().getIngestCount();
-                        value[1] += stat.getStats().getIngestFailedCount();
-                        value[2] += stat.getStats().getIngestCurrent();
-                        value[3] += stat.getStats().getIngestTimeInMillis();
+                        value[0] += stat.stats().getIngestCount();
+                        value[1] += stat.stats().getIngestFailedCount();
+                        value[2] += stat.stats().getIngestCurrent();
+                        value[3] += stat.stats().getIngestTimeInMillis();
                         return value;
                     }
                 });

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -98,7 +98,7 @@ public class TransportWriteActionTests extends ESTestCase {
     @Before
     public void initCommonMocks() {
         indexShard = mock(IndexShard.class);
-        location = mock(Translog.Location.class);
+        location = new Translog.Location(0, 0, 0);
         clusterService = createClusterService(threadPool);
     }
 

--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -56,7 +56,7 @@ public class CacheTests extends ESTestCase {
         Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder()
             .setMaximumWeight(numberOfEntries / 2)
             .removalListener(notification -> {
-                keys.remove(notification.getKey());
+                keys.remove(notification.key());
                 evictions.incrementAndGet();
             })
             .build();
@@ -79,10 +79,10 @@ public class CacheTests extends ESTestCase {
                 cache.get(key);
             }
         }
-        assertEquals(hits, cache.stats().getHits());
-        assertEquals(misses, cache.stats().getMisses());
+        assertEquals(hits, cache.stats().hits());
+        assertEquals(misses, cache.stats().misses());
         assertEquals((long) Math.ceil(numberOfEntries / 2.0), evictions.get());
-        assertEquals(evictions.get(), cache.stats().getEvictions());
+        assertEquals(evictions.get(), cache.stats().evictions());
     }
 
     // cache some entries in batches of size maximumWeight; for each batch, touch the even entries to affect the
@@ -97,7 +97,7 @@ public class CacheTests extends ESTestCase {
             .setMaximumWeight(maximumWeight)
             .removalListener(notification -> {
                 evictions.incrementAndGet();
-                evictedKeys.add(notification.getKey());
+                evictedKeys.add(notification.key());
             })
             .build();
         // cache entries up to numberOfEntries - maximumWeight; all of these entries will ultimately be evicted in
@@ -123,7 +123,7 @@ public class CacheTests extends ESTestCase {
             cache.put(i, Integer.toString(i));
         }
         assertEquals(numberOfEntries - maximumWeight, evictions.get());
-        assertEquals(evictions.get(), cache.stats().getEvictions());
+        assertEquals(evictions.get(), cache.stats().evictions());
 
         // assert that the keys were evicted in LRU order
         Set<Integer> keys = new HashSet<>();
@@ -166,7 +166,7 @@ public class CacheTests extends ESTestCase {
         // the number of evicted entries should be the number of entries that fit in the excess weight
         assertEquals((int) Math.ceil((weight - 2) * numberOfEntries / (1.0 * weight)), evictions.get());
 
-        assertEquals(evictions.get(), cache.stats().getEvictions());
+        assertEquals(evictions.get(), cache.stats().evictions());
     }
 
     // cache some entries, randomly invalidate some of them, then check that the weight of the cache is correct
@@ -216,8 +216,8 @@ public class CacheTests extends ESTestCase {
         cache.setExpireAfterAccessNanos(1);
         List<Integer> evictedKeys = new ArrayList<>();
         cache.setRemovalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.EVICTED, notification.getRemovalReason());
-            evictedKeys.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.EVICTED, notification.removalReason());
+            evictedKeys.add(notification.key());
         });
         now.set(0);
         for (int i = 0; i < numberOfEntries; i++) {
@@ -275,8 +275,8 @@ public class CacheTests extends ESTestCase {
         cache.setExpireAfterWriteNanos(1);
         List<Integer> evictedKeys = new ArrayList<>();
         cache.setRemovalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.EVICTED, notification.getRemovalReason());
-            evictedKeys.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.EVICTED, notification.removalReason());
+            evictedKeys.add(notification.key());
         });
         now.set(0);
         for (int i = 0; i < numberOfEntries; i++) {
@@ -324,7 +324,7 @@ public class CacheTests extends ESTestCase {
         for (int i = 0; i < numberOfEntries; i++) {
             assertEquals(i + "-second", cache.get(i));
         }
-        assertEquals(numberOfEntries, cache.stats().getEvictions());
+        assertEquals(numberOfEntries, cache.stats().evictions());
     }
 
     public void testComputeIfAbsentDeadlock() throws BrokenBarrierException, InterruptedException {
@@ -421,8 +421,8 @@ public class CacheTests extends ESTestCase {
     public void testNotificationOnInvalidate() {
         Set<Integer> notifications = new HashSet<>();
         Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().removalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.getRemovalReason());
-            notifications.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.removalReason());
+            notifications.add(notification.key());
         }).build();
         for (int i = 0; i < numberOfEntries; i++) {
             cache.put(i, Integer.toString(i));
@@ -469,8 +469,8 @@ public class CacheTests extends ESTestCase {
     public void testNotificationOnInvalidateWithValue() {
         Set<Integer> notifications = new HashSet<>();
         Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().removalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.getRemovalReason());
-            notifications.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.removalReason());
+            notifications.add(notification.key());
         }).build();
         for (int i = 0; i < numberOfEntries; i++) {
             cache.put(i, Integer.toString(i));
@@ -505,8 +505,8 @@ public class CacheTests extends ESTestCase {
     public void testNotificationOnInvalidateAll() {
         Set<Integer> notifications = new HashSet<>();
         Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().removalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.getRemovalReason());
-            notifications.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, notification.removalReason());
+            notifications.add(notification.key());
         }).build();
         Set<Integer> invalidated = new HashSet<>();
         for (int i = 0; i < numberOfEntries; i++) {
@@ -566,8 +566,8 @@ public class CacheTests extends ESTestCase {
     public void testNotificationOnReplace() {
         Set<Integer> notifications = new HashSet<>();
         Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().removalListener(notification -> {
-            assertEquals(RemovalNotification.RemovalReason.REPLACED, notification.getRemovalReason());
-            notifications.add(notification.getKey());
+            assertEquals(RemovalNotification.RemovalReason.REPLACED, notification.removalReason());
+            notifications.add(notification.key());
         }).build();
         for (int i = 0; i < numberOfEntries; i++) {
             cache.put(i, Integer.toString(i));
@@ -903,8 +903,8 @@ public class CacheTests extends ESTestCase {
 
         assertEquals(expectedRemovals.size(), removalNotifications.size());
         for (int i = 0; i < expectedRemovals.size(); i++) {
-            assertEquals(expectedRemovals.get(i), removalNotifications.get(i).getValue());
-            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, removalNotifications.get(i).getRemovalReason());
+            assertEquals(expectedRemovals.get(i), removalNotifications.get(i).value());
+            assertEquals(RemovalNotification.RemovalReason.INVALIDATED, removalNotifications.get(i).removalReason());
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
@@ -55,8 +55,8 @@ public class VersionLookupTests extends ESTestCase {
         // found doc
         DocIdAndVersion result = lookup.lookupVersion(new BytesRef("6"), randomBoolean(), segment);
         assertNotNull(result);
-        assertEquals(87, result.version);
-        assertEquals(0, result.docId);
+        assertEquals(87, result.version());
+        assertEquals(0, result.docId());
         // not found doc
         assertNull(lookup.lookupVersion(new BytesRef("7"), randomBoolean(), segment));
         // deleted doc
@@ -91,8 +91,8 @@ public class VersionLookupTests extends ESTestCase {
         // return the last doc when there are duplicates
         DocIdAndVersion result = lookup.lookupVersion(new BytesRef("6"), randomBoolean(), segment);
         assertNotNull(result);
-        assertEquals(87, result.version);
-        assertEquals(1, result.docId);
+        assertEquals(87, result.version());
+        assertEquals(1, result.docId());
         // delete the first doc only
         assertTrue(writer.tryDeleteDocument(reader, 0) >= 0);
         reader.close();
@@ -101,8 +101,8 @@ public class VersionLookupTests extends ESTestCase {
         lookup = new PerThreadIDVersionAndSeqNoLookup(segment.reader(), IdFieldMapper.NAME);
         result = lookup.lookupVersion(new BytesRef("6"), randomBoolean(), segment);
         assertNotNull(result);
-        assertEquals(87, result.version);
-        assertEquals(1, result.docId);
+        assertEquals(87, result.version());
+        assertEquals(1, result.docId());
         // delete both docs
         assertTrue(writer.tryDeleteDocument(reader, 1) >= 0);
         reader.close();

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -62,7 +62,7 @@ public class VersionsTests extends ESTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(1L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version(), equalTo(1L));
 
         doc = new Document();
         Field uid = new Field(IdFieldMapper.NAME, "1", IdFieldMapper.Defaults.FIELD_TYPE);
@@ -73,7 +73,7 @@ public class VersionsTests extends ESTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(2L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version(), equalTo(2L));
 
         // test reuse of uid field
         doc = new Document();
@@ -85,7 +85,7 @@ public class VersionsTests extends ESTestCase {
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
 
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(3L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version(), equalTo(3L));
 
         writer.deleteDocuments(new Term(IdFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
@@ -117,14 +117,14 @@ public class VersionsTests extends ESTestCase {
 
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "_na_", 1));
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(5L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version(), equalTo(5L));
 
         version.setLongValue(6L);
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         version.setLongValue(7L);
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(7L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version(), equalTo(7L));
 
         writer.deleteDocuments(new Term(IdFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
@@ -148,10 +148,10 @@ public class VersionsTests extends ESTestCase {
         writer.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(writer);
         // should increase cache size by 1
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version());
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
         // should be cache hit
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version());
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
 
         reader.close();
@@ -174,11 +174,11 @@ public class VersionsTests extends ESTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(writer);
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version());
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
         // now wrap the reader
         DirectoryReader wrapped = ElasticsearchDirectoryReader.wrap(reader, new ShardId("bogus", "_na_", 5));
-        assertEquals(87, loadDocIdAndVersion(wrapped, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(wrapped, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version());
         // same size map: core cache key is shared
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
 

--- a/server/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
@@ -28,15 +28,15 @@ public class DistanceUnitTests extends ESTestCase {
     }
 
     public void testDistanceUnitParsing() {
-        assertThat(DistanceUnit.Distance.parseDistance("50km").unit, equalTo(DistanceUnit.KILOMETERS));
-        assertThat(DistanceUnit.Distance.parseDistance("500m").unit, equalTo(DistanceUnit.METERS));
-        assertThat(DistanceUnit.Distance.parseDistance("51mi").unit, equalTo(DistanceUnit.MILES));
-        assertThat(DistanceUnit.Distance.parseDistance("53nmi").unit, equalTo(DistanceUnit.NAUTICALMILES));
-        assertThat(DistanceUnit.Distance.parseDistance("53NM").unit, equalTo(DistanceUnit.NAUTICALMILES));
-        assertThat(DistanceUnit.Distance.parseDistance("52yd").unit, equalTo(DistanceUnit.YARD));
-        assertThat(DistanceUnit.Distance.parseDistance("12in").unit, equalTo(DistanceUnit.INCH));
-        assertThat(DistanceUnit.Distance.parseDistance("23mm").unit, equalTo(DistanceUnit.MILLIMETERS));
-        assertThat(DistanceUnit.Distance.parseDistance("23cm").unit, equalTo(DistanceUnit.CENTIMETERS));
+        assertThat(DistanceUnit.Distance.parseDistance("50km").unit(), equalTo(DistanceUnit.KILOMETERS));
+        assertThat(DistanceUnit.Distance.parseDistance("500m").unit(), equalTo(DistanceUnit.METERS));
+        assertThat(DistanceUnit.Distance.parseDistance("51mi").unit(), equalTo(DistanceUnit.MILES));
+        assertThat(DistanceUnit.Distance.parseDistance("53nmi").unit(), equalTo(DistanceUnit.NAUTICALMILES));
+        assertThat(DistanceUnit.Distance.parseDistance("53NM").unit(), equalTo(DistanceUnit.NAUTICALMILES));
+        assertThat(DistanceUnit.Distance.parseDistance("52yd").unit(), equalTo(DistanceUnit.YARD));
+        assertThat(DistanceUnit.Distance.parseDistance("12in").unit(), equalTo(DistanceUnit.INCH));
+        assertThat(DistanceUnit.Distance.parseDistance("23mm").unit(), equalTo(DistanceUnit.MILLIMETERS));
+        assertThat(DistanceUnit.Distance.parseDistance("23cm").unit(), equalTo(DistanceUnit.CENTIMETERS));
 
         double testValue = 12345.678;
         for (DistanceUnit unit : DistanceUnit.values()) {
@@ -48,7 +48,7 @@ public class DistanceUnitTests extends ESTestCase {
             );
             assertThat(
                 "Value can be parsed from '" + testValue + unit.toString() + "'",
-                DistanceUnit.Distance.parseDistance(unit.toString(testValue)).value,
+                DistanceUnit.Distance.parseDistance(unit.toString(testValue)).value(),
                 equalTo(testValue)
             );
         }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
@@ -230,8 +230,8 @@ public class PrioritizedExecutorsTests extends ESTestCase {
         invoked.await();
         PrioritizedEsThreadPoolExecutor.Pending[] pending = executor.getPending();
         assertThat(pending.length, equalTo(1));
-        assertThat(pending[0].task.toString(), equalTo("the blocking"));
-        assertThat(pending[0].executing, equalTo(true));
+        assertThat(pending[0].task().toString(), equalTo("the blocking"));
+        assertThat(pending[0].executing(), equalTo(true));
 
         final AtomicBoolean executeCalled = new AtomicBoolean();
         final CountDownLatch timedOut = new CountDownLatch(1);
@@ -254,10 +254,10 @@ public class PrioritizedExecutorsTests extends ESTestCase {
 
         pending = executor.getPending();
         assertThat(pending.length, equalTo(2));
-        assertThat(pending[0].task.toString(), equalTo("the blocking"));
-        assertThat(pending[0].executing, equalTo(true));
-        assertThat(pending[1].task.toString(), equalTo("the waiting"));
-        assertThat(pending[1].executing, equalTo(false));
+        assertThat(pending[0].task().toString(), equalTo("the blocking"));
+        assertThat(pending[0].executing(), equalTo(true));
+        assertThat(pending[1].task().toString(), equalTo("the waiting"));
+        assertThat(pending[1].executing(), equalTo(false));
 
         assertThat(timedOut.await(2, TimeUnit.SECONDS), equalTo(true));
         block.countDown();

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -132,7 +132,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
         handshakingTransportAddressConnector.connectToRemoteMasterNode(discoveryAddress, new ActionListener<ProbeConnectionResult>() {
             @Override
             public void onResponse(ProbeConnectionResult connectResult) {
-                receivedNode.set(connectResult.getDiscoveryNode());
+                receivedNode.set(connectResult.discoveryNode());
                 completionLatch.countDown();
             }
 
@@ -235,7 +235,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
 
         @Override
         public void onResponse(ProbeConnectionResult connectResult) {
-            fail(connectResult.getDiscoveryNode().toString());
+            fail(connectResult.discoveryNode().toString());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -101,8 +101,8 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("test", indexSettings, mapping).mapperService();
 
         MappedFieldType fieldType = mapperService.fieldType("field");
-        assertThat(fieldType.getTextSearchInfo().getSearchAnalyzer(), instanceOf(NamedAnalyzer.class));
-        NamedAnalyzer fieldMapperNamedAnalyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
+        assertThat(fieldType.getTextSearchInfo().searchAnalyzer(), instanceOf(NamedAnalyzer.class));
+        NamedAnalyzer fieldMapperNamedAnalyzer = fieldType.getTextSearchInfo().searchAnalyzer();
 
         assertThat(fieldMapperNamedAnalyzer.analyzer(), is(namedAnalyzer.analyzer()));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -101,7 +101,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
 
         checker.registerUpdateCheck(
             b -> b.field("search_analyzer", "standard"),
-            m -> assertEquals("standard", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name())
+            m -> assertEquals("standard", m.fieldType().getTextSearchInfo().searchAnalyzer().name())
         );
         checker.registerUpdateCheck(b -> b.field("max_input_length", 30), m -> {
             CompletionFieldMapper cfm = (CompletionFieldMapper) m;
@@ -149,7 +149,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertThat(analyzer.preservePositionIncrements(), equalTo(true));
         assertThat(analyzer.preserveSep(), equalTo(true));
 
-        NamedAnalyzer searchAnalyzer = completionFieldType.getTextSearchInfo().getSearchAnalyzer();
+        NamedAnalyzer searchAnalyzer = completionFieldType.getTextSearchInfo().searchAnalyzer();
         assertThat(searchAnalyzer.name(), equalTo("simple"));
         assertThat(searchAnalyzer.analyzer(), instanceOf(CompletionAnalyzer.class));
         analyzer = (CompletionAnalyzer) searchAnalyzer.analyzer();
@@ -178,7 +178,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertThat(analyzer.preservePositionIncrements(), equalTo(true));
         assertThat(analyzer.preserveSep(), equalTo(false));
 
-        NamedAnalyzer searchAnalyzer = completionFieldType.getTextSearchInfo().getSearchAnalyzer();
+        NamedAnalyzer searchAnalyzer = completionFieldType.getTextSearchInfo().searchAnalyzer();
         assertThat(searchAnalyzer.name(), equalTo("standard"));
         assertThat(searchAnalyzer.analyzer(), instanceOf(CompletionAnalyzer.class));
         analyzer = (CompletionAnalyzer) searchAnalyzer.analyzer();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DefaultAnalyzersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DefaultAnalyzersTests.java
@@ -49,31 +49,31 @@ public class DefaultAnalyzersTests extends MapperServiceTestCase {
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default", ft.getTextSearchInfo().getSearchAnalyzer().name());
+            assertEquals("default", ft.getTextSearchInfo().searchAnalyzer().name());
         }
         {
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchAnalyzer().name());
         }
         {
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default_search", ft.getTextSearchInfo().getSearchAnalyzer().name());
+            assertEquals("default_search", ft.getTextSearchInfo().searchAnalyzer().name());
         }
         {
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchAnalyzer().name());
         }
         {
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchAnalyzer().name());
         }
 
     }
@@ -84,70 +84,70 @@ public class DefaultAnalyzersTests extends MapperServiceTestCase {
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("default", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = false;
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_quote_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default_search_quote", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("default_search_quote", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_quote_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = false;
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default_search", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("default_search", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = false;
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_quote_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("default_search_quote", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("default_search_quote", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = true;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_quote_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
         {
             setDefaultSearchQuoteAnalyzer = true;
             setDefaultSearchAnalyzer = false;
             MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
-            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+            assertEquals("configured", ft.getTextSearchInfo().searchQuoteAnalyzer().name());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -125,14 +125,14 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             b.field("search_analyzer", "whitespace");
         }));
 
-        assertThat(mapperService.fieldType("field").getTextSearchInfo().getSearchAnalyzer().name(), equalTo("whitespace"));
+        assertThat(mapperService.fieldType("field").getTextSearchInfo().searchAnalyzer().name(), equalTo("whitespace"));
 
         merge(mapperService, fieldMapping(b -> {
             b.field("type", "text");
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
         }));
-        assertThat(mapperService.fieldType("field").getTextSearchInfo().getSearchAnalyzer().name(), equalTo("keyword"));
+        assertThat(mapperService.fieldType("field").getTextSearchInfo().searchAnalyzer().name(), equalTo("keyword"));
     }
 
     public void testChangeSearchAnalyzerToDefault() throws Exception {
@@ -143,14 +143,14 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             b.field("search_analyzer", "whitespace");
         }));
 
-        assertThat(mapperService.fieldType("field").getTextSearchInfo().getSearchAnalyzer().name(), equalTo("whitespace"));
+        assertThat(mapperService.fieldType("field").getTextSearchInfo().searchAnalyzer().name(), equalTo("whitespace"));
 
         merge(mapperService, fieldMapping(b -> {
             b.field("type", "text");
             b.field("analyzer", "default");
         }));
 
-        assertThat(mapperService.fieldType("field").getTextSearchInfo().getSearchAnalyzer().name(), equalTo("default"));
+        assertThat(mapperService.fieldType("field").getTextSearchInfo().searchAnalyzer().name(), equalTo("default"));
     }
 
     public void testConcurrentMergeTest() throws Throwable {

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -166,7 +166,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         checker.registerUpdateCheck(
             b -> b.field("split_queries_on_whitespace", true),
-            m -> assertEquals("_whitespace", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name())
+            m -> assertEquals("_whitespace", m.fieldType().getTextSearchInfo().searchAnalyzer().name())
         );
 
         // norms can be set from true to false, but not vice versa
@@ -393,7 +393,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testConfigureSimilarity() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("similarity", "boolean")));
         MappedFieldType ft = mapperService.documentMapper().mappers().fieldTypesLookup().get("field");
-        assertEquals("boolean", ft.getTextSearchInfo().getSimilarity().name());
+        assertEquals("boolean", ft.getTextSearchInfo().similarity().name());
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -514,18 +514,18 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         MappedFieldType fieldType = mapperService.fieldType("field");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         KeywordFieldMapper.KeywordFieldType ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
-        Analyzer a = ft.getTextSearchInfo().getSearchAnalyzer();
+        Analyzer a = ft.getTextSearchInfo().searchAnalyzer();
         assertTokenStreamContents(a.tokenStream("", "Hello World"), new String[] { "Hello World" });
 
         fieldType = mapperService.fieldType("field_with_normalizer");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
-        assertThat(ft.getTextSearchInfo().getSearchAnalyzer().name(), equalTo("lowercase"));
+        assertThat(ft.getTextSearchInfo().searchAnalyzer().name(), equalTo("lowercase"));
         assertTokenStreamContents(
-            ft.getTextSearchInfo().getSearchAnalyzer().analyzer().tokenStream("", "Hello World"),
+            ft.getTextSearchInfo().searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] { "hello", "world" }
         );
-        Analyzer q = ft.getTextSearchInfo().getSearchQuoteAnalyzer();
+        Analyzer q = ft.getTextSearchInfo().searchQuoteAnalyzer();
         assertTokenStreamContents(q.tokenStream("", "Hello World"), new String[] { "hello world" });
 
         mapperService = createMapperService(mapping(b -> {
@@ -543,16 +543,16 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
         assertTokenStreamContents(
-            ft.getTextSearchInfo().getSearchAnalyzer().analyzer().tokenStream("", "Hello World"),
+            ft.getTextSearchInfo().searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] { "Hello", "World" }
         );
 
         fieldType = mapperService.fieldType("field_with_normalizer");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
-        assertThat(ft.getTextSearchInfo().getSearchAnalyzer().name(), equalTo("lowercase"));
+        assertThat(ft.getTextSearchInfo().searchAnalyzer().name(), equalTo("lowercase"));
         assertTokenStreamContents(
-            ft.getTextSearchInfo().getSearchAnalyzer().analyzer().tokenStream("", "Hello World"),
+            ft.getTextSearchInfo().searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] { "hello world" }
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ReloadableAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ReloadableAnalyzerTests.java
@@ -90,12 +90,12 @@ public class ReloadableAnalyzerTests extends ESSingleNodeTestCase {
 
         assertFalse(assertSameContainedFilters(originalTokenFilters, current.get("reloadableAnalyzer")));
         assertFalse(
-            assertSameContainedFilters(originalTokenFilters, mapperService.fieldType("field").getTextSearchInfo().getSearchAnalyzer())
+            assertSameContainedFilters(originalTokenFilters, mapperService.fieldType("field").getTextSearchInfo().searchAnalyzer())
         );
         assertFalse(
             assertSameContainedFilters(
                 originalTokenFilters,
-                mapperService.fieldType("otherField").getTextSearchInfo().getSearchQuoteAnalyzer()
+                mapperService.fieldType("otherField").getTextSearchInfo().searchQuoteAnalyzer()
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -136,12 +136,12 @@ public class TextFieldMapperTests extends MapperTestCase {
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchAnalyzer().name()));
         checker.registerUpdateCheck(b -> {
             b.field("analyzer", "default");
             b.field("search_analyzer", "keyword");
             b.field("search_quote_analyzer", "keyword");
-        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().getSearchQuoteAnalyzer().name()));
+        }, m -> assertEquals("keyword", m.fieldType().getTextSearchInfo().searchQuoteAnalyzer().name()));
 
         checker.registerConflictCheck("index", b -> b.field("index", false));
         checker.registerConflictCheck("store", b -> b.field("store", true));

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -59,7 +59,7 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         checker.registerUpdateCheck(b -> b.field("ignore_above", 256), m -> assertEquals(256, ((FlattenedFieldMapper) m).ignoreAbove()));
         checker.registerUpdateCheck(
             b -> b.field("split_queries_on_whitespace", true),
-            m -> assertEquals("_whitespace", m.fieldType().getTextSearchInfo().getSearchAnalyzer().name())
+            m -> assertEquals("_whitespace", m.fieldType().getTextSearchInfo().searchAnalyzer().name())
         );
         checker.registerUpdateCheck(b -> b.field("depth_limit", 10), m -> assertEquals(10, ((FlattenedFieldMapper) m).depthLimit()));
     }
@@ -380,16 +380,16 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         }));
 
         RootFlattenedFieldType rootFieldType = (RootFlattenedFieldType) mapperService.fieldType("field");
-        assertThat(rootFieldType.getTextSearchInfo().getSearchAnalyzer().name(), equalTo("_whitespace"));
+        assertThat(rootFieldType.getTextSearchInfo().searchAnalyzer().name(), equalTo("_whitespace"));
         assertTokenStreamContents(
-            rootFieldType.getTextSearchInfo().getSearchAnalyzer().analyzer().tokenStream("", "Hello World"),
+            rootFieldType.getTextSearchInfo().searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] { "Hello", "World" }
         );
 
         KeyedFlattenedFieldType keyedFieldType = (KeyedFlattenedFieldType) mapperService.fieldType("field.key");
-        assertThat(keyedFieldType.getTextSearchInfo().getSearchAnalyzer().name(), equalTo("_whitespace"));
+        assertThat(keyedFieldType.getTextSearchInfo().searchAnalyzer().name(), equalTo("_whitespace"));
         assertTokenStreamContents(
-            keyedFieldType.getTextSearchInfo().getSearchAnalyzer().analyzer().tokenStream("", "Hello World"),
+            keyedFieldType.getTextSearchInfo().searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] { "Hello", "World" }
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -271,11 +271,11 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                 assertThat(newReplica.recoveryState().getIndex().fileDetails(), empty());
                 assertThat(
                     newReplica.recoveryState().getTranslog().totalLocal(),
-                    equalTo(Math.toIntExact(globalCheckpointOnOldPrimary - safeCommitOnOldPrimary.get().localCheckpoint))
+                    equalTo(Math.toIntExact(globalCheckpointOnOldPrimary - safeCommitOnOldPrimary.get().localCheckpoint()))
                 );
                 assertThat(
                     newReplica.recoveryState().getTranslog().recoveredOperations(),
-                    equalTo(Math.toIntExact(totalDocs - 1 - safeCommitOnOldPrimary.get().localCheckpoint))
+                    equalTo(Math.toIntExact(totalDocs - 1 - safeCommitOnOldPrimary.get().localCheckpoint()))
                 );
             } else {
                 assertThat(newReplica.recoveryState().getIndex().fileDetails(), not(empty()));
@@ -394,7 +394,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                     assertThat("unexpected op: " + next, (int) next.seqNo(), lessThan(initialDocs + extraDocs));
                     assertThat("unexpected primaryTerm: " + next.primaryTerm(), next.primaryTerm(), is(oldPrimary.getPendingPrimaryTerm()));
                     final Translog.Source source = next.getSource();
-                    assertThat(source.source.utf8ToString(), is("{ \"f\": \"normal\"}"));
+                    assertThat(source.source().utf8ToString(), is("{ \"f\": \"normal\"}"));
                 }
             }
             assertThat(translogOperations, either(equalTo(initialDocs + extraDocs)).or(equalTo(task.getResyncedOperations())));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -220,7 +220,7 @@ public class IndexShardTests extends IndexShardTestCase {
             write(state3, env.availableShardPaths(id));
             shardStateMetadata = load(logger, env.availableShardPaths(id));
             assertEquals(shardStateMetadata, state3);
-            assertEquals("fooUUID", state3.indexUUID);
+            assertEquals("fooUUID", state3.indexUUID());
         }
     }
 
@@ -300,12 +300,12 @@ public class IndexShardTests extends IndexShardTestCase {
             allocationId
         );
 
-        assertEquals(meta, new ShardStateMetadata(meta.primary, meta.indexUUID, meta.allocationId));
-        assertEquals(meta.hashCode(), new ShardStateMetadata(meta.primary, meta.indexUUID, meta.allocationId).hashCode());
+        assertEquals(meta, new ShardStateMetadata(meta.primary(), meta.indexUUID(), meta.allocationId()));
+        assertEquals(meta.hashCode(), new ShardStateMetadata(meta.primary(), meta.indexUUID(), meta.allocationId()).hashCode());
 
-        assertFalse(meta.equals(new ShardStateMetadata(meta.primary == false, meta.indexUUID, meta.allocationId)));
-        assertFalse(meta.equals(new ShardStateMetadata(meta.primary == false, meta.indexUUID + "foo", meta.allocationId)));
-        assertFalse(meta.equals(new ShardStateMetadata(meta.primary == false, meta.indexUUID + "foo", randomAllocationId())));
+        assertFalse(meta.equals(new ShardStateMetadata(meta.primary() == false, meta.indexUUID(), meta.allocationId())));
+        assertFalse(meta.equals(new ShardStateMetadata(meta.primary() == false, meta.indexUUID() + "foo", meta.allocationId())));
+        assertFalse(meta.equals(new ShardStateMetadata(meta.primary() == false, meta.indexUUID() + "foo", randomAllocationId())));
         Set<Integer> hashCodes = new HashSet<>();
         for (int i = 0; i < 30; i++) { // just a sanity check that we impl hashcode
             allocationId = randomBoolean() ? null : randomAllocationId();
@@ -617,7 +617,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testPrimaryPromotionRollsGeneration() throws Exception {
         final IndexShard indexShard = newStartedShard(false);
 
-        final long currentTranslogGeneration = getTranslog(indexShard).getGeneration().translogFileGeneration;
+        final long currentTranslogGeneration = getTranslog(indexShard).getGeneration().translogFileGeneration();
 
         // promote the replica
         final ShardRouting replicaRouting = indexShard.routingEntry();
@@ -658,7 +658,7 @@ public class IndexShardTests extends IndexShardTestCase {
         }, ThreadPool.Names.GENERIC, "");
 
         latch.await();
-        assertThat(getTranslog(indexShard).getGeneration().translogFileGeneration, equalTo(currentTranslogGeneration + 1));
+        assertThat(getTranslog(indexShard).getGeneration().translogFileGeneration(), equalTo(currentTranslogGeneration + 1));
         assertThat(TestTranslog.getCurrentTerm(getTranslog(indexShard)), equalTo(newPrimaryTerm));
 
         closeShards(indexShard);
@@ -967,7 +967,7 @@ public class IndexShardTests extends IndexShardTestCase {
         }
 
         final long primaryTerm = indexShard.getPendingPrimaryTerm();
-        final long translogGen = engineClosed ? -1 : getTranslog(indexShard).getGeneration().translogFileGeneration;
+        final long translogGen = engineClosed ? -1 : getTranslog(indexShard).getGeneration().translogFileGeneration();
 
         final Releasable operation1;
         final Releasable operation2;
@@ -1088,7 +1088,7 @@ public class IndexShardTests extends IndexShardTestCase {
                     assertTrue(onResponse.get());
                     assertNull(onFailure.get());
                     assertThat(
-                        getTranslog(indexShard).getGeneration().translogFileGeneration,
+                        getTranslog(indexShard).getGeneration().translogFileGeneration(),
                         // if rollback happens we roll translog twice: one when we flush a commit before opening a read-only engine
                         // and one after replaying translog (upto the global checkpoint); otherwise we roll translog once.
                         either(equalTo(translogGen + 1)).or(equalTo(translogGen + 2))
@@ -3327,9 +3327,9 @@ public class IndexShardTests extends IndexShardTestCase {
             while (stop.get() == false) {
                 try {
                     Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
-                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).different.size());
-                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).missing.size());
-                    assertEquals(storeFileMetadatas.size(), storeFileMetadatas.recoveryDiff(readMeta).identical.size());
+                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).different().size());
+                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).missing().size());
+                    assertEquals(storeFileMetadatas.size(), storeFileMetadatas.recoveryDiff(readMeta).identical().size());
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
@@ -3585,9 +3585,9 @@ public class IndexShardTests extends IndexShardTestCase {
                 try {
                     Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
                     assertThat(readMeta.getNumDocs(), equalTo(numDocs));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).different.size(), equalTo(0));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).missing.size(), equalTo(0));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).identical.size(), equalTo(storeFileMetadatas.size()));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).different().size(), equalTo(0));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).missing().size(), equalTo(0));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).identical().size(), equalTo(storeFileMetadatas.size()));
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -433,9 +433,9 @@ public class RefreshListenersTests extends ESTestCase {
                         ) {
                             assertTrue("document not found", getResult.exists());
                             assertEquals(iteration, getResult.version());
-                            org.apache.lucene.document.Document document = getResult.docIdAndVersion().reader.document(
-                                getResult.docIdAndVersion().docId
-                            );
+                            org.apache.lucene.document.Document document = getResult.docIdAndVersion()
+                                .reader()
+                                .document(getResult.docIdAndVersion().docId());
                             assertThat(document.getValues("test"), arrayContaining(testFieldValue));
                         }
                     } catch (Exception t) {
@@ -542,9 +542,9 @@ public class RefreshListenersTests extends ESTestCase {
         SeqNoFieldMapper.SequenceIDFields seqID = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
         document.add(idField);
         document.add(versionField);
-        document.add(seqID.seqNo);
-        document.add(seqID.seqNoDocValue);
-        document.add(seqID.primaryTerm);
+        document.add(seqID.seqNo());
+        document.add(seqID.seqNoDocValue());
+        document.add(seqID.primaryTerm());
         BytesReference source = new BytesArray(new byte[] { 1 });
         ParsedDocument doc = new ParsedDocument(versionField, seqID, id, null, Arrays.asList(document), source, XContentType.JSON, null);
         Engine.Index index = new Engine.Index(uid, engine.config().getPrimaryTermSupplier().getAsLong(), doc);

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardSplittingQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardSplittingQueryTests.java
@@ -73,7 +73,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                     Arrays.asList(
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
                 writer.addDocuments(docs);
@@ -82,7 +82,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                     Arrays.asList(
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
             }
@@ -128,7 +128,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new StringField(RoutingFieldMapper.NAME, routing, Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
                 writer.addDocuments(docs);
@@ -138,7 +138,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new StringField(RoutingFieldMapper.NAME, routing, Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
             }
@@ -173,14 +173,14 @@ public class ShardSplittingQueryTests extends ESTestCase {
                     new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                     new StringField(RoutingFieldMapper.NAME, routing, Field.Store.YES),
                     new SortedNumericDocValuesField("shard_id", shardId),
-                    sequenceIDFields.primaryTerm
+                    sequenceIDFields.primaryTerm()
                 );
             } else {
                 shardId = IndexRouting.fromIndexMetadata(metadata).getShard(Integer.toString(j), null);
                 rootDoc = Arrays.asList(
                     new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                     new SortedNumericDocValuesField("shard_id", shardId),
-                    sequenceIDFields.primaryTerm
+                    sequenceIDFields.primaryTerm()
                 );
             }
 
@@ -244,7 +244,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new StringField(RoutingFieldMapper.NAME, routing, Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
                 writer.addDocuments(docs);
@@ -254,7 +254,7 @@ public class ShardSplittingQueryTests extends ESTestCase {
                         new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(j)), Field.Store.YES),
                         new StringField(RoutingFieldMapper.NAME, routing, Field.Store.YES),
                         new SortedNumericDocValuesField("shard_id", shardId),
-                        sequenceIDFields.primaryTerm
+                        sequenceIDFields.primaryTerm()
                     )
                 );
             }

--- a/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
@@ -100,14 +100,14 @@ public class ScriptedSimilarityTests extends ESTestCase {
                     assertEquals(2f, doc.getFreq(), 0);
                     assertEquals(3, doc.getLength(), 0);
                     assertNotNull(field);
-                    assertEquals(3, field.getDocCount());
-                    assertEquals(5, field.getSumDocFreq());
-                    assertEquals(6, field.getSumTotalTermFreq());
+                    assertEquals(3, field.docCount());
+                    assertEquals(5, field.sumDocFreq());
+                    assertEquals(6, field.sumTotalTermFreq());
                     assertNotNull(term);
-                    assertEquals(2, term.getDocFreq());
-                    assertEquals(3, term.getTotalTermFreq());
+                    assertEquals(2, term.docFreq());
+                    assertEquals(3, term.totalTermFreq());
                     assertNotNull(query);
-                    assertEquals(3.2f, query.getBoost(), 0);
+                    assertEquals(3.2f, query.boost(), 0);
                     called.set(true);
                     return 42f;
                 }
@@ -158,14 +158,14 @@ public class ScriptedSimilarityTests extends ESTestCase {
 
                 @Override
                 public double execute(ScriptedSimilarity.Query query, ScriptedSimilarity.Field field, ScriptedSimilarity.Term term) {
-                    assertEquals(3, field.getDocCount());
-                    assertEquals(5, field.getSumDocFreq());
-                    assertEquals(6, field.getSumTotalTermFreq());
+                    assertEquals(3, field.docCount());
+                    assertEquals(5, field.sumDocFreq());
+                    assertEquals(6, field.sumTotalTermFreq());
                     assertNotNull(term);
-                    assertEquals(1, term.getDocFreq());
-                    assertEquals(2, term.getTotalTermFreq());
+                    assertEquals(1, term.docFreq());
+                    assertEquals(2, term.totalTermFreq());
                     assertNotNull(query);
-                    assertEquals(3.2f, query.getBoost(), 0);
+                    assertEquals(3.2f, query.boost(), 0);
                     initCalled.set(true);
                     return 28;
                 }
@@ -199,14 +199,14 @@ public class ScriptedSimilarityTests extends ESTestCase {
                     assertEquals(2f, doc.getFreq(), 0);
                     assertEquals(3, doc.getLength(), 0);
                     assertNotNull(field);
-                    assertEquals(3, field.getDocCount());
-                    assertEquals(5, field.getSumDocFreq());
-                    assertEquals(6, field.getSumTotalTermFreq());
+                    assertEquals(3, field.docCount());
+                    assertEquals(5, field.sumDocFreq());
+                    assertEquals(6, field.sumTotalTermFreq());
                     assertNotNull(term);
-                    assertEquals(1, term.getDocFreq());
-                    assertEquals(2, term.getTotalTermFreq());
+                    assertEquals(1, term.docFreq());
+                    assertEquals(2, term.totalTermFreq());
                     assertNotNull(query);
-                    assertEquals(3.2f, query.getBoost(), 0);
+                    assertEquals(3.2f, query.boost(), 0);
                     called.set(true);
                     return 42;
                 }

--- a/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -74,12 +74,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.discount_overlaps", false)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(LegacyBM25Similarity.class));
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(LegacyBM25Similarity.class));
 
-        LegacyBM25Similarity similarity = (LegacyBM25Similarity) mapperService.fieldType("field1")
-            .getTextSearchInfo()
-            .getSimilarity()
-            .get();
+        LegacyBM25Similarity similarity = (LegacyBM25Similarity) mapperService.fieldType("field1").getTextSearchInfo().similarity().get();
         assertThat(similarity.getK1(), equalTo(2.0f));
         assertThat(similarity.getB(), equalTo(0.5f));
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
@@ -99,7 +96,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .endObject();
 
         MapperService mapperService = createIndex("foo", Settings.EMPTY, mapping).mapperService();
-        assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(BooleanSimilarity.class));
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(BooleanSimilarity.class));
     }
 
     public void testResolveSimilaritiesFromMapping_DFR() throws IOException {
@@ -123,9 +120,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(DFRSimilarity.class));
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(DFRSimilarity.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get();
+        DFRSimilarity similarity = (DFRSimilarity) mapperService.fieldType("field1").getTextSearchInfo().similarity().get();
         assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
         assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -153,9 +150,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(IBSimilarity.class));
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(IBSimilarity.class));
 
-        IBSimilarity similarity = (IBSimilarity) mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get();
+        IBSimilarity similarity = (IBSimilarity) mapperService.fieldType("field1").getTextSearchInfo().similarity().get();
         assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
         assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -182,8 +179,8 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         MappedFieldType fieldType = mapperService.fieldType("field1");
 
-        assertThat(fieldType.getTextSearchInfo().getSimilarity().get(), instanceOf(DFISimilarity.class));
-        DFISimilarity similarity = (DFISimilarity) fieldType.getTextSearchInfo().getSimilarity().get();
+        assertThat(fieldType.getTextSearchInfo().similarity().get(), instanceOf(DFISimilarity.class));
+        DFISimilarity similarity = (DFISimilarity) fieldType.getTextSearchInfo().similarity().get();
         assertThat(similarity.getIndependence(), instanceOf(IndependenceChiSquared.class));
     }
 
@@ -206,12 +203,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
 
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(LMDirichletSimilarity.class));
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(LMDirichletSimilarity.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) mapperService.fieldType("field1")
-            .getTextSearchInfo()
-            .getSimilarity()
-            .get();
+        LMDirichletSimilarity similarity = (LMDirichletSimilarity) mapperService.fieldType("field1").getTextSearchInfo().similarity().get();
         assertThat(similarity.getMu(), equalTo(3000f));
     }
 
@@ -233,14 +227,11 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.lambda", 0.7f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(
-            mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(),
-            instanceOf(LMJelinekMercerSimilarity.class)
-        );
+        assertThat(mapperService.fieldType("field1").getTextSearchInfo().similarity().get(), instanceOf(LMJelinekMercerSimilarity.class));
 
         LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) mapperService.fieldType("field1")
             .getTextSearchInfo()
-            .getSimilarity()
+            .similarity()
             .get();
         assertThat(similarity.getLambda(), equalTo(0.7f));
     }

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -52,7 +52,7 @@ public class FileInfoTests extends ESTestCase {
                 writerUuid
             );
             ByteSizeValue size = new ByteSizeValue(Math.abs(randomLong()));
-            BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo("_foobar", meta, size);
+            BlobStoreIndexShardSnapshot.FileInfo info = BlobStoreIndexShardSnapshot.FileInfo.of("_foobar", meta, size);
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();
             boolean serializeWriterUUID = randomBoolean();
             final ToXContent.Params params;
@@ -161,7 +161,7 @@ public class FileInfoTests extends ESTestCase {
     }
 
     public void testGetPartSize() {
-        BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo(
+        BlobStoreIndexShardSnapshot.FileInfo info = BlobStoreIndexShardSnapshot.FileInfo.of(
             "foo",
             new StoreFileMetadata("foo", 36, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
             new ByteSizeValue(6)
@@ -172,7 +172,7 @@ public class FileInfoTests extends ESTestCase {
         }
         assertEquals(numBytes, 36);
 
-        info = new BlobStoreIndexShardSnapshot.FileInfo(
+        info = BlobStoreIndexShardSnapshot.FileInfo.of(
             "foo",
             new StoreFileMetadata("foo", 35, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
             new ByteSizeValue(6)
@@ -190,7 +190,7 @@ public class FileInfoTests extends ESTestCase {
                 "666",
                 MIN_SUPPORTED_LUCENE_VERSION.toString()
             );
-            info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
+            info = BlobStoreIndexShardSnapshot.FileInfo.of("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {
                 numBytes += info.partBytes(i);

--- a/server/src/test/java/org/elasticsearch/index/translog/TestTranslog.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TestTranslog.java
@@ -55,7 +55,7 @@ public class TestTranslog {
      * See {@link TestTranslog#corruptFile(Logger, Random, Path, boolean)} for details of the corruption applied.
      */
     public static void corruptRandomTranslogFile(Logger logger, Random random, Path translogDir) throws IOException {
-        corruptRandomTranslogFile(logger, random, translogDir, Translog.readCheckpoint(translogDir).minTranslogGeneration);
+        corruptRandomTranslogFile(logger, random, translogDir, Translog.readCheckpoint(translogDir).minTranslogGeneration());
     }
 
     /**
@@ -73,7 +73,7 @@ public class TestTranslog {
         try {
             final Path checkpointPath = translogDir.resolve(CHECKPOINT_FILE_NAME);
             final Checkpoint checkpoint = Checkpoint.read(checkpointPath);
-            unnecessaryCheckpointCopyPath = translogDir.resolve(Translog.getCommitCheckpointFileName(checkpoint.generation));
+            unnecessaryCheckpointCopyPath = translogDir.resolve(Translog.getCommitCheckpointFileName(checkpoint.generation()));
             if (LuceneTestCase.rarely(random) && Files.exists(unnecessaryCheckpointCopyPath) == false) {
                 // if we crashed while rolling a generation then we might have copied `translog.ckp` to its numbered generation file but
                 // have not yet written a new `translog.ckp`. During recovery we must also verify that this file is intact, so it's ok to
@@ -82,19 +82,19 @@ public class TestTranslog {
                 if (LuceneTestCase.usually(random)) {
                     checkpointCopy = checkpoint;
                 } else {
-                    long newTranslogGeneration = checkpoint.generation + random.nextInt(2);
-                    long newMinTranslogGeneration = Math.min(newTranslogGeneration, checkpoint.minTranslogGeneration + random.nextInt(2));
-                    long newMaxSeqNo = checkpoint.maxSeqNo + random.nextInt(2);
-                    long newMinSeqNo = Math.min(newMaxSeqNo, checkpoint.minSeqNo + random.nextInt(2));
-                    long newTrimmedAboveSeqNo = Math.min(newMaxSeqNo, checkpoint.trimmedAboveSeqNo + random.nextInt(2));
+                    long newTranslogGeneration = checkpoint.generation() + random.nextInt(2);
+                    long newMinTranslogGeneration = Math.min(newTranslogGeneration, checkpoint.minTranslogGeneration() + random.nextInt(2));
+                    long newMaxSeqNo = checkpoint.maxSeqNo() + random.nextInt(2);
+                    long newMinSeqNo = Math.min(newMaxSeqNo, checkpoint.minSeqNo() + random.nextInt(2));
+                    long newTrimmedAboveSeqNo = Math.min(newMaxSeqNo, checkpoint.trimmedAboveSeqNo() + random.nextInt(2));
 
                     checkpointCopy = new Checkpoint(
-                        checkpoint.offset + random.nextInt(2),
-                        checkpoint.numOps + random.nextInt(2),
+                        checkpoint.offset() + random.nextInt(2),
+                        checkpoint.numOps() + random.nextInt(2),
                         newTranslogGeneration,
                         newMinSeqNo,
                         newMaxSeqNo,
-                        checkpoint.globalCheckpoint + random.nextInt(2),
+                        checkpoint.globalCheckpoint() + random.nextInt(2),
                         newMinTranslogGeneration,
                         newTrimmedAboveSeqNo
                     );

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1238,7 +1238,7 @@ public class TranslogTests extends ESTestCase {
             max = max(max, location);
         }
 
-        assertEquals(max.generation, translog.currentFileGeneration());
+        assertEquals(max.generation(), translog.currentFileGeneration());
         try (Translog.Snapshot snap = new SortedSnapshot(translog.newSnapshot())) {
             Translog.Operation next;
             Translog.Operation maxOp = null;
@@ -1246,7 +1246,7 @@ public class TranslogTests extends ESTestCase {
                 maxOp = next;
             }
             assertNotNull(maxOp);
-            assertEquals(maxOp.getSource().source.utf8ToString(), Integer.toString(count));
+            assertEquals(maxOp.getSource().source().utf8ToString(), Integer.toString(count));
         }
     }
 
@@ -1298,7 +1298,7 @@ public class TranslogTests extends ESTestCase {
             for (int op = 0; op < translogOperations; op++) {
                 if (op <= lastSynced) {
                     final Translog.Operation read = snapshot.next();
-                    assertEquals(Integer.toString(op), read.getSource().source.utf8ToString());
+                    assertEquals(Integer.toString(op), read.getSource().source().utf8ToString());
                 } else {
                     Translog.Operation next = snapshot.next();
                     assertNull(next);
@@ -1308,7 +1308,7 @@ public class TranslogTests extends ESTestCase {
             assertNull(next);
         }
         assertEquals(translogOperations + 1, translog.totalOperations());
-        assertThat(checkpoint.globalCheckpoint, equalTo(lastSyncedGlobalCheckpoint));
+        assertThat(checkpoint.globalCheckpoint(), equalTo(lastSyncedGlobalCheckpoint));
         translog.close();
     }
 
@@ -1350,8 +1350,8 @@ public class TranslogTests extends ESTestCase {
         }
         final long minSeqNo = seenSeqNos.stream().min(Long::compareTo).orElse(SequenceNumbers.NO_OPS_PERFORMED);
         final long maxSeqNo = seenSeqNos.stream().max(Long::compareTo).orElse(SequenceNumbers.NO_OPS_PERFORMED);
-        assertThat(reader.getCheckpoint().minSeqNo, equalTo(minSeqNo));
-        assertThat(reader.getCheckpoint().maxSeqNo, equalTo(maxSeqNo));
+        assertThat(reader.getCheckpoint().minSeqNo(), equalTo(minSeqNo));
+        assertThat(reader.getCheckpoint().maxSeqNo(), equalTo(maxSeqNo));
 
         byte[] bytes = new byte[4];
         DataOutput out = EndiannessReverserUtil.wrapDataOutput(new ByteArrayDataOutput(bytes));
@@ -1655,7 +1655,7 @@ public class TranslogTests extends ESTestCase {
         } else {
             translog = new Translog(
                 config,
-                translogGeneration.translogUUID,
+                translogGeneration.translogUUID(),
                 translog.getDeletionPolicy(),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
@@ -1663,7 +1663,7 @@ public class TranslogTests extends ESTestCase {
             );
             assertEquals(
                 "lastCommitted must be 1 less than current",
-                translogGeneration.translogFileGeneration + 1,
+                translogGeneration.translogFileGeneration() + 1,
                 translog.currentFileGeneration()
             );
             assertFalse(translog.syncNeeded());
@@ -1672,11 +1672,11 @@ public class TranslogTests extends ESTestCase {
                     assertEquals(
                         "expected operation" + i + " to be in the previous translog but wasn't",
                         translog.currentFileGeneration() - 1,
-                        locations.get(i).generation
+                        locations.get(i).generation()
                     );
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null", next);
-                    assertEquals(i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals(i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
         }
@@ -1698,9 +1698,9 @@ public class TranslogTests extends ESTestCase {
                 assertEquals(
                     "expected this to be the first roll (1 gen is on creation, 2 when opened)",
                     2L,
-                    translogGeneration.translogFileGeneration
+                    translogGeneration.translogFileGeneration()
                 );
-                assertNotNull(translogGeneration.translogUUID);
+                assertNotNull(translogGeneration.translogUUID());
             }
         }
         if (sync) {
@@ -1724,7 +1724,7 @@ public class TranslogTests extends ESTestCase {
             assertNotNull(translogGeneration);
             assertEquals(
                 "lastCommitted must be 2 less than current - we never finished the commit",
-                translogGeneration.translogFileGeneration + 2,
+                translogGeneration.translogFileGeneration() + 2,
                 translog.currentFileGeneration()
             );
             assertFalse(translog.syncNeeded());
@@ -1733,7 +1733,7 @@ public class TranslogTests extends ESTestCase {
                 for (int i = 0; i < upTo; i++) {
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null synced: " + sync, next);
-                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
         }
@@ -1751,7 +1751,7 @@ public class TranslogTests extends ESTestCase {
                 assertNotNull(translogGeneration);
                 assertEquals(
                     "lastCommitted must be 3 less than current - we never finished the commit and run recovery twice",
-                    translogGeneration.translogFileGeneration + 3,
+                    translogGeneration.translogFileGeneration() + 3,
                     translog.currentFileGeneration()
                 );
                 assertFalse(translog.syncNeeded());
@@ -1760,7 +1760,7 @@ public class TranslogTests extends ESTestCase {
                     for (int i = 0; i < upTo; i++) {
                         Translog.Operation next = snapshot.next();
                         assertNotNull("operation " + i + " must be non-null synced: " + sync, next);
-                        assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                        assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source().utf8ToString()));
                     }
                 }
             }
@@ -1783,9 +1783,9 @@ public class TranslogTests extends ESTestCase {
                 assertEquals(
                     "expected this to be the first roll (1 gen is on creation, 2 when opened)",
                     2L,
-                    translogGeneration.translogFileGeneration
+                    translogGeneration.translogFileGeneration()
                 );
-                assertNotNull(translogGeneration.translogUUID);
+                assertNotNull(translogGeneration.translogUUID());
             }
         }
         if (sync) {
@@ -1796,7 +1796,7 @@ public class TranslogTests extends ESTestCase {
         TranslogConfig config = translog.getConfig();
         Path ckp = config.getTranslogPath().resolve(Translog.CHECKPOINT_FILE_NAME);
         Checkpoint read = Checkpoint.read(ckp);
-        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)));
+        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation())));
 
         final String translogUUID = translog.getTranslogUUID();
         final TranslogDeletionPolicy deletionPolicy = translog.getDeletionPolicy();
@@ -1813,7 +1813,7 @@ public class TranslogTests extends ESTestCase {
             assertNotNull(translogGeneration);
             assertEquals(
                 "lastCommitted must be 2 less than current - we never finished the commit",
-                translogGeneration.translogFileGeneration + 2,
+                translogGeneration.translogFileGeneration() + 2,
                 translog.currentFileGeneration()
             );
             assertFalse(translog.syncNeeded());
@@ -1822,7 +1822,7 @@ public class TranslogTests extends ESTestCase {
                 for (int i = 0; i < upTo; i++) {
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null synced: " + sync, next);
-                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
         }
@@ -1841,7 +1841,7 @@ public class TranslogTests extends ESTestCase {
                 assertNotNull(translogGeneration);
                 assertEquals(
                     "lastCommitted must be 3 less than current - we never finished the commit and run recovery twice",
-                    translogGeneration.translogFileGeneration + 3,
+                    translogGeneration.translogFileGeneration() + 3,
                     translog.currentFileGeneration()
                 );
                 assertFalse(translog.syncNeeded());
@@ -1850,7 +1850,7 @@ public class TranslogTests extends ESTestCase {
                     for (int i = 0; i < upTo; i++) {
                         Translog.Operation next = snapshot.next();
                         assertNotNull("operation " + i + " must be non-null synced: " + sync, next);
-                        assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                        assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source().utf8ToString()));
                     }
                 }
             }
@@ -1870,9 +1870,9 @@ public class TranslogTests extends ESTestCase {
                 assertEquals(
                     "expected this to be the first roll (1 gen is on creation, 2 when opened)",
                     2L,
-                    translogGeneration.translogFileGeneration
+                    translogGeneration.translogFileGeneration()
                 );
-                assertNotNull(translogGeneration.translogUUID);
+                assertNotNull(translogGeneration.translogUUID());
             }
         }
         translog.sync();
@@ -1884,7 +1884,7 @@ public class TranslogTests extends ESTestCase {
         Checkpoint corrupted = Checkpoint.emptyTranslogCheckpoint(0, 0, SequenceNumbers.NO_OPS_PERFORMED, 0);
         Checkpoint.write(
             FileChannel::open,
-            config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)),
+            config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation())),
             corrupted,
             StandardOpenOption.WRITE,
             StandardOpenOption.CREATE_NEW
@@ -1898,15 +1898,15 @@ public class TranslogTests extends ESTestCase {
         assertThat(
             translogCorruptedException.getMessage(),
             endsWith(
-                "] is corrupted, checkpoint file translog-3.ckp already exists but has corrupted content: expected Checkpoint{offset=2750, "
+                "] is corrupted, checkpoint file translog-3.ckp already exists but has corrupted content: expected Checkpoint[offset=2750, "
                     + "numOps=55, generation=3, minSeqNo=45, maxSeqNo=99, globalCheckpoint=-1, minTranslogGeneration=1, "
-                    + "trimmedAboveSeqNo=-2} but got Checkpoint{offset=0, numOps=0, generation=0, minSeqNo=-1, maxSeqNo=-1, "
-                    + "globalCheckpoint=-1, minTranslogGeneration=0, trimmedAboveSeqNo=-2}"
+                    + "trimmedAboveSeqNo=-2] but got Checkpoint[offset=0, numOps=0, generation=0, minSeqNo=-1, maxSeqNo=-1, "
+                    + "globalCheckpoint=-1, minTranslogGeneration=0, trimmedAboveSeqNo=-2]"
             )
         );
         Checkpoint.write(
             FileChannel::open,
-            config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)),
+            config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation())),
             read,
             StandardOpenOption.WRITE,
             StandardOpenOption.TRUNCATE_EXISTING
@@ -1924,7 +1924,7 @@ public class TranslogTests extends ESTestCase {
             assertNotNull(translogGeneration);
             assertEquals(
                 "lastCommitted must be 2 less than current - we never finished the commit",
-                translogGeneration.translogFileGeneration + 2,
+                translogGeneration.translogFileGeneration() + 2,
                 translog.currentFileGeneration()
             );
             assertFalse(translog.syncNeeded());
@@ -1933,7 +1933,7 @@ public class TranslogTests extends ESTestCase {
                 for (int i = 0; i < upTo; i++) {
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null synced: " + sync, next);
-                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals("payload mismatch, synced: " + sync, i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
         }
@@ -2208,7 +2208,7 @@ public class TranslogTests extends ESTestCase {
         Translog.TranslogGeneration translogGeneration = translog.getGeneration();
         translog.close();
 
-        final String foreignTranslog = randomRealisticUnicodeOfCodepointLengthBetween(1, translogGeneration.translogUUID.length());
+        final String foreignTranslog = randomRealisticUnicodeOfCodepointLengthBetween(1, translogGeneration.translogUUID().length());
         try {
             new Translog(
                 config,
@@ -2234,7 +2234,7 @@ public class TranslogTests extends ESTestCase {
             for (int i = firstUncommitted; i < translogOperations; i++) {
                 Translog.Operation next = snapshot.next();
                 assertNotNull("" + i, next);
-                assertEquals(Integer.parseInt(next.getSource().source.utf8ToString()), i);
+                assertEquals(Integer.parseInt(next.getSource().source().utf8ToString()), i);
             }
             assertNull(snapshot.next());
         }
@@ -2454,7 +2454,7 @@ public class TranslogTests extends ESTestCase {
         ) {
             assertEquals(
                 "lastCommitted must be 1 less than current",
-                translogGeneration.translogFileGeneration + 1,
+                translogGeneration.translogFileGeneration() + 1,
                 tlog.currentFileGeneration()
             );
             assertFalse(tlog.syncNeeded());
@@ -2465,11 +2465,11 @@ public class TranslogTests extends ESTestCase {
                     assertEquals(
                         "expected operation" + i + " to be in the previous translog but wasn't",
                         tlog.currentFileGeneration() - 1,
-                        locations.get(i).generation
+                        locations.get(i).generation()
                     );
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null", next);
-                    assertEquals(i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals(i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
         }
@@ -2496,7 +2496,7 @@ public class TranslogTests extends ESTestCase {
                     assertEquals(
                         "expected operation" + i + " to be in the current translog but wasn't",
                         translog.currentFileGeneration(),
-                        locations.get(i).generation
+                        locations.get(i).generation()
                     );
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null", next);
@@ -2598,7 +2598,7 @@ public class TranslogTests extends ESTestCase {
             assertFalse(translog.isOpen());
             final Checkpoint checkpoint = Checkpoint.read(config.getTranslogPath().resolve(Translog.CHECKPOINT_FILE_NAME));
             // drop all that haven't been synced
-            writtenOperations.removeIf(next -> checkpoint.offset < (next.location.translogLocation + next.location.size));
+            writtenOperations.removeIf(next -> checkpoint.offset() < (next.location.translogLocation() + next.location.size()));
             try (
                 Translog tlog = new Translog(
                     config,
@@ -2622,7 +2622,7 @@ public class TranslogTests extends ESTestCase {
                     assertEquals(
                         "expected operation" + i + " to be in the previous translog but wasn't",
                         tlog.currentFileGeneration() - 1,
-                        writtenOperations.get(i).location.generation
+                        writtenOperations.get(i).location.generation()
                     );
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null", next);
@@ -2653,7 +2653,7 @@ public class TranslogTests extends ESTestCase {
                 translog.rollGeneration();
             }
         }
-        long minRetainedGen = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
+        long minRetainedGen = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration();
         // engine blows up, after committing the above generation
         translog.close();
         TranslogConfig config = translog.getConfig();
@@ -2711,7 +2711,7 @@ public class TranslogTests extends ESTestCase {
                 }
             }
             deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
-            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
+            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration();
             fail.failRandomly();
             try {
                 translog.trimUnreferencedReaders();
@@ -2735,7 +2735,7 @@ public class TranslogTests extends ESTestCase {
             assertThat(translog.getMinFileGeneration(), greaterThanOrEqualTo(1L));
             assertThat(translog.getMinFileGeneration(), lessThanOrEqualTo(minGenForRecovery));
             assertFilePresences(translog);
-            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
+            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration();
             translog.trimUnreferencedReaders();
             assertThat(translog.getMinFileGeneration(), equalTo(minGenForRecovery));
             assertFilePresences(translog);
@@ -3002,14 +3002,14 @@ public class TranslogTests extends ESTestCase {
 
         Path ckp = config.getTranslogPath().resolve(Translog.CHECKPOINT_FILE_NAME);
         Checkpoint read = Checkpoint.read(ckp);
-        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)));
-        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation + 1) + ".tlog"));
+        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation())));
+        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation() + 1) + ".tlog"));
         try (Translog tlog = openTranslog(config, translog.getTranslogUUID()); Translog.Snapshot snapshot = tlog.newSnapshot()) {
             assertFalse(tlog.syncNeeded());
 
             Translog.Operation op = snapshot.next();
             assertNotNull("operation 1 must be non-null", op);
-            assertEquals("payload mismatch for operation 1", 1, Integer.parseInt(op.getSource().source.utf8ToString()));
+            assertEquals("payload mismatch for operation 1", 1, Integer.parseInt(op.getSource().source().utf8ToString()));
 
             tlog.add(new Translog.Index("" + 1, 1, primaryTerm.get(), Integer.toString(2).getBytes(Charset.forName("UTF-8"))));
         }
@@ -3019,11 +3019,11 @@ public class TranslogTests extends ESTestCase {
 
             Translog.Operation secondOp = snapshot.next();
             assertNotNull("operation 2 must be non-null", secondOp);
-            assertEquals("payload mismatch for operation 2", Integer.parseInt(secondOp.getSource().source.utf8ToString()), 2);
+            assertEquals("payload mismatch for operation 2", Integer.parseInt(secondOp.getSource().source().utf8ToString()), 2);
 
             Translog.Operation firstOp = snapshot.next();
             assertNotNull("operation 1 must be non-null", firstOp);
-            assertEquals("payload mismatch for operation 1", Integer.parseInt(firstOp.getSource().source.utf8ToString()), 1);
+            assertEquals("payload mismatch for operation 1", Integer.parseInt(firstOp.getSource().source().utf8ToString()), 1);
         }
     }
 
@@ -3034,7 +3034,7 @@ public class TranslogTests extends ESTestCase {
         Path ckp = config.getTranslogPath().resolve(Translog.CHECKPOINT_FILE_NAME);
         Checkpoint read = Checkpoint.read(ckp);
         // don't copy the new file
-        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation + 1) + ".tlog"));
+        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation() + 1) + ".tlog"));
 
         TranslogException ex = expectThrows(
             TranslogException.class,
@@ -3060,10 +3060,10 @@ public class TranslogTests extends ESTestCase {
 
         Path ckp = config.getTranslogPath().resolve(Translog.CHECKPOINT_FILE_NAME);
         Checkpoint read = Checkpoint.read(ckp);
-        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)));
-        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation + 1) + ".tlog"));
+        Files.copy(ckp, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation())));
+        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation() + 1) + ".tlog"));
         // we add N+1 and N+2 to ensure we only delete the N+1 file and never jump ahead and wipe without the right condition
-        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation + 2) + ".tlog"));
+        Files.createFile(config.getTranslogPath().resolve("translog-" + (read.generation() + 2) + ".tlog"));
         try (
             Translog tlog = new Translog(
                 config,
@@ -3079,7 +3079,7 @@ public class TranslogTests extends ESTestCase {
                 for (int i = 0; i < 1; i++) {
                     Translog.Operation next = snapshot.next();
                     assertNotNull("operation " + i + " must be non-null", next);
-                    assertEquals("payload missmatch", i, Integer.parseInt(next.getSource().source.utf8ToString()));
+                    assertEquals("payload missmatch", i, Integer.parseInt(next.getSource().source().utf8ToString()));
                 }
             }
             tlog.add(new Translog.Index("" + 1, 1, primaryTerm.get(), Integer.toString(1).getBytes(Charset.forName("UTF-8"))));
@@ -3165,11 +3165,11 @@ public class TranslogTests extends ESTestCase {
                     assertNull("Don't consider failures while trimming unreferenced readers as tragedy", failableTLog.getTragicException());
                 } finally {
                     Checkpoint checkpoint = Translog.readCheckpoint(config.getTranslogPath());
-                    if (checkpoint.numOps == unsynced.size() + syncedDocs.size()) {
+                    if (checkpoint.numOps() == unsynced.size() + syncedDocs.size()) {
                         syncedDocs.addAll(unsynced); // failed in fsync but got fully written
                         unsynced.clear();
                     }
-                    if (committing && checkpoint.minTranslogGeneration == checkpoint.generation) {
+                    if (committing && checkpoint.minTranslogGeneration() == checkpoint.generation()) {
                         // we were committing and blew up in one of the syncs, but they made it through
                         syncedDocs.clear();
                         assertThat(unsynced, empty());
@@ -3222,7 +3222,7 @@ public class TranslogTests extends ESTestCase {
                 assertEquals(syncedDocs.size(), snapshot.totalOperations());
                 for (int i = 0; i < syncedDocs.size(); i++) {
                     Translog.Operation next = snapshot.next();
-                    assertEquals(syncedDocs.get(i), next.getSource().source.utf8ToString());
+                    assertEquals(syncedDocs.get(i), next.getSource().source().utf8ToString());
                     assertNotNull("operation " + i + " must be non-null", next);
                 }
             }
@@ -3337,18 +3337,18 @@ public class TranslogTests extends ESTestCase {
         SeqNoFieldMapper.SequenceIDFields seqID = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
         long randomSeqNum = randomNonNegativeLong();
         long randomPrimaryTerm = randomBoolean() ? 0 : randomNonNegativeLong();
-        seqID.seqNo.setLongValue(randomSeqNum);
-        seqID.seqNoDocValue.setLongValue(randomSeqNum);
-        seqID.primaryTerm.setLongValue(randomPrimaryTerm);
+        seqID.seqNo().setLongValue(randomSeqNum);
+        seqID.seqNoDocValue().setLongValue(randomSeqNum);
+        seqID.primaryTerm().setLongValue(randomPrimaryTerm);
         Field idField = new Field("_id", Uid.encodeId("1"), IdFieldMapper.Defaults.FIELD_TYPE);
         Field versionField = new NumericDocValuesField("_version", 1);
         LuceneDocument document = new LuceneDocument();
         document.add(new TextField("value", "test", Field.Store.YES));
         document.add(idField);
         document.add(versionField);
-        document.add(seqID.seqNo);
-        document.add(seqID.seqNoDocValue);
-        document.add(seqID.primaryTerm);
+        document.add(seqID.seqNo());
+        document.add(seqID.seqNoDocValue());
+        document.add(seqID.primaryTerm());
         ParsedDocument doc = new ParsedDocument(versionField, seqID, "1", null, Arrays.asList(document), B_1, XContentType.JSON, null);
 
         Engine.Index eIndex = new Engine.Index(
@@ -3438,15 +3438,15 @@ public class TranslogTests extends ESTestCase {
 
         final BaseTranslogReader minRetainedReader = randomFrom(
             Stream.concat(translog.getReaders().stream(), Stream.of(translog.getCurrent()))
-                .filter(r -> r.getCheckpoint().minSeqNo >= 0)
+                .filter(r -> r.getCheckpoint().minSeqNo() >= 0)
                 .collect(Collectors.toList())
         );
         int retainedOps = Stream.concat(translog.getReaders().stream(), Stream.of(translog.getCurrent()))
-            .filter(r -> r.getCheckpoint().generation >= minRetainedReader.generation)
-            .mapToInt(r -> r.getCheckpoint().numOps)
+            .filter(r -> r.getCheckpoint().generation() >= minRetainedReader.generation)
+            .mapToInt(r -> r.getCheckpoint().numOps())
             .sum();
         deletionPolicy.setLocalCheckpointOfSafeCommit(
-            randomLongBetween(minRetainedReader.getCheckpoint().minSeqNo, minRetainedReader.getCheckpoint().maxSeqNo) - 1
+            randomLongBetween(minRetainedReader.getCheckpoint().minSeqNo(), minRetainedReader.getCheckpoint().maxSeqNo()) - 1
         );
         translog.trimUnreferencedReaders();
         assertThat(translog.currentFileGeneration(), equalTo(generation + rolls));
@@ -3486,7 +3486,7 @@ public class TranslogTests extends ESTestCase {
         translog.rollGeneration();
         for (long seqNo = 0; seqNo < operations; seqNo++) {
             final Set<Tuple<Long, Long>> seenSeqNos = new HashSet<>();
-            final long generation = translog.getMinGenerationForSeqNo(seqNo).translogFileGeneration;
+            final long generation = translog.getMinGenerationForSeqNo(seqNo).translogFileGeneration();
             int expectedSnapshotOps = 0;
             for (long g = generation; g < translog.currentFileGeneration(); g++) {
                 if (seqNoPerGeneration.containsKey(g) == false) {
@@ -3501,7 +3501,7 @@ public class TranslogTests extends ESTestCase {
                             opCount++;
                         }
                         assertThat(opCount, equalTo(reader.totalOperations()));
-                        assertThat(opCount, equalTo(checkpoint.numOps));
+                        assertThat(opCount, equalTo(checkpoint.numOps()));
                     }
                     opCountPerGeneration.put(g, opCount);
                     seqNoPerGeneration.put(g, generationSeenSeqNos);
@@ -3870,13 +3870,13 @@ public class TranslogTests extends ESTestCase {
                                 assertThat("seq# " + op.seqNo() + " was not marked as persisted", persistedSeqNos, hasItem(op.seqNo()));
                             }
                             Checkpoint checkpoint = translog.getLastSyncedCheckpoint();
-                            assertThat(checkpoint.offset, greaterThanOrEqualTo(location.translogLocation));
+                            assertThat(checkpoint.offset(), greaterThanOrEqualTo(location.translogLocation()));
                             for (Translog.Operation op : ops) {
-                                assertThat(checkpoint.minSeqNo, lessThanOrEqualTo(op.seqNo()));
-                                assertThat(checkpoint.maxSeqNo, greaterThanOrEqualTo(op.seqNo()));
+                                assertThat(checkpoint.minSeqNo(), lessThanOrEqualTo(op.seqNo()));
+                                assertThat(checkpoint.maxSeqNo(), greaterThanOrEqualTo(op.seqNo()));
                             }
                             if (synced) {
-                                assertThat(checkpoint.globalCheckpoint, greaterThanOrEqualTo(globalCheckpoint));
+                                assertThat(checkpoint.globalCheckpoint(), greaterThanOrEqualTo(globalCheckpoint));
                             }
                         } catch (Exception e) {
                             throw new AssertionError(e);

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -431,10 +431,10 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
                 assertTrue(overLimitTriggered.compareAndSet(false, true));
                 if (saveTheDay) {
                     return new HierarchyCircuitBreakerService.MemoryUsage(
-                        memoryUsed.baseUsage / 2,
-                        memoryUsed.totalUsage - (memoryUsed.baseUsage / 2),
-                        memoryUsed.transientChildUsage,
-                        memoryUsed.permanentChildUsage
+                        memoryUsed.baseUsage() / 2,
+                        memoryUsed.totalUsage() - (memoryUsed.baseUsage() / 2),
+                        memoryUsed.transientChildUsage(),
+                        memoryUsed.permanentChildUsage()
                     );
                 } else {
                     return memoryUsed;
@@ -506,19 +506,19 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         memoryUsage.set(99);
         HierarchyCircuitBreakerService.MemoryUsage output = strategy.overLimit(input);
         assertThat(output, not(sameInstance(input)));
-        assertThat(output.baseUsage, equalTo(memoryUsage.get()));
-        assertThat(output.totalUsage, equalTo(99 + input.totalUsage - 100));
-        assertThat(output.transientChildUsage, equalTo(input.transientChildUsage));
-        assertThat(output.permanentChildUsage, equalTo(input.permanentChildUsage));
+        assertThat(output.baseUsage(), equalTo(memoryUsage.get()));
+        assertThat(output.totalUsage(), equalTo(99 + input.totalUsage() - 100));
+        assertThat(output.transientChildUsage(), equalTo(input.transientChildUsage()));
+        assertThat(output.permanentChildUsage(), equalTo(input.permanentChildUsage()));
         assertThat(nonLeaderTriggerCount.get(), equalTo(1));
 
         time.addAndGet(randomLongBetween(interval, interval * 2));
         output = strategy.overLimit(input);
         assertThat(output, not(sameInstance(input)));
-        assertThat(output.baseUsage, equalTo(memoryUsage.get()));
-        assertThat(output.totalUsage, equalTo(99 + input.totalUsage - 100));
-        assertThat(output.transientChildUsage, equalTo(input.transientChildUsage));
-        assertThat(output.permanentChildUsage, equalTo(input.permanentChildUsage));
+        assertThat(output.baseUsage(), equalTo(memoryUsage.get()));
+        assertThat(output.totalUsage(), equalTo(99 + input.totalUsage() - 100));
+        assertThat(output.transientChildUsage(), equalTo(input.transientChildUsage()));
+        assertThat(output.permanentChildUsage(), equalTo(input.permanentChildUsage()));
         assertThat(leaderTriggerCount.get(), equalTo(2));
     }
 
@@ -603,9 +603,9 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
                     randomLongBetween(0, 100)
                 );
                 HierarchyCircuitBreakerService.MemoryUsage output = strategy.overLimit(input);
-                assertThat(output.totalUsage, equalTo(output.baseUsage + input.totalUsage - input.baseUsage));
-                assertThat(output.transientChildUsage, equalTo(input.transientChildUsage));
-                assertThat(output.permanentChildUsage, equalTo(input.permanentChildUsage));
+                assertThat(output.totalUsage(), equalTo(output.baseUsage() + input.totalUsage() - input.baseUsage()));
+                assertThat(output.transientChildUsage(), equalTo(input.transientChildUsage()));
+                assertThat(output.permanentChildUsage(), equalTo(input.permanentChildUsage()));
                 countDown.get().countDown();
             } while (Thread.interrupted() == false);
         })).collect(Collectors.toList());

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -176,7 +176,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         recoveryTarget.decRef();
         Store.MetadataSnapshot targetSnapshot = targetShard.snapshotStoreMetadata();
         Store.RecoveryDiff diff = sourceSnapshot.recoveryDiff(targetSnapshot);
-        assertThat(diff.different, empty());
+        assertThat(diff.different(), empty());
         closeShards(sourceShard, targetShard);
     }
 
@@ -228,8 +228,8 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         Optional<SequenceNumbers.CommitInfo> safeCommit = shard.store().findSafeIndexCommit(globalCheckpoint);
         assertTrue(safeCommit.isPresent());
         int expectedTotalLocal = 0;
-        if (safeCommit.get().localCheckpoint < globalCheckpoint) {
-            try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
+        if (safeCommit.get().localCheckpoint() < globalCheckpoint) {
+            try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint() + 1, globalCheckpoint)) {
                 Translog.Operation op;
                 while ((op = snapshot.next()) != null) {
                     if (op.seqNo() <= globalCheckpoint) {
@@ -281,7 +281,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
         if (safeCommit.isPresent()) {
-            assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint + 1));
+            assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint() + 1));
             assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(0));
         } else {
             assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -324,7 +324,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         );
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
-        assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint + 1));
+        assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint() + 1));
         assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(0));
         assertThat(replica.recoveryState().getTranslog().recoveredOperations(), equalTo(0));
         assertThat(replica.getLastKnownGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -440,7 +440,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         String repositoryName = "repo";
         IndexId indexId = new IndexId("index", "uuid");
         ShardId shardId = shard.shardId();
-        BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
             "name",
             storeFileMetadata,
             SNAPSHOT_FILE_PART_SIZE
@@ -562,7 +562,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
         String repositoryName = "repo";
         IndexId indexId = new IndexId("index", "uuid");
-        BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
             "name",
             storeFileMetadata,
             SNAPSHOT_FILE_PART_SIZE
@@ -637,7 +637,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
             recoveryStateIndex.addFileDetail(storeFileMetadata.name(), storeFileMetadata.length(), false);
 
-            BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            BlobStoreIndexShardSnapshot.FileInfo fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
                 "name",
                 storeFileMetadata,
                 SNAPSHOT_FILE_PART_SIZE
@@ -759,7 +759,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
         String repository = "repo";
         IndexId indexId = new IndexId("index", "uuid");
-        BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
             "name",
             storeFileMetadata,
             new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -250,7 +250,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
                     replica.getPendingPrimaryTerm()
                 );
             } else {
-                translogUUIDtoUse = translogGeneration.translogUUID;
+                translogUUIDtoUse = translogGeneration.translogUUID();
             }
             try (IndexWriter writer = new IndexWriter(replica.store().directory(), iwc)) {
                 userData.put(Engine.HISTORY_UUID_KEY, historyUUIDtoUse);

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -218,10 +218,10 @@ public class IngestServiceTests extends ESTestCase {
             .build();
         ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState));
         assertThat(ingestService.pipelines().size(), is(1));
-        assertThat(ingestService.pipelines().get("_id").pipeline.getId(), equalTo("_id"));
-        assertThat(ingestService.pipelines().get("_id").pipeline.getDescription(), nullValue());
-        assertThat(ingestService.pipelines().get("_id").pipeline.getProcessors().size(), equalTo(1));
-        assertThat(ingestService.pipelines().get("_id").pipeline.getProcessors().get(0).getType(), equalTo("set"));
+        assertThat(ingestService.pipelines().get("_id").pipeline().getId(), equalTo("_id"));
+        assertThat(ingestService.pipelines().get("_id").pipeline().getDescription(), nullValue());
+        assertThat(ingestService.pipelines().get("_id").pipeline().getProcessors().size(), equalTo(1));
+        assertThat(ingestService.pipelines().get("_id").pipeline().getProcessors().get(0).getType(), equalTo("set"));
     }
 
     public void testInnerUpdatePipelines() {
@@ -233,39 +233,39 @@ public class IngestServiceTests extends ESTestCase {
 
         ingestService.innerUpdatePipelines(ingestMetadata);
         assertThat(ingestService.pipelines().size(), is(1));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getId(), equalTo("_id1"));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getId(), equalTo("_id1"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getProcessors().size(), equalTo(0));
 
         PipelineConfiguration pipeline2 = new PipelineConfiguration("_id2", new BytesArray("{\"processors\": []}"), XContentType.JSON);
         ingestMetadata = new IngestMetadata(Map.of("_id1", pipeline1, "_id2", pipeline2));
 
         ingestService.innerUpdatePipelines(ingestMetadata);
         assertThat(ingestService.pipelines().size(), is(2));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getId(), equalTo("_id1"));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getProcessors().size(), equalTo(0));
-        assertThat(ingestService.pipelines().get("_id2").pipeline.getId(), equalTo("_id2"));
-        assertThat(ingestService.pipelines().get("_id2").pipeline.getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getId(), equalTo("_id1"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id2").pipeline().getId(), equalTo("_id2"));
+        assertThat(ingestService.pipelines().get("_id2").pipeline().getProcessors().size(), equalTo(0));
 
         PipelineConfiguration pipeline3 = new PipelineConfiguration("_id3", new BytesArray("{\"processors\": []}"), XContentType.JSON);
         ingestMetadata = new IngestMetadata(Map.of("_id1", pipeline1, "_id2", pipeline2, "_id3", pipeline3));
 
         ingestService.innerUpdatePipelines(ingestMetadata);
         assertThat(ingestService.pipelines().size(), is(3));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getId(), equalTo("_id1"));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getProcessors().size(), equalTo(0));
-        assertThat(ingestService.pipelines().get("_id2").pipeline.getId(), equalTo("_id2"));
-        assertThat(ingestService.pipelines().get("_id2").pipeline.getProcessors().size(), equalTo(0));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getId(), equalTo("_id3"));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getId(), equalTo("_id1"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id2").pipeline().getId(), equalTo("_id2"));
+        assertThat(ingestService.pipelines().get("_id2").pipeline().getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getId(), equalTo("_id3"));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getProcessors().size(), equalTo(0));
 
         ingestMetadata = new IngestMetadata(Map.of("_id1", pipeline1, "_id3", pipeline3));
 
         ingestService.innerUpdatePipelines(ingestMetadata);
         assertThat(ingestService.pipelines().size(), is(2));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getId(), equalTo("_id1"));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getProcessors().size(), equalTo(0));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getId(), equalTo("_id3"));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getId(), equalTo("_id1"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getId(), equalTo("_id3"));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getProcessors().size(), equalTo(0));
 
         pipeline3 = new PipelineConfiguration("_id3", new BytesArray("""
             {"processors": [{"set" : {"field": "_field", "value": "_value"}}]}"""), XContentType.JSON);
@@ -273,11 +273,11 @@ public class IngestServiceTests extends ESTestCase {
 
         ingestService.innerUpdatePipelines(ingestMetadata);
         assertThat(ingestService.pipelines().size(), is(2));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getId(), equalTo("_id1"));
-        assertThat(ingestService.pipelines().get("_id1").pipeline.getProcessors().size(), equalTo(0));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getId(), equalTo("_id3"));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getProcessors().size(), equalTo(1));
-        assertThat(ingestService.pipelines().get("_id3").pipeline.getProcessors().get(0).getType(), equalTo("set"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getId(), equalTo("_id1"));
+        assertThat(ingestService.pipelines().get("_id1").pipeline().getProcessors().size(), equalTo(0));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getId(), equalTo("_id3"));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getProcessors().size(), equalTo(1));
+        assertThat(ingestService.pipelines().get("_id3").pipeline().getProcessors().get(0).getType(), equalTo("set"));
 
         // Perform an update with no changes:
         Map<String, IngestService.PipelineHolder> pipelines = ingestService.pipelines();
@@ -1515,8 +1515,8 @@ public class IngestServiceTests extends ESTestCase {
         final IngestStats afterFirstRequestStats = ingestService.stats();
         assertThat(afterFirstRequestStats.getPipelineStats().size(), equalTo(2));
 
-        afterFirstRequestStats.getProcessorStats().get("_id1").forEach(p -> assertEquals(p.getName(), "mock:mockTag"));
-        afterFirstRequestStats.getProcessorStats().get("_id2").forEach(p -> assertEquals(p.getName(), "mock:mockTag"));
+        afterFirstRequestStats.getProcessorStats().get("_id1").forEach(p -> assertEquals(p.name(), "mock:mockTag"));
+        afterFirstRequestStats.getProcessorStats().get("_id2").forEach(p -> assertEquals(p.name(), "mock:mockTag"));
 
         // total
         assertStats(afterFirstRequestStats.getTotalStats(), 1, 0, 0);
@@ -2196,7 +2196,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private void assertProcessorStats(int processor, IngestStats stats, String pipelineId, long count, long failed, long time) {
-        assertStats(stats.getProcessorStats().get(pipelineId).get(processor).getStats(), count, failed, time);
+        assertStats(stats.getProcessorStats().get(pipelineId).get(processor).stats(), count, failed, time);
     }
 
     private void assertPipelineStats(List<IngestStats.PipelineStat> pipelineStats, String pipelineId, long count, long failed, long time) {
@@ -2211,6 +2211,6 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private IngestStats.Stats getPipelineStats(List<IngestStats.PipelineStat> pipelineStats, String id) {
-        return pipelineStats.stream().filter(p1 -> p1.getPipelineId().equals(id)).findFirst().map(p2 -> p2.getStats()).orElse(null);
+        return pipelineStats.stream().filter(p1 -> p1.pipelineId().equals(id)).findFirst().map(p2 -> p2.stats()).orElse(null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -50,8 +50,8 @@ public class IngestStatsTests extends ESTestCase {
         );
         // pipeline1 -> processor1,processor2; pipeline2 -> processor3
         return MapBuilder.<String, List<IngestStats.ProcessorStat>>newMapBuilder()
-            .put(pipelineStats.get(0).getPipelineId(), Stream.of(processor1Stat, processor2Stat).collect(Collectors.toList()))
-            .put(pipelineStats.get(1).getPipelineId(), Collections.singletonList(processor3Stat))
+            .put(pipelineStats.get(0).pipelineId(), Stream.of(processor1Stat, processor2Stat).collect(Collectors.toList()))
+            .put(pipelineStats.get(1).pipelineId(), Collections.singletonList(processor3Stat))
             .map();
     }
 
@@ -78,25 +78,25 @@ public class IngestStatsTests extends ESTestCase {
 
         for (IngestStats.PipelineStat serializedPipelineStat : serializedStats.getPipelineStats()) {
             assertStats(
-                getPipelineStats(ingestStats.getPipelineStats(), serializedPipelineStat.getPipelineId()),
-                serializedPipelineStat.getStats()
+                getPipelineStats(ingestStats.getPipelineStats(), serializedPipelineStat.pipelineId()),
+                serializedPipelineStat.stats()
             );
             List<IngestStats.ProcessorStat> serializedProcessorStats = serializedStats.getProcessorStats()
-                .get(serializedPipelineStat.getPipelineId());
-            List<IngestStats.ProcessorStat> processorStat = ingestStats.getProcessorStats().get(serializedPipelineStat.getPipelineId());
+                .get(serializedPipelineStat.pipelineId());
+            List<IngestStats.ProcessorStat> processorStat = ingestStats.getProcessorStats().get(serializedPipelineStat.pipelineId());
             if (expectProcessors) {
                 if (processorStat != null) {
                     Iterator<IngestStats.ProcessorStat> it = processorStat.iterator();
                     // intentionally enforcing the identical ordering
                     for (IngestStats.ProcessorStat serializedProcessorStat : serializedProcessorStats) {
                         IngestStats.ProcessorStat ps = it.next();
-                        assertEquals(ps.getName(), serializedProcessorStat.getName());
+                        assertEquals(ps.name(), serializedProcessorStat.name());
                         if (expectProcessorTypes) {
-                            assertEquals(ps.getType(), serializedProcessorStat.getType());
+                            assertEquals(ps.type(), serializedProcessorStat.type());
                         } else {
-                            assertEquals("_NOT_AVAILABLE", serializedProcessorStat.getType());
+                            assertEquals("_NOT_AVAILABLE", serializedProcessorStat.type());
                         }
-                        assertStats(ps.getStats(), serializedProcessorStat.getStats());
+                        assertStats(ps.stats(), serializedProcessorStat.stats());
                     }
                     assertFalse(it.hasNext());
                 }
@@ -116,6 +116,6 @@ public class IngestStatsTests extends ESTestCase {
     }
 
     private IngestStats.Stats getPipelineStats(List<IngestStats.PipelineStat> pipelineStats, String id) {
-        return pipelineStats.stream().filter(p1 -> p1.getPipelineId().equals(id)).findFirst().map(p2 -> p2.getStats()).orElse(null);
+        return pipelineStats.stream().filter(p1 -> p1.pipelineId().equals(id)).findFirst().map(p2 -> p2.stats()).orElse(null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/CustomPassageFormatterTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/CustomPassageFormatterTests.java
@@ -51,11 +51,11 @@ public class CustomPassageFormatterTests extends ESTestCase {
         Snippet[] fragments = passageFormatter.format(passages, content);
         assertThat(fragments, notNullValue());
         assertThat(fragments.length, equalTo(3));
-        assertThat(fragments[0].getText(), equalTo("This is a really cool <em>highlighter</em>."));
+        assertThat(fragments[0].text(), equalTo("This is a really cool <em>highlighter</em>."));
         assertThat(fragments[0].isHighlighted(), equalTo(true));
-        assertThat(fragments[1].getText(), equalTo("Unified <em>highlighter</em> gives nice snippets back."));
+        assertThat(fragments[1].text(), equalTo("Unified <em>highlighter</em> gives nice snippets back."));
         assertThat(fragments[1].isHighlighted(), equalTo(true));
-        assertThat(fragments[2].getText(), equalTo("No matches here."));
+        assertThat(fragments[2].text(), equalTo("No matches here."));
         assertThat(fragments[2].isHighlighted(), equalTo(false));
     }
 
@@ -87,7 +87,7 @@ public class CustomPassageFormatterTests extends ESTestCase {
         Snippet[] fragments = passageFormatter.format(passages, content);
         assertThat(fragments, notNullValue());
         assertThat(fragments.length, equalTo(2));
-        assertThat(fragments[0].getText(), equalTo("&lt;b&gt;This is a really cool <em>highlighter</em>.&lt;&#x2F;b&gt;"));
-        assertThat(fragments[1].getText(), equalTo("Unified <em>highlighter</em> gives nice snippets back."));
+        assertThat(fragments[0].text(), equalTo("&lt;b&gt;This is a really cool <em>highlighter</em>.&lt;&#x2F;b&gt;"));
+        assertThat(fragments[1].text(), equalTo("Unified <em>highlighter</em> gives nice snippets back."));
     }
 }

--- a/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
@@ -122,7 +122,7 @@ public class CustomUnifiedHighlighterTests extends ESTestCase {
                 final Snippet[] snippets = highlighter.highlightField(getOnlyLeafReader(reader), topDocs.scoreDocs[0].doc, () -> rawValue);
                 assertEquals(snippets.length, expectedPassages.length);
                 for (int i = 0; i < snippets.length; i++) {
-                    assertEquals(snippets[i].getText(), expectedPassages[i]);
+                    assertEquals(snippets[i].text(), expectedPassages[i]);
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmMonitorTests.java
@@ -169,9 +169,9 @@ public class JvmMonitorTests extends ESTestCase {
             void onSlowGc(final Threshold threshold, final long seq, final SlowGcEvent slowGcEvent) {
                 count.incrementAndGet();
                 assertThat(seq, equalTo(1L));
-                assertThat(slowGcEvent.elapsed, equalTo(expectedElapsed));
-                assertThat(slowGcEvent.currentGc.getName(), anyOf(equalTo("young"), equalTo("old")));
-                if ("young".equals(slowGcEvent.currentGc.getName())) {
+                assertThat(slowGcEvent.elapsed(), equalTo(expectedElapsed));
+                assertThat(slowGcEvent.currentGc().getName(), anyOf(equalTo("young"), equalTo("old")));
+                if ("young".equals(slowGcEvent.currentGc().getName())) {
                     assertCollection(
                         threshold,
                         youngThresholdLevel,
@@ -181,7 +181,7 @@ public class JvmMonitorTests extends ESTestCase {
                         initialYoungCollectionTime,
                         youngIncrement
                     );
-                } else if ("old".equals(slowGcEvent.currentGc.getName())) {
+                } else if ("old".equals(slowGcEvent.currentGc().getName())) {
                     assertCollection(
                         threshold,
                         oldThresholdLevel,
@@ -227,10 +227,10 @@ public class JvmMonitorTests extends ESTestCase {
         final int increment
     ) {
         assertThat(actualThreshold, equalTo(expectedThreshold));
-        assertThat(slowGcEvent.currentGc.getCollectionCount(), equalTo((long) (initialCollectionCount + collections)));
-        assertThat(slowGcEvent.collectionCount, equalTo((long) collections));
-        assertThat(slowGcEvent.collectionTime, equalTo(TimeValue.timeValueMillis(increment)));
-        assertThat(slowGcEvent.currentGc.getCollectionTime(), equalTo(TimeValue.timeValueMillis(initialCollectionTime + increment)));
+        assertThat(slowGcEvent.currentGc().getCollectionCount(), equalTo((long) (initialCollectionCount + collections)));
+        assertThat(slowGcEvent.collectionCount(), equalTo((long) collections));
+        assertThat(slowGcEvent.collectionTime(), equalTo(TimeValue.timeValueMillis(increment)));
+        assertThat(slowGcEvent.currentGc().getCollectionTime(), equalTo(TimeValue.timeValueMillis(initialCollectionTime + increment)));
     }
 
     private JvmStats jvmStats(JvmStats.GarbageCollector youngCollector, JvmStats.GarbageCollector oldCollector) {

--- a/server/src/test/java/org/elasticsearch/persistent/decider/AssignmentDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/decider/AssignmentDecisionTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 public class AssignmentDecisionTests extends ESTestCase {
 
     public void testConstantsTypes() {
-        assertEquals(AssignmentDecision.Type.YES, AssignmentDecision.YES.getType());
+        assertEquals(AssignmentDecision.Type.YES, AssignmentDecision.YES.type());
     }
 
     public void testResolveFromType() {

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -244,8 +244,8 @@ public class RepositoryDataTests extends ESTestCase {
                 new RepositoryData.SnapshotDetails(
                     parsedRepositoryData.getSnapshotState(snapshotId),
                     parsedRepositoryData.getVersion(snapshotId),
-                    parsedRepositoryData.getSnapshotDetails(snapshotId).getStartTimeMillis(),
-                    parsedRepositoryData.getSnapshotDetails(snapshotId).getEndTimeMillis(),
+                    parsedRepositoryData.getSnapshotDetails(snapshotId).startTimeMillis(),
+                    parsedRepositoryData.getSnapshotDetails(snapshotId).endTimeMillis(),
                     randomAlphaOfLength(10)
                 )
             );
@@ -347,7 +347,8 @@ public class RepositoryDataTests extends ESTestCase {
         final SnapshotId snapshotId = randomFrom(repositoryData.getSnapshotIds());
         final IndexMetaDataGenerations indexMetaDataGenerations = repositoryData.indexMetaDataGenerations();
         final Collection<IndexId> indicesToUpdate = repositoryData.indicesToUpdateAfterRemovingSnapshot(Collections.singleton(snapshotId));
-        final Map<IndexId, Collection<String>> identifiersToRemove = indexMetaDataGenerations.lookup.get(snapshotId)
+        final Map<IndexId, Collection<String>> identifiersToRemove = indexMetaDataGenerations.lookup()
+            .get(snapshotId)
             .entrySet()
             .stream()
             .filter(e -> indicesToUpdate.contains(e.getKey()))
@@ -386,7 +387,7 @@ public class RepositoryDataTests extends ESTestCase {
             builder.put(indexId, 0, ShardGeneration.newGeneration(random()));
         }
         final ShardGenerations shardGenerations = builder.build();
-        final Map<IndexId, String> indexLookup = new HashMap<>(repositoryData.indexMetaDataGenerations().lookup.get(otherSnapshotId));
+        final Map<IndexId, String> indexLookup = new HashMap<>(repositoryData.indexMetaDataGenerations().lookup().get(otherSnapshotId));
         indexLookup.putAll(newIndices);
         final SnapshotId newSnapshot = new SnapshotId(randomAlphaOfLength(7), UUIDs.randomBase64UUID(random()));
 

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -296,15 +296,15 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         final SnapshotId snapshotId = createSnapshotResponse.getSnapshotInfo().snapshotId();
 
         final Consumer<RepositoryData.SnapshotDetails> snapshotDetailsAsserter = snapshotDetails -> {
-            assertThat(snapshotDetails.getSnapshotState(), equalTo(SnapshotState.PARTIAL));
-            assertThat(snapshotDetails.getVersion(), equalTo(Version.CURRENT));
-            assertThat(snapshotDetails.getStartTimeMillis(), allOf(greaterThanOrEqualTo(beforeStartTime), lessThanOrEqualTo(afterEndTime)));
+            assertThat(snapshotDetails.snapshotState(), equalTo(SnapshotState.PARTIAL));
+            assertThat(snapshotDetails.version(), equalTo(Version.CURRENT));
+            assertThat(snapshotDetails.startTimeMillis(), allOf(greaterThanOrEqualTo(beforeStartTime), lessThanOrEqualTo(afterEndTime)));
             assertThat(
-                snapshotDetails.getEndTimeMillis(),
+                snapshotDetails.endTimeMillis(),
                 allOf(
                     greaterThanOrEqualTo(beforeStartTime),
                     lessThanOrEqualTo(afterEndTime),
-                    greaterThanOrEqualTo(snapshotDetails.getStartTimeMillis())
+                    greaterThanOrEqualTo(snapshotDetails.startTimeMillis())
                 )
             );
         };

--- a/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
@@ -124,7 +124,7 @@ public class FsRepositoryTests extends ESTestCase {
                 );
                 future1.actionGet();
                 IndexShardSnapshotStatus.Copy copy = snapshotStatus.asCopy();
-                assertEquals(copy.getTotalFileCount(), copy.getIncrementalFileCount());
+                assertEquals(copy.totalFileCount(), copy.incrementalFileCount());
             });
             final ShardGeneration shardGeneration = future1.actionGet().getGeneration();
             Lucene.cleanLuceneIndex(directory);
@@ -168,8 +168,8 @@ public class FsRepositoryTests extends ESTestCase {
                 );
                 future2.actionGet();
                 IndexShardSnapshotStatus.Copy copy = snapshotStatus.asCopy();
-                assertEquals(2, copy.getIncrementalFileCount());
-                assertEquals(commitFileNames.size(), copy.getTotalFileCount());
+                assertEquals(2, copy.incrementalFileCount());
+                assertEquals(commitFileNames.size(), copy.totalFileCount());
             });
 
             // roll back to the first snap and then incrementally restore

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -661,14 +661,14 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Document root;
             root = new Document();
             root.add(new Field(IdFieldMapper.NAME, Uid.encodeId("1"), IdFieldMapper.Defaults.FIELD_TYPE));
-            root.add(sequenceIDFields.primaryTerm);
+            root.add(sequenceIDFields.primaryTerm());
             root.add(new StringField(rootNameField, new BytesRef("Ballpoint"), Field.Store.NO));
             documents.add(root);
 
             root = new Document();
             root.add(new Field(IdFieldMapper.NAME, Uid.encodeId("2"), IdFieldMapper.Defaults.FIELD_TYPE));
             root.add(new StringField(rootNameField, new BytesRef("Notebook"), Field.Store.NO));
-            root.add(sequenceIDFields.primaryTerm);
+            root.add(sequenceIDFields.primaryTerm());
             documents.add(root);
             iw.addDocuments(documents);
         }, (InternalSingleBucketAggregation parent) -> {
@@ -715,14 +715,14 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Document root;
             root = new Document();
             root.add(new Field(IdFieldMapper.NAME, Uid.encodeId("1"), IdFieldMapper.Defaults.FIELD_TYPE));
-            root.add(sequenceIDFields.primaryTerm);
+            root.add(sequenceIDFields.primaryTerm());
             root.add(new StringField(rootNameField, new BytesRef("Ballpoint"), Field.Store.NO));
             documents.add(root);
 
             root = new Document();
             root.add(new Field(IdFieldMapper.NAME, Uid.encodeId("2"), IdFieldMapper.Defaults.FIELD_TYPE));
             root.add(new StringField(rootNameField, new BytesRef("Notebook"), Field.Store.NO));
-            root.add(sequenceIDFields.primaryTerm);
+            root.add(sequenceIDFields.primaryTerm());
             documents.add(root);
             iw.addDocuments(documents);
         }, (InternalSingleBucketAggregation parent) -> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -181,7 +181,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     Document document = new Document();
                     document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), IdFieldMapper.Defaults.FIELD_TYPE));
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                    document.add(sequenceIDFields.primaryTerm);
+                    document.add(sequenceIDFields.primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }
@@ -235,7 +235,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     Document document = new Document();
                     document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), IdFieldMapper.Defaults.FIELD_TYPE));
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                    document.add(sequenceIDFields.primaryTerm);
+                    document.add(sequenceIDFields.primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }
@@ -287,7 +287,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     Document document = new Document();
                     document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), IdFieldMapper.Defaults.FIELD_TYPE));
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                    document.add(sequenceIDFields.primaryTerm);
+                    document.add(sequenceIDFields.primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }
@@ -346,7 +346,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("1"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
                 iw.commit();
@@ -361,7 +361,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("2"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
                 documents.clear();
@@ -373,7 +373,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("3"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
 
@@ -619,7 +619,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("1"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "_doc", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
                 iw.commit();
@@ -640,7 +640,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("2"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "_doc", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
                 iw.commit();
@@ -661,7 +661,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId("3"), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "_doc", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 documents.add(document);
                 iw.addDocuments(documents);
                 iw.commit();
@@ -731,7 +731,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     Document document = new Document();
                     document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), IdFieldMapper.Defaults.FIELD_TYPE));
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                    document.add(sequenceIDFields.primaryTerm);
+                    document.add(sequenceIDFields.primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }
@@ -771,7 +771,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     Document document = new Document();
                     document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), IdFieldMapper.Defaults.FIELD_TYPE));
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                    document.add(sequenceIDFields.primaryTerm);
+                    document.add(sequenceIDFields.primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }
@@ -863,7 +863,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 Document document = new Document();
                 document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(p)), IdFieldMapper.Defaults.FIELD_TYPE));
                 document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-                document.add(sequenceIDFields.primaryTerm);
+                document.add(sequenceIDFields.primaryTerm());
                 document.add(new SortedNumericDocValuesField("product_id", p));
                 documents.add(document);
                 iw.addDocuments(documents);
@@ -913,7 +913,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
         Document document = new Document();
         document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE));
         document.add(new Field(NestedPathFieldMapper.NAME, "book", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-        document.add(sequenceIDFields.primaryTerm);
+        document.add(sequenceIDFields.primaryTerm());
         for (String author : authors) {
             document.add(new Field("author", author, KeywordFieldMapper.Defaults.FIELD_TYPE));
             document.add(new SortedSetDocValuesField("author", new BytesRef(author)));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -107,7 +107,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     document.add(new Field(NestedPathFieldMapper.NAME, "test", NestedPathFieldMapper.Defaults.FIELD_TYPE));
                     long value = randomNonNegativeLong() % 10000;
                     document.add(new SortedNumericDocValuesField(VALUE_FIELD_NAME, value));
-                    document.add(SeqNoFieldMapper.SequenceIDFields.emptySeqID().primaryTerm);
+                    document.add(SeqNoFieldMapper.SequenceIDFields.emptySeqID().primaryTerm());
                     if (numNestedDocs > 0) {
                         expectedMaxValue = Math.max(expectedMaxValue, value);
                         expectedParentDocs++;
@@ -168,7 +168,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
 
                     long value = randomNonNegativeLong() % 10000;
                     document.add(new SortedNumericDocValuesField(VALUE_FIELD_NAME, value));
-                    document.add(SeqNoFieldMapper.SequenceIDFields.emptySeqID().primaryTerm);
+                    document.add(SeqNoFieldMapper.SequenceIDFields.emptySeqID().primaryTerm());
                     documents.add(document);
                     iw.addDocuments(documents);
                 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -511,7 +511,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
         document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE));
         document.add(new Field(NestedPathFieldMapper.NAME, "docs", NestedPathFieldMapper.Defaults.FIELD_TYPE));
         document.add(new SortedNumericDocValuesField("value", value));
-        document.add(sequenceIDFields.primaryTerm);
+        document.add(sequenceIDFields.primaryTerm());
         documents.add(document);
 
         return documents;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -335,6 +335,6 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected FieldMapper buildMockFieldMapper(MappedFieldType ft) {
-        return new MockFieldMapper(ft, Map.of(ft.name(), ft.getTextSearchInfo().getSearchAnalyzer()));
+        return new MockFieldMapper(ft, Map.of(ft.name(), ft.getTextSearchInfo().searchAnalyzer()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -2109,7 +2109,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE));
         document.add(new Field(NestedPathFieldMapper.NAME, "docs", NestedPathFieldMapper.Defaults.FIELD_TYPE));
         document.add(new SortedNumericDocValuesField("value", value));
-        document.add(sequenceIDFields.primaryTerm);
+        document.add(sequenceIDFields.primaryTerm());
         documents.add(document);
 
         return documents;
@@ -2138,7 +2138,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE));
         document.addAll(doc(animalFieldType, animal));
         document.add(new Field(NestedPathFieldMapper.NAME, "docs", NestedPathFieldMapper.Defaults.FIELD_TYPE));
-        document.add(sequenceIDFields.primaryTerm);
+        document.add(sequenceIDFields.primaryTerm());
         documents.add(document);
 
         return documents;

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -394,9 +394,9 @@ public abstract class EngineTestCase extends ESTestCase {
         SeqNoFieldMapper.SequenceIDFields seqID = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
         document.add(uidField);
         document.add(versionField);
-        document.add(seqID.seqNo);
-        document.add(seqID.seqNoDocValue);
-        document.add(seqID.primaryTerm);
+        document.add(seqID.seqNo());
+        document.add(seqID.seqNoDocValue());
+        document.add(seqID.primaryTerm());
         BytesRef ref = source.toBytesRef();
         if (recoverySource) {
             document.add(new StoredField(SourceFieldMapper.RECOVERY_SOURCE_NAME, ref.bytes, ref.offset, ref.length));
@@ -1327,7 +1327,7 @@ public abstract class EngineTestCase extends ESTestCase {
             assertThat(luceneOp.toString(), luceneOp.primaryTerm(), equalTo(translogOp.primaryTerm()));
             assertThat(luceneOp.opType(), equalTo(translogOp.opType()));
             if (luceneOp.opType() == Translog.Operation.Type.INDEX) {
-                assertThat(luceneOp.getSource().source, equalTo(translogOp.getSource().source));
+                assertThat(luceneOp.getSource().source(), equalTo(translogOp.getSource().source()));
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -114,7 +114,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
     private static final Consumer<IndexShard.ShardFailure> DEFAULT_SHARD_FAILURE_HANDLER = failure -> {
         if (failOnShardFailures.get()) {
-            throw new AssertionError(failure.reason, failure.cause);
+            throw new AssertionError(failure.reason(), failure.cause());
         }
     };
 
@@ -1017,9 +1017,9 @@ public abstract class IndexShardTestCase extends ESTestCase {
         }
 
         final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
-        assertEquals(IndexShardSnapshotStatus.Stage.DONE, lastSnapshotStatus.getStage());
-        assertEquals(shard.snapshotStoreMetadata().size(), lastSnapshotStatus.getTotalFileCount());
-        assertNull(lastSnapshotStatus.getFailure());
+        assertEquals(IndexShardSnapshotStatus.Stage.DONE, lastSnapshotStatus.stage());
+        assertEquals(shard.snapshotStoreMetadata().size(), lastSnapshotStatus.totalFileCount());
+        assertNull(lastSnapshotStatus.failure());
         return shardGen;
     }
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -537,9 +537,9 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
             ).asCopy();
 
             assertThat(indexShardSnapshotStatus, notNullValue());
-            assertThat(indexShardSnapshotStatus.getStage(), is(IndexShardSnapshotStatus.Stage.DONE));
+            assertThat(indexShardSnapshotStatus.stage(), is(IndexShardSnapshotStatus.Stage.DONE));
             assertThat(
-                indexShardSnapshotStatus.getTotalSize(),
+                indexShardSnapshotStatus.totalSize(),
                 equalTo(indexStats.getIndexShards().get(shardId).getPrimary().getStore().getSizeInBytes())
             );
         }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -645,7 +645,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             ArrayList<FileInfo> fileInfos = new ArrayList<>();
             for (StoreFileMetadata fileMetadata : sourceMetadata) {
                 ByteSizeValue fileSize = new ByteSizeValue(fileMetadata.length());
-                fileInfos.add(new FileInfo(fileMetadata.name(), fileMetadata, fileSize));
+                fileInfos.add(FileInfo.of(fileMetadata.name(), fileMetadata, fileSize));
             }
             SnapshotFiles snapshotFiles = new SnapshotFiles(LATEST, fileInfos, null);
             restore(snapshotFiles, store, listener);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
@@ -164,7 +164,7 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
      * Cleanup (synchronize) the internal state when an object is removed from the primary cache
      */
     private void onCacheEviction(RemovalNotification<BitsetCacheKey, BitSet> notification) {
-        final BitsetCacheKey bitsetKey = notification.getKey();
+        final BitsetCacheKey bitsetKey = notification.key();
         final IndexReader.CacheKey indexKey = bitsetKey.index;
         if (keysByIndex.getOrDefault(indexKey, Set.of()).contains(bitsetKey) == false) {
             // If the bitsetKey isn't in the lookup map, then there's nothing to synchronize

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -182,9 +182,9 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             );
             shardGeneration = future.actionGet().getGeneration();
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
-            assertEquals(copy.getTotalFileCount(), copy.getIncrementalFileCount());
-            totalFileCount = copy.getTotalFileCount();
-            assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
+            assertEquals(copy.totalFileCount(), copy.incrementalFileCount());
+            totalFileCount = copy.totalFileCount();
+            assertEquals(copy.stage(), IndexShardSnapshotStatus.Stage.DONE);
         }
 
         indexDoc(shard, "_doc", Integer.toString(10));
@@ -214,10 +214,10 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             shardGeneration = future.actionGet().getGeneration();
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
             // we processed the segments_N file plus _1.si, _1.fnm, _1.fdx, _1.fdt, _1.fdm
-            assertEquals(6, copy.getIncrementalFileCount());
+            assertEquals(6, copy.incrementalFileCount());
             // in total we have 5 more files than the previous snap since we don't count the segments_N twice
-            assertEquals(totalFileCount + 5, copy.getTotalFileCount());
-            assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
+            assertEquals(totalFileCount + 5, copy.totalFileCount());
+            assertEquals(copy.stage(), IndexShardSnapshotStatus.Stage.DONE);
         }
         deleteDoc(shard, Integer.toString(10));
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
@@ -245,10 +245,10 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             future.actionGet();
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
             // we processed the segments_N file plus _1_1.liv
-            assertEquals(2, copy.getIncrementalFileCount());
+            assertEquals(2, copy.incrementalFileCount());
             // in total we have 6 more files than the previous snap since we don't count the segments_N twice
-            assertEquals(totalFileCount + 6, copy.getTotalFileCount());
-            assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
+            assertEquals(totalFileCount + 6, copy.totalFileCount());
+            assertEquals(copy.stage(), IndexShardSnapshotStatus.Stage.DONE);
         }
         closeShards(shard);
     }
@@ -333,8 +333,8 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                 finFuture.actionGet();
             });
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
-            assertEquals(copy.getTotalFileCount(), copy.getIncrementalFileCount());
-            assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
+            assertEquals(copy.totalFileCount(), copy.incrementalFileCount());
+            assertEquals(copy.stage(), IndexShardSnapshotStatus.Stage.DONE);
         }
         shard.refresh("test");
         ShardRouting shardRouting = TestShardRouting.newShardRouting(
@@ -414,8 +414,8 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             assertEquals(original.exists(), restored.exists());
 
             if (original.exists()) {
-                Document document = original.docIdAndVersion().reader.document(original.docIdAndVersion().docId);
-                Document restoredDocument = restored.docIdAndVersion().reader.document(restored.docIdAndVersion().docId);
+                Document document = original.docIdAndVersion().reader().document(original.docIdAndVersion().docId());
+                Document restoredDocument = restored.docIdAndVersion().reader().document(restored.docIdAndVersion().docId());
                 for (IndexableField field : document) {
                     assertEquals(document.get(field.name()), restoredDocument.get(field.name()));
                 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -77,9 +77,9 @@ public class EnrichCache {
         return new EnrichStatsAction.Response.CacheStats(
             localNodeId,
             cache.count(),
-            cacheStats.getHits(),
-            cacheStats.getMisses(),
-            cacheStats.getEvictions()
+            cacheStats.hits(),
+            cacheStats.misses(),
+            cacheStats.evictions()
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -441,10 +441,10 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         for (GetTrainedModelsStatsAction.Response.TrainedModelStats modelStats : statsResponse.getResources().results()) {
             pipelineCount += modelStats.getPipelineCount();
             modelStats.getIngestStats().getProcessorStats().values().stream().flatMap(List::stream).forEach(processorStat -> {
-                if (processorStat.getName().equals(InferenceProcessor.TYPE)) {
-                    docCountStats.add(processorStat.getStats().getIngestCount());
-                    timeStats.add(processorStat.getStats().getIngestTimeInMillis());
-                    failureStats.add(processorStat.getStats().getIngestFailedCount());
+                if (processorStat.name().equals(InferenceProcessor.TYPE)) {
+                    docCountStats.add(processorStat.stats().getIngestCount());
+                    timeStats.add(processorStat.stats().getIngestTimeInMillis());
+                    failureStats.add(processorStat.stats().getIngestFailedCount());
                 }
             });
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -297,7 +297,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         filteredProcessorStats.keySet().retainAll(pipelineIds);
         List<IngestStats.PipelineStat> filteredPipelineStats = fullNodeStats.getPipelineStats()
             .stream()
-            .filter(pipelineStat -> pipelineIds.contains(pipelineStat.getPipelineId()))
+            .filter(pipelineStat -> pipelineIds.contains(pipelineStat.pipelineId()))
             .collect(Collectors.toList());
         CounterMetric ingestCount = new CounterMetric();
         CounterMetric ingestTimeInMillis = new CounterMetric();
@@ -305,7 +305,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         CounterMetric ingestFailedCount = new CounterMetric();
 
         filteredPipelineStats.forEach(pipelineStat -> {
-            IngestStats.Stats stats = pipelineStat.getStats();
+            IngestStats.Stats stats = pipelineStat.stats();
             ingestCount.inc(stats.getIngestCount());
             ingestTimeInMillis.inc(stats.getIngestTimeInMillis());
             ingestCurrent.inc(stats.getIngestCurrent());
@@ -328,8 +328,8 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
 
             ingestStats.getPipelineStats()
                 .forEach(
-                    pipelineStat -> pipelineStatsAcc.computeIfAbsent(pipelineStat.getPipelineId(), p -> new IngestStatsAccumulator())
-                        .inc(pipelineStat.getStats())
+                    pipelineStat -> pipelineStatsAcc.computeIfAbsent(pipelineStat.pipelineId(), p -> new IngestStatsAccumulator())
+                        .inc(pipelineStat.stats())
                 );
 
             ingestStats.getProcessorStats().forEach((pipelineId, processorStat) -> {
@@ -338,7 +338,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
                     k -> new LinkedHashMap<>()
                 );
                 processorStat.forEach(
-                    p -> processorAcc.computeIfAbsent(p.getName(), k -> new IngestStatsAccumulator(p.getType())).inc(p.getStats())
+                    p -> processorAcc.computeIfAbsent(p.name(), k -> new IngestStatsAccumulator(p.type())).inc(p.stats())
                 );
             });
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -561,20 +561,20 @@ public class ModelLoadingService implements ClusterStateListener {
 
     private void cacheEvictionListener(RemovalNotification<String, ModelAndConsumer> notification) {
         try {
-            if (notification.getRemovalReason() == RemovalNotification.RemovalReason.EVICTED) {
+            if (notification.removalReason() == RemovalNotification.RemovalReason.EVICTED) {
                 MessageSupplier msg = () -> new ParameterizedMessage(
                     "model cache entry evicted."
                         + "current cache [{}] current max [{}] model size [{}]. "
                         + "If this is undesired, consider updating setting [{}] or [{}].",
                     ByteSizeValue.ofBytes(localModelCache.weight()).getStringRep(),
                     maxCacheSize.getStringRep(),
-                    ByteSizeValue.ofBytes(notification.getValue().model.ramBytesUsed()).getStringRep(),
+                    ByteSizeValue.ofBytes(notification.value().model.ramBytesUsed()).getStringRep(),
                     INFERENCE_MODEL_CACHE_SIZE.getKey(),
                     INFERENCE_MODEL_CACHE_TTL.getKey()
                 );
-                auditIfNecessary(notification.getKey(), msg);
+                auditIfNecessary(notification.key(), msg);
             }
-            String modelId = modelAliasToId.getOrDefault(notification.getKey(), notification.getKey());
+            String modelId = modelAliasToId.getOrDefault(notification.key(), notification.key());
             logger.trace(
                 () -> new ParameterizedMessage(
                     "Persisting stats for evicted model [{}] (model_aliases {})",
@@ -588,9 +588,9 @@ public class ModelLoadingService implements ClusterStateListener {
             }
 
             // If the model is no longer referenced, flush the stats to persist as soon as possible
-            notification.getValue().model.persistStats(referencedModels.contains(modelId) == false);
+            notification.value().model.persistStats(referencedModels.contains(modelId) == false);
         } finally {
-            notification.getValue().model.release();
+            notification.value().model.release();
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -335,7 +335,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
         List<IngestStats.PipelineStat> pipelineNames,
         List<List<IngestStats.ProcessorStat>> processorStats
     ) {
-        List<String> pipelineids = pipelineNames.stream().map(IngestStats.PipelineStat::getPipelineId).collect(Collectors.toList());
+        List<String> pipelineids = pipelineNames.stream().map(IngestStats.PipelineStat::pipelineId).collect(Collectors.toList());
         IngestStats ingestStats = new IngestStats(
             overallStats,
             pipelineNames,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
@@ -422,7 +422,7 @@ public class PutJobStateMachineTests extends ESTestCase {
                 RollupField.TASK_NAME,
                 job,
                 123,
-                mock(PersistentTasksCustomMetadata.Assignment.class)
+                new PersistentTasksCustomMetadata.Assignment("node", "")
             );
             requestCaptor.getValue().onResponse(response);
             return null;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
@@ -158,7 +158,7 @@ public class CacheService extends AbstractLifecycleComponent {
             .weigher((key, entry) -> entry.getLength())
             // NORELEASE This does not immediately free space on disk, as cache file are only deleted when all index inputs
             // are done with reading/writing the cache file
-            .removalListener(notification -> onCacheFileEviction(notification.getValue()))
+            .removalListener(notification -> onCacheFileEviction(notification.value()))
             .build();
         this.persistentCache = Objects.requireNonNull(persistentCache);
         this.cacheSyncLock = new ReentrantLock();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -644,7 +644,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             fileChecksum,
             Version.CURRENT.luceneVersion.toString()
         );
-        final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, new ByteSizeValue(fileContent.length)));
+        final List<FileInfo> files = List.of(FileInfo.of(blobName, metadata, new ByteSizeValue(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);
         final Path shardDir = randomShardPath(shardId);
         final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -470,17 +470,17 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
 
                 assertThat(
                     "List of different files should be empty but got [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
-                    diff.different.isEmpty(),
+                    diff.different().isEmpty(),
                     is(true)
                 );
                 assertThat(
                     "List of missing files should be empty but got [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
-                    diff.missing.isEmpty(),
+                    diff.missing().isEmpty(),
                     is(true)
                 );
                 assertThat(
                     "List of files should be identical [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
-                    diff.identical.size(),
+                    diff.identical().size(),
                     equalTo(metadata.size())
                 );
                 assertThat("Number of files should be identical", snapshotMetadata.size(), equalTo(metadata.size()));
@@ -719,7 +719,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 final String blobName = randomAlphaOfLength(15);
                 Files.write(shardSnapshotDir.resolve(blobName), input, StandardOpenOption.CREATE_NEW);
                 randomFiles.add(
-                    new BlobStoreIndexShardSnapshot.FileInfo(
+                    BlobStoreIndexShardSnapshot.FileInfo.of(
                         blobName,
                         new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion.toString()),
                         new ByteSizeValue(input.length)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -82,7 +82,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(
                     snapshotId.getName(),
                     0L,
-                    List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, new ByteSizeValue(partSize))),
+                    List.of(BlobStoreIndexShardSnapshot.FileInfo.of(blobName, metadata, new ByteSizeValue(partSize))),
                     0L,
                     0L,
                     0,
@@ -200,7 +200,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(
                 snapshotId.getName(),
                 0L,
-                List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, new ByteSizeValue(input.length + 1))),
+                List.of(BlobStoreIndexShardSnapshot.FileInfo.of(blobName, metadata, new ByteSizeValue(input.length + 1))),
                 0L,
                 0L,
                 0,

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
@@ -64,7 +64,7 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
         Runnable onReadBlob
     ) throws IOException {
         final String fileName = randomAlphaOfLength(5) + randomFileExtension();
-        final FileInfo fileInfo = new FileInfo(
+        final FileInfo fileInfo = FileInfo.of(
             randomAlphaOfLength(5),
             new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST.toString()),
             partSize == input.length

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -52,7 +52,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         final byte[] fileData = bytes.v2();
         final String checksum = bytes.v1();
 
-        final FileInfo fileInfo = new FileInfo(
+        final FileInfo fileInfo = FileInfo.of(
             randomAlphaOfLength(10),
             new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion.toString()),
             new ByteSizeValue(fileData.length)

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -1300,11 +1300,11 @@ public class ApiKeyService {
 
     private RemovalListener<String, ListenableFuture<CachedApiKeyHashResult>> getAuthCacheRemovalListener(int maximumWeight) {
         return notification -> {
-            if (RemovalReason.EVICTED == notification.getRemovalReason() && getApiKeyAuthCache().count() >= maximumWeight) {
+            if (RemovalReason.EVICTED == notification.removalReason() && getApiKeyAuthCache().count() >= maximumWeight) {
                 evictionCounter.increment();
                 logger.trace(
                     "API key with ID [{}] was evicted from the authentication cache, " + "possibly due to cache size limit",
-                    notification.getKey()
+                    notification.key()
                 );
                 final long last = lastEvictionCheckedAt.get();
                 final long now = System.nanoTime();

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -846,7 +846,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             Store.MetadataSnapshot replicaAfterFailoverMetadataSnapshot = getMetadataSnapshot(replicaNodeNameAfterFailOver, indexName);
             Store.RecoveryDiff recoveryDiff = primaryMetadataSnapshot.recoveryDiff(replicaAfterFailoverMetadataSnapshot);
-            assertThat(recoveryDiff.identical, is(not(empty())));
+            assertThat(recoveryDiff.identical(), is(not(empty())));
         }
     }
 

--- a/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -515,8 +515,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
     }
 
     private void assertUsesExpectedSnapshot(ShardRecoveryPlan shardRecoveryPlan, ShardSnapshot expectedSnapshotToUse) {
-        assertThat(shardRecoveryPlan.getSnapshotFilesToRecover().getIndexId(), equalTo(expectedSnapshotToUse.getIndexId()));
-        assertThat(shardRecoveryPlan.getSnapshotFilesToRecover().getRepository(), equalTo(expectedSnapshotToUse.getRepository()));
+        assertThat(shardRecoveryPlan.getSnapshotFilesToRecover().indexId(), equalTo(expectedSnapshotToUse.getIndexId()));
+        assertThat(shardRecoveryPlan.getSnapshotFilesToRecover().repository(), equalTo(expectedSnapshotToUse.getRepository()));
 
         final Store.MetadataSnapshot shardSnapshotMetadataSnapshot = expectedSnapshotToUse.getMetadataSnapshot();
         for (BlobStoreIndexShardSnapshot.FileInfo fileInfo : shardRecoveryPlan.getSnapshotFilesToRecover()) {
@@ -602,7 +602,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
     ) {
         List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles = randomList(10, 20, () -> {
             StoreFileMetadata storeFileMetadata = randomStoreFileMetadata();
-            return new BlobStoreIndexShardSnapshot.FileInfo(randomAlphaOfLength(10), storeFileMetadata, PART_SIZE);
+            return BlobStoreIndexShardSnapshot.FileInfo.of(randomAlphaOfLength(10), storeFileMetadata, PART_SIZE);
         });
 
         return createShardSnapshot(repoName, snapshotFiles, version, luceneVersion);
@@ -614,7 +614,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
 
         List<BlobStoreIndexShardSnapshot.FileInfo> snapshotFiles = new ArrayList<>(sourceMetadata.size());
         for (StoreFileMetadata storeFileMetadata : sourceMetadata) {
-            BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            BlobStoreIndexShardSnapshot.FileInfo fileInfo = BlobStoreIndexShardSnapshot.FileInfo.of(
                 randomAlphaOfLength(10),
                 storeFileMetadata,
                 PART_SIZE


### PR DESCRIPTION
Try to represent immutable data with Java records introduced in JEP 395

Convert only existing immutable classes, no "POJO with setters to a record" refactorings.