### PR TITLE
[DRAFT] [ML] confidence interval experimentations

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -275,6 +275,9 @@ import org.elasticsearch.xpack.ml.aggs.categorization.CategorizeTextAggregationB
 import org.elasticsearch.xpack.ml.aggs.categorization.InternalCategorizationAggregation;
 import org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointAggregationBuilder;
 import org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointNamedContentProvider;
+import org.elasticsearch.xpack.ml.aggs.confidence.ConfidenceAggregationBuilder;
+import org.elasticsearch.xpack.ml.aggs.confidence.ConfidenceNamedWriteableProvider;
+import org.elasticsearch.xpack.ml.aggs.confidence.InternalConfidenceAggregation;
 import org.elasticsearch.xpack.ml.aggs.correlation.BucketCorrelationAggregationBuilder;
 import org.elasticsearch.xpack.ml.aggs.correlation.CorrelationNamedContentProvider;
 import org.elasticsearch.xpack.ml.aggs.heuristic.PValueScore;
@@ -1426,7 +1429,10 @@ public class MachineLearning extends Plugin
             ).addResultReader(org.elasticsearch.xpack.ml.aggs.categorization2.InternalCategorizationAggregation::new)
                 .setAggregatorRegistrar(
                     s -> s.registerUsage(org.elasticsearch.xpack.ml.aggs.categorization2.CategorizeTextAggregationBuilder.NAME)
-                )
+                ),
+            new AggregationSpec(ConfidenceAggregationBuilder.NAME, ConfidenceAggregationBuilder::new, ConfidenceAggregationBuilder.PARSER)
+                .addResultReader(InternalConfidenceAggregation::new)
+                .setAggregatorRegistrar(s -> s.registerUsage(ConfidenceAggregationBuilder.NAME))
         );
     }
 
@@ -1558,6 +1564,7 @@ public class MachineLearning extends Plugin
         namedWriteables.addAll(MlAutoscalingNamedWritableProvider.getNamedWriteables());
         namedWriteables.addAll(new CorrelationNamedContentProvider().getNamedWriteables());
         namedWriteables.addAll(new ChangePointNamedContentProvider().getNamedWriteables());
+        namedWriteables.addAll(ConfidenceNamedWriteableProvider.getNamedWriteables());
         return namedWriteables;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregationBuilder.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.AbstractRangeBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregatorFactory;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class ConfidenceAggregationBuilder extends AbstractAggregationBuilder<ConfidenceAggregationBuilder> {
+
+    public static final String NAME = "confidence";
+
+    static final ParseField CONFIDENCE_INTERVAL = new ParseField("confidence_interval");
+    static final ParseField KEYED = new ParseField("keyed");
+    static final ParseField DEBUG = new ParseField("debug");
+
+    public static final ObjectParser<ConfidenceAggregationBuilder, String> PARSER = ObjectParser.fromBuilder(
+        ConfidenceAggregationBuilder.NAME,
+        ConfidenceAggregationBuilder::new
+    );
+    static {
+        PARSER.declareInt(ConfidenceAggregationBuilder::setConfidenceInterval, CONFIDENCE_INTERVAL);
+        PARSER.declareBoolean(ConfidenceAggregationBuilder::setKeyed, KEYED);
+        PARSER.declareBoolean(ConfidenceAggregationBuilder::setDebug, DEBUG);
+    }
+
+    public static ConfidenceAggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
+        return PARSER.parse(parser, new ConfidenceAggregationBuilder(aggregationName), null);
+    }
+
+    private int confidenceInterval = 20;
+    private boolean keyed;
+    private boolean debug;
+
+    private ConfidenceAggregationBuilder(String name) {
+        super(name);
+    }
+
+    public ConfidenceAggregationBuilder setConfidenceInterval(int confidenceInterval) {
+        if (confidenceInterval <= 0 || confidenceInterval >= 100) {
+            throw ExceptionsHelper.badRequestException(
+                "[{}] must be greater than 0 and less than 100. Found [{}] in [{}]",
+                CONFIDENCE_INTERVAL.getPreferredName(),
+                confidenceInterval,
+                name
+            );
+        }
+        this.confidenceInterval = confidenceInterval;
+        return this;
+    }
+
+    @Override
+    public boolean supportsSampling() {
+        return true;
+    }
+
+    public ConfidenceAggregationBuilder setKeyed(boolean keyed) {
+        this.keyed = keyed;
+        return this;
+    }
+
+    public ConfidenceAggregationBuilder setDebug(boolean debug) {
+        this.debug = debug;
+        return this;
+    }
+
+    public ConfidenceAggregationBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.confidenceInterval = in.readVInt();
+        this.keyed = in.readBoolean();
+        this.debug = in.readBoolean();
+    }
+
+    protected ConfidenceAggregationBuilder(
+        ConfidenceAggregationBuilder clone,
+        AggregatorFactories.Builder factoriesBuilder,
+        Map<String, Object> metadata
+    ) {
+        super(clone, factoriesBuilder, metadata);
+        this.confidenceInterval = clone.confidenceInterval;
+        this.keyed = clone.keyed;
+        this.debug = clone.debug;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeVInt(confidenceInterval);
+        out.writeBoolean(keyed);
+        out.writeBoolean(debug);
+    }
+
+    static void recursivelyCheckSubAggs(Collection<AggregationBuilder> builders, Consumer<AggregationBuilder> aggregationCheck) {
+        if (builders == null || builders.isEmpty()) {
+            return;
+        }
+        for (AggregationBuilder b : builders) {
+            aggregationCheck.accept(b);
+            recursivelyCheckSubAggs(b.getSubAggregations(), aggregationCheck);
+        }
+    }
+
+    @Override
+    protected AggregatorFactory doBuild(
+        AggregationContext context,
+        AggregatorFactory parent,
+        AggregatorFactories.Builder subfactoriesBuilder
+    ) throws IOException {
+        ActionRequestValidationException validationException = null;
+        if (parent instanceof RandomSamplerAggregatorFactory == false) {
+            validationException = ValidateActions.addValidationError(
+                "parent aggregation must be [" + RandomSamplerAggregationBuilder.NAME + "]",
+                validationException
+            );
+        }
+        Set<String> previousAggNames = new HashSet<>();
+        previousAggNames.add(getName());
+        recursivelyCheckSubAggs(subfactoriesBuilder.getAggregatorFactories(), builder -> {
+            if (previousAggNames.add(builder.getName()) == false) {
+                throw new IllegalArgumentException(
+                    "[confidence] aggregation requires all sub-aggs have unique names; found duplicate name[" + builder.getName() + "]"
+                );
+            }
+            if (builder instanceof ValuesSourceAggregationBuilder.SingleMetricAggregationBuilder
+                || builder instanceof PercentilesAggregationBuilder
+                || builder instanceof TermsAggregationBuilder
+                || builder instanceof AbstractRangeBuilder
+                || builder instanceof DateHistogramAggregationBuilder
+                || builder instanceof HistogramAggregationBuilder
+                || builder instanceof FilterAggregationBuilder
+                || builder instanceof FiltersAggregationBuilder) if (builder.supportsSampling() == false) {
+                    throw new IllegalArgumentException(
+                        "[random_sampler] aggregation ["
+                            + getName()
+                            + "] does not support sampling ["
+                            + builder.getType()
+                            + "] aggregation ["
+                            + builder.getName()
+                            + "]"
+                    );
+                }
+        });
+
+        if (validationException != null) {
+            throw validationException;
+        }
+        return new ConfidenceAggregatorFactory(name, confidenceInterval, keyed, debug, context, parent, subfactoriesBuilder, metadata);
+    }
+
+    @Override
+    protected XContentBuilder internalXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(CONFIDENCE_INTERVAL.getPreferredName(), confidenceInterval);
+        builder.field(KEYED.getPreferredName(), keyed);
+        builder.field(DEBUG.getPreferredName(), debug);
+        builder.endObject();
+        return null;
+    }
+
+    @Override
+    protected AggregationBuilder shallowCopy(AggregatorFactories.Builder factoriesBuilder, Map<String, Object> metadata) {
+        return new ConfidenceAggregationBuilder(this, factoriesBuilder, metadata);
+    }
+
+    @Override
+    public AggregationBuilder.BucketCardinality bucketCardinality() {
+        return AggregationBuilder.BucketCardinality.MANY;
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_3_0;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.bucket.DeferableBucketAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.xpack.ml.math.FastOnePoisson;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.SplittableRandom;
+
+public class ConfidenceAggregator extends DeferableBucketAggregator {
+
+    private final int confidenceInterval;
+    private final int bucketCount;
+    private final double probability;
+    private final boolean keyed;
+    private final boolean debug;
+    private final FastOnePoisson fastOnePoisson;
+
+    protected ConfidenceAggregator(
+        String name,
+        AggregatorFactories factories,
+        AggregationContext context,
+        Aggregator parent,
+        int confidenceInterval,
+        double probability,
+        boolean keyed,
+        boolean debug,
+        int seed,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, factories, context, parent, metadata);
+        this.confidenceInterval = confidenceInterval;
+        double calculatedConfidenceInterval = confidenceInterval / 100.0;
+        this.bucketCount = (int) (Math.ceil(2.0 / (1.0 - calculatedConfidenceInterval))) + 1;
+        this.probability = probability;
+        this.fastOnePoisson = new FastOnePoisson(new SplittableRandom(seed));
+        this.keyed = keyed;
+        this.debug = debug;
+    }
+
+    @Override
+    protected void doClose() {
+        super.doClose();
+    }
+
+    @Override
+    public InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
+        return buildAggregationsForFixedBucketCount(owningBucketOrds, bucketCount, InternalConfidenceAggregation.Bucket::new, buckets -> {
+            CollectionUtil.introSort(buckets, Comparator.comparingLong(InternalConfidenceAggregation.Bucket::getRawKey));
+            return new InternalConfidenceAggregation(name, confidenceInterval, probability, keyed, debug, metadata(), buckets, List.of());
+        });
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalConfidenceAggregation(name, confidenceInterval, probability, keyed, debug, metadata());
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        return new LeafBucketCollectorBase(sub, null) {
+            @Override
+            public void collect(int doc, long owningBucketOrd) throws IOException {
+                collectBucket(sub, doc, calculateBucket(0, owningBucketOrd));
+                for (int i = 1; i < bucketCount; i++) {
+                    int iter = fastOnePoisson.next();
+                    for (int j = 0; j < iter; j++) {
+                        collectBucket(sub, doc, calculateBucket(i, owningBucketOrd));
+                    }
+                }
+            }
+        };
+    }
+
+    private long calculateBucket(int bucketNum, long owningBucketOrd) {
+        return owningBucketOrd * bucketCount + bucketNum;
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregatorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceAggregatorFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.apache.lucene.util.hppc.BitMixer;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.SamplingContext;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ConfidenceAggregatorFactory extends AggregatorFactory {
+
+    private final int confidenceInterval;
+    private final boolean keyed;
+    private final boolean debug;
+
+    public ConfidenceAggregatorFactory(
+        String name,
+        int confidenceInterval,
+        boolean keyed,
+        boolean debug,
+        AggregationContext context,
+        AggregatorFactory parent,
+        AggregatorFactories.Builder subFactoriesBuilder,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, context, parent, subFactoriesBuilder, metadata);
+        this.confidenceInterval = confidenceInterval;
+        this.keyed = keyed;
+        this.debug = debug;
+    }
+
+    @Override
+    protected Aggregator createInternal(Aggregator parent, CardinalityUpperBound cardinality, Map<String, Object> metadata)
+        throws IOException {
+        SamplingContext samplingContext = getSamplingContext().orElseThrow(
+            () -> new UnsupportedOperationException(
+                ConfidenceAggregationBuilder.NAME
+                    + " aggregation ["
+                    + name()
+                    + "] must be within a sampling context, please verify it is nested under a random_sampler aggregation"
+            )
+        );
+        return new ConfidenceAggregator(
+            name,
+            factories,
+            context,
+            parent,
+            confidenceInterval,
+            samplingContext.probability(),
+            keyed,
+            debug,
+            BitMixer.mix(context.shardRandomSeed() ^ samplingContext.seed()),
+            metadata
+        );
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalCardinality;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.Percentiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+abstract class ConfidenceBuilder {
+    protected final String name;
+    protected final InternalAggregation calculatedValue;
+    protected final List<InternalAggregation> values = new ArrayList<>();
+
+    static ConfidenceBuilder factory(InternalAggregation internalAggregation, String name, long docCount) {
+        if (internalAggregation instanceof InternalCardinality) {
+            throw new AggregationExecutionException("aggregations of type [cardinality] are not supported");
+        }
+        if (internalAggregation instanceof InternalNumericMetricsAggregation.SingleValue singleValue) {
+            return SingleMetricConfidenceBuilder.factory(singleValue, name, docCount);
+        } else if (internalAggregation instanceof Percentiles) {
+            return new MultiMetricConfidenceBuilder.MeanMultiMetricConfidenceBuilder(name, internalAggregation, agg -> {
+                List<Double> values = new ArrayList<>();
+                ((Percentiles) agg).iterator().forEachRemaining(p -> values.add(p.getValue()));
+                return values.stream().mapToDouble(Double::doubleValue).toArray();
+            }, agg -> {
+                List<String> keys = new ArrayList<>();
+                ((Percentiles) agg).iterator().forEachRemaining(p -> keys.add(Double.toString(p.getPercent())));
+                return keys.toArray(String[]::new);
+            });
+        } else if (internalAggregation instanceof InternalSingleBucketAggregation singleBucketAggregation) {
+            return new SingleBucketConfidenceBuilder(name, singleBucketAggregation.getAggregations(), singleBucketAggregation);
+        } else if (internalAggregation instanceof InternalMultiBucketAggregation<?, ?> bucketsAggregation) {
+            return new MultiBucketConfidenceBuilder(name, bucketsAggregation);
+        }
+        throw new AggregationExecutionException("aggregations of type [" + internalAggregation.getType() + "] are not supported");
+    }
+
+    ConfidenceBuilder(String name, InternalAggregation calculatedValue) {
+        this.name = name;
+        this.calculatedValue = calculatedValue;
+    }
+
+    void addAgg(InternalAggregation agg) {
+        values.add(agg);
+    }
+
+    abstract InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed);
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceNamedWriteableProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceNamedWriteableProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+
+import java.util.List;
+
+public final class ConfidenceNamedWriteableProvider {
+    private ConfidenceNamedWriteableProvider() {}
+
+    public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(
+            new NamedWriteableRegistry.Entry(
+                ConfidenceValue.class,
+                SingleMetricConfidenceBuilder.SingleMetricConfidenceValue.NAME,
+                SingleMetricConfidenceBuilder.SingleMetricConfidenceValue::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                ConfidenceValue.class,
+                MultiMetricConfidenceBuilder.MultiMetricConfidenceValue.NAME,
+                MultiMetricConfidenceBuilder.MultiMetricConfidenceValue::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                ConfidenceValue.class,
+                ConfidenceValue.BucketConfidenceValue.NAME,
+                ConfidenceValue.BucketConfidenceValue::fromStream
+            ),
+            new NamedWriteableRegistry.Entry(
+                ConfidenceValue.class,
+                MultiBucketConfidenceBuilder.MultiBucketConfidenceValue.NAME,
+                MultiBucketConfidenceBuilder.MultiBucketConfidenceValue::new
+            )
+        );
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceValue.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/ConfidenceValue.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+interface ConfidenceValue extends NamedWriteable, ToXContentObject {
+
+    record BucketConfidenceValue(double count, Map<String, ConfidenceValue> innerValues) implements ConfidenceValue {
+
+        static BucketConfidenceValue fromStream(StreamInput in) throws IOException {
+            return new BucketConfidenceValue(
+                in.readDouble(),
+                in.readMap(StreamInput::readString, (i) -> i.readNamedWriteable(ConfidenceValue.class))
+            );
+        }
+
+        static final String NAME = "bucket";
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(Aggregation.CommonFields.DOC_COUNT.getPreferredName(), count);
+            for (var entry : innerValues.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(count);
+            out.writeMap(innerValues, StreamOutput::writeString, StreamOutput::writeNamedWriteable);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/InternalConfidenceAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/InternalConfidenceAggregation.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.IteratorAndCurrent;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.support.SamplingContext;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class InternalConfidenceAggregation extends InternalMultiBucketAggregation<
+    InternalConfidenceAggregation,
+    InternalConfidenceAggregation.Bucket> {
+
+    static class ConfidenceBucket implements ToXContentObject, Writeable {
+        final ConfidenceValue upper;
+        final ConfidenceValue lower;
+        final ConfidenceValue value;
+        final String name;
+        final boolean keyed;
+
+        ConfidenceBucket(String name, boolean keyed, ConfidenceValue upper, ConfidenceValue lower, ConfidenceValue value) {
+            this.name = name;
+            this.upper = upper;
+            this.lower = lower;
+            this.value = value;
+            this.keyed = keyed;
+        }
+
+        ConfidenceBucket(StreamInput in) throws IOException {
+            this.name = in.readString();
+            this.upper = in.readNamedWriteable(ConfidenceValue.class);
+            this.lower = in.readNamedWriteable(ConfidenceValue.class);
+            this.value = in.readNamedWriteable(ConfidenceValue.class);
+            this.keyed = in.readBoolean();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            if (keyed) {
+                builder.startObject(name);
+            } else {
+                builder.startObject();
+                builder.field(CommonFields.KEY.getPreferredName(), name);
+            }
+            builder.field("calculated", value);
+            builder.field("upper", upper);
+            builder.field("lower", lower);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeNamedWriteable(upper);
+            out.writeNamedWriteable(lower);
+            out.writeNamedWriteable(value);
+            out.writeBoolean(keyed);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ConfidenceBucket that = (ConfidenceBucket) o;
+            return that.keyed == keyed
+                && Objects.equals(that.upper, upper)
+                && Objects.equals(that.lower, lower)
+                && Objects.equals(that.value, value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, upper, lower, value, keyed);
+        }
+    }
+
+    public static class Bucket extends InternalBucket implements MultiBucketsAggregation.Bucket {
+        final long key;
+        final long docCount;
+        InternalAggregations aggregations;
+
+        public Bucket(long key, long docCount, InternalAggregations aggregations) {
+            this.key = key;
+            this.docCount = docCount;
+            this.aggregations = aggregations;
+        }
+
+        public Bucket(StreamInput in) throws IOException {
+            key = in.readVLong();
+            docCount = in.readVLong();
+            aggregations = InternalAggregations.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(key);
+            out.writeVLong(getDocCount());
+            aggregations.writeTo(out);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(Aggregation.CommonFields.DOC_COUNT.getPreferredName(), docCount);
+            builder.field(Aggregation.CommonFields.KEY.getPreferredName(), key);
+            aggregations.toXContentInternal(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        public long getRawKey() {
+            return key;
+        }
+
+        @Override
+        public String getKeyAsString() {
+            return Long.toString(key);
+        }
+
+        @Override
+        public long getDocCount() {
+            return docCount;
+        }
+
+        @Override
+        public Aggregations getAggregations() {
+            return aggregations;
+        }
+
+        @Override
+        public String toString() {
+            return "Bucket{" + "key=" + getKeyAsString() + ", docCount=" + docCount + ", aggregations=" + aggregations.asMap() + "}";
+        }
+
+    }
+
+    private final List<Bucket> buckets;
+    private final List<ConfidenceBucket> confidences;
+    private final int confidenceInterval;
+    private final double probability;
+    private final double pLower;
+    private final double pUpper;
+    private final boolean keyed;
+    private final boolean debug;
+
+    protected InternalConfidenceAggregation(
+        String name,
+        int confidenceInterval,
+        double probability,
+        boolean keyed,
+        boolean debug,
+        Map<String, Object> metadata
+    ) {
+        this(name, confidenceInterval, probability, keyed, debug, metadata, new ArrayList<>(), new ArrayList<>());
+    }
+
+    protected InternalConfidenceAggregation(
+        String name,
+        int confidenceInterval,
+        double probability,
+        boolean keyed,
+        boolean debug,
+        Map<String, Object> metadata,
+        List<Bucket> buckets,
+        List<ConfidenceBucket> confidences
+    ) {
+        super(name, metadata);
+        this.confidenceInterval = confidenceInterval;
+        this.buckets = buckets;
+        this.probability = probability;
+        this.confidences = confidences;
+        double calculatedConfidenceInterval = confidenceInterval / 100.0;
+        this.pLower = (1.0 - calculatedConfidenceInterval) / 2.0;
+        this.pUpper = (1.0 + calculatedConfidenceInterval) / 2.0;
+        this.keyed = keyed;
+        this.debug = debug;
+    }
+
+    public InternalConfidenceAggregation(StreamInput in) throws IOException {
+        super(in);
+        this.buckets = in.readList(Bucket::new);
+        this.probability = in.readDouble();
+        this.confidenceInterval = in.readVInt();
+        this.confidences = in.readList(ConfidenceBucket::new);
+        this.keyed = in.readBoolean();
+        this.debug = in.readBoolean();
+        double calculatedConfidenceInterval = confidenceInterval / 100.0;
+        this.pLower = (1.0 - calculatedConfidenceInterval) / 2.0;
+        this.pUpper = (1.0 + calculatedConfidenceInterval) / 2.0;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeList(buckets);
+        out.writeDouble(probability);
+        out.writeVInt(confidenceInterval);
+        out.writeList(confidences);
+        out.writeBoolean(keyed);
+        out.writeBoolean(debug);
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (keyed) {
+            builder.startObject("confidences");
+        } else {
+            builder.startArray("confidences");
+        }
+        for (ConfidenceBucket confidences : confidences) {
+            confidences.toXContent(builder, params);
+        }
+        if (keyed) {
+            builder.endObject();
+        } else {
+            builder.endArray();
+        }
+        if (debug) {
+            builder.startArray(CommonFields.BUCKETS.getPreferredName());
+            for (Bucket bucket : buckets) {
+                bucket.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+        return builder;
+    }
+
+    @Override
+    public InternalConfidenceAggregation create(List<Bucket> buckets) {
+        return new InternalConfidenceAggregation(name, confidenceInterval, probability, keyed, debug, super.metadata, buckets, confidences);
+    }
+
+    @Override
+    public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
+        return new Bucket(prototype.key, prototype.docCount, aggregations);
+    }
+
+    public Bucket createBucket(long key, long docCount, InternalAggregations aggregations) {
+        return new Bucket(key, docCount, aggregations);
+    }
+
+    @Override
+    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+        assert buckets.size() > 0;
+        List<InternalAggregations> aggregations = new ArrayList<>(buckets.size());
+        long docCount = 0;
+        for (Bucket bucket : buckets) {
+            docCount += bucket.docCount;
+            aggregations.add((InternalAggregations) bucket.getAggregations());
+        }
+        InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
+        return createBucket(buckets.get(0).key, docCount, aggs);
+    }
+
+    @Override
+    public List<Bucket> getBuckets() {
+        return buckets;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ConfidenceAggregationBuilder.NAME;
+    }
+
+    private List<Bucket> reduceBuckets(List<InternalAggregation> aggregations, AggregationReduceContext reduceContext) {
+        final PriorityQueue<IteratorAndCurrent<Bucket>> pq = new PriorityQueue<>(aggregations.size()) {
+            @Override
+            protected boolean lessThan(IteratorAndCurrent<Bucket> a, IteratorAndCurrent<Bucket> b) {
+                return a.current().key < b.current().key;
+            }
+        };
+        for (InternalAggregation aggregation : aggregations) {
+            InternalConfidenceAggregation confidence = (InternalConfidenceAggregation) aggregation;
+            if (confidence.buckets.isEmpty() == false) {
+                pq.add(new IteratorAndCurrent<>(confidence.buckets.iterator()));
+            }
+        }
+
+        List<Bucket> reducedBuckets = new ArrayList<>();
+        if (pq.size() > 0) {
+            // list of buckets coming from different shards that have the same key
+            List<Bucket> currentBuckets = new ArrayList<>();
+            long key = pq.top().current().key;
+            do {
+                final IteratorAndCurrent<Bucket> top = pq.top();
+                if (top.current().key != key) {
+                    // The key changes, reduce what we already buffered and reset the buffer for current buckets.
+                    // Using Double.compare instead of != to handle NaN correctly.
+                    final Bucket reduced = reduceBucket(currentBuckets, reduceContext);
+                    reducedBuckets.add(reduced);
+                    currentBuckets.clear();
+                    key = top.current().key;
+                }
+
+                currentBuckets.add(top.current());
+
+                if (top.hasNext()) {
+                    top.next();
+                    assert top.current().key > key : "shards must return data sorted by key";
+                    pq.updateTop();
+                } else {
+                    pq.pop();
+                }
+            } while (pq.size() > 0);
+
+            if (currentBuckets.isEmpty() == false) {
+                final Bucket reduced = reduceBucket(currentBuckets, reduceContext);
+                reducedBuckets.add(reduced);
+            }
+        }
+
+        return reducedBuckets;
+    }
+
+    @Override
+    public InternalAggregation reduce(List<InternalAggregation> aggregations, AggregationReduceContext reduceContext) {
+        List<Bucket> mergedBuckets = reduceBuckets(aggregations, reduceContext);
+        if (reduceContext.isFinalReduce() == false || mergedBuckets.isEmpty()) {
+            return new InternalConfidenceAggregation(
+                name,
+                this.confidenceInterval,
+                probability,
+                keyed,
+                debug,
+                metadata,
+                mergedBuckets,
+                List.of()
+            );
+        }
+
+        Map<String, ConfidenceBuilder> builders = new HashMap<>();
+        final Bucket calculatedValueBucket = mergedBuckets.get(0);
+        final long docCount = calculatedValueBucket.getDocCount();
+        calculatedValueBucket.aggregations.asList()
+            .forEach(agg -> builders.put(agg.getName(), ConfidenceBuilder.factory((InternalAggregation) agg, agg.getName(), docCount)));
+
+        for (Bucket b : mergedBuckets.subList(1, mergedBuckets.size())) {
+            b.aggregations.asList().forEach(agg -> builders.get(agg.getName()).addAgg((InternalAggregation) agg));
+        }
+        return new InternalConfidenceAggregation(
+            name,
+            this.confidenceInterval,
+            probability,
+            this.keyed,
+            this.debug,
+            metadata,
+            mergedBuckets,
+            builders.values().stream().map((cb) -> cb.build(probability, pUpper, pLower, keyed)).collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public InternalAggregation finalizeSampling(SamplingContext samplingContext) {
+        return this;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/MultiBucketConfidenceBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/MultiBucketConfidenceBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MultiBucketConfidenceBuilder extends ConfidenceBuilder {
+
+    private final Map<String, BucketConfidenceBuilder> innerConfidenceBuilders;
+
+    MultiBucketConfidenceBuilder(String name, InternalMultiBucketAggregation<?, ?> calculatedValue) {
+        super(name, calculatedValue);
+        this.innerConfidenceBuilders = new LinkedHashMap<>();
+        calculatedValue.getBuckets()
+            .forEach(bucket -> innerConfidenceBuilders.put(bucket.getKeyAsString(), new BucketConfidenceBuilder(bucket)));
+    }
+
+    @Override
+    InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+        values.forEach(agg -> {
+            InternalMultiBucketAggregation<?, ?> bootStrapped = (InternalMultiBucketAggregation<?, ?>) agg;
+            bootStrapped.getBuckets().forEach(b -> {
+                BucketConfidenceBuilder builder = innerConfidenceBuilders.get(b.getKeyAsString());
+                if (builder == null) {
+                    throw new AggregationExecutionException(
+                        "cannot calculate confidence for multi-bucket agg ["
+                            + name
+                            + "] sampled aggregation has unexpected bucket key ["
+                            + b.getKeyAsString()
+                            + "]"
+                    );
+                }
+                builder.addBucket(b);
+            });
+        });
+        Map<String, ConfidenceValue> upperBucketValues = new LinkedHashMap<>();
+        Map<String, ConfidenceValue> calculatedBucketValues = new LinkedHashMap<>();
+        Map<String, ConfidenceValue> lowerBucketValues = new LinkedHashMap<>();
+        innerConfidenceBuilders.forEach((bucketKey, builder) -> {
+            InternalConfidenceAggregation.ConfidenceBucket intermediateResult = builder.build(probability, pUpper, pLower, keyed);
+            upperBucketValues.put(bucketKey, intermediateResult.upper);
+            lowerBucketValues.put(bucketKey, intermediateResult.lower);
+            calculatedBucketValues.put(bucketKey, intermediateResult.value);
+        });
+        return new InternalConfidenceAggregation.ConfidenceBucket(
+            name,
+            keyed,
+            new MultiBucketConfidenceValue(upperBucketValues),
+            new MultiBucketConfidenceValue(lowerBucketValues),
+            new MultiBucketConfidenceValue(calculatedBucketValues)
+        );
+    }
+
+    static class MultiBucketConfidenceValue implements ConfidenceValue {
+        static final String NAME = "single_bucket_confidence_value";
+        private final Map<String, ConfidenceValue> bucketConfidenceValues;
+
+        MultiBucketConfidenceValue(Map<String, ConfidenceValue> innerValue) {
+            this.bucketConfidenceValues = innerValue;
+        }
+
+        MultiBucketConfidenceValue(StreamInput in) throws IOException {
+            this.bucketConfidenceValues = in.readOrderedMap(StreamInput::readString, i -> i.readNamedWriteable(ConfidenceValue.class));
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(Aggregation.CommonFields.BUCKETS.getPreferredName(), bucketConfidenceValues);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeMap(bucketConfidenceValues, StreamOutput::writeString, StreamOutput::writeNamedWriteable);
+        }
+    }
+
+    private static class BucketConfidenceBuilder {
+        private final Map<String, ConfidenceBuilder> innerBucketConfidenceBuilders;
+        private final MultiBucketsAggregation.Bucket bucketValue;
+
+        private BucketConfidenceBuilder(MultiBucketsAggregation.Bucket trueBucketValue) {
+            this.bucketValue = trueBucketValue;
+            this.innerBucketConfidenceBuilders = new LinkedHashMap<>();
+            trueBucketValue.getAggregations()
+                .forEach(
+                    agg -> innerBucketConfidenceBuilders.put(
+                        agg.getName(),
+                        ConfidenceBuilder.factory((InternalAggregation) agg, agg.getName(), bucketValue.getDocCount())
+                    )
+                );
+        }
+
+        private void addBucket(MultiBucketsAggregation.Bucket bucket) {
+            assert bucket.getKey().equals(bucketValue.getKey())
+                : "cannot build confidence between mismatched buckets ["
+                    + bucketValue.getKeyAsString()
+                    + "] ["
+                    + bucket.getKeyAsString()
+                    + "]";
+            bucket.getAggregations().forEach(agg -> innerBucketConfidenceBuilders.get(agg.getName()).addAgg((InternalAggregation) agg));
+        }
+
+        private InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+            Map<String, ConfidenceValue> upperValues = new HashMap<>();
+            Map<String, ConfidenceValue> calculatedValues = new HashMap<>();
+            Map<String, ConfidenceValue> lowerValues = new HashMap<>();
+            innerBucketConfidenceBuilders.forEach((aggName, builder) -> {
+                InternalConfidenceAggregation.ConfidenceBucket intermediateResult = builder.build(probability, pUpper, pLower, keyed);
+                upperValues.put(aggName, intermediateResult.upper);
+                lowerValues.put(aggName, intermediateResult.lower);
+                calculatedValues.put(aggName, intermediateResult.value);
+            });
+            InternalConfidenceAggregation.ConfidenceBucket intermediateResult = SingleMetricConfidenceBuilder.fromCount(
+                bucketValue.getKeyAsString(),
+                bucketValue.getDocCount(),
+                probability,
+                pUpper,
+                pLower,
+                keyed
+            );
+            return new InternalConfidenceAggregation.ConfidenceBucket(
+                bucketValue.getKeyAsString(),
+                keyed,
+                new ConfidenceValue.BucketConfidenceValue(
+                    ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.upper).value(),
+                    upperValues
+                ),
+                new ConfidenceValue.BucketConfidenceValue(
+                    ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.lower).value(),
+                    lowerValues
+                ),
+                new ConfidenceValue.BucketConfidenceValue(
+                    ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.value).value(),
+                    calculatedValues
+                )
+            );
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/MultiMetricConfidenceBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/MultiMetricConfidenceBuilder.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+abstract class MultiMetricConfidenceBuilder extends ConfidenceBuilder {
+
+    @FunctionalInterface
+    interface ValueExtractor {
+        double[] extract(InternalAggregation internalAggregation);
+    }
+
+    @FunctionalInterface
+    interface KeyExtractor {
+        String[] extract(InternalAggregation internalAggregation);
+    }
+
+    @FunctionalInterface
+    interface CountExtractor {
+        long[] extract(InternalAggregation internalAggregation);
+    }
+
+    static double percentile(double p, double value, double[][] values, int index) {
+        final double r = Math.max(p, 1 - p);
+        final int n = (int) Math.floor(r * values.length);
+        double alpha = Math.abs(r - (n + 1.0) / values.length);
+        double beta = Math.abs(r - n / (double) values.length);
+        final double z = alpha + beta;
+        alpha /= z;
+        beta /= z;
+        final double shift;
+        if (p < 0.5) {
+            shift = n < values.length
+                ? alpha * values[values.length - n][index] + beta * values[values.length - n - 1][index]
+                : values[0][index];
+        } else {
+            shift = n + 1 < values.length ? alpha * values[n - 1][index] + beta * values[n][index] : values[values.length - 1][index];
+        }
+        return value * 2.0 - shift;
+    }
+
+    protected final ValueExtractor valueExtractor;
+    protected final KeyExtractor keyExtractor;
+
+    MultiMetricConfidenceBuilder(
+        String name,
+        InternalAggregation calculatedValue,
+        ValueExtractor valueExtractor,
+        KeyExtractor keyExtractor
+    ) {
+        super(name, calculatedValue);
+        this.valueExtractor = valueExtractor;
+        this.keyExtractor = keyExtractor;
+    }
+
+    static class MeanMultiMetricConfidenceBuilder extends MultiMetricConfidenceBuilder {
+
+        MeanMultiMetricConfidenceBuilder(
+            String name,
+            InternalAggregation calculatedValue,
+            ValueExtractor valueExtractor,
+            KeyExtractor keyExtractor
+        ) {
+            super(name, calculatedValue, valueExtractor, keyExtractor);
+        }
+
+        @Override
+        InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+            double[] calculated = valueExtractor.extract(calculatedValue);
+            double[][] extractedValues = new double[this.values.size()][];
+            int i = 0;
+            for (InternalAggregation agg : this.values) {
+                extractedValues[i++] = valueExtractor.extract(agg);
+            }
+            Arrays.sort(extractedValues, Comparator.comparingDouble((double[] o) -> o[0]).reversed());
+
+            double[] upper = new double[calculated.length];
+            double[] lower = new double[calculated.length];
+            double[] center = new double[calculated.length];
+            for (int j = 0; j < calculated.length; j++) {
+                upper[j] = probability * calculated[j] + (1 - probability) * percentile(pUpper, calculated[j], extractedValues, j);
+                lower[j] = probability * calculated[j] + (1 - probability) * percentile(pLower, calculated[j], extractedValues, j);
+                center[j] = probability * calculated[j] + (1 - probability) * percentile(0.5, calculated[j], extractedValues, j);
+            }
+            String[] keys = keyExtractor.extract(calculatedValue);
+            return new InternalConfidenceAggregation.ConfidenceBucket(
+                name,
+                keyed,
+                new MultiMetricConfidenceValue(upper, keys),
+                new MultiMetricConfidenceValue(lower, keys),
+                new MultiMetricConfidenceValue(center, keys)
+            );
+        }
+    }
+
+    static class MultiMetricConfidenceValue implements ConfidenceValue {
+        static final String NAME = "multi_metric_confidence";
+
+        private final double[] value;
+        private final String[] keys;
+
+        MultiMetricConfidenceValue(double[] value, String[] keys) {
+            this.value = value;
+            this.keys = keys;
+        }
+
+        MultiMetricConfidenceValue(StreamInput in) throws IOException {
+            this.value = in.readDoubleArray();
+            this.keys = in.readStringArray();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            for (int i = 0; i < keys.length; i++) {
+                builder.field(keys[i], value[i]);
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDoubleArray(value);
+            out.writeStringArray(keys);
+        }
+
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/SingleBucketConfidenceBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/SingleBucketConfidenceBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SingleBucketConfidenceBuilder extends ConfidenceBuilder {
+
+    private final Map<String, ConfidenceBuilder> innerConfidenceBuilders;
+
+    SingleBucketConfidenceBuilder(String name, InternalAggregations internalAggregations, InternalSingleBucketAggregation calculatedValue) {
+        super(name, calculatedValue);
+        this.innerConfidenceBuilders = new HashMap<>();
+        internalAggregations.asList()
+            .forEach(
+                agg -> innerConfidenceBuilders.put(
+                    agg.getName(),
+                    ConfidenceBuilder.factory((InternalAggregation) agg, agg.getName(), calculatedValue.getDocCount())
+                )
+            );
+    }
+
+    @Override
+    InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+        Map<String, ConfidenceValue> upperValues = new HashMap<>();
+        Map<String, ConfidenceValue> calculatedValues = new HashMap<>();
+        Map<String, ConfidenceValue> lowerValues = new HashMap<>();
+        values.forEach(agg -> {
+            InternalSingleBucketAggregation singleBucketAggregation = (InternalSingleBucketAggregation) agg;
+            singleBucketAggregation.getAggregations().forEach(innerAgg -> {
+                ConfidenceBuilder builder = innerConfidenceBuilders.get(innerAgg.getName());
+                if (builder == null) {
+                    throw new AggregationExecutionException(
+                        "calculating confidence for aggregation [" + name + "] encountered missing sub-agg [" + innerAgg.getName() + "]"
+                    );
+                }
+                builder.addAgg((InternalAggregation) innerAgg);
+            });
+        });
+        innerConfidenceBuilders.forEach((aggName, builder) -> {
+            InternalConfidenceAggregation.ConfidenceBucket intermediateResult = builder.build(probability, pUpper, pLower, keyed);
+            upperValues.put(aggName, intermediateResult.upper);
+            lowerValues.put(aggName, intermediateResult.lower);
+            calculatedValues.put(aggName, intermediateResult.value);
+        });
+        InternalConfidenceAggregation.ConfidenceBucket intermediateResult = SingleMetricConfidenceBuilder.fromCount(
+            name,
+            ((SingleBucketAggregation) calculatedValue).getDocCount(),
+            probability,
+            pUpper,
+            pLower,
+            keyed
+        );
+        return new InternalConfidenceAggregation.ConfidenceBucket(
+            name,
+            keyed,
+            new ConfidenceValue.BucketConfidenceValue(
+                ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.upper).value(),
+                upperValues
+            ),
+            new ConfidenceValue.BucketConfidenceValue(
+                ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.lower).value(),
+                lowerValues
+            ),
+            new ConfidenceValue.BucketConfidenceValue(
+                ((SingleMetricConfidenceBuilder.SingleMetricConfidenceValue) intermediateResult.value).value(),
+                calculatedValues
+            )
+        );
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/SingleMetricConfidenceBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/confidence/SingleMetricConfidenceBuilder.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.confidence;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.Sum;
+import org.elasticsearch.search.aggregations.metrics.ValueCount;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.ml.math.LongBinomialDistribution;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+abstract class SingleMetricConfidenceBuilder extends ConfidenceBuilder {
+
+    SingleMetricConfidenceBuilder(String name, InternalAggregation calculatedValue) {
+        super(name, calculatedValue);
+    }
+
+    double calculatedValue() {
+        return extractValue(calculatedValue);
+    }
+
+    double extractValue(InternalAggregation aggregation) {
+        return ((InternalNumericMetricsAggregation.SingleValue) aggregation).value();
+    }
+
+    static SingleMetricConfidenceValue constructConfidenceValue(double value) {
+        return new SingleMetricConfidenceValue(value);
+    }
+
+    protected Double[] extractValues() {
+        Double[] extractedValues = new Double[this.values.size()];
+        int i = 0;
+        for (InternalAggregation agg : this.values) {
+            extractedValues[i++] = extractValue(agg);
+        }
+        Arrays.sort(extractedValues, Collections.reverseOrder());
+        return extractedValues;
+    }
+
+    static ConfidenceBuilder factory(InternalNumericMetricsAggregation.SingleValue internalAggregation, String name, long docCount) {
+        if (internalAggregation instanceof Sum) {
+            return new SumSingleMetricConfidenceBuilder(name, internalAggregation, docCount);
+        } else if (internalAggregation instanceof ValueCount) {
+            return new CountSingleMetricConfidenceBuilder(name, internalAggregation);
+        }
+        return new MeanSingleMetricConfidenceBuilder(name, internalAggregation);
+    }
+
+    static double percentile(double p, double value, Double[] values) {
+        final double r = Math.max(p, 1 - p);
+        final int n = (int) Math.floor(r * values.length);
+        double alpha = Math.abs(r - (n + 1.0) / values.length);
+        double beta = Math.abs(r - n / (double) values.length);
+        final double z = alpha + beta;
+        alpha /= z;
+        beta /= z;
+        final double shift;
+        if (p < 0.5) {
+            shift = n < values.length ? alpha * values[values.length - n] + beta * values[values.length - n - 1] : values[0];
+        } else {
+            shift = n + 1 < values.length ? alpha * values[n - 1] + beta * values[n] : values[values.length - 1];
+        }
+        return value * 2.0 - shift;
+    }
+
+    static InternalConfidenceAggregation.ConfidenceBucket fromCount(
+        String name,
+        double calculated,
+        double probability,
+        double pUpper,
+        double pLower,
+        boolean keyed
+    ) {
+        double upper = new LongBinomialDistribution((long) (calculated / probability), probability).inverseCumulativeProbability(pUpper);
+        double lower = new LongBinomialDistribution((long) (calculated / probability), probability).inverseCumulativeProbability(pLower);
+        double scale = (1 - probability) / probability;
+        SingleMetricConfidenceValue upperValue = constructConfidenceValue(calculated + scale * upper);
+        SingleMetricConfidenceValue lowerValue = constructConfidenceValue(calculated + scale * lower);
+        SingleMetricConfidenceValue centerValue = constructConfidenceValue((scale + 1) * calculated);
+        return new InternalConfidenceAggregation.ConfidenceBucket(name, keyed, upperValue, lowerValue, centerValue);
+    }
+
+    static class MeanSingleMetricConfidenceBuilder extends SingleMetricConfidenceBuilder {
+
+        MeanSingleMetricConfidenceBuilder(String name, InternalAggregation calculatedValue) {
+            super(name, calculatedValue);
+        }
+
+        @Override
+        InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+            double calculated = calculatedValue();
+            Double[] extractedValues = extractValues();
+            double upper = percentile(pUpper, calculated, extractedValues);
+            double center = percentile(0.5, calculated, extractedValues);
+            double lower = percentile(pLower, calculated, extractedValues);
+            return new InternalConfidenceAggregation.ConfidenceBucket(
+                name,
+                keyed,
+                constructConfidenceValue(probability * calculated + (1 - probability) * upper),
+                constructConfidenceValue(probability * calculated + (1 - probability) * lower),
+                constructConfidenceValue(probability * calculated + (1 - probability) * center)
+            );
+        }
+
+    }
+
+    static class CountSingleMetricConfidenceBuilder extends SingleMetricConfidenceBuilder {
+
+        CountSingleMetricConfidenceBuilder(String name, InternalAggregation calculatedValue) {
+            super(name, calculatedValue);
+        }
+
+        @Override
+        InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+            return fromCount(name, calculatedValue(), probability, pUpper, pLower, keyed);
+        }
+    }
+
+    static class SumSingleMetricConfidenceBuilder extends SingleMetricConfidenceBuilder {
+
+        private final long docCount;
+
+        SumSingleMetricConfidenceBuilder(String name, InternalAggregation calculatedValue, long docCount) {
+            super(name, calculatedValue);
+            this.docCount = docCount;
+        }
+
+        @Override
+        InternalConfidenceAggregation.ConfidenceBucket build(double probability, double pUpper, double pLower, boolean keyed) {
+            double calculatedValue = extractValue(this.calculatedValue);
+            Double[] samples = extractValues();
+            double scale = (1.0 - probability) / probability;
+            double upperErrorCount = scale * (new LongBinomialDistribution((long) (docCount / probability), probability)
+                .inverseCumulativeProbability(pUpper)) + calculatedValue / docCount - calculatedValue;
+            double lowerErrorCount = scale * (new LongBinomialDistribution((long) (docCount / probability), probability)
+                .inverseCumulativeProbability(pLower)) + calculatedValue / docCount - calculatedValue;
+            double sampleMedian = percentile(0.5, calculatedValue, samples);
+            double upperErrorMetric = scale * (percentile(pUpper, calculatedValue, samples) - sampleMedian);
+            double lowerErrorMetric = scale * (percentile(pLower, calculatedValue, samples) - sampleMedian);
+            return new InternalConfidenceAggregation.ConfidenceBucket(
+                name,
+                keyed,
+                new SingleMetricConfidenceValue(
+                    (1 + scale) * calculatedValue + Math.sqrt(Math.pow(upperErrorMetric, 2) + Math.pow(upperErrorCount, 2))
+                ),
+                new SingleMetricConfidenceValue(
+                    (1 + scale) * calculatedValue - Math.sqrt(Math.pow(lowerErrorMetric, 2) + Math.pow(lowerErrorCount, 2))
+                ),
+                new SingleMetricConfidenceValue((1 + scale) * calculatedValue)
+            );
+        }
+    }
+
+    static class SingleMetricConfidenceValue implements ConfidenceValue {
+        static final String NAME = "single_metric_confidence";
+
+        private final double value;
+
+        protected SingleMetricConfidenceValue(double value) {
+            this.value = value;
+        }
+
+        SingleMetricConfidenceValue(StreamInput in) throws IOException {
+            this.value = in.readDouble();
+        }
+
+        double value() {
+            return value;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(Aggregation.CommonFields.VALUE.getPreferredName(), value);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(value);
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScore.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScore.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.ml.math.LongBinomialDistribution;
+import org.elasticsearch.xpack.ml.math.MlChiSquaredDistribution;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/FastOnePoisson.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/FastOnePoisson.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.math;
+
+import java.util.Arrays;
+import java.util.SplittableRandom;
+
+/**
+ * Optimized distribution sampling for the poisson distribution
+ */
+public class FastOnePoisson {
+
+    private static final double[] CDF;
+    private static final double[] COND_CDF;
+    private static final int[] BUCKET_SAMPLES;
+    private static final double[] CORRECTIONS;
+    private static final int NEED_TO_GENERATE = 4;
+    private static final double RNG_RANGE = 4294967296.0; // = 2^32
+    static {
+        CDF = new double[12];
+        double f = Math.exp(-1.0);
+        CDF[0] = f;
+        for (int i = 1; i < 12; i++) {
+            f /= (i);
+            CDF[i] = CDF[i - 1] + f;
+        }
+
+        {
+            f = Math.exp(-1.0);
+            double F = f;
+            int i = 0;
+            for (; F < 255.0 / 256.0; i++) {
+                f /= (i + 1);
+                F += f;
+            }
+            COND_CDF = new double[12];
+            COND_CDF[i] = F - 255.0 / 256.0;
+            for (i++; i < COND_CDF.length; i++) {
+                f /= i;
+                COND_CDF[i] = COND_CDF[i - 1] + f;
+            }
+        }
+        for (int i = 0; i < COND_CDF.length; i++) {
+            COND_CDF[i] /= COND_CDF[COND_CDF.length - 1];
+        }
+
+        BUCKET_SAMPLES = new int[256];
+        for (int i = 0; i < BUCKET_SAMPLES.length; ++i) {
+            BUCKET_SAMPLES[i] = sample(CDF, (i + 0.5) / 256.0);
+        }
+
+        CORRECTIONS = new double[4];
+        CORRECTIONS[0] = 256.0 * CDF[0] - 94.0;
+        CORRECTIONS[1] = 256.0 * CDF[1] - 188.0;
+        CORRECTIONS[2] = 256.0 * CDF[2] - 235.0;
+        CORRECTIONS[3] = 256.0 * CDF[3] - 251.0;
+    }
+
+    private final SplittableRandom rng;
+    private int currentSample = NEED_TO_GENERATE - 1;
+    private final int[] currentSamples = new int[NEED_TO_GENERATE];
+
+    public FastOnePoisson(SplittableRandom pcg) {
+        rng = pcg;
+    }
+
+    public int next() {
+        currentSample++;
+        // Branch prediction should be essentially perfect here so this should be free.
+        if (currentSample == NEED_TO_GENERATE) {
+            generate();
+            currentSample = 0;
+        }
+        return currentSamples[currentSample];
+    }
+
+    private void generate() {
+        final int rn = rng.nextInt();
+        currentSamples[0] = sample(rn & 255);
+        currentSamples[1] = sample((rn >> 8) & 255);
+        currentSamples[2] = sample((rn >> 16) & 255);
+        currentSamples[3] = sample((rn >> 24) & 255);
+    }
+
+    // Fast 32 bit accurate Poisson sampling.
+    private int sample(int bucket) {
+        switch (bucket) {
+            case 94: {
+                final double u01 = 0.5 + rng.nextInt() / RNG_RANGE;
+                return u01 < CORRECTIONS[0] ? 0 : 1;
+            }
+            case 188: {
+                final double u01 = 0.5 + rng.nextInt() / RNG_RANGE;
+                return u01 < CORRECTIONS[1] ? 1 : 2;
+            }
+            case 235: {
+                final double u01 = 0.5 + rng.nextInt() / RNG_RANGE;
+                return u01 < CORRECTIONS[2] ? 2 : 3;
+            }
+            case 251: {
+                final double u01 = 0.5 + rng.nextInt() / RNG_RANGE;
+                return u01 < CORRECTIONS[3] ? 3 : 4;
+            }
+            case 255: {
+                // Fallback to expensive method but cost is amortised away.
+                final double u01 = 0.5 + rng.nextInt() / RNG_RANGE;
+                return sample(COND_CDF, u01);
+            }
+            default:
+                return BUCKET_SAMPLES[bucket];
+        }
+    }
+
+    private static int sample(double[] cdf, double u01) {
+        final int pos = Arrays.binarySearch(cdf, u01);
+        return pos < 0 ? -pos - 1 : pos;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/LongBinomialDistribution.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/LongBinomialDistribution.java
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.elasticsearch.xpack.ml.aggs.heuristic;
+package org.elasticsearch.xpack.ml.math;
 
+import org.apache.commons.math3.exception.OutOfRangeException;
+import org.apache.commons.math3.special.Beta;
 import org.apache.commons.math3.special.Gamma;
 import org.apache.commons.math3.util.FastMath;
 import org.apache.commons.math3.util.MathUtils;
@@ -92,6 +94,68 @@ public class LongBinomialDistribution {
             ret = logBinomialProbability(x, numberOfTrials, probabilityOfSuccess, 1.0 - probabilityOfSuccess);
         }
         return ret;
+    }
+
+    public long inverseCumulativeProbability(final double p) throws OutOfRangeException {
+        if (p < 0.0 || p > 1.0) {
+            throw new OutOfRangeException(p, 0, 1);
+        }
+
+        long lower = -1;
+        long upper = numberOfTrials;
+
+        // use the one-sided Chebyshev inequality to narrow the bracket
+        // cf. AbstractRealDistribution.inverseCumulativeProbability(double)
+        final double mu = numberOfTrials * probabilityOfSuccess;
+        final double sigma = FastMath.sqrt(numberOfTrials * probabilityOfSuccess * (1 - probabilityOfSuccess));
+        double k = FastMath.sqrt((1.0 - p) / p);
+        double tmp = mu - k * sigma;
+        if (tmp > lower) {
+            lower = ((int) FastMath.ceil(tmp)) - 1;
+        }
+        k = 1.0 / k;
+        tmp = mu + k * sigma;
+        if (tmp < upper) {
+            upper = ((int) FastMath.ceil(tmp)) - 1;
+        }
+        return solveInverseCumulativeProbability(p, lower, upper);
+    }
+
+    public double cumulativeProbability(long x) {
+        double ret;
+        if (x < 0) {
+            ret = 0.0;
+        } else if (x >= numberOfTrials) {
+            ret = 1.0;
+        } else {
+            ret = 1.0 - Beta.regularizedBeta(probabilityOfSuccess, x + 1.0, numberOfTrials - x);
+        }
+        return ret;
+    }
+
+    protected long solveInverseCumulativeProbability(final double p, long lower, long upper) {
+        while (lower + 1 < upper) {
+            long xm = (lower + upper) / 2;
+            if (xm < lower || xm > upper) {
+                /*
+                 * Overflow.
+                 * There will never be an overflow in both calculation methods
+                 * for xm at the same time
+                 */
+                xm = lower + (upper - lower) / 2;
+            }
+
+            double pm = cumulativeProbability(xm);
+            if (Double.isNaN(pm)) {
+                throw new IllegalStateException("cdf of binomial distrib threw NaN");
+            }
+            if (pm >= p) {
+                upper = xm;
+            } else {
+                lower = xm;
+            }
+        }
+        return upper;
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/MlChiSquaredDistribution.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/math/MlChiSquaredDistribution.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.ml.aggs.heuristic;
+package org.elasticsearch.xpack.ml.math;
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 import org.apache.commons.math3.special.Gamma;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/MlChiSquaredDistributionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/MlChiSquaredDistributionTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.aggs.heuristic;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ml.math.MlChiSquaredDistribution;
 
 import static org.hamcrest.Matchers.closeTo;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/math/FastOnePoissonTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/math/FastOnePoissonTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.math;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.SplittableRandom;
+
+import static org.hamcrest.Matchers.closeTo;
+
+public class FastOnePoissonTests extends ESTestCase {
+
+    private static final int N = 10_000_000;
+
+    public void testOnePoissonSeries() {
+        final SplittableRandom rng = new SplittableRandom(randomLong());
+        final int size = 12;
+
+        double[] expected = new double[size];
+        double f = Math.exp(-1.0);
+        for (int k = 0; k < size;) {
+            expected[k] = Math.floor((double) N * f + 0.5) / (double) N;
+            f /= ++k;
+        }
+
+        FastOnePoisson poisson = new FastOnePoisson(rng);
+        int[] counts = new int[size];
+        double mean = 0.0;
+        for (int i = 0; i < N; ++i) {
+            int sample = poisson.next();
+            if (sample < counts.length) {
+                counts[sample]++;
+            }
+            mean += sample;
+        }
+        mean /= N;
+        double[] fractions = new double[counts.length];
+        for (int i = 0; i < counts.length; ++i) {
+            fractions[i] = (double) (counts[i]) / (double) (N);
+        }
+        for (int i = 0; i < size; i++) {
+            assertThat(fractions[i], closeTo(expected[i], 1e-4));
+        }
+        assertThat(mean, closeTo(1.0, 1e-4));
+    }
+
+}


### PR DESCRIPTION
This draft is for building and testing confidence interval calculations for the `random_sampler` aggregation.

This is not to be reviewed or merged as is, this is mainly for testing.

## Using
```js
//POST kibana_sample_data_flights/_search?size=1&error_trace
{
  "aggs": {
    "sampler": {
      "random_sampler": {
        "probability": 0.5
      },
      "aggs": {
        "avg": {
          "avg": {
            "field": "AvgTicketPrice"
          }
        },
        "confidence": {
          "confidence": {
            "confidence_interval": 60,
            "keyed": true
          },
          "aggs": {
            "filters": {
              "filters": {
                "filters": {
                  "one": {"term": {
                    "Dest": "Zurich Airport"
                  }},
                  "two": {"term": {
                    "Dest": "Xi'an Xianyang International Airport"
                  }}
                }
              }, 
              "aggs": {
                "terms_avg": {
                  "avg": {
                    "field": "AvgTicketPrice"
                  }
                }
              }
            },
            "percents": {
              "percentiles": {
                "field": "AvgTicketPrice",
                "percents": [
                  1,
                  5,
                  25,
                  50,
                  75,
                  95,
                  99
                ]
              }
            },
            "count": {
              "value_count": {
                "field": "AvgTicketPrice"
              }
            },
            "avg": {
              "avg": {
                "field": "AvgTicketPrice"
              }
            }
          }
        }
      }
    }
  }
}
```
##Result format:
```json
"aggregations" : {
    "sampler" : {
      "seed" : -2091739333,
      "probability" : 0.5,
      "doc_count" : 6514,
      "avg" : {
        "value" : 631.8859657952856
      },
      "confidence" : {
        "confidences" : {
          "other" : {
            "calculated" : {
              "value" : 631.8330291871564
            },
            "upper" : {
              "value" : 632.9070410284497
            },
            "lower" : {
              "value" : 631.2727272409908
            }
          },
          "avg" : {
            "calculated" : {
              "value" : 631.8330291871564
            },
            "upper" : {
              "value" : 632.9070410284497
            },
            "lower" : {
              "value" : 631.2727272409908
            }
          },
          "count" : {
            "calculated" : {
              "value" : 13028.0
            },
            "upper" : {
              "value" : 13076.0
            },
            "lower" : {
              "value" : 12980.0
            }
          },
          "percents" : {
            "calculated" : {
              "1.0" : 119.28283651351929,
              "5.0" : 192.04020541715417,
              "25.0" : 417.2635508385806,
              "50.0" : 645.1540612874768,
              "75.0" : 846.2269664894716,
              "95.0" : 1042.5262145713518,
              "99.0" : 1172.4521807861329
            },
            "upper" : {
              "1.0" : 120.94320000330606,
              "5.0" : 191.5986024162986,
              "25.0" : 413.47951642306987,
              "50.0" : 643.5197280765112,
              "75.0" : 843.5681843677353,
              "95.0" : 1043.058770294189,
              "99.0" : 1170.8546435546875
            },
            "lower" : {
              "1.0" : 118.68564542770386,
              "5.0" : 190.5013316109067,
              "25.0" : 417.52054732876945,
              "50.0" : 644.6728282841361,
              "75.0" : 847.5332278050059,
              "95.0" : 1041.8368400008585,
              "99.0" : 1173.2389575195314
            }
          },
          "filters" : {
            "calculated" : {
              "buckets" : {
                "one" : {
                  "doc_count" : 688.0,
                  "terms_avg" : {
                    "value" : 551.9370835272653
                  }
                },
                "two" : {
                  "doc_count" : 488.0,
                  "terms_avg" : {
                    "value" : 621.1813428756582
                  }
                }
              }
            },
            "upper" : {
              "buckets" : {
                "one" : {
                  "doc_count" : 699.0,
                  "terms_avg" : {
                    "value" : 564.1506690229044
                  }
                },
                "two" : {
                  "doc_count" : 497.0,
                  "terms_avg" : {
                    "value" : 635.1649435360354
                  }
                }
              }
            },
            "lower" : {
              "buckets" : {
                "one" : {
                  "doc_count" : 677.0,
                  "terms_avg" : {
                    "value" : 551.6911182065311
                  }
                },
                "two" : {
                  "doc_count" : 479.0,
                  "terms_avg" : {
                    "value" : 619.4340132082746
                  }
                }
              }
            }
          }
        }
      }
    }
  }
```