### PR TITLE
fix flakiness of snapshot.restore/10_basic.yml yaml it

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="PROJECT_RELATIVE:/home/idegtiarenko/Projects/elastic/elasticsearch/checkstyle_ide.xml:Elasticsearch" />
+        <entry key="active-configuration" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_ide.xml:Elasticsearch" />
         <entry key="checkstyle-version" value="8.42" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="PROJECT_RELATIVE:/home/idegtiarenko/Projects/elastic/elasticsearch/checkstyle_ide.xml:Elasticsearch" />
+        <entry key="location-2" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_ide.xml:Elasticsearch" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="JavaOnlyWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_ide.xml:Elasticsearch" />
+        <entry key="active-configuration" value="PROJECT_RELATIVE:/home/idegtiarenko/Projects/elastic/elasticsearch/checkstyle_ide.xml:Elasticsearch" />
         <entry key="checkstyle-version" value="8.42" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_ide.xml:Elasticsearch" />
+        <entry key="location-2" value="PROJECT_RELATIVE:/home/idegtiarenko/Projects/elastic/elasticsearch/checkstyle_ide.xml:Elasticsearch" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="JavaOnlyWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -22,7 +22,7 @@ setup:
         wait_for_status: green
 
 ---
-"Create a snapshot and then restore it":
+"Create a snapshot with single index and then restore it":
 
   - skip:
       features: ["allowed_warnings"]
@@ -32,24 +32,10 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot_1
         wait_for_completion: true
-
-  - match: { snapshot.snapshot: test_snapshot_1 }
-  - match: { snapshot.state : SUCCESS }
-  # snapshot can contain system indices and have shards.successful >=1
-  - gt: { snapshot.shards.successful: 0 }
-  - match: { snapshot.shards.failed : 0 }
-  - is_true: snapshot.version
-  - gt: { snapshot.version_id: 0}
-
-  - do:
-      snapshot.create:
-        repository: test_repo_restore_1
-        snapshot: test_snapshot_2
-        wait_for_completion: true
         body:
           indices: "test_index"
 
-  - match: { snapshot.snapshot: test_snapshot_2 }
+  - match: { snapshot.snapshot: test_snapshot_1 }
   - match: { snapshot.state : SUCCESS }
   - match: { snapshot.shards.successful: 1 }
   - match: { snapshot.shards.failed : 0 }
@@ -65,8 +51,53 @@ setup:
   - do:
       snapshot.restore:
         repository: test_repo_restore_1
+        snapshot: test_snapshot_1
+        wait_for_completion: true
+
+  - do:
+      indices.recovery:
+        index: test_index
+
+  - match: { test_index.shards.0.type: SNAPSHOT }
+  - match: { test_index.shards.0.stage: DONE }
+  - match: { test_index.shards.0.index.files.recovered: 1}
+  - gt:    { test_index.shards.0.index.size.recovered_in_bytes: 0}
+  - match: { test_index.shards.0.index.files.reused: 0}
+  - match: { test_index.shards.0.index.size.reused_in_bytes: 0}
+
+---
+"Create a snapshot and then restore single index from it":
+
+  - skip:
+      features: ["allowed_warnings"]
+
+  - do:
+      snapshot.create:
+        repository: test_repo_restore_1
         snapshot: test_snapshot_2
         wait_for_completion: true
+
+  - match: { snapshot.snapshot: test_snapshot_2 }
+  - match: { snapshot.state : SUCCESS }
+  # snapshot can contain system indices and have shards.successful >=1
+  - gt: { snapshot.shards.successful: 0 }
+  - match: { snapshot.shards.failed : 0 }
+  - is_true: snapshot.version
+  - gt: { snapshot.version_id: 0}
+
+  - do:
+      indices.close:
+        index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
+
+  - do:
+      snapshot.restore:
+        repository: test_repo_restore_1
+        snapshot: test_snapshot_2
+        wait_for_completion: true
+        body:
+          indices: "test_index"
 
   - do:
       indices.recovery:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -32,6 +32,8 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot
         wait_for_completion: true
+        body:
+          indices: "test_index"
 
   - match: { snapshot.snapshot: test_snapshot }
   - match: { snapshot.state : SUCCESS }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -30,12 +30,26 @@ setup:
   - do:
       snapshot.create:
         repository: test_repo_restore_1
-        snapshot: test_snapshot
+        snapshot: test_snapshot_1
+        wait_for_completion: true
+
+  - match: { snapshot.snapshot: test_snapshot_1 }
+  - match: { snapshot.state : SUCCESS }
+  # snapshot can contain system indices and have shards.successful >=1
+  - gt: { snapshot.shards.successful: 0 }
+  - match: { snapshot.shards.failed : 0 }
+  - is_true: snapshot.version
+  - gt: { snapshot.version_id: 0}
+
+  - do:
+      snapshot.create:
+        repository: test_repo_restore_1
+        snapshot: test_snapshot_2
         wait_for_completion: true
         body:
           indices: "test_index"
 
-  - match: { snapshot.snapshot: test_snapshot }
+  - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : SUCCESS }
   - match: { snapshot.shards.successful: 1 }
   - match: { snapshot.shards.failed : 0 }
@@ -51,7 +65,7 @@ setup:
   - do:
       snapshot.restore:
         repository: test_repo_restore_1
-        snapshot: test_snapshot
+        snapshot: test_snapshot_2
         wait_for_completion: true
 
   - do:


### PR DESCRIPTION
This test performs snapshot and verifies it has exactly 1 successful
shard. It could fail when additional indices might be added (such as
system .task index).

Closes: #83028 