### PR TITLE
[DOCS] Re-add network traffic reduction tip to terms lookup docs

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -87,10 +87,16 @@ By default, {es} limits the `terms` query to a maximum of 65,536
 terms. This includes terms fetched using terms lookup. You can change
 this limit using the <<index-max-terms-count, `index.max_terms_count`>> setting.
 
+To reduce network traffic, a terms lookup will fetch the document's values from
+a shard on a local data node if possible. If the your terms data is not large,
+consider using an index with a single primary shard that's fully replicated
+across all applicable data nodes to minimize network traffic.
+
 To perform a terms lookup, use the following parameters.
 
 [[query-dsl-terms-lookup-params]]
 ====== Terms lookup parameters
+
 `index`::
 (Required, string) Name of the index from which to fetch field values.
 


### PR DESCRIPTION
Re-adds a paragraph about minimizing network traffic for a terms lookup.

This paragraph was erroneously removed as part of https://github.com/elastic/elasticsearch/pull/42889.

### Preview
https://elasticsearch_83047.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-terms-query.html#query-dsl-terms-lookup