### PR TITLE
Carry over release highlights from Lucene 9.0.

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -18,22 +18,22 @@ For detailed information about this release, see the <<es-release-notes>> and
 [discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
 
-We've updated inverted indices, an internal data structure, to use a more space-efficient encoding.
-This change will benefit `keyword` fields, `match_only_text` fields, and, to a
-lesser extent, `text` fields. In our benchmarks using application logs, this translated into a 14.4% reduction of the
-size of the index of the `message` field (mapped as `match_only_text`) and an
-overall 3.5% reduction of the on-disk footprint.
+We've updated inverted indices, an internal data structure, to use a more
+space-efficient encoding. This change will benefit `keyword` fields,
+`match_only_text` fields, and, to a lesser extent, `text` fields. In our
+benchmarks using application logs, this translated into a 14.4% reduction of
+the size of the index of the `message` field (mapped as `match_only_text`) and
+an overall 3.5% reduction of the on-disk footprint.
 
-This change will be picked up automatically by both new indices, and existing
-indices for every new segment.
+This change will be picked up automatically by both new indices, and existing indices for every new segment.
 
 [discrete]
 === Faster indexing of `geo_point`, `geo_shape`, and range fields
 
-We've optimized indexing speeds for multi-dimensional points, an
-internal data structure used for `geo_point`, `geo_shape`, and range fields.
-Our benchmarks reported 10-15% faster indexing for these fields types. {es}
-indices and data streams that mostly consist of these fields may see noticeable
+We've optimized indexing speeds for multi-dimensional points, an internal data
+structure used for `geo_point`, `geo_shape`, and range fields. Lucene-level
+benchmarks reported 10-15% faster indexing for these fields types. {es} indices
+and data streams that mostly consist of these fields may see noticeable
 improvements to indexing speed.
 
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -21,8 +21,9 @@ For detailed information about this release, see the <<es-release-notes>> and
 The inverted index switched to a new encoding that is more space-efficient.
 This change will benefit `keyword` fields, `match_only_text` fields and, to a
 lesser extent, `text` fields. On the dataset of application logs that the {es}
-team uses for nightly benchmarks, this translated into an overall 3.5%
-reduction of the on-disk footprint.
+team uses for nightly benchmarks, this translated into a 14.4% reduction of the
+size of the index of the `message` field (mapped as `match_only_text`) and an
+overall 3.5% reduction of the on-disk footprint.
 
 [discrete]
 === Faster indexing of `geo_point`, `geo_shape` and range fields

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -29,7 +29,7 @@ This change will be picked up automatically by both new indices, and existing
 indices for every new segment.
 
 [discrete]
-=== Faster indexing of `geo_point`, `geo_shape` and range fields
+=== Faster indexing of `geo_point`, `geo_shape`, and range fields
 
 Some optimizations have been made to indexing of multi-dimensional points,
 which are used by `geo_point` fields, `geo_shape` fields and range fields.

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -16,7 +16,7 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // tag::notable-highlights[] 
 [discrete]
-=== Better space efficiency for `keyword`, `text` and `match_only_text` fields
+=== Better space efficiency for `keyword`, `match_only_text`, and `text` fields
 
 The inverted index switched to a new encoding that is more space-efficient.
 This change will benefit `keyword` fields, `match_only_text` fields and, to a

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -31,8 +31,8 @@ indices for every new segment.
 [discrete]
 === Faster indexing of `geo_point`, `geo_shape`, and range fields
 
-Some optimizations have been made to indexing of multi-dimensional points,
-which are used by `geo_point` fields, `geo_shape` fields and range fields.
+We've optimized indexing speeds for multi-dimensional points, an
+internal data structure used for `geo_point`, `geo_shape`, and range fields.
 Lucene-level benchmarks reported 10-15% faster indexing, so Elasticsearch
 indices and data streams that mostly consist of these field types may observe a
 non-negligible indexing speedup.

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -20,8 +20,7 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 We've updated inverted indices, an internal data structure, to use a more space-efficient encoding.
 This change will benefit `keyword` fields, `match_only_text` fields and, to a
-lesser extent, `text` fields. On the dataset of application logs that the {es}
-team uses for nightly benchmarks, this translated into a 14.4% reduction of the
+lesser extent, `text` fields. In our benchmarks using application logs, this translated into a 14.4% reduction of the
 size of the index of the `message` field (mapped as `match_only_text`) and an
 overall 3.5% reduction of the on-disk footprint.
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -25,7 +25,8 @@ benchmarks using application logs, this translated into a 14.4% reduction of
 the size of the index of the `message` field (mapped as `match_only_text`) and
 an overall 3.5% reduction of the on-disk footprint.
 
-This change will be picked up automatically by both new indices, and existing indices for every new segment.
+This change will be picked up automatically by both new indices, and existing
+indices for every new segment.
 
 [discrete]
 === Faster indexing of `geo_point`, `geo_shape`, and range fields

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -18,7 +18,7 @@ For detailed information about this release, see the <<es-release-notes>> and
 [discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
 
-The inverted index switched to a new encoding that is more space-efficient.
+We've updated inverted indices, an internal data structure, to use a more space-efficient encoding.
 This change will benefit `keyword` fields, `match_only_text` fields and, to a
 lesser extent, `text` fields. On the dataset of application logs that the {es}
 team uses for nightly benchmarks, this translated into a 14.4% reduction of the

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -25,6 +25,9 @@ team uses for nightly benchmarks, this translated into a 14.4% reduction of the
 size of the index of the `message` field (mapped as `match_only_text`) and an
 overall 3.5% reduction of the on-disk footprint.
 
+This change will be picked up automatically by both new indices, and existing
+indices for every new segment.
+
 [discrete]
 === Faster indexing of `geo_point`, `geo_shape` and range fields
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -13,11 +13,26 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // Use the notable-highlights tag to mark entries that 
 // should be featured in the Stack Installation and Upgrade Guide:
+
 // tag::notable-highlights[] 
-// [discrete]
-// === Heading
-//
-// Description. 
+[discrete]
+=== Better space efficiency for `keyword`, `text` and `match_only_text` fields
+
+The inverted index switched to a new encoding that is more space-efficient.
+This change will benefit `keyword` fields, `match_only_text` fields and, to a
+lesser extent, `text` fields. On the dataset of application logs that the {es}
+team uses for nightly benchmarks, this translated into an overall 3.5%
+reduction of the on-disk footprint.
+
+[discrete]
+=== Faster indexing of `geo_point`, `geo_shape` and range fields
+
+Some optimizations have been made to indexing of multi-dimensional points,
+which are used by `geo_point` fields, `geo_shape` fields and range fields.
+Lucene-level benchmarks reported 10-15% faster indexing, so Elasticsearch
+indices and data streams that mostly consist of these field types may observe a
+non-negligible indexing speedup.
+
 // end::notable-highlights[]
 
 // Omit the notable highlights tag for entries that only need to appear in the ES ref:

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -19,7 +19,7 @@ For detailed information about this release, see the <<es-release-notes>> and
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
 
 We've updated inverted indices, an internal data structure, to use a more space-efficient encoding.
-This change will benefit `keyword` fields, `match_only_text` fields and, to a
+This change will benefit `keyword` fields, `match_only_text` fields, and, to a
 lesser extent, `text` fields. In our benchmarks using application logs, this translated into a 14.4% reduction of the
 size of the index of the `message` field (mapped as `match_only_text`) and an
 overall 3.5% reduction of the on-disk footprint.

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,9 +32,9 @@ indices for every new segment.
 
 We've optimized indexing speeds for multi-dimensional points, an
 internal data structure used for `geo_point`, `geo_shape`, and range fields.
-Lucene-level benchmarks reported 10-15% faster indexing, so Elasticsearch
-indices and data streams that mostly consist of these field types may observe a
-non-negligible indexing speedup.
+Our benchmarks reported 10-15% faster indexing for these fields types. {es}
+indices and data streams that mostly consist of these fields may see noticeable
+improvements to indexing speed.
 
 // end::notable-highlights[]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -16,7 +16,7 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // tag::notable-highlights[] 
 [discrete]
-=== Better space efficiency for `keyword`, `match_only_text`, and `text` fields
+=== Storage savings for `keyword`, `match_only_text`, and `text` fields
 
 The inverted index switched to a new encoding that is more space-efficient.
 This change will benefit `keyword` fields, `match_only_text` fields and, to a


### PR DESCRIPTION
This carries over release highlights from Lucene 9.0 that translate into
immediate benefits for Elasticsearch users.