### PR TITLE
[DOCS] Clarify transform requirements

### DIFF
--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -36,20 +36,14 @@ scenario requires {kib} feature privileges and {es} security privileges.
 Management features must also be visible in the relevant space.
 
 You can configure these privileges under **{stack-manage-app}** > **Security**
-in {kib} or via the respective {es} security APIs.
+in {kib} or via the respective {es} security APIs. There are built-in roles and
+privileges that make it easier to control which users can manage or view
+{transforms}. For more information, see <<security-privileges>> and
+<<built-in-roles>>.
 
 [discrete]
 [[transform-es-security-privileges]]
 === {es} API user
-
-The {es} {security-features} provide <<built-in-roles,built-in roles>>
-and <<security-privileges,privileges>> that make it easier to control
-which users can manage or view {transforms}.
-
-To _view_ the configuration and status of {transforms}, you must have:
-
-* `transform_user` built-in role or `monitor_transform`
-cluster privileges
 
 To _manage_ {transforms}, you must have:
 
@@ -58,7 +52,10 @@ cluster privileges
 * `read` and `view_index_metadata` index privileges on source indices
 * `read`, `create_index`, and `index` index privileges on destination indices
 
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+To view only the configuration and status of {transforms}, you must have:
+
+* `transform_user` built-in role or `monitor_transform`
+cluster privileges
 
 [discrete]
 [[transform-kib-security-privileges]]
@@ -69,7 +66,6 @@ Within a {kib} space, for full access to {transforms}, you must have:
 [%interactive]
 * [ ] Management features visible in the {kib} space, including
 `Data View Management` and `Stack Monitoring`
-* [ ] `Data Views Management: All` {kib} feature privileges
 * [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
 * [ ] `kibana_admin` built-in role
 * [ ] `monitoring_user` built-in role

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -49,7 +49,7 @@ To view only the configuration and status of {transforms}, you must have:
 * `transform_user` built-in role or `monitor_transform` cluster privileges
 
 For more information about {es} roles and privileges, refer to
-<<built-in-roles>> and <<security-privileges,privileges>>.
+<<built-in-roles>> and <<security-privileges>>.
 
 [discrete]
 [[transform-kib-security-privileges]]

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -44,7 +44,8 @@ To _manage_ {transforms}, you must have the following
 * `transform_admin` built-in role or `manage_transform`
 cluster privileges
 * `read` and `view_index_metadata` index privileges on source indices
-* `read`, `create_index`, and `index` index privileges on destination indices
+* `create_index`, `index`, `manage`, and `read` index privileges on destination
+indices
 
 To view only the configuration and status of {transforms}, you must have:
 
@@ -66,7 +67,7 @@ for the Data View Management feature
 * [ ] `monitoring_user` built-in role
 * [ ] data views for your source indices
 * [ ] `read` and `view_index_metadata` index privileges on source indices
-* [ ] `create_index`, `index`, `read`, and `monitor` index privileges on
+* [ ] `create_index`, `index`, `manage`, and `read` index privileges on
 destination indices
 
 Within a {kib} space, for read-only access to {transforms}, you must have:

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -33,19 +33,13 @@ the two main categories:
 {es} security privileges.
 * *<<transform-kib-security-privileges>>*: uses {transforms} in {kib}. This
 scenario requires {kib} feature privileges and {es} security privileges.
-Management features must also be visible in the relevant space.
-
-You can configure these privileges under **{stack-manage-app}** > **Security**
-in {kib} or via the respective {es} security APIs. There are built-in roles and
-privileges that make it easier to control which users can manage or view
-{transforms}. For more information, see <<security-privileges>> and
-<<built-in-roles>>.
 
 [discrete]
 [[transform-es-security-privileges]]
 === {es} API user
 
-To _manage_ {transforms}, you must have:
+To _manage_ {transforms}, you must have the following
+<<built-in-roles,built-in roles>> and <<security-privileges,privileges>>:
 
 * `transform_admin` built-in role or `manage_transform`
 cluster privileges
@@ -59,7 +53,7 @@ cluster privileges
 
 [discrete]
 [[transform-kib-security-privileges]]
-==== {kib} user
+=== {kib} user
 
 Within a {kib} space, for full access to {transforms}, you must have:
 
@@ -84,9 +78,14 @@ Within a {kib} space, for read-only access to {transforms}, you must have:
 * [ ] `read`, and `view_index_metadata` index privileges on source indices and
 destination indices
 
+For more information, see
+{kibana-ref}/kibana-role-management.html[{kib} role management] and
+{kibana-ref}/kibana-privileges.html[{kib} privileges].
+
+
 [discrete]
 [[transform-kib-spaces]]
-==== {kib} spaces
+== {kib} spaces
 
 {kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
 destination indices and other saved objects in {kib} and to see only the objects 

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -33,6 +33,7 @@ the two main categories:
 {es} security privileges.
 * *<<transform-kib-security-privileges>>*: uses {transforms} in {kib}. This
 scenario requires {kib} feature privileges and {es} security privileges.
+Management features must also be visible in the relevant space.
 
 You can configure these privileges under **{stack-manage-app}** > **Security**
 in {kib} or via the respective {es} security APIs.
@@ -66,6 +67,8 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 Within a {kib} space, for full access to {transforms}, you must have:
 
 [%interactive]
+* [ ] Management features visible in the {kib} space, including
+`Data View Management` and `Stack Monitoring`
 * [ ] `Data Views Management: All` {kib} feature privileges
 //TBD Is this feature privilege required in order to create a data view for the destination indices?
 * [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
@@ -85,15 +88,14 @@ Within a {kib} space, for read-only access to {transforms}, you must have:
 * [ ] `read`, and `view_index_metadata` index privileges on source indices and
 destination indices
 
-////
 [discrete]
-[[transform-kib-visibility-spaces]]
-==== Feature visibility in Spaces
+[[transform-kib-spaces]]
+==== {kib} spaces
 
 {kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
 destination indices and other saved objects in {kib} and to see only the objects 
 that belong to your space. However, this limited scope does not apply to 
 {transforms}; they are visible in all spaces.
 
-//TBD: Does this mean that transforms have access to data that exists in any space or only that users in all spaces can access all transforms?
-////
+To successfully create {transforms} in {kib}, you must be logged into a space
+where the source indices are visible.

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -5,24 +5,41 @@
 <titleabbrev>Setup</titleabbrev>
 ++++
 
-To use the {transforms}, you must have the
-{subscriptions}[appropriate license] and at least one
-<<transform-setup-nodes,{transform} node>> in your {es} cluster. If {stack}
-{security-features} are enabled, you must also ensure your users have the
-<<transform-privileges,necessary privileges>>.
-
 [discrete]
-[[transform-setup-nodes]]
-== {transform-cap} nodes
+[[requirements-overview]]
+== Requirements overview
 
-To use {transforms}, there must be at least one {transform} node in your cluster.
-If you want to control which nodes run {transforms}, add or remove `transform`
-from the `node.roles` setting on some nodes. For more information, see
-<<modules-node>> and <<transform-settings>>.
+To use {transforms}, you must have:
+
+[%interactive]
+- [ ] the {subscriptions}[appropriate license]
+- [ ] at least one <<transform-node,{transform} node>>
+- [ ] security privileges assigned to users that:
++
+--
+* grant use of {transforms}, and
+* grant access to source and destination indices
+--
 
 [discrete]
 [[transform-privileges]]
 == Security privileges
+
+Assigning security privileges affects how users access {transforms}. Consider 
+the two main categories:
+
+* *<<transform-es-security-privileges>>*: uses an {es} client, cURL, or {kib}
+**{dev-tools-app}** to access {transforms} via {es} APIs. This scenario requires
+{es} security privileges.
+* *<<transform-kib-security-privileges>>*: uses {transforms} in {kib}. This
+scenario requires {kib} feature privileges and {es} security privileges.
+
+You can configure these privileges under **{stack-manage-app}** > **Security**
+in {kib} or via the respective {es} security APIs.
+
+[discrete]
+[[transform-es-security-privileges]]
+=== {es} API user
 
 The {es} {security-features} provide <<built-in-roles,built-in roles>>
 and <<security-privileges,privileges>> that make it easier to control
@@ -41,3 +58,44 @@ cluster privileges
 * `read`, `create_index`, and `index` index privileges on destination indices
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
+
+[discrete]
+[[transform-kib-security]]
+=== {kib} security
+
+[discrete]
+[[transform-kib-visibility-spaces]]
+==== Feature visibility in Spaces
+
+{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
+destination indices and other saved objects in {kib} and to see only the objects 
+that belong to your space. However, this limited scope does not apply to 
+{transforms}; they are visible in all spaces.
+
+//TBD: Does this likewise mean that transforms have access to data that exists in any space?
+
+[discrete]
+[[transform-kib-security-privileges]]
+==== {kib} user
+
+Within a {kib} space, for full access to {transforms}, you must have:
+
+[%interactive]
+* [ ] `Data Views Management: All` {kib} feature privileges
+//TBD Is this feature privilege required in order to create a data view for the destination indices?
+* [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
+* [ ] `kibana_admin` built-in role
+* [ ] `monitor` cluster privileges
+//TBD is monitor included in transform_admin?
+* [ ] data views for your source indices
+* [ ] `read` and `view_index_metadata` index privileges on source indices
+* [ ] `create_index`, `index`, `read`, and `monitor` index privileges on
+destination indices
+
+Within a {kib} space, for read-only access to {transforms}, you must have:
+
+[%interactive]
+* [ ] `transform_user` built-in role or `monitor_transform` cluster privileges
+* [ ] data views for your source and destination indices
+* [ ] `read`, and `view_index_metadata` index privileges on source indices and
+destination indices

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -60,26 +60,27 @@ following requirements:
 
 *  Management features visible in the {kib} space, including
 `Data View Management` and `Stack Monitoring`,
-* `transform_admin` built-in role or `manage_transform` cluster privileges,
-* `kibana_admin` built-in role or a custom role with `all` {kib} privileges
-for the Data View Management feature,
 * `monitoring_user` built-in role,
-* data views for your source indices, 
+* `transform_admin` built-in role or `manage_transform` cluster privileges,
+* `kibana_admin` built-in role or a custom role with `read` or `all` {kib}
+privileges for the `Data View Management` feature (dependent on whether data
+views already exist for your destination indices),
+* data views for your source indices,
 * `read` and `view_index_metadata` index privileges on source indices, and
 * `create_index`, `index`, `manage`, and `read` index privileges on destination
-indices
+indices 
 
 Within a {kib} space, for read-only access to {transforms}, you must meet all of
 the following requirements:
 
 * Management features visible in the {kib} space, including `Stack Monitoring`,
-* `transform_user` built-in role or `monitor_transform` cluster privileges,
 * `monitoring_user` built-in role,
+* `transform_user` built-in role or `monitor_transform` cluster privileges,
 * `kibana_admin` built-in role or a custom role with `read` {kib} privileges
 for at least one feature in the space,
 * data views for your source and destination indices, and
 * `read`, and `view_index_metadata` index privileges on source indices and
-destination indices
+destination indices 
 
 For more information and {kib} security features, see
 {kibana-ref}/kibana-role-management.html[{kib} role management] and
@@ -96,4 +97,5 @@ that belong to your space. However, this limited scope does not apply to
 {transforms}; they are visible in all spaces.
 
 To successfully create {transforms} in {kib}, you must be logged into a space
-where the source indices are visible.
+where the source indices are visible and the `Data View Management` and
+`Stack Monitoring` features are visible.

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -60,21 +60,6 @@ cluster privileges
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 [discrete]
-[[transform-kib-security]]
-=== {kib} security
-
-[discrete]
-[[transform-kib-visibility-spaces]]
-==== Feature visibility in Spaces
-
-{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
-destination indices and other saved objects in {kib} and to see only the objects 
-that belong to your space. However, this limited scope does not apply to 
-{transforms}; they are visible in all spaces.
-
-//TBD: Does this likewise mean that transforms have access to data that exists in any space?
-
-[discrete]
 [[transform-kib-security-privileges]]
 ==== {kib} user
 
@@ -99,3 +84,16 @@ Within a {kib} space, for read-only access to {transforms}, you must have:
 * [ ] data views for your source and destination indices
 * [ ] `read`, and `view_index_metadata` index privileges on source indices and
 destination indices
+
+////
+[discrete]
+[[transform-kib-visibility-spaces]]
+==== Feature visibility in Spaces
+
+{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
+destination indices and other saved objects in {kib} and to see only the objects 
+that belong to your space. However, this limited scope does not apply to 
+{transforms}; they are visible in all spaces.
+
+//TBD: Does this mean that transforms have access to data that exists in any space or only that users in all spaces can access all transforms?
+////

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -61,7 +61,8 @@ Within a {kib} space, for full access to {transforms}, you must have:
 * [ ] Management features visible in the {kib} space, including
 `Data View Management` and `Stack Monitoring`
 * [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
-* [ ] `kibana_admin` built-in role
+* [ ] `kibana_admin` built-in role or a custom role with `all` {kib} privileges
+for the Data View Management feature
 * [ ] `monitoring_user` built-in role
 * [ ] data views for your source indices
 * [ ] `read` and `view_index_metadata` index privileges on source indices
@@ -72,8 +73,9 @@ Within a {kib} space, for read-only access to {transforms}, you must have:
 
 [%interactive]
 * [ ] `transform_user` built-in role or `monitor_transform` cluster privileges
-* [ ] `kibana_admin` built-in role
 * [ ] `monitoring_user` built-in role
+* [ ] `kibana_admin` built-in role or a custom role with `read` {kib} privileges
+for at least one feature in the space
 * [ ] data views for your source and destination indices
 * [ ] `read`, and `view_index_metadata` index privileges on source indices and
 destination indices

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -73,6 +73,8 @@ destination indices
 Within a {kib} space, for read-only access to {transforms}, you must have:
 
 [%interactive]
+* [ ] Management features visible in the {kib} space, including
+`Stack Monitoring`
 * [ ] `transform_user` built-in role or `monitor_transform` cluster privileges
 * [ ] `monitoring_user` built-in role
 * [ ] `kibana_admin` built-in role or a custom role with `read` {kib} privileges

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -70,11 +70,9 @@ Within a {kib} space, for full access to {transforms}, you must have:
 * [ ] Management features visible in the {kib} space, including
 `Data View Management` and `Stack Monitoring`
 * [ ] `Data Views Management: All` {kib} feature privileges
-//TBD Is this feature privilege required in order to create a data view for the destination indices?
 * [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
 * [ ] `kibana_admin` built-in role
-* [ ] `monitor` cluster privileges
-//TBD is monitor included in transform_admin?
+* [ ] `monitoring_user` built-in role
 * [ ] data views for your source indices
 * [ ] `read` and `view_index_metadata` index privileges on source indices
 * [ ] `create_index`, `index`, `read`, and `monitor` index privileges on
@@ -84,6 +82,8 @@ Within a {kib} space, for read-only access to {transforms}, you must have:
 
 [%interactive]
 * [ ] `transform_user` built-in role or `monitor_transform` cluster privileges
+* [ ] `kibana_admin` built-in role
+* [ ] `monitoring_user` built-in role
 * [ ] data views for your source and destination indices
 * [ ] `read`, and `view_index_metadata` index privileges on source indices and
 destination indices

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -11,10 +11,9 @@
 
 To use {transforms}, you must have:
 
-[%interactive]
-- [ ] the {subscriptions}[appropriate license]
-- [ ] at least one <<transform-node,{transform} node>>
-- [ ] security privileges assigned to users that:
+* at least one <<transform-node,{transform} node>>,
+* management features visible in the {kib} space, and
+* security privileges that:
 +
 --
 * grant use of {transforms}, and
@@ -32,58 +31,57 @@ the two main categories:
 **{dev-tools-app}** to access {transforms} via {es} APIs. This scenario requires
 {es} security privileges.
 * *<<transform-kib-security-privileges>>*: uses {transforms} in {kib}. This
-scenario requires {kib} feature privileges and {es} security privileges.
+scenario requires {kib} feature privileges _and_ {es} security privileges.
 
 [discrete]
 [[transform-es-security-privileges]]
 === {es} API user
 
-To _manage_ {transforms}, you must have the following
-<<built-in-roles,built-in roles>> and <<security-privileges,privileges>>:
+To _manage_ {transforms}, you must meet all of the following requirements:
 
-* `transform_admin` built-in role or `manage_transform`
-cluster privileges
-* `read` and `view_index_metadata` index privileges on source indices
+* `transform_admin` built-in role or `manage_transform` cluster privileges,
+* `read` and `view_index_metadata` index privileges on source indices, and
 * `create_index`, `index`, `manage`, and `read` index privileges on destination
 indices
 
 To view only the configuration and status of {transforms}, you must have:
 
-* `transform_user` built-in role or `monitor_transform`
-cluster privileges
+* `transform_user` built-in role or `monitor_transform` cluster privileges
+
+For more information about {es} roles and privileges, refer to
+<<built-in-roles>> and <<security-privileges,privileges>>.
 
 [discrete]
 [[transform-kib-security-privileges]]
 === {kib} user
 
-Within a {kib} space, for full access to {transforms}, you must have:
+Within a {kib} space, for full access to {transforms}, you must meet all of the
+following requirements:
 
-[%interactive]
-* [ ] Management features visible in the {kib} space, including
-`Data View Management` and `Stack Monitoring`
-* [ ] `transform_admin` built-in role or `manage_transform` cluster privileges
-* [ ] `kibana_admin` built-in role or a custom role with `all` {kib} privileges
-for the Data View Management feature
-* [ ] `monitoring_user` built-in role
-* [ ] data views for your source indices
-* [ ] `read` and `view_index_metadata` index privileges on source indices
-* [ ] `create_index`, `index`, `manage`, and `read` index privileges on
+*  Management features visible in the {kib} space, including
+`Data View Management` and `Stack Monitoring`,
+* `transform_admin` built-in role or `manage_transform` cluster privileges,
+* `kibana_admin` built-in role or a custom role with `all` {kib} privileges
+for the Data View Management feature,
+* `monitoring_user` built-in role,
+* data views for your source indices, 
+* `read` and `view_index_metadata` index privileges on source indices, and
+* `create_index`, `index`, `manage`, and `read` index privileges on destination
+indices
+
+Within a {kib} space, for read-only access to {transforms}, you must meet all of
+the following requirements:
+
+* Management features visible in the {kib} space, including `Stack Monitoring`,
+* `transform_user` built-in role or `monitor_transform` cluster privileges,
+* `monitoring_user` built-in role,
+* `kibana_admin` built-in role or a custom role with `read` {kib} privileges
+for at least one feature in the space,
+* data views for your source and destination indices, and
+* `read`, and `view_index_metadata` index privileges on source indices and
 destination indices
 
-Within a {kib} space, for read-only access to {transforms}, you must have:
-
-[%interactive]
-* [ ] Management features visible in the {kib} space, including
-`Stack Monitoring`
-* [ ] `transform_user` built-in role or `monitor_transform` cluster privileges
-* [ ] `monitoring_user` built-in role
-* [ ] `kibana_admin` built-in role or a custom role with `read` {kib} privileges
-for at least one feature in the space
-* [ ] data views for your source and destination indices
-* [ ] `read`, and `view_index_metadata` index privileges on source indices and
-destination indices
-
-For more information, see
+For more information and {kib} security features, see
 {kibana-ref}/kibana-role-management.html[{kib} role management] and
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
 

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -184,8 +184,8 @@ Grants `manage_transform` cluster privileges, which enable you to manage
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-transform-user]] `transform_user`::
-Grants `monitor_transform` cluster privileges, which enable you to use
-{transforms}. This role also includes all
+Grants `monitor_transform` cluster privileges, which enable you to perform
+read-only operations related to {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-transport-client]] `transport_client`::


### PR DESCRIPTION
Relates to https://github.com/elastic/stack-docs/pull/1858

This PR aligns the formatting of the [Set up transforms](https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-setup.html) page with the equivalent machine learning page. It also adds the missing details about requirements that are specific to Kibana users.

### Preview

https://elasticsearch_83295.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-setup.html
https://elasticsearch_83295.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/built-in-roles.html