### PR TITLE
[8.0] Remove unnecessary deprecation warning in Get Alias API (#82773)

### DIFF
--- a/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/SystemAliasIT.java
+++ b/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/SystemAliasIT.java
@@ -191,9 +191,7 @@ public class SystemAliasIT extends ESRestTestCase {
                 "this request accesses system indices: ["
                     + indexName
                     + "], "
-                    + "but in a future major version, direct access to system indices will be prevented by default",
-                "this request accesses aliases with names reserved for system indices: [.internal-unmanaged-alias], "
-                    + "but in a future major version, direct access to system indices and their aliases will not be allowed"
+                    + "but in a future major version, direct access to system indices will be prevented by default"
             )
         );
         Response response = client().performRequest(request);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -195,49 +195,5 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         if (netNewSystemIndices.isEmpty() == false) {
             throw systemIndices.netNewSystemIndexAccessException(threadContext, netNewSystemIndices);
         }
-        checkSystemAliasAccess(request, systemIndices, systemIndexAccessLevel, threadContext);
-    }
-
-    private static void checkSystemAliasAccess(
-        GetAliasesRequest request,
-        SystemIndices systemIndices,
-        SystemIndexAccessLevel systemIndexAccessLevel,
-        ThreadContext threadContext
-    ) {
-        final Predicate<String> systemIndexAccessAllowPredicate;
-        if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
-            systemIndexAccessAllowPredicate = name -> true;
-        } else if (systemIndexAccessLevel == SystemIndexAccessLevel.RESTRICTED) {
-            systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexNamePredicate(threadContext).negate();
-        } else {
-            throw new IllegalArgumentException("Unexpected system index access level: " + systemIndexAccessLevel);
-        }
-
-        final List<String> systemAliases = new ArrayList<>();
-        final List<String> netNewSystemAliases = new ArrayList<>();
-        for (String alias : request.aliases()) {
-            if (systemIndices.isSystemName(alias)) {
-                if (systemIndexAccessAllowPredicate.test(alias)) {
-                    if (systemIndices.isNetNewSystemIndex(alias)) {
-                        netNewSystemAliases.add(alias);
-                    } else {
-                        systemAliases.add(alias);
-                    }
-                }
-            }
-        }
-
-        if (systemAliases.isEmpty() == false) {
-            deprecationLogger.warn(
-                DeprecationCategory.API,
-                "open_system_alias_access",
-                "this request accesses aliases with names reserved for system indices: {}, but in a future major version, direct "
-                    + "access to system indices and their aliases will not be allowed",
-                systemAliases
-            );
-        }
-        if (netNewSystemAliases.isEmpty() == false) {
-            throw systemIndices.netNewSystemIndexAccessException(threadContext, netNewSystemAliases);
-        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -239,39 +239,6 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         assertThat(result.get("c").size(), equalTo(1));
     }
 
-    public void testDeprecationWarningEmittedWhenRequestingNonExistingAliasInSystemPattern() {
-        ClusterState state = systemIndexTestClusterState();
-        SystemIndices systemIndices = new SystemIndices(
-            Collections.singletonMap(
-                this.getTestName(),
-                new SystemIndices.Feature(
-                    this.getTestName(),
-                    "test feature",
-                    Collections.singletonList(new SystemIndexDescriptor(".y*", "an index that doesn't exist"))
-                )
-            )
-        );
-
-        GetAliasesRequest request = new GetAliasesRequest(".y");
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder().build();
-        final String[] concreteIndices = {};
-        assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
-            request,
-            concreteIndices,
-            aliases,
-            state,
-            SystemIndexAccessLevel.NONE,
-            null,
-            systemIndices
-        );
-        assertThat(result.size(), equalTo(0));
-        assertWarnings(
-            "this request accesses aliases with names reserved for system indices: [.y], but in a future major version, direct"
-                + " access to system indices and their aliases will not be allowed"
-        );
-    }
-
     public void testPostProcessDataStreamAliases() {
         var resolver = TestIndexNameExpressionResolver.newInstance();
         var tuples = List.of(new Tuple<>("logs-foo", 1), new Tuple<>("logs-bar", 1), new Tuple<>("logs-baz", 1));

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetDataStreamIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetDataStreamIT.java
@@ -111,9 +111,7 @@ public class FleetDataStreamIT extends ESRestTestCase {
             .setWarningsHandler(
                 warnings -> List.of(
                     "this request accesses system indices: [.fleet-artifacts-7], but "
-                        + "in a future major version, direct access to system indices will be prevented by default",
-                    "this request accesses aliases with names reserved for system indices: [.fleet-artifacts], but in a future major "
-                        + "version, direct access to system indices and their aliases will not be allowed"
+                        + "in a future major version, direct access to system indices will be prevented by default"
                 ).equals(warnings) == false
             )
             .build();


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove unnecessary deprecation warning in Get Alias API (#82773)