### PR TITLE
[7.17] [DOCS] Fixes field names in ML sum functions. (#83048)

### DIFF
--- a/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
@@ -282,5 +282,5 @@ PUT _ml/anomaly_detectors/example7
 
 This example detects instances of port scanning. When you use this function in a
 detector in your {anomaly-job}, it models the distinct count of ports. It also
-detects the `src_ip` values that connect to an unusually high number of different
-`dst_ports` values compared to other `src_ip` values.
+detects the `src_ip` values that connect to an unusually high number of 
+different `dst_ports` values compared to other `src_ip` values.

--- a/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
@@ -102,8 +102,8 @@ is not applicable for this function.
 --------------------------------------------------
 {
   "function" : "high_non_null_sum",
-  "fieldName" : "amount_approved",
-  "byFieldName" : "employee"
+  "field_name" : "amount_approved",
+  "by_field_name" : "employee"
 }
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Fixes field names in ML sum functions. (#83048)