### PR TITLE
[Transform] Forward deprecations from search response to transform _preview API response

### DIFF
--- a/docs/changelog/83257.yaml
+++ b/docs/changelog/83257.yaml
@@ -1,0 +1,5 @@
+pr: 83257
+summary: Forward deprecations from search response to transform `_preview` API response
+area: Transform
+type: upgrade
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -208,14 +208,45 @@ public final class ClientHelper {
         Request request,
         ActionListener<Response> listener
     ) {
+        executeWithHeadersAsync(headers, origin, client, action, false, request, listener);
+    }
+
+    /**
+     * Execute a client operation asynchronously, try to run an action with
+     * least privileges, when headers exist
+     *
+     * @param headers
+     *            Request headers, ideally including security headers
+     * @param origin
+     *            The origin to fall back to if there are no security headers
+     * @param action
+     *            The action to execute
+     * @param preserveResponseHeaders
+     *            Whether to preserve the response headers of the restore thread
+     * @param request
+     *            The request object for the action
+     * @param listener
+     *            The listener to call when the action is complete
+     */
+    public static <Request extends ActionRequest, Response extends ActionResponse> void executeWithHeadersAsync(
+        Map<String, String> headers,
+        String origin,
+        Client client,
+        ActionType<Response> action,
+        boolean preserveResponseHeaders,
+        Request request,
+        ActionListener<Response> listener
+    ) {
         final Map<String, String> filteredHeaders = filterSecurityHeaders(headers);
         final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(preserveResponseHeaders);
         // No headers (e.g. security not installed/in use) so execute as origin
         if (filteredHeaders.isEmpty()) {
-            ClientHelper.executeAsyncWithOrigin(client, origin, action, request, listener);
+            try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(origin)) {
+                client.execute(action, request, new ContextPreservingActionListener<>(supplier, listener));
+            }
         } else {
             // Otherwise stash the context and copy in the saved headers before executing
-            final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
             try (ThreadContext.StoredContext ignore = stashWithHeaders(threadContext, filteredHeaders)) {
                 client.execute(action, request, new ContextPreservingActionListener<>(supplier, listener));
             }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -1073,19 +1073,16 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
         final Request request = new Request(method, endpoint);
         request.setJsonEntity(config);
-        try {
-            client().performRequest(request);
-        } catch (WarningFailureException e) {
-            Response response = e.getResponse();
-            assertThat(
-                "Warnings were: " + response.getWarnings(),
-                response.getWarnings(),
-                hasItems(
-                    "Use of the joda time method [getMillis()] is deprecated. Use [toInstant().toEpochMilli()] instead.",
-                    "Use of the joda time method [getEra()] is deprecated. Use [get(ChronoField.ERA)] instead."
-                )
-            );
-        }
+        WarningFailureException e = expectThrows(WarningFailureException.class, () -> client().performRequest(request));
+        Response response = e.getResponse();
+        assertThat(
+            "Warnings were: " + response.getWarnings(),
+            response.getWarnings(),
+            hasItems(
+                "Use of the joda time method [getMillis()] is deprecated. Use [toInstant().toEpochMilli()] instead.",
+                "Use of the joda time method [getEra()] is deprecated. Use [get(ChronoField.ERA)] instead."
+            )
+        );
     }
 
     public void testPivotWithMaxOnDateField() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -1003,6 +1004,66 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         assertThat(
             createPreviewResponse.getWarnings().get(createPreviewResponse.getWarnings().size() - 1),
             allOf(containsString("Pipeline returned 100 errors, first error:"), containsString("type=script_exception"))
+        );
+    }
+
+    /**
+     * This test case makes sure that deprecation warnings from _search API are propagated to _preview API.
+     */
+    public void testPreviewTransformWithScriptedMetricUsingDeprecatedSyntax() throws Exception {
+        String config = "{"
+            + "  \"source\": {"
+            + "    \"index\": \""
+            + REVIEWS_INDEX_NAME
+            + "\","
+            + "    \"runtime_mappings\": {"
+            + "      \"timestamp-5m\": {"
+            + "        \"type\": \"date\","
+            + "        \"script\": {"
+            // We don't use "era" for anything in this script. This is solely to generate the deprecation warning.
+            + "          \"source\": \"def era = doc['timestamp'].value.era; emit(doc['timestamp'].value.millis)\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  },"
+            + "  \"pivot\": {"
+            + "    \"group_by\": {"
+            + "      \"timestamp\": {"
+            + "        \"date_histogram\": {"
+            + "          \"field\": \"timestamp-5m\","
+            + "          \"calendar_interval\": \"1m\""
+            + "        }"
+            + "      }"
+            + "    },"
+            + "    \"aggregations\": {"
+            + "      \"bytes.avg\": {"
+            + "        \"avg\": {"
+            + "          \"field\": \"bytes\""
+            + "        }"
+            + "      },"
+            + "      \"millis\": {"
+            + "        \"scripted_metric\": {"
+            + "          \"init_script\": \"state.m = 0\","
+            + "          \"map_script\": \"state.m = doc['timestamp'].value.millis;\","
+            + "          \"combine_script\": \"return state.m;\","
+            + "          \"reduce_script\": \"def last = 0; for (s in states) {last = s;} return last;\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
+        final Request previewRequest = new Request("POST", getTransformEndpoint() + "_preview");
+        previewRequest.setJsonEntity(config);
+        previewRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+
+        Response previewResponse = client().performRequest(previewRequest);
+        assertThat(
+            "Warnings were: " + previewResponse.getWarnings(),
+            previewResponse.getWarnings(),
+            hasItems(
+                "Use of the joda time method [getMillis()] is deprecated. Use [toInstant().toEpochMilli()] instead.",
+                "Use of the joda time method [getEra()] is deprecated. Use [get(ChronoField.ERA)] instead."
+            )
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -74,6 +74,7 @@ public abstract class AbstractCompositeAggFunction implements Function {
             ClientHelper.TRANSFORM_ORIGIN,
             client,
             SearchAction.INSTANCE,
+            true,
             buildSearchRequest(sourceConfig, null, numberOfBuckets),
             ActionListener.wrap(r -> {
                 try {


### PR DESCRIPTION
This PR makes sure any deprecation warnings generated by the `_search` API (which is internally used by `_preview` API) show up in `_preview` response.
This is achieved by setting `preserveResponseHeaders` flag to `true`.

Additionally, this PR adds an integration test which verifies that the deprecated Java methods used in painless scripts are correctly reported.

Relates #82935