### PR TITLE
[DOCS] Add redirect for 'Java client and security' page

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -3,6 +3,15 @@
 
 The following pages have moved or been deleted.
 
+[role="exclude",id="java-clients"]
+=== Java transport client and security
+
+The Java transport client has been removed. Use the
+https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java
+high-level REST client] instead. For migration steps, refer to the
+https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration
+guide].
+
 // [START] Snapshot and restore
 
 [role="exclude",id="snapshot-lifecycle-management"]


### PR DESCRIPTION
Adds a redirect for the [Java client and security](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/java-clients.html) page, which has been removed in 8.0+.

We saw this missing page create several broken links in https://github.com/elastic/docs/pull/2312. I've opened separate PRs to update those links. This adds a redirect for anyone who otherwise lands on the page.

### Preview
https://elasticsearch_83180.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/java-clients.html