### PR TITLE
Fix testMasterFailoverDuringStaleIndicesCleanup

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1083,9 +1083,10 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             masterName
         );
 
+        // wait for the delete to show up in the CS so that the below snapshot is queued after it for sure
+        awaitNDeletionsInProgress(1);
         final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshotFromDataNode(repoName, "new-full-snapshot");
         waitForBlock(masterName, repoName);
-        awaitNDeletionsInProgress(1);
         awaitNumberOfSnapshotsInProgress(1);
         networkDisruption.startDisrupting();
         ensureStableCluster(3, dataNode);


### PR DESCRIPTION
We could run into the edge case where the delete randomly gets
queued after the snapshot so we don't trigger a stale index
cleanup as expected, never try to delete any data files and thus
fail on waiting for a block on data files.

Closes #83014
