### PR TITLE
[8.0] [CI] Mute BasicDistributedJobsIT::testFailOverBasics_withDataFeeder (#83317)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -91,6 +91,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         awaitJobOpenedAndAssigned(job.getId(), null);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82591")
     public void testFailOverBasics_withDataFeeder() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(4);
         ensureStableCluster(4);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [CI] Mute BasicDistributedJobsIT::testFailOverBasics_withDataFeeder (#83317)