### PR TITLE
[8.0] Fix testMasterFailoverDuringStaleIndicesCleanup (#83018)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1083,9 +1083,10 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             masterName
         );
 
+        // wait for the delete to show up in the CS so that the below snapshot is queued after it for sure
+        awaitNDeletionsInProgress(1);
         final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshotFromDataNode(repoName, "new-full-snapshot");
         waitForBlock(masterName, repoName);
-        awaitNDeletionsInProgress(1);
         awaitNumberOfSnapshotsInProgress(1);
         networkDisruption.startDisrupting();
         ensureStableCluster(3, dataNode);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix testMasterFailoverDuringStaleIndicesCleanup (#83018)