### PR TITLE
[8.0] [Docs] Add supported _terms_enum field types (#83244)

### DIFF
--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -5,7 +5,9 @@
 ++++
 
 The terms enum API can be used to discover terms in the index that match
-a partial string. This is used for auto-complete:
+a partial string. Supported field types are <<keyword-field-type,`keyword`>>,
+<<constant-keyword-field-type,`constant_keyword`>> and 
+<<flattened,`flattened`>>. This is used for auto-complete:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Docs] Add supported _terms_enum field types (#83244)