### PR TITLE
[DOCS] Fix stored script example snippet

### DIFF
--- a/docs/reference/scripting/apis/create-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/create-stored-script-api.asciidoc
@@ -13,13 +13,18 @@ PUT _scripts/my-stored-script
 {
   "script": {
     "lang": "painless",
-    "source": """
-      TimestampHour date =  doc['@timestamp'].value; 
-      return date.getHour()
-    """
+    "source": "Math.log(_score * 2) + params['my_modifier']"
   }
 }
 ----
+
+////
+[source,console]
+----
+DELETE _scripts/my-stored-script
+----
+// TEST[continued]
+////
 
 [[create-stored-script-api-request]]
 ==== {api-request-title}

--- a/docs/reference/scripting/apis/delete-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/delete-stored-script-api.asciidoc
@@ -14,10 +14,7 @@ PUT _scripts/my-stored-script
 {
   "script": {
     "lang": "painless",
-    "source": """
-      TimestampHour date =  doc['@timestamp'].value; 
-      return date.getHour()
-    """
+    "source": "Math.log(_score * 2) + params['my_modifier']"
   }
 }
 ----

--- a/docs/reference/scripting/apis/get-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/get-stored-script-api.asciidoc
@@ -14,10 +14,7 @@ PUT _scripts/my-stored-script
 {
   "script": {
     "lang": "painless",
-    "source": """
-      TimestampHour date =  doc['@timestamp'].value; 
-      return date.getHour()
-    """
+    "source": "Math.log(_score * 2) + params['my_modifier']"
   }
 }
 ----
@@ -28,6 +25,14 @@ PUT _scripts/my-stored-script
 GET _scripts/my-stored-script
 ----
 // TEST[continued]
+
+////
+[source,console]
+----
+DELETE _scripts/my-stored-script
+----
+// TEST[continued]
+////
 
 [[get-stored-script-api-request]]
 ==== {api-request-title}


### PR DESCRIPTION
Changes:

* Updates the example Painless script to be valid and aligns it with the example in [How to write a script](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-using.html#script-stored-scripts).
* Adds a hidden snippets to delete the script for cleanup.

Relates to https://github.com/elastic/elasticsearch/issues/83038