### PR TITLE
[8.0] [ML][DOCS] Add Trained model APIs to the REST APIs index (#82791)

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -32,6 +32,7 @@ not be included yet.
 * <<logstash-apis,Logstash APIs>>
 * <<ml-apis,{ml-cap} {anomaly-detect} APIs>>
 * <<ml-df-analytics-apis,{ml-cap} {dfanalytics} APIs>>
+* <<ml-df-trained-models-apis,{ml-cap} trained model APIs>>
 * <<migration-api,Migration APIs>>
 * <<node-lifecycle-api,Node lifecycle API>>
 * <<indices-reload-analyzers,Reload search analyzers API>>


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML][DOCS] Add Trained model APIs to the REST APIs index (#82791)