### PR TITLE
[7.17] Support GKE Workload Identity for Searchable Snapshots (#82974)

### DIFF
--- a/docs/changelog/82974.yaml
+++ b/docs/changelog/82974.yaml
@@ -1,0 +1,6 @@
+pr: 82974
+summary: Support GKE Workload Identity for Searchable Snapshots
+area: Snapshot/Restore
+type: bug
+issues:
+ - 82702

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -188,7 +188,7 @@ public class GoogleCloudStorageService {
         } else {
             String defaultProjectId = null;
             try {
-                defaultProjectId = ServiceOptions.getDefaultProjectId();
+                defaultProjectId = SocketAccess.doPrivilegedIOException(ServiceOptions::getDefaultProjectId);
                 if (defaultProjectId != null) {
                     storageOptionsBuilder.setProjectId(defaultProjectId);
                 }
@@ -212,7 +212,7 @@ public class GoogleCloudStorageService {
         }
         if (gcsClientSettings.getCredential() == null) {
             try {
-                storageOptionsBuilder.setCredentials(GoogleCredentials.getApplicationDefault());
+                storageOptionsBuilder.setCredentials(SocketAccess.doPrivilegedIOException(GoogleCredentials::getApplicationDefault));
             } catch (Exception e) {
                 logger.warn("failed to load Application Default Credentials", e);
             }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Support GKE Workload Identity for Searchable Snapshots (#82974)