### PR TITLE
[8.0] Correct context for batched reroute notifications (#83019)

### DIFF
--- a/docs/changelog/83019.yaml
+++ b/docs/changelog/83019.yaml
@@ -1,0 +1,5 @@
+pr: 83019
+summary: Correct context for batched reroute notifications
+area: Allocation
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Correct context for batched reroute notifications (#83019)