### PR TITLE
Update release notes for 7.17.0 BC5

### DIFF
--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -4,6 +4,8 @@
 
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
+coming::[7.17.0]
+
 [[deprecation-7.17.0]]
 [float]
 === Deprecations
@@ -29,6 +31,7 @@ Authorization::
 * Add {kib} system permissions for Endpoint action indices {es-pull}81953[#81953]
 
 ILM+SLM::
+* Add an index->step cache to the `PolicyStepsRegistry` {es-pull}82316[#82316] (issue: {es-issue}77466[#77466])
 * Migrate legacy/v2/component templates away from custom attributes routing {es-pull}82472[#82472] (issue: {es-issue}82170[#82170])
 * Migrate to data tiers API dry run on any ILM status {es-pull}82226[#82226] (issue: {es-issue}82169[#82169])
 
@@ -65,6 +68,9 @@ Aggregations::
 * Fix bucket keys format for range aggregations on float field {es-pull}81801[#81801] (issue: {es-issue}81749[#81749])
 * Fix cardinality aggregation in asynchronous search {es-pull}82108[#82108]
 * Fix missing fields in range aggregation response for date fields {es-pull}82732[#82732] (issue: {es-issue}82688[#82688])
+
+Allocation::
+* Correct context for batched reroute notifications {es-pull}83019[#83019]
 
 Authorization::
 * Fix field level security for frozen tier {es-pull}82521[#82521] (issues: {es-issue}78988[#78988], {es-issue}82044[#82044])
@@ -109,19 +115,25 @@ Machine Learning::
 Monitoring::
 * Always attempt upgrade monitoring templates {es-pull}82713[#82713] (issue: {es-issue}82453[#82453])
 
-Search::
-* Fix bug where field is not returned if it has the same prefix as a nested field {es-pull}82922[#82922] (issue: {es-issue}82905[#82905])
+Network::
+* Correct context for `ClusterConnManager` listener {es-pull}83035[#83035]
 
 Settings::
 * Change `deprecation.skip_deprecated_settings` to work with dynamic settings {es-pull}81836[#81836]
 * Check both node and cluster settings in `NodeDeprecationChecks` {es-pull}82487[#82487] (issue: {es-issue}82484[#82484])
 * Ignore dynamic settings specified by `deprecation.skip_deprecated_settings` in node deprecation checks {es-pull}82883[#82883] (issue: {es-issue}82889[#82889])
 
+Search::
+* Fix bug where field is not returned if it has the same prefix as a nested field {es-pull}82922[#82922] (issue: {es-issue}82905[#82905])
+
 Snapshot/Restore::
 * Always fail snapshot deletion listeners on master failover {es-pull}82361[#82361] (issue: {es-issue}81596[#81596])
 * Fix potential repository corruption during master failover {es-pull}82912[#82912] (issue: {es-issue}82911[#82911])
 * Remove requirement for key setting on Azure client settings {es-pull}82030[#82030]
-* Support GKE workload identity for searchable snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
+* Support GKE Workload Identity for Searchable Snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
+
+Stats::
+* Correct context for CancellableSOCache listener {es-pull}83021[#83021]
 
 
 

--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -97,6 +97,9 @@ Infra/Logging::
 * Add `doPrivileged` section in deprecation logger {es-pull}81819[#81819] (issue: {es-issue}81708[#81708])
 * Always emit product origin to deprecation log if present {es-pull}83115[#83115]
 
+Infra/Scripting::
+* Fix deprecated suggestions for `JodaCompatibleZonedDateTime` {es-pull}83276[#83276]
+
 Ingest::
 * Filter enrich policy index deletes to just the policy's associated indices {es-pull}82568[#82568]
 * Fix enrich cache corruption bug {es-pull}82441[#82441] (issue: {es-issue}82340[#82340])
@@ -129,6 +132,7 @@ Settings::
 Snapshot/Restore::
 * Always fail snapshot deletion listeners on master failover {es-pull}82361[#82361] (issue: {es-issue}81596[#81596])
 * Fix potential repository corruption during master failover {es-pull}82912[#82912] (issue: {es-issue}82911[#82911])
+* Move `GetSnapshots` serialization to management pool {es-pull}83215[#83215] (issue: {es-issue}77466[#77466])
 * Remove requirement for key setting on Azure client settings {es-pull}82030[#82030]
 * Support GKE workload identity for searchable snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
 
@@ -140,6 +144,9 @@ Stats::
 [[upgrade-7.17.0]]
 [float]
 === Upgrades
+
+Packaging::
+* Upgrade bundled JDK to version 17.0.2+8 {es-pull}83243[#83243] (issue: {es-issue}83242[#83242])
 
 Search::
 * Upgrade to Lucene 8.11.1 {es-pull}81900[#81900]

--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -97,9 +97,6 @@ Infra/Logging::
 * Add `doPrivileged` section in deprecation logger {es-pull}81819[#81819] (issue: {es-issue}81708[#81708])
 * Always emit product origin to deprecation log if present {es-pull}83115[#83115]
 
-Infra/Scripting::
-* Fix deprecated suggestions for `JodaCompatibleZonedDateTime` {es-pull}83276[#83276]
-
 Ingest::
 * Filter enrich policy index deletes to just the policy's associated indices {es-pull}82568[#82568]
 * Fix enrich cache corruption bug {es-pull}82441[#82441] (issue: {es-issue}82340[#82340])
@@ -132,7 +129,6 @@ Settings::
 Snapshot/Restore::
 * Always fail snapshot deletion listeners on master failover {es-pull}82361[#82361] (issue: {es-issue}81596[#81596])
 * Fix potential repository corruption during master failover {es-pull}82912[#82912] (issue: {es-issue}82911[#82911])
-* Move `GetSnapshots` serialization to management pool {es-pull}83215[#83215] (issue: {es-issue}77466[#77466])
 * Remove requirement for key setting on Azure client settings {es-pull}82030[#82030]
 * Support GKE workload identity for searchable snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
 
@@ -144,9 +140,6 @@ Stats::
 [[upgrade-7.17.0]]
 [float]
 === Upgrades
-
-Packaging::
-* Upgrade bundled JDK to version 17.0.2+8 {es-pull}83243[#83243] (issue: {es-issue}83242[#83242])
 
 Search::
 * Upgrade to Lucene 8.11.1 {es-pull}81900[#81900]

--- a/docs/reference/release-notes/7.17.asciidoc
+++ b/docs/reference/release-notes/7.17.asciidoc
@@ -118,22 +118,22 @@ Monitoring::
 Network::
 * Correct context for `ClusterConnManager` listener {es-pull}83035[#83035]
 
+Search::
+* Fix bug where field is not returned if it has the same prefix as a nested field {es-pull}82922[#82922] (issue: {es-issue}82905[#82905])
+
 Settings::
 * Change `deprecation.skip_deprecated_settings` to work with dynamic settings {es-pull}81836[#81836]
 * Check both node and cluster settings in `NodeDeprecationChecks` {es-pull}82487[#82487] (issue: {es-issue}82484[#82484])
 * Ignore dynamic settings specified by `deprecation.skip_deprecated_settings` in node deprecation checks {es-pull}82883[#82883] (issue: {es-issue}82889[#82889])
 
-Search::
-* Fix bug where field is not returned if it has the same prefix as a nested field {es-pull}82922[#82922] (issue: {es-issue}82905[#82905])
-
 Snapshot/Restore::
 * Always fail snapshot deletion listeners on master failover {es-pull}82361[#82361] (issue: {es-issue}81596[#81596])
 * Fix potential repository corruption during master failover {es-pull}82912[#82912] (issue: {es-issue}82911[#82911])
 * Remove requirement for key setting on Azure client settings {es-pull}82030[#82030]
-* Support GKE Workload Identity for Searchable Snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
+* Support GKE workload identity for searchable snapshots {es-pull}82974[#82974] (issue: {es-issue}82702[#82702])
 
 Stats::
-* Correct context for CancellableSOCache listener {es-pull}83021[#83021]
+* Correct context for `CancellableSOCache` listener {es-pull}83021[#83021]
 
 
 


### PR DESCRIPTION
https://elasticsearch_83331.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.0.html

The updated release notes for BC5 bee8632870 .

Follow up on #83153