### PR TITLE
[8.0] Make ValidateJsonNoKeywordsTask gradle configuration cache ready (#82864)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
@@ -47,7 +47,6 @@ import java.util.stream.StreamSupport;
  */
 public class ValidateJsonNoKeywordsTask extends DefaultTask {
 
-    private final ObjectMapper mapper = new ObjectMapper().configure(JsonParser.Feature.ALLOW_COMMENTS, true);
     private File jsonKeywords;
     private File report;
     private FileCollection inputFiles;
@@ -82,11 +81,12 @@ public class ValidateJsonNoKeywordsTask extends DefaultTask {
 
     @TaskAction
     public void validate(InputChanges inputChanges) {
+        final ObjectMapper mapper = new ObjectMapper().configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         final Map<File, Set<String>> errors = new LinkedHashMap<>();
 
         getLogger().debug("Loading keywords from {}", jsonKeywords.getName());
 
-        final Map<String, Set<String>> languagesByKeyword = loadKeywords();
+        final Map<String, Set<String>> languagesByKeyword = loadKeywords(mapper);
 
         // incrementally evaluate input files
         StreamSupport.stream(inputChanges.getFileChanges(getInputFiles()).spliterator(), false)
@@ -173,7 +173,7 @@ public class ValidateJsonNoKeywordsTask extends DefaultTask {
      *
      * @return a mapping from keyword to languages.
      */
-    private Map<String, Set<String>> loadKeywords() {
+    private Map<String, Set<String>> loadKeywords(ObjectMapper mapper) {
         Map<String, Set<String>> languagesByKeyword = new HashMap<>();
 
         try {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Make ValidateJsonNoKeywordsTask gradle configuration cache ready (#82864)