### PR TITLE
[Test] Fix header value assertion for 401 error

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -82,10 +82,7 @@ public class AnonymousUserIntegTests extends SecurityIntegTestCase {
                     .filter(header -> "WWW-Authenticate".equalsIgnoreCase(header.getName()))
                     .map(Header::getValue)
                     .toList();
-                assertThat(
-                    wwwAuthenticateHeaders,
-                    containsInAnyOrder(containsString("Basic"), containsString("Bearer"), containsString("ApiKey"))
-                );
+                assertThat(wwwAuthenticateHeaders, hasItems(containsString("Basic"), containsString("ApiKey")));
                 assertThat(EntityUtils.toString(response.getEntity()), containsString("security_exception"));
             }
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.user;
 
+import org.apache.http.Header;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
@@ -26,8 +27,12 @@ import org.elasticsearch.xpack.security.authz.AuthorizationService;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -75,8 +80,14 @@ public class AnonymousUserIntegTests extends SecurityIntegTestCase {
                 assertThat(EntityUtils.toString(response.getEntity()), containsString("security_exception"));
             } else {
                 assertThat(statusCode, is(401));
-                assertThat(response.getHeader("WWW-Authenticate"), notNullValue());
-                assertThat(response.getHeader("WWW-Authenticate"), containsString("Basic"));
+                final List<String> wwwAuthenticateHeaders = Arrays.stream(response.getHeaders())
+                    .filter(header -> "WWW-Authenticate".equalsIgnoreCase(header.getName()))
+                    .map(Header::getValue)
+                    .toList();
+                assertThat(
+                    wwwAuthenticateHeaders,
+                    containsInAnyOrder(containsString("Basic"), containsString("Bearer"), containsString("ApiKey"))
+                );
                 assertThat(EntityUtils.toString(response.getEntity()), containsString("security_exception"));
             }
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/user/AnonymousUserIntegTests.java
@@ -31,13 +31,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class AnonymousUserIntegTests extends SecurityIntegTestCase {


### PR DESCRIPTION
The WWW-Authenticate header is multi-valued. In rare cases, the first
value may not be the one beginning with "Basic". The PR makes the
assertion agnostic to the order and also asserts for all possible header
values.

Resolves: #83022
