### PR TITLE
[DOCS] Release highlight for security-on-by-default

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -33,8 +33,8 @@ protection, internode communication secured with TLS, and encrypted connections
 between {es} and {kib}.
 
 We're also shipping the
-<<create-enrollment-token,`elasticsearch-create-enrollment-token`>> tool, which
-you can use to generate enrollment tokens to enroll new {es} nodes with an
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool,
+which you can use to generate enrollment tokens to enroll new {es} nodes with an
 existing cluster, or configure {kib} instances to communicate with an existing
 {es} cluster that has security features enabled. Just pass the enrollment token
 when starting new nodes and {es} handles all of the security configuration for

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -24,9 +24,9 @@ security features and then configure password protection and Transport Layer
 Security (TLS).
 
 Starting in {es} 8.0, security is
-<<configuring-stack-security,enabled and configured by default>> when you start
-{es} for the first time. We also generate an enrollment token at startup for
-{kib} so that you can quickly and easily connect a {kib} instance to your
+{ref}/configuring-stack-security.html[enabled and configured by default] when
+you start {es} for the first time. We also generate an enrollment token at
+startup for {kib} so that you can quickly and easily connect a {kib} instance to your
 secured {es} cluster without having to generate security certificates or update
 `yml` configuration files. Just by starting {es}, you’ll have password
 protection, internode communication secured with TLS, and encrypted connections

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -16,12 +16,11 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // tag::notable-highlights[] 
 [discrete]
-=== Security is enabled and configured by default
+=== Security features are enabled and configured by default
 
 Running {es} without security leaves your cluster exposed to anyone who can send
-network traffic to {es}. In previous versions, you had to enable the {es}
-security features and then configure password protection and Transport Layer
-Security (TLS).
+network traffic to {es}. In previous versions, you had to explicitly enable the {es}
+security features such as authantication, authorization and network encryption (TLS).
 
 Starting in {es} 8.0, security is
 {ref}/configuring-stack-security.html[enabled and configured by default] when

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -16,6 +16,32 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // tag::notable-highlights[] 
 [discrete]
+=== Security is enabled and configured by default
+
+Running {es} without security leaves your cluster exposed to anyone who can send
+network traffic to {es}. In previous versions, you had to enable the {es}
+security features and then configure password protection and Transport Layer
+Security (TLS).
+
+Starting in {es} 8.0, security is
+<<configuring-stack-security,enabled and configured by default>> when you start
+{es} for the first time. We also generate an enrollment token at startup for
+{kib} so that you can quickly and easily connect a {kib} instance to your
+secured {es} cluster without having to generate security certificates or update
+`yml` configuration files. Just by starting {es}, you’ll have password
+protection, internode communication secured with TLS, and encrypted connections
+between {es} and {kib}.
+
+We're also shipping the
+<<create-enrollment-token,`elasticsearch-create-enrollment-token`>> tool, which
+you can use to generate enrollment tokens to enroll new {es} nodes with an
+existing cluster, or configure {kib} instances to communicate with an existing
+{es} cluster that has security features enabled. Just pass the enrollment token
+when starting new nodes and {es} handles all of the security configuration for
+you.
+
+
+[discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
 
 We've updated inverted indices, an internal data structure, to use a more

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -25,16 +25,21 @@ encryption (TLS). Starting in {es} 8.0, security is
 {ref}/configuring-stack-security.html[enabled and configured by default] when
 you start {es} for the first time. 
 
-At startup, we generate enrollment tokens so that you can connect a {kib} 
+At startup, we generate enrollment tokens that you use to connect a {kib} 
 instance or enroll additional nodes in your secured {es} cluster, without having 
-to generate security certificates or update `yml` configuration files. Just use 
+to generate security certificates or update YAML configuration files. Just use 
 the generated enrollment token when starting new nodes or {kib} instances, and 
 the {stack} handles all of the security configuration for you. Out of the box, 
-you'll get authentication, authorization, and network encryption with TLS for 
-internode communications between {es} and {kib}. You can create new enrollment 
-tokens for {es} nodes and {kib} instances using the 
+you'll get:
+
+* User authentication
+* User authorization
+* Encrypted internode communication with TLS
+* Encrypted communication between {es} and {kib} with TLS
+
+Need a new enrollment token? Use the 
 {ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] 
-tool.
+tool to create enrollment tokens for {es} nodes and {kib} instances.
 
 [discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -19,26 +19,22 @@ For detailed information about this release, see the <<es-release-notes>> and
 === Security features are enabled and configured by default
 
 Running {es} without security leaves your cluster exposed to anyone who can send
-network traffic to {es}. In previous versions, you had to explicitly enable the {es}
-security features such as authantication, authorization and network encryption (TLS).
-
-Starting in {es} 8.0, security is
+network traffic to {es}. In previous versions, you had to explicitly enable the 
+{es} security features such as authentication, authorization, and network
+encryption (TLS). Starting in {es} 8.0, security is
 {ref}/configuring-stack-security.html[enabled and configured by default] when
-you start {es} for the first time. We also generate an enrollment token at
-startup for {kib} so that you can quickly and easily connect a {kib} instance to your
-secured {es} cluster without having to generate security certificates or update
-`yml` configuration files. Just by starting {es}, you’ll have password
-protection, internode communication secured with TLS, and encrypted connections
-between {es} and {kib}.
+you start {es} for the first time. 
 
-We're also shipping the
-{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool,
-which you can use to generate enrollment tokens to enroll new {es} nodes with an
-existing cluster, or configure {kib} instances to communicate with an existing
-{es} cluster that has security features enabled. Just pass the enrollment token
-when starting new nodes and {es} handles all of the security configuration for
-you.
-
+At startup, we generate enrollment tokens so that you can connect a {kib} 
+instance or enroll additional nodes in your secured {es} cluster, without having 
+to generate security certificates or update `yml` configuration files. Just use 
+the generated enrollment token when starting new nodes or {kib} instances, and 
+the {stack} handles all of the security configuration for you. Out of the box, 
+you'll get authentication, authorization, and network encryption with TLS for 
+internode communications between {es} and {kib}. You can create new enrollment 
+tokens for {es} nodes and {kib} instances using the 
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] 
+tool.
 
 [discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields


### PR DESCRIPTION
Adds a highlight to the 8.0 release notes for security-on-by-default.

Preview link: https://elasticsearch_83292.docs-preview.app.elstc.co/guide/en/elastic-stack/8.0/elasticsearch-highlights.html#_security_is_enabled_and_configured_by_default