### PR TITLE
Fix deprecated suggestions for JodaCompatibleZonedDateTime

### DIFF
--- a/docs/changelog/83276.yaml
+++ b/docs/changelog/83276.yaml
@@ -1,0 +1,5 @@
+pr: 83276
+summary: Fix deprecated suggestions for `JodaCompatibleZonedDateTime`
+area: Infra/Scripting
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -33,6 +33,7 @@ import java.time.chrono.ChronoZonedDateTime;
 import java.time.chrono.Chronology;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjuster;
@@ -470,14 +471,14 @@ public class JodaCompatibleZonedDateTime
 
     @Deprecated
     public int getWeekOfWeekyear() {
-        logDeprecatedMethod("getWeekOfWeekyear()", "get(DateFormatters.WEEK_FIELDS_ROOT.weekOfWeekBasedYear())");
-        return dt.get(DateFormatters.WEEK_FIELDS_ROOT.weekOfWeekBasedYear());
+        logDeprecatedMethod("getWeekOfWeekyear()", "get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)");
+        return dt.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
     }
 
     @Deprecated
     public int getWeekyear() {
-        logDeprecatedMethod("getWeekyear()", "get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear())");
-        return dt.get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear());
+        logDeprecatedMethod("getWeekyear()", "get(IsoFields.WEEK_BASED_YEAR)");
+        return dt.get(IsoFields.WEEK_BASED_YEAR);
     }
 
     @Deprecated

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.joda.time.DateTime;

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -234,7 +234,7 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
         assertMethodDeprecation(
             () -> assertThat(javaTime.getWeekOfWeekyear(), equalTo(jodaTime.getWeekOfWeekyear())),
             "getWeekOfWeekyear()",
-            "get(DateFormatters.WEEK_FIELDS_ROOT.weekOfWeekBasedYear())"
+            "get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)"
         );
     }
 
@@ -242,7 +242,7 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
         assertMethodDeprecation(
             () -> assertThat(javaTime.getWeekyear(), equalTo(jodaTime.getWeekyear())),
             "getWeekyear()",
-            "get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear())"
+            "get(IsoFields.WEEK_BASED_YEAR)"
         );
     }
 


### PR DESCRIPTION
This updates the suggestions for `getWeekyear` and `getWeekOfWeekyear` in `JodaCompatibleZonedDateTime` to be correct within Painless.