### PR TITLE
[Docs] Add supported _terms_enum field types

### DIFF
--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -5,7 +5,9 @@
 ++++
 
 The terms enum API can be used to discover terms in the index that match
-a partial string. This is used for auto-complete:
+a partial string. Supported field types are <<keyword-field-type,`keyword`>>,
+<<constant-keyword-field-type,`constant_keyword`>> and 
+<<flattened,`flattened`>>. This is used for auto-complete:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
The `_terms_enum` API currently supported keyword, constant_keyword and
flattened fields. This should be documented more clearly.
