### PR TITLE
[8.0] [DOCS] Expand operator privileges explanation for users and roles (#82893)

### DIFF
--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -7,7 +7,28 @@ up and running. These users have a fixed set of privileges and cannot be
 authenticated until their passwords have been set. The `elastic` user can be
 used to <<set-built-in-user-passwords,set all of the built-in user passwords>>.
 
+.Create users with minimum privileges
+****
+The built-in users serve specific purposes and are not intended for general
+use. In particular, do not use the `elastic` superuser unless full access to
+the cluster is absolutely required. On self-managed deployments, use the
+`elastic` user to create users that have the minimum necessary roles or 
+privileges for their activities.
+****
+
+[NOTE]
+====
+On {ecloud}, {ref}/operator-privileges.html[operator privileges] are enabled.
+These privileges restrict some infrastructure functionality, even if a role
+would otherwise permit a user to complete an administrative task.
+====
+
 `elastic`:: A built-in <<built-in-roles,superuser>>.
++
+IMPORTANT: Anyone who can log in as the `elastic` user has direct read-only
+access to restricted indices, such as `.security`. This user also has the ability
+to manage security and create roles with unlimited privileges.
+
 `kibana_system`:: The user Kibana uses to connect and communicate with {es}.
 `logstash_system`:: The user Logstash uses when storing monitoring information in {es}.
 `beats_system`:: The user the Beats use when storing monitoring information in {es}.
@@ -15,11 +36,6 @@ used to <<set-built-in-user-passwords,set all of the built-in user passwords>>.
 `remote_monitoring_user`:: The user {metricbeat} uses when collecting and
 storing monitoring information in {es}. It has the `remote_monitoring_agent` and
 `remote_monitoring_collector` built-in roles.
-
-TIP: The built-in users serve specific purposes and are not intended for general
-use. In particular, do not use the `elastic` superuser unless full access to
-the cluster is required. Instead, create users that have the minimum necessary
-roles or privileges for their activities.
 
 [discrete]
 [[built-in-user-explanation]]

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -170,9 +170,12 @@ to change index settings or to read or update data stream or index data.
 [[built-in-roles-superuser]] `superuser`::
 Grants full access to cluster management and data indices. This role also grants
 direct read-only access to restricted indices like `.security`. A user with the
-`superuser` role can <<run-as-privilege, impersonate>> any other user in the system. 
+`superuser` role can <<run-as-privilege, impersonate>> any other user in the system.
 +
-NOTE: This role can manage security and create roles with unlimited privileges.
+On {ecloud}, all standard users, including those with the `superuser` role are 
+restricted from performing <<operator-only-functionality,operator-only>> actions.
++
+IMPORTANT: This role can manage security and create roles with unlimited privileges.
 Take extra care when assigning it to a user.
 
 [[built-in-roles-transform-admin]] `transform_admin`::

--- a/x-pack/docs/en/security/operator-privileges/index.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/index.asciidoc
@@ -11,14 +11,18 @@ this environment. However, in more managed environments, such as
 {ess-trial}[{ess}], there is a distinction between the operator of the cluster
 infrastructure and the administrator of the cluster. 
 
-Operator privileges limit some functionality to operator users only. Operator
-users are just regular Elasticsearch users with access to specific
+Operator privileges limit some functionality to operator users _only_. Operator
+users are just regular {es} users with access to specific
 <<operator-only-functionality,operator-only functionality>>. These
 privileges are not available to cluster administrators, even if they log in as
 a highly privileged user such as the `elastic` user or another user with the
-superuser role. By limiting system access, operator privileges enhance the
-Elasticsearch security model while safeguarding user capabilities.
+`superuser` role. By limiting system access, operator privileges enhance the
+{es} security model while safeguarding user capabilities.
 
+Operator privileges are enabled on {ecloud}, which means that some 
+infrastructure management functionality is restricted and cannot be accessed by
+your administrative users. This capability protects your cluster from unintended 
+infrastructure changes.
 
 include::configure-operator-privileges.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Expand operator privileges explanation for users and roles (#82893)