### PR TITLE
Fix get-snapshot-api :docs:integTest

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -115,7 +115,7 @@ include::restore-snapshot-api.asciidoc[tag=cluster-state-contents]
 Comma-separated list of data streams and indices to include in the snapshot.
 Supports <<api-multi-index,multi-index syntax>>. Defaults to an empty array
 (`[]`), which includes all regular data streams and regular indices. To exclude
-all data streams and indices, use `-*` or `none`.
+all data streams and indices, use `-*`.
 +
 You can't use this parameter to include or exclude <<system-indices,system
 indices or system data streams>> from a snapshot. Use

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -17,8 +17,6 @@ PUT /_snapshot/my_repository
   }
 }
 
-PUT someindex
-
 PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
 {
   "indices":"-*"

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -17,6 +17,8 @@ PUT /_snapshot/my_repository
   }
 }
 
+PUT someindex
+
 PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
 
 PUT /_snapshot/my_repository/snapshot_1?wait_for_completion=true

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -20,10 +20,24 @@ PUT /_snapshot/my_repository
 PUT someindex
 
 PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
+{
+  "indices":"-*"
+}
 
 PUT /_snapshot/my_repository/snapshot_1?wait_for_completion=true
+{
+  "indices":"-*"
+}
+
 PUT /_snapshot/my_repository/snapshot_2?wait_for_completion=true
+{
+  "indices":"-*"
+}
+
 PUT /_snapshot/my_repository/snapshot_3?wait_for_completion=true
+{
+  "indices":"-*"
+}
 ----
 // TESTSETUP
 ////


### PR DESCRIPTION
I ran into this on https://gradle-enterprise.elastic.co/s/dezdqwxhe7652/tests/:docs:integTest/org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT/test%20%7Byaml=reference%2Fsnapshot-restore%2Fapis%2Fget-snapshot-api%2Fline_508%7D?top-execution=1 yesterday.

If you win the timing lottery, then there can be a backing index for the slm history datastream, and it'll get snapshotted (e.g. `.ds-.slm-history-5-2022.01.27-000001`), but then the later API calls will fail because they're all written to expect no indices in the snapshot.

```
./gradlew ':docs:integTest' --tests "org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT.test {yaml=reference/snapshot-restore/apis/get-snapshot-api/*}"
```

Also there's a docs change for the create-snapshot-api -- there's no `none` option for `indices` (there is one for `feature_states` and I've left that one alone).