### PR TITLE
Update test-failure Issue Template to include "needs:triage" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-failure.yml
+++ b/.github/ISSUE_TEMPLATE/test-failure.yml
@@ -1,6 +1,6 @@
 name: Test Failure
 description: A test failure in CI
-labels: [">test-failure"]
+labels: [">test-failure","needs:triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Adds the `needs:triage` label to Test Failure issue types. Tested on DJRickyB/elasticsearch `master`, though I had to recreate the labels in my repo to get the templates to pre-populate them, you can click on "Test Failure" there and see the desired labels are applied.

https://github.com/DJRickyB/elasticsearch/issues/new/choose