### PR TITLE
[8.0] [DOCS] Correct header syntax (#83275)

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -388,10 +388,10 @@ of the above metadata fields, this field will also be retrievable using either
 the alias name or via wildcard patterns that match the alias.
 
 [discrete]
-[[Ignored-field values]]
+[[ignored-field-values]]
 ==== Ignored field values
 The `fields` section of the response only returns values that were valid when indexed.
-If your search request asks for values from a field that ignored certain
+If your search request asks for values from a field that ignored certain values 
 because they were malformed or too large these values are returned
 separately in an `ignored_field_values` section.
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Correct header syntax (#83275)