### PR TITLE
Always emit product origin to deprecation log if present

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -49,7 +49,7 @@ public class DeprecatedMessage extends ESLogMessage {
         if (Strings.isNullOrEmpty(xOpaqueId) == false) {
             builder.put(X_OPAQUE_ID_FIELD_NAME, xOpaqueId);
         }
-        if (Strings.isNullOrEmpty(xOpaqueId) == false) {
+        if (Strings.isNullOrEmpty(productOrigin) == false) {
             builder.put(ELASTIC_ORIGIN_FIELD_NAME, productOrigin);
         }
         return builder.immutableMap();


### PR DESCRIPTION
Prior to this commit, we only emit the product origin to the deprecation log
if there's an opaque ID present. This is very counterintuitive, and probably
not intentional given that it doesn't match the behavior in `master`.

This commit changes the behavior so that the product origin
will always be included in the deprecation log JSON if it's present in the
context of the request.