### PR TITLE
Disable ANSI formatting for security autoconfiguration on Windows cmd prompt

### DIFF
--- a/distribution/tools/ansi-console/src/main/java/org/elasticsearch/io/ansi/AnsiConsoleLoader.java
+++ b/distribution/tools/ansi-console/src/main/java/org/elasticsearch/io/ansi/AnsiConsoleLoader.java
@@ -40,7 +40,11 @@ public class AnsiConsoleLoader implements Supplier<ConsoleLoader.Console> {
     // package-private for tests
     static @Nullable ConsoleLoader.Console newConsole(AnsiPrintStream out) {
         if (isValidConsole(out)) {
-            return new ConsoleLoader.Console(out, () -> out.getTerminalWidth(), Ansi.isEnabled(), tryExtractPrintCharset(out));
+            // virtual terminal does support ANSI escape sequences, but the JVM must toggle a mode
+            // option on the console using the Kernel32 API, which JANSI knows to do, but ES currently lacks
+            // the testing infra to assert the behavior
+            boolean ansiEnabled = Ansi.isEnabled() && out.getType() != AnsiType.VirtualTerminal;
+            return new ConsoleLoader.Console(out, () -> out.getTerminalWidth(), ansiEnabled, tryExtractPrintCharset(out));
         } else {
             return null;
         }

--- a/docs/changelog/83326.yaml
+++ b/docs/changelog/83326.yaml
@@ -1,0 +1,5 @@
+pr: 83326
+summary: Disable ANSI formatting for security autoconfiguration on Windows cmd line
+area: Security
+type: bug
+issues: []


### PR DESCRIPTION
In order to display formatted (bolded) autoconfiguration text on
Windows cmd prompt using JANSI, one needs to invoke the
SetConsoleMode Kernel32 API, via JANSI's AnsiConsole#install.
But we lack the testing infra to properly assert the formatting behavior,
so this PR disables ANSI-formatted output on Windows cmd prompt.

Fixes: #83316