### PR TITLE
Bump bundled JDK to 17.0.2+8

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -69,7 +69,7 @@ import static org.elasticsearch.gradle.internal.vagrant.VagrantMachine.convertWi
  * This class defines gradle tasks for testing our various distribution artifacts.
  */
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "17.0.1+12";
+    private static final String SYSTEM_JDK_VERSION = "17.0.2+8";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
     private static final String GRADLE_JDK_VERSION = "16.0.2+7";
     private static final String GRADLE_JDK_VENDOR = "adoptium";

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.1.0
 lucene            = 9.0.0
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17.0.1+12
+bundled_jdk = 17.0.2+8
 
 checkstyle = 8.45.1
 

--- a/docs/changelog/83243.yaml
+++ b/docs/changelog/83243.yaml
@@ -1,0 +1,5 @@
+pr: 83243
+summary: Bump bundled JDK to 17.0.2+8
+area: Packaging
+type: upgrade
+issues: []

--- a/docs/changelog/83243.yaml
+++ b/docs/changelog/83243.yaml
@@ -2,4 +2,5 @@ pr: 83243
 summary: Bump bundled JDK to 17.0.2+8
 area: Packaging
 type: upgrade
-issues: []
+issues:
+ - 83242


### PR DESCRIPTION
JDK 17.0.2 is released so upgrade our bundled JDK.

Closes #83242. 