### PR TITLE
Cleanup jackson build tool dependencies

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -202,14 +202,9 @@ configurations {
   integTestRuntimeOnly.extendsFrom(testRuntimeOnly)
 }
 dependencies {
-  constraints {
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.getProperty('jackson')}") {
-      version {
-        strictly "${versions.getProperty('jackson')}"
-      }
-      because 'We want to use the exact same jackson version we use in production'
-    }
-  }
+  components.all(JacksonAlignmentRule)
+  // Forcefully downgrade the jackson platform as used in production
+  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:${versions.getProperty('jackson')}")
   api localGroovy()
   api gradleApi()
 
@@ -230,7 +225,8 @@ dependencies {
   api 'de.thetaphi:forbiddenapis:3.2'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.13'
   api 'org.apache.maven:maven-model:3.6.2'
-  api 'com.networknt:json-schema-validator:1.0.65'
+  // needs to match the jackson minor version in use
+  api 'com.networknt:json-schema-validator:1.0.49'
   api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.getProperty('jackson')}"
   api 'org.ow2.asm:asm:9.2'
   api 'org.ow2.asm:asm-tree:9.2'
@@ -297,4 +293,15 @@ tasks.register("bootstrapPerformanceTests", Copy) {
   into('build/performanceTests')
   def root = file('..')
   filter(ReplaceTokens, tokens: [testGitCommit:GitInfo.gitInfo(root).revision])
+}
+
+abstract class JacksonAlignmentRule implements ComponentMetadataRule {
+  void execute(ComponentMetadataContext ctx) {
+    ctx.details.with {d ->
+      if (d.id.group.startsWith("com.fasterxml.jackson")) {
+        // declare that Jackson modules all belong to the Jackson virtual platform
+        belongsTo("com.fasterxml.jackson:jackson-bom:${d.id.version}")
+      }
+    }
+  }
 }


### PR DESCRIPTION
- use jackson platform
- use compatible schema validator version