### PR TITLE
[7.17] Clarify commands shown for "permanently" setting max_map_count (#82345)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -140,12 +140,12 @@ The following requirements and recommendations apply when running {es} in Docker
 
 The `vm.max_map_count` kernel setting must be set to at least `262144` for production use.
 
-How you set `vm.max_map_count` depends on your platform:
+How you set `vm.max_map_count` depends on your platform.
 
-* Linux
-+
---
-The `vm.max_map_count` setting should be set permanently in `/etc/sysctl.conf`:
+====== Linux
+
+To view the current value for the `vm.max_map_count` setting, run:
+
 [source,sh]
 --------------------------------------------
 grep vm.max_map_count /etc/sysctl.conf
@@ -158,11 +158,12 @@ To apply the setting on a live system, run:
 --------------------------------------------
 sysctl -w vm.max_map_count=262144
 --------------------------------------------
---
 
-* macOS with https://docs.docker.com/docker-for-mac[Docker for Mac]
-+
---
+To permanently change the value for the `vm.max_map_count` setting, update the
+value in `/etc/sysctl.conf`.
+
+====== macOS with https://docs.docker.com/docker-for-mac[Docker for Mac]
+
 The `vm.max_map_count` setting must be set within the xhyve virtual machine:
 
 . From the command line, run:
@@ -172,7 +173,7 @@ The `vm.max_map_count` setting must be set within the xhyve virtual machine:
 screen ~/Library/Containers/com.docker.docker/Data/vms/0/tty
 --------------------------------------------
 
-. Press enter and use`sysctl` to configure `vm.max_map_count`:
+. Press enter and use `sysctl` to configure `vm.max_map_count`:
 +
 [source,sh]
 --------------------------------------------
@@ -180,11 +181,9 @@ sysctl -w vm.max_map_count=262144
 --------------------------------------------
 
 . To exit the `screen` session, type `Ctrl a d`.
---
 
-* Windows and macOS with https://www.docker.com/products/docker-desktop[Docker Desktop]
-+
---
+====== Windows and macOS with https://www.docker.com/products/docker-desktop[Docker Desktop]
+
 The `vm.max_map_count` setting must be set via docker-machine:
 
 [source,sh]
@@ -192,11 +191,9 @@ The `vm.max_map_count` setting must be set via docker-machine:
 docker-machine ssh
 sudo sysctl -w vm.max_map_count=262144
 --------------------------------------------
---
 
-* Windows with https://docs.docker.com/docker-for-windows/wsl[Docker Desktop WSL 2 backend]
-+
---
+====== Windows with https://docs.docker.com/docker-for-windows/wsl[Docker Desktop WSL 2 backend]
+
 The `vm.max_map_count` setting must be set in the docker-desktop container:
 
 [source,sh]
@@ -204,7 +201,7 @@ The `vm.max_map_count` setting must be set in the docker-desktop container:
 wsl -d docker-desktop
 sysctl -w vm.max_map_count=262144
 --------------------------------------------
---
+
 
 ===== Configuration files must be readable by the `elasticsearch` user
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Clarify commands shown for "permanently" setting max_map_count (#82345)