### PR TITLE
[7.17] Minor typo, attribute -> attributes (#83150)

### DIFF
--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -190,8 +190,8 @@ sp.logout::
     proxies involved, but it will typically be +$\{kibana-url}/logout+ where
     _$\{kibana-url}_ is the base URL for your {kib} instance.
 
-attribute.principal:: See <<saml-attributes-mapping>>.
-attribute.groups:: See <<saml-attributes-mapping>>.
+attributes.principal:: See <<saml-attributes-mapping>>.
+attributes.groups:: See <<saml-attributes-mapping>>.
 
 [[saml-attributes-mapping]]
 ==== Attribute mapping


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Minor typo, attribute -> attributes (#83150)