### PR TITLE
[DOCS] Delete pipeline containing stored script

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -883,6 +883,7 @@ PUT _ingest/pipeline/my-pipeline
 [source,console]
 ----
 DELETE _scripts/my-prod-tag-script
+DELETE _ingest/pipeline/my-pipeline
 ----
 // TEST[continued]
 ////


### PR DESCRIPTION
Adds a hidden snippet to delete the pipeline containing a stored script for cleanup.

Relates to https://github.com/elastic/elasticsearch/issues/83097.