### PR TITLE
[DOCS] Update dynamic mapping docs to clarify supported match_mapping_type

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -15,7 +15,7 @@ explicitly map all other data types.
 
 [[dynamic-field-mapping-types]]
 // tag::dynamic-field-mapping-types-tag[]
-[cols="3"]
+[cols="3",frame=all]
 |===
 h|                2+^h|{es} data type
 h| JSON data type h| `"dynamic":"true"` h| `"dynamic":"runtime"`
@@ -28,7 +28,6 @@ h| JSON data type h| `"dynamic":"true"` h| `"dynamic":"runtime"`
  |`string` that passes <<date-detection,date detection>> 2*| `date`
  |`string` that passes <<numeric-detection,numeric detection>> | `float` or `long` | `double` or `long`
  |`string` that doesn't pass `date` detection or `numeric` detection | `text` with a `.keyword` sub-field | `keyword`
-3+|
 |===
 // end::dynamic-field-mapping-types-tag[]
 

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -17,6 +17,7 @@ explicitly map all other data types.
 // tag::dynamic-field-mapping-types-tag[]
 [cols="3"]
 |===
+h|                2+^h|{es} data type
 h| JSON data type h| `"dynamic":"true"` h| `"dynamic":"runtime"`
  |`null` 2*| No field added
  |`true` or `false` 2*| `boolean`

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -21,7 +21,7 @@ h| JSON data type h| `"dynamic":"true"` h| `"dynamic":"runtime"`
  |`null` 2*| No field added
  |`true` or `false` 2*| `boolean`
  |`double` | `float` | `double`
- |`integer` 2*| `long`
+ |`long` 2*| `long`
  |`object` | `object` | No field added
  |`array` 2*|  Depends on the first non-`null` value in the array
  |`string` that passes <<date-detection,date detection>> 2*| `date`

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -118,10 +118,7 @@ to map `string` fields as either indexed fields or runtime fields.
 [[match-mapping-type]]
 ==== `match_mapping_type`
 
-The `match_mapping_type` is the data type detected by the JSON parser. Because
-JSON doesn't distinguish a `long` from an `integer` or a `double` from
-a `float`, it always chooses the wider data type such as `long` for integers
-and `double` for floating-point numbers.
+The `match_mapping_type` is the data type detected by the JSON parser.
 
 NOTE: With dynamic mappings, {es} will always choose the wider data type. The
 one exception is `float`, which requires less storage space than `double` and

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -118,7 +118,10 @@ to map `string` fields as either indexed fields or runtime fields.
 [[match-mapping-type]]
 ==== `match_mapping_type`
 
-The `match_mapping_type` is the data type detected by the JSON parser.
+The `match_mapping_type` is the data type detected by the JSON parser. Because
+JSON doesn't distinguish a `long` from an `integer` or a `double` from
+a `float`, any parsed floating point number is considered a `double` JSON data
+type, while any parsed `integer` number is considered a `long`.
 
 NOTE: With dynamic mappings, {es} will always choose the wider data type. The
 one exception is `float`, which requires less storage space than `double` and

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -123,6 +123,11 @@ JSON doesn't distinguish a `long` from an `integer` or a `double` from
 a `float`, it always chooses the wider data type such as `long` for integers
 and `double` for floating-point numbers.
 
+NOTE: With dynamic mappings, {es} will always choose the wider data type. The
+one exception is `float`, which requires less storage space than `double` and
+is precise enough for most applications. Runtime fields do not support `float`,
+which is why `"dynamic":"runtime"` uses `double`.
+
 {es} automatically detects the following data types:
 
 include::field-mapping.asciidoc[tag=dynamic-field-mapping-types-tag]


### PR DESCRIPTION
The current dynamic mappings documentation is confusing in relation to `double` and `float` types. This PR adds a note to clarify the distinction, and also updates the data type detected by the JSON parser from `integer` to `long`.

Preview link: https://elasticsearch_83274.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/dynamic-templates.html#match-mapping-type

Closes #82965