### PR TITLE
[7.17] Remove unnecessary deprecation warning in Get Alias API (#82773)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -241,40 +241,6 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         assertThat(result.get("c").size(), equalTo(1));
     }
 
-    public void testDeprecationWarningEmittedWhenRequestingNonExistingAliasInSystemPattern() {
-        ClusterState state = systemIndexTestClusterState();
-        SystemIndices systemIndices = new SystemIndices(
-            Collections.singletonMap(
-                this.getTestName(),
-                new SystemIndices.Feature(
-                    this.getTestName(),
-                    "test feature",
-                    Collections.singletonList(new SystemIndexDescriptor(".y*", "an index that doesn't exist"))
-                )
-            )
-        );
-
-        GetAliasesRequest request = new GetAliasesRequest(".y");
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder().build();
-        final String[] concreteIndices = {};
-        assertEquals(state.metadata().findAliases(request, concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
-            request,
-            concreteIndices,
-            aliases,
-            state,
-            SystemIndexAccessLevel.NONE,
-            null,
-            systemIndices
-        );
-        assertThat(result.size(), equalTo(0));
-        assertWarnings(
-            Level.WARN,
-            "this request accesses aliases with names reserved for system indices: [.y], but in a future major version, direct"
-                + " access to system indices and their aliases will not be allowed"
-        );
-    }
-
     public void testPostProcessDataStreamAliases() {
         IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
         List<Tuple<String, Integer>> tuples = Arrays.asList(

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetDataStreamIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetDataStreamIT.java
@@ -111,9 +111,7 @@ public class FleetDataStreamIT extends ESRestTestCase {
             .setWarningsHandler(
                 warnings -> org.elasticsearch.core.List.of(
                     "this request accesses system indices: [.fleet-artifacts-7], but "
-                        + "in a future major version, direct access to system indices will be prevented by default",
-                    "this request accesses aliases with names reserved for system indices: [.fleet-artifacts], but in a future major "
-                        + "version, direct access to system indices and their aliases will not be allowed"
+                        + "in a future major version, direct access to system indices will be prevented by default"
                 ).equals(warnings) == false
             )
             .build();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Remove unnecessary deprecation warning in Get Alias API (#82773)