### PR TITLE
Update release notes for 7.17.0 BC3

### DIFF
--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -74,9 +74,6 @@ Authorization::
 CRUD::
 * Fix potential listener leak in `TransportBulkAction` {es-pull}81894[#81894]
 
-Data streams::
-* Change `DataStream` class to have a single public constructor {es-pull}82464[#82464]
-
 Geo::
 * Handle degenerated rectangles in vector tiles {es-pull}82404[#82404] (issue: {es-issue}81891[#81891])
 * `GeoPolygonDecomposer` might fail due to numerical errors when calculating intersection with the dateline {es-pull}82953[#82953] (issue: {es-issue}82840[#82840])

--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -94,6 +94,7 @@ Infra/Core::
 
 Infra/Logging::
 * Add `doPrivileged` section in deprecation logger {es-pull}81819[#81819] (issue: {es-issue}81708[#81708])
+* Always emit product origin to deprecation log if present {es-pull}83115[#83115]
 
 Ingest::
 * Filter enrich policy index deletes to just the policy's associated indices {es-pull}82568[#82568]
@@ -117,14 +118,16 @@ Search::
 * Fix bug where field is not returned if it has the same prefix as a nested field {es-pull}82922[#82922] (issue: {es-issue}82905[#82905])
 
 Settings::
-* Check both node and cluster settings in `NodeDeprecationChecks` {es-pull}82487[#82487] (issue: {es-issue}82484[#82484])
 * Change `deprecation.skip_deprecated_settings` to work with dynamic settings {es-pull}81836[#81836]
+* Check both node and cluster settings in `NodeDeprecationChecks` {es-pull}82487[#82487] (issue: {es-issue}82484[#82484])
 * Ignore dynamic settings specified by `deprecation.skip_deprecated_settings` in node deprecation checks {es-pull}82883[#82883] (issue: {es-issue}82889[#82889])
 
 Snapshot/Restore::
 * Always fail snapshot deletion listeners on master failover {es-pull}82361[#82361] (issue: {es-issue}81596[#81596])
 * Fix potential repository corruption during master failover {es-pull}82912[#82912] (issue: {es-issue}82911[#82911])
 * Remove requirement for key setting on Azure client settings {es-pull}82030[#82030]
+* Support GKE workload identity for searchable snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
+
 
 
 [[upgrade-7.17.0]]


### PR DESCRIPTION
https://elasticsearch_83153.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.0.html

Follow-up on https://github.com/elastic/elasticsearch/pull/82858 .