### PR TITLE
[Transform] Do not mention "deduce mappings" in audit log when the deduce_mappings setting is disabled

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -193,7 +193,10 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
 
             if (dest.length == 0) {
                 createDestinationIndex(transformConfigHolder.get(), validationResponse.getDestIndexMappings(), ActionListener.wrap(r -> {
-                    auditor.info(request.getId(), "Created destination index [" + destinationIndex + "] with deduced mappings.");
+                    String message = Boolean.FALSE.equals(transformConfigHolder.get().getSettings().getDeduceMappings())
+                        ? "Created destination index [" + destinationIndex + "]."
+                        : "Created destination index [" + destinationIndex + "] with deduced mappings.";
+                    auditor.info(request.getId(), message);
                     createOrGetIndexListener.onResponse(r);
                 }, createOrGetIndexListener::onFailure));
             } else {


### PR DESCRIPTION
This PR changes audit log message generated when creating destination index.

Relates #82559

Marking a non-issue as this fix is related to the functionality that was not yet released.