### PR TITLE
[Docs] Watcher clarification on CSV formulas warning.

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -264,6 +264,13 @@ HTML feature groups>>.
 Set to `false` to completely disable HTML sanitation. Not recommended.
 Defaults to `true`.
 
+`xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
+(<<dynamic-cluster-setting,Dynamic>>)
+Specifies a custom message to be sent if the formula verification criteria
+for CSV files, from {kib}'s {kib-ref}/reporting-settings-kb.html#reporting-csv-settings[`xpack.reporting.csv.checkForFormulas`], is true.
+Use %s in the message as a placeholder for the filename.
+Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
+
 [[ssl-notification-smtp-settings]]
 :ssl-prefix:             xpack.notification.email
 :component:              {watcher} Email
@@ -272,12 +279,6 @@ Defaults to `true`.
 :ssl-context:            watcher-email
 
 include::ssl-settings.asciidoc[]
-
-`xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
-(<<dynamic-cluster-setting,Dynamic>>) 
-Specifies a custom message to be sent if the formula verification criteria
-for CSV files, from kibana `xpack.reporting.csv.checkForFormulas`, is true.
-Use %s in the message as a placeholder for the filename.  
 
 [[slack-notification-settings]]
 ==== Slack Notification Settings

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -266,8 +266,8 @@ Defaults to `true`.
 
 `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
 (<<dynamic-cluster-setting,Dynamic>>)
-Specifies a custom message to be sent if the formula verification criteria
-for CSV files, from {kib}'s {kibana-ref}/reporting-settings-kb.html#reporting-csv-settings[`xpack.reporting.csv.checkForFormulas`], is true.
+Specifies a custom message, which is sent if the formula verification criteria
+for CSV files from {kib}'s {kibana-ref}/reporting-settings-kb.html#reporting-csv-settings[`xpack.reporting.csv.checkForFormulas`] is `true`.
 Use `%s` in the message as a placeholder for the filename.
 Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
 

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -267,8 +267,8 @@ Defaults to `true`.
 `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
 (<<dynamic-cluster-setting,Dynamic>>)
 Specifies a custom message to be sent if the formula verification criteria
-for CSV files, from {kib}'s {kib-ref}/reporting-settings-kb.html#reporting-csv-settings[`xpack.reporting.csv.checkForFormulas`], is true.
-Use %s in the message as a placeholder for the filename.
+for CSV files, from {kib}'s {kibana-ref}/reporting-settings-kb.html#reporting-csv-settings[`xpack.reporting.csv.checkForFormulas`], is true.
+Use `%s` in the message as a placeholder for the filename.
 Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
 
 [[ssl-notification-smtp-settings]]


### PR DESCRIPTION
Update docs for Watcher notification settings to include default `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text` value and link to the Kibana documentation.

Existing https://www.elastic.co/guide/en/elasticsearch/reference/master/notification-settings.html#watcher-email-pkcs12-files

> **PKCS#12 files**
> ...
>
>  `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`
>    (Dynamic) Specifies a custom message to be sent if the formula verification criteria for CSV files, from kibana `xpack.reporting.csv.checkForFormulas`, is true. Use %s in the message as a placeholder for the filename. 
> 
> **Slack Notification Settings**
> ...


Proposed https://www.elastic.co/guide/en/elasticsearch/reference/master/notification-settings.html#email-notification-settings

> **Email Notification Settings**
> ...
> 
>  `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`
>    (Dynamic) Specifies a custom message to be sent if the formula verification criteria for CSV files, from Kibana's [`xpack.reporting.csv.checkForFormulas`](https://www.elastic.co/guide/en/kibana/7.16/reporting-settings-kb.html#reporting-csv-settings), is true. Use %s in the message as a placeholder for the filename. 
> Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
> 
> **Watcher Email TLS/SSL settings**
> ...

The missing space in the default value was already fixed on the master branch but it isn't on 7.16.