### PR TITLE
Make AllocationDeciders.canRemain more Efficient

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * A composite {@link AllocationDecider} combining the "decision" of multiple
@@ -27,10 +26,10 @@ public class AllocationDeciders extends AllocationDecider {
 
     private static final Logger logger = LogManager.getLogger(AllocationDeciders.class);
 
-    private final Collection<AllocationDecider> allocations;
+    private final AllocationDecider[] allocations;
 
     public AllocationDeciders(Collection<AllocationDecider> allocations) {
-        this.allocations = Collections.unmodifiableCollection(allocations);
+        this.allocations = allocations.toArray(AllocationDecider[]::new);
     }
 
     @Override
@@ -265,7 +264,7 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    private void addDecision(Decision.Multi ret, Decision decision, RoutingAllocation allocation) {
+    private static void addDecision(Decision.Multi ret, Decision decision, RoutingAllocation allocation) {
         // We never add ALWAYS decisions and only add YES decisions when requested by debug mode (since Multi default is YES).
         if (decision != Decision.ALWAYS
             && (allocation.getDebugMode() == RoutingAllocation.DebugMode.ON || decision.type() != Decision.Type.YES)) {


### PR DESCRIPTION
The iteration before this change was over the value collection
of a linked hash map, wrapped in unmodifiable. Given that this runs
approximately #deciders * #shards iterations during a reroute it
makes sense to optimize here.
In practice the iteration did not inline well and showed up as about
25% of the overall cost of this method.

relates #77466 