### PR TITLE
Fix cyclic resolution of references to aliases in filters when the field not exists

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -894,7 +894,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         && (qualified
                             ? Objects.equals(alias.qualifiedName(), u.qualifiedName())
                             : Objects.equals(alias.name(), u.name()))) {
-                        return alias;
+                        return alias.child().equals(u) ? u : alias;
                     }
                 }
                 return u;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/AnalyzerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/AnalyzerTests.java
@@ -58,6 +58,15 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(gt.left().toString(), is("emp_no + 1"));
     }
 
+    public void testResolveRecursiveFilterRefsWhenFieldNotExists() {
+        try {
+            LogicalPlan plan = analyze("SELECT not_exists_field AS not_exists_field FROM test WHERE not_exists_field > 0");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(VerificationException.class));
+        }
+
+    }
+
     public void testResolveAlternatingRecursiveFilterRefs() {
         // Queries like the following used to cause a StackOverflowError in ResolveFilterRefs.
         // see https://github.com/elastic/elasticsearch/issues/81577


### PR DESCRIPTION
Fix cyclic resolution of references to aliases in filters when the field not exists.

For example:
`SELECT not_exists_field AS not_exists_field FROM test WHERE not_exists_field > 0` will be stuck in a loop parsing and will throw an exception -- RuleExecutionException[Rule execution limit [100] reached]

with the fix,it will throw an exception --  VerificationException[Unknown column [not_exists_field], did you mean any of [xxx,yyy,zzz]]