### PR TITLE
Adding binary data to SMILE should not generate the 0xFF byte separator

### DIFF
--- a/docs/changelog/83197.yaml
+++ b/docs/changelog/83197.yaml
@@ -1,0 +1,5 @@
+pr: 83197
+summary: Adding binary data to SMILE should not generate the 0xFF byte separator
+area: Distributed
+type: bug
+issues: []

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/smile/SmileXContent.java
@@ -41,8 +41,8 @@ public class SmileXContent implements XContent {
 
     static {
         smileFactory = new SmileFactory();
-        // for now, this is an overhead, might make sense for web sockets
-        smileFactory.configure(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT, false);
+        // necessary so 0xFF is not included in the output
+        smileFactory.configure(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT, true);
         smileFactory.configure(SmileFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.dataformat.smile.SmileGenerator#close() method
         smileFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);

--- a/server/src/test/java/org/elasticsearch/action/bulk/AbstractBulkRequestParserTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/AbstractBulkRequestParserTests.java
@@ -315,9 +315,13 @@ public abstract class AbstractBulkRequestParserTests extends ESTestCase {
 
     public void testParseDeduplicatesParameterStrings() throws IOException {
         XContentBuilder builderIndex = getBuilder();
-        builderIndex.startObject().startObject("index")
-            .field("_id", "bar").field("pipeline", "foo").field("routing", "blub")
-            .endObject().endObject();
+        builderIndex.startObject()
+            .startObject("index")
+            .field("_id", "bar")
+            .field("pipeline", "foo")
+            .field("routing", "blub")
+            .endObject()
+            .endObject();
         XContentBuilder builderDocument = getBuilder().startObject().endObject();
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserJsonTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserJsonTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+
+public class BulkRequestParserJsonTests extends AbstractBulkRequestParserTests {
+    @Override
+    protected XContentBuilder getBuilder() throws IOException {
+        return XContentFactory.jsonBuilder();
+    }
+
+    @Override
+    protected XContentType getXContentType() {
+        return XContentType.JSON;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserSmileTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserSmileTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+
+public class BulkRequestParserSmileTests extends AbstractBulkRequestParserTests {
+    @Override
+    protected XContentBuilder getBuilder() throws IOException {
+        return XContentFactory.smileBuilder();
+    }
+
+    @Override
+    protected XContentType getXContentType() {
+        return XContentType.SMILE;
+    }
+}


### PR DESCRIPTION
Currently if you try to add a document using the Bulk API into Elasticsearch encoded in SMILE that contains binary data (e.g added to the document using the method (#field(String, byte[])) it might fail because we just add to the final document the raw bytes that might contain the 0xFF byte separator.

The issue is because we are disabling the option `ENCODE_BINARY_AS_7BIT` which is necessary to prevent that byte to be added to the final document. I have a look and this set up is being like that since the beginning and I think there is no reason why not to change it. 

This commit proposed to enable the flag so we don't fail on binary data when using the Bulk API.