### PR TITLE
[7.17] Remove assertion about GCS credentials always being null when not set explicetly (#83139)

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.repositories.gcs;
 
-import com.google.auth.Credentials;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 
@@ -33,7 +32,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class GoogleCloudStorageServiceTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/83131")
     public void testClientInitializer() throws Exception {
         final String clientName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final TimeValue connectTimeValue = TimeValue.timeValueNanos(randomIntBetween(0, 2000000));
@@ -84,7 +82,6 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
             ((HttpTransportOptions) storage.getOptions().getTransportOptions()).getReadTimeout(),
             Matchers.is((int) readTimeValue.millis())
         );
-        assertThat(storage.getOptions().getCredentials(), Matchers.nullValue(Credentials.class));
     }
 
     public void testReinitClientSettings() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Remove assertion about GCS credentials always being null when not set explicetly (#83139)