### PR TITLE
Fix migration docs for painless week of year changes

### DIFF
--- a/docs/reference/migration/migrate_8_0/painless-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/painless-changes.asciidoc
@@ -37,7 +37,8 @@ The following `JodaCompatibleZonedDateTime` methods must be replaced using
 * `getMonthOfYear()` -> `getMonthValue()`
 * `getSecondOfDay()` -> `get(ChronoField.SECOND_OF_DAY)`
 * `getSecondOfMinute()` -> `getSecond()`
-* `getWeekOfWeekyear()` -> `get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear())`
+* `getWeekOfWeekyear()` -> `get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)`
+* `getWeekyear()` -> `get(IsoFields.WEEK_BASED_YEAR)`
 * `getYearOfCentury()` -> `get(ChronoField.YEAR_OF_ERA) % 100`
 * `getYearOfEra()` -> `get(ChronoField.YEAR_OF_ERA)`
 * `toString(String)` -> a DateTimeFormatter


### PR DESCRIPTION
This fixes the suggested changes for `week based year` and `week of week based year` when translating from `JodaCompatibleZonedDateTime` to `ZonedDateTime` in Painless.