### PR TITLE
[DOCS] Fix typo in `action.destructive_requires_name` breaking change

### DIFF
--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -8,7 +8,7 @@
 //tag::notable-breaking-changes[]
 TIP: {ess-setting-change}
 
-.`action.destructive_requires_name` now defaults to `false`. {ess-icon}
+.`action.destructive_requires_name` now defaults to `true`. {ess-icon}
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
In 8.0+, the `action.destructive_requires_name` setting defaults to `true`, not `false`.