### PR TITLE
[8.0] Remove assertion about GCS credentials always being null when not set explicetly (#83139)

### DIFF
--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.repositories.gcs;
 
-import com.google.auth.Credentials;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 
@@ -94,7 +93,6 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
             ((HttpTransportOptions) storage.getOptions().getTransportOptions()).getReadTimeout(),
             Matchers.is((int) readTimeValue.millis())
         );
-        assertThat(storage.getOptions().getCredentials(), Matchers.nullValue(Credentials.class));
         assertThat(proxy.get().toString(), equalTo("HTTP @ /192.168.52.15:8080"));
     }
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove assertion about GCS credentials always being null when not set explicetly (#83139)