### PR TITLE
[8.0] Mute ActivateWatchTests (#83312)

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
@@ -50,6 +50,7 @@ public class ActivateWatchTests extends AbstractWatcherIntegrationTestCase {
         return false;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82797")
     public void testDeactivateAndActivate() throws Exception {
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client()).setId("_id")
             .setSource(
@@ -106,6 +107,7 @@ public class ActivateWatchTests extends AbstractWatcherIntegrationTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82797")
     public void testLoadWatchWithoutAState() throws Exception {
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client()).setId("_id")
             .setSource(


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Mute ActivateWatchTests (#83312)