### PR TITLE
[DOCS] Rename example stored script

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -848,7 +848,7 @@ You can also specify a <<modules-scripting-stored-scripts,stored script>> as the
 
 [source,console]
 ----
-PUT _scripts/my-stored-script
+PUT _scripts/my-prod-tag-script
 {
   "script": {
     "lang": "painless",
@@ -872,12 +872,20 @@ PUT _ingest/pipeline/my-pipeline
     {
       "drop": {
         "description": "Drop documents that don't contain 'prod' tag",
-        "if": { "id": "my-stored-script" }
+        "if": { "id": "my-prod-tag-script" }
       }
     }
   ]
 }
 ----
+
+////
+[source,console]
+----
+DELETE _scripts/my-prod-tag-script
+----
+// TEST[continued]
+////
 
 Incoming documents often contain object fields. If a processor script attempts
 to access a field whose parent object does not exist, {es} returns a


### PR DESCRIPTION
Changes:

* Renames the example stored script to avoid naming collisions with the [stored script API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/create-stored-script-api.html).
* Adds a hidden snippet to delete the script for cleanup.

Relates to https://github.com/elastic/elasticsearch/issues/83038