### PR TITLE
Copy trace.id in threadcontext stash

### DIFF
--- a/docs/changelog/83218.yaml
+++ b/docs/changelog/83218.yaml
@@ -1,0 +1,5 @@
+pr: 83218
+summary: Copy `trace.id` in threadcontext stash
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -728,7 +728,7 @@ public class Node implements Closeable {
             final Transport transport = networkModule.getTransportSupplier().get();
             Set<String> taskHeaders = Stream.concat(
                 pluginsService.filterPlugins(ActionPlugin.class).stream().flatMap(p -> p.getTaskHeaders().stream()),
-                Stream.of(Task.X_OPAQUE_ID_HTTP_HEADER, Task.TRACE_ID, Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER)
+                Task.HEADERS_TO_COPY.stream()
             ).collect(Collectors.toSet());
             final TransportService transportService = newTransportService(
                 settings,

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -41,16 +41,13 @@ public class Task {
      */
     public static final String X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER = "X-elastic-product-origin";
 
-    public static final Set<String> HEADERS_TO_COPY = Set.of(
-        X_OPAQUE_ID_HTTP_HEADER,
-        TRACE_PARENT_HTTP_HEADER,
-        X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER
-    );
     /**
      * Parsed part of traceparent. It is stored in thread context and emitted in logs.
      * Has to be declared as a header copied over for tasks.
      */
     public static final String TRACE_ID = "trace.id";
+
+    public static final Set<String> HEADERS_TO_COPY = Set.of(X_OPAQUE_ID_HTTP_HEADER, TRACE_ID, X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER);
 
     private final long id;
 

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -730,4 +730,8 @@ public class TaskManager implements ClusterStateApplier {
             throw new IllegalStateException("TaskCancellationService is not initialized");
         }
     }
+
+    public List<String> getTaskHeaders() {
+        return taskHeaders;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -31,11 +31,13 @@ import org.elasticsearch.plugins.CircuitBreakerPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RecoveryPlannerPlugin;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ContextParser;
 import org.elasticsearch.xcontent.MediaType;
 import org.elasticsearch.xcontent.NamedObjectNotFoundException;
@@ -60,6 +62,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -345,6 +348,15 @@ public class NodeTests extends ESTestCase {
         plugins.add(MockRecoveryPlannerPlugin.class);
         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> new MockNode(baseSettings().build(), plugins));
         assertThat(exception.getMessage(), containsString("A single RecoveryPlannerPlugin was expected but got:"));
+    }
+
+    public void testHeadersToCopyInTaskManagerAreTheSameAsDeclaredInTask() throws IOException {
+        Settings.Builder settings = baseSettings();
+        try (Node node = new MockNode(settings.build(), basePlugins())) {
+            final TransportService transportService = node.injector().getInstance(TransportService.class);
+            final List<String> taskHeaders = transportService.getTaskManager().getTaskHeaders();
+            assertThat(taskHeaders, containsInAnyOrder(Task.HEADERS_TO_COPY.toArray(new String[] {})));
+        }
     }
 
     public static class MockRecoveryPlannerPlugin extends Plugin implements RecoveryPlannerPlugin {


### PR DESCRIPTION
because of incorrect change in #81381 trace.id value (set in RestController basted on 
traceparent) was not copied when stashing a context.
This commit do not allow to copy traceparent but allows to copy trace.id when stashing 
ThreadContext