### PR TITLE
[DOCS] Add breaking change for renaming the XContent library

### DIFF
--- a/docs/reference/migration/migrate_7_16.asciidoc
+++ b/docs/reference/migration/migrate_7_16.asciidoc
@@ -64,6 +64,44 @@ disk space management if needed.
 
 This change has no impact on users outside of orchestrated environments.
 ====
+
+
+[discrete]
+[[breaking_716_hlrc_changes]]
+==== High Level REST Client changes
+
+[[breaking_716_xcontent_migration]]
+.The `XContent` API is renamed and breaks imports when upgrading.
+[%collapsible]
+====
+*Details* +
+The `XContent` library exported package is renamed from
+`org.elasticsearch.common.xcontent` to `org.elasticsearch.xcontent`. This change
+breaks imports when migrating to {es} 7.16.
+
+*Impact* +
+If you're maintaining a Java client application that uses the Java High Level
+Rest Client (HLRC), update any `import` statements in your Java source code that
+match:
+
+[source,java]
+----
+import org.elasticsearch.common.xcontent.<class>
+----
+
+to instead use:
+
+[source,java]
+----
+import org.elasticsearch.xcontent.<class> 
+----
+
+This is the minimum required change. You must then recompile your source code to
+work with {es} 7.17.
+
+A more permanent solution is to 
+{java-api-client}/migrate-hlrc.html[migrate from the (HLRC)] entirely.
+====
 // end::notable-breaking-changes[]
 
 [discrete]


### PR DESCRIPTION
#78831 moved the x-content library exported package from `org.elasticsearch.common.xcontent` to `org.elasticsearch.xcontent`. This is a breaking change in 7.16. This PR documents the breaking change in 7.17 (will also backport to 7.16).

Preview link: https://elasticsearch_83234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/migrating-7.16.html#breaking_716_hlrc_changes

Closes #82357