### PR TITLE
Remove empty cluster test for cat allocation

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
@@ -18,28 +18,6 @@
                $/
 
 ---
-"Empty cluster":
-
-  - do:
-      cat.allocation: {}
-
-  - match:
-      $body: |
-            /^
-              ( 0                      \s+
-                0b                     \s+
-                \d+(\.\d+)?[kmgt]?b    \s+
-                (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
-                (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
-                (\d+                   \s+)?  #no value from client nodes
-                [-\w.]+                \s+
-                \d+(\.\d+){3}          \s+
-                [-\w.]+
-                \n
-              )+
-            $/
-
----
 "One index":
 
   - do:


### PR DESCRIPTION
Internally we create many indices that may cause this not to show 0 indices. There isn't really a
reason to test this specifically, as we later test an empty repsonse with a master-only node.

Resolves #82647
