### PR TITLE
[ML] Update running process when global calendar changes

### DIFF
--- a/docs/changelog/83044.yaml
+++ b/docs/changelog/83044.yaml
@@ -1,0 +1,5 @@
+pr: 83044
+summary: Update running process when global calendar changes
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml.job.config;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -443,6 +444,11 @@ public class JobUpdate implements Writeable, ToXContentObject {
         }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this::toXContent);
     }
 
     public Set<String> getUpdateFields() {


### PR DESCRIPTION
Adding events to global calendars did not update open
jobs as the special _all job Id was not checked.

Back port of #83044