### PR TITLE
Incorrect parsing of large long values

### DIFF
--- a/docs/changelog/83294.yaml
+++ b/docs/changelog/83294.yaml
@@ -1,0 +1,5 @@
+pr: 83294
+summary: "Fix: cast the double to long before getting the string representation"
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -29,6 +29,17 @@ setup:
                 format: strict_date_time||strict_date
 
   - do:
+      indices.create:
+        index: long_value_test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              long:
+                type: long
+
+  - do:
       cluster.health:
         wait_for_status: yellow
 
@@ -46,6 +57,13 @@ setup:
 # For testing missing values
          - {"index": {}}
          - {}
+  - do:
+      bulk:
+        index: long_value_test
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "long": -9223372036854775808 }
 
   - do:
       bulk:
@@ -409,3 +427,27 @@ setup:
   - match: { aggregations.date_range.buckets.0.from_as_string: "2021-05-01T00:00:00.000Z" }
   - match: { aggregations.date_range.buckets.0.to: 1620172800000 }
   - match: { aggregations.date_range.buckets.0.to_as_string: "2021-05-05T00:00:00.000Z" }
+
+---
+"Min long value":
+  - skip:
+      version: " - 8.0.99"
+      reason: Bug fixed in 8.1.0
+  - do:
+      search:
+        index: long_value_test
+        body:
+          size: 0
+          aggs:
+            long_range:
+              range:
+                field: "long"
+                ranges:
+                  { from: -9223372036854775808, to: 9223372036854775807 }
+  - match: { hits.total.relation: "eq" }
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.long_range.buckets: 1 }
+  - match: { aggregations.long_range.buckets.0.key: "-9.223372036854776E18-9.223372036854776E18" }
+  - match: { aggregations.long_range.buckets.0.from: -9.223372036854776E18 }
+  - match: { aggregations.long_range.buckets.0.to: 9.223372036854776E18 }
+  - match: { aggregations.long_range.buckets.0.doc_count: 1 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1097,7 +1097,7 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             // longs need special handling so we don't lose precision while parsing
-            String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
+            String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : String.valueOf((long) doubleValue);
             return Numbers.toLong(stringValue, coerce);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1097,8 +1097,10 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             // longs need special handling so we don't lose precision while parsing
-            String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : String.valueOf((long) doubleValue);
-            return Numbers.toLong(stringValue, coerce);
+            if (value instanceof BytesRef) {
+                return Numbers.toLong(((BytesRef) value).utf8ToString(), coerce);
+            }
+            return Math.round(doubleValue);
         }
 
         public static Query doubleRangeQuery(


### PR DESCRIPTION
Double values are represented using scientific notation. As a result,
the string representation of a double value might include an 'E' character
which causes parsing of long values to fail. When parsing a Double use
the `Math.round` method to correctly handle rounding.

Fix bug #81529.