### PR TITLE
Docs: Date Ingest Processor adds year

### DIFF
--- a/docs/reference/ingest/processors/date.asciidoc
+++ b/docs/reference/ingest/processors/date.asciidoc
@@ -17,7 +17,7 @@ in the same order they were defined as part of the processor definition.
 | Name                   | Required  | Default             | Description
 | `field`                | yes       | -                   | The field to get the date from.
 | `target_field`         | no        | @timestamp          | The field that will hold the parsed date.
-| `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
+| `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N. When the format is missing the year, the current year will be added in the result.
 | `timezone`             | no        | UTC                 | The timezone to use when parsing the date. Supports <<template-snippets,template snippets>>.
 | `locale`               | no        | ENGLISH             | The locale to use when parsing the date, relevant when parsing month names or week days. Supports <<template-snippets,template snippets>>.
 | `output_format`        | no        | `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` | The format to use when writing the date to `target_field`. Must be a valid <<mapping-date-format,java time pattern>>.


### PR DESCRIPTION
When no year information is present, the date ingest processor adds the current year. This PR adds this as a note at the `format` parameter description
