### PR TITLE
Move Get Snapshots Serialization to Management Pool

### DIFF
--- a/docs/changelog/83215.yaml
+++ b/docs/changelog/83215.yaml
@@ -1,0 +1,5 @@
+pr: 83215
+summary: Move Get Snapshots Serialization to Management Pool
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -704,7 +704,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestDeleteRepositoryAction());
         registerHandler.accept(new RestVerifyRepositoryAction());
         registerHandler.accept(new RestCleanupRepositoryAction());
-        registerHandler.accept(new RestGetSnapshotsAction());
+        registerHandler.accept(new RestGetSnapshotsAction(threadPool));
         registerHandler.accept(new RestCreateSnapshotAction());
         registerHandler.accept(new RestCloneSnapshotAction());
         registerHandler.accept(new RestRestoreSnapshotAction());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -86,7 +86,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             GetSnapshotsRequest::new,
             indexNameExpressionResolver,
             GetSnapshotsResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT // Execute this on the management pool because creating the response can become fairly expensive
+                                        // for large repositories in the verbose=false case when there are a lot of indices per snapshot.
+                                        // This is intentionally not using the snapshot_meta pool because that pool is sized rather large
+                                        // to accommodate concurrent IO and could consume excessive CPU resources through concurrent
+                                        // verbose=false requests that are CPU bound only.
         );
         this.repositoriesService = repositoriesService;
     }


### PR DESCRIPTION
It's in the title. For large index counts generating the response,
both for transport as well as REST layer gets quite expensive and 
I've seen a couple of clusters slow-log for verbose=false requests or on the REST layer.
(also it's easy to reproduce in benchmarks when the repo contains 50k indices)
Better generate it off the transport threads.

relates #77466 
