### PR TITLE
Avoid duplicate _type fields in v7 compat layer

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -624,7 +624,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (index != null) {
             builder.field(Fields._INDEX, RemoteClusterAware.buildRemoteIndexName(clusterAlias, index));
         }
-        if (builder.getRestApiVersion() == RestApiVersion.V_7) {
+        if (builder.getRestApiVersion() == RestApiVersion.V_7 && metaFields.containsKey(MapperService.TYPE_FIELD_NAME) == false) {
             builder.field(MapperService.TYPE_FIELD_NAME, MapperService.SINGLE_MAPPING_NAME);
         }
         if (id != null) {

--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
@@ -395,8 +395,14 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
         boolean sourceOnlyRepository,
         Version oldVersion
     ) throws IOException {
+        RequestOptions v7RequestOptions = RequestOptions.DEFAULT.toBuilder()
+            .addHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=7")
+            .addHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=7")
+            .build();
+        RequestOptions randomRequestOptions = randomBoolean() ? RequestOptions.DEFAULT : v7RequestOptions;
+
         // run a search against the index
-        SearchResponse searchResponse = client.search(new SearchRequest(index), RequestOptions.DEFAULT);
+        SearchResponse searchResponse = client.search(new SearchRequest(index), randomRequestOptions);
         logger.info(searchResponse);
         // check hit count
         assertEquals(numDocs, searchResponse.getHits().getTotalHits().value);
@@ -420,7 +426,7 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
                     .query(QueryBuilders.matchQuery("val", num))
                     .runtimeMappings(Map.of("val", Map.of("type", "long")))
             ),
-            RequestOptions.DEFAULT
+            randomRequestOptions
         );
         logger.info(searchResponse);
         assertEquals(1, searchResponse.getHits().getTotalHits().value);
@@ -445,7 +451,7 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
                         .query(QueryBuilders.matchAllQuery())
                         .sort(SortBuilders.fieldSort("val").order(SortOrder.DESC))
                 ),
-                RequestOptions.DEFAULT
+                randomRequestOptions
             );
             logger.info(searchResponse);
             // check sort order
@@ -460,7 +466,7 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
                 long typeCount = expectedIds.stream().filter(idd -> getType(oldVersion, idd).equals(randomType)).count();
                 searchResponse = client.search(
                     new SearchRequest(index).source(SearchSourceBuilder.searchSource().query(QueryBuilders.termQuery("_type", randomType))),
-                    RequestOptions.DEFAULT
+                    randomRequestOptions
                 );
                 logger.info(searchResponse);
                 assertEquals(typeCount, searchResponse.getHits().getTotalHits().value);


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/pull/83195#issuecomment-1023476252