### PR TITLE
[8.0] [DOCS] Fix typo in `action.destructive_requires_name` breaking change (#83085)

### DIFF
--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -8,7 +8,7 @@
 //tag::notable-breaking-changes[]
 TIP: {ess-setting-change}
 
-.`action.destructive_requires_name` now defaults to `false`. {ess-icon}
+.`action.destructive_requires_name` now defaults to `true`. {ess-icon}
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix typo in `action.destructive_requires_name` breaking change (#83085)