### PR TITLE
[8.0] refactor: use the original from/to values when creating the bucket (#83262)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -124,8 +124,8 @@ setup:
 ---
 "Float range":
   - skip:
-      version: " - 8.1.0"
-      reason: Bug fixed in 8.1.0
+      version: " - 7.16.99"
+      reason: Bug fixed in 8.1.0 and backported to 7.17.0
   - do:
       search:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -124,8 +124,8 @@ setup:
 ---
 "Float range":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/82476"
+      version: " - 8.1.0"
+      reason: Bug fixed in 8.1.0
   - do:
       search:
         index: test

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
@@ -364,7 +364,7 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
             } else if (Double.isFinite(to)) {
                 to = parser.parseDouble(Long.toString((long) to), false, context::nowInMillis);
             }
-            return new RangeAggregator.Range(range.getKey(), from, from, fromAsString, to, to, toAsString);
+            return new RangeAggregator.Range(range.getKey(), from, fromAsString, to, toAsString);
         });
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -69,7 +69,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         }
 
         private static Bucket createFromStream(StreamInput in, DocValueFormat format, boolean keyed) throws IOException {
-            String key = in.getVersion().onOrAfter(Version.V_8_1_0) ? in.readOptionalString() : in.readString();
+            String key = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalString() : in.readString();
             BytesRef from = in.readBoolean() ? in.readBytesRef() : null;
             BytesRef to = in.readBoolean() ? in.readBytesRef() : null;
             long docCount = in.readLong();
@@ -80,7 +80,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
                 out.writeOptionalString(key);
             } else {
                 out.writeString(key == null ? generateKey(from, to, format) : key);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
@@ -28,29 +28,25 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
         public Bucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             List<InternalAggregation> aggregations,
             boolean keyed,
             DocValueFormat formatter
         ) {
-            super(key, from, originalFrom, to, originalTo, docCount, InternalAggregations.from(aggregations), keyed, formatter);
+            super(key, from, to, docCount, InternalAggregations.from(aggregations), keyed, formatter);
         }
 
         public Bucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             InternalAggregations aggregations,
             boolean keyed,
             DocValueFormat formatter
         ) {
-            super(key, from, originalFrom, to, originalTo, docCount, aggregations, keyed, formatter);
+            super(key, from, to, docCount, aggregations, keyed, formatter);
         }
 
         @Override
@@ -73,14 +69,6 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
 
         private Double internalGetTo() {
             return to;
-        }
-
-        private Double internalGetOriginalFrom() {
-            return originalFrom;
-        }
-
-        private Double internalGetOriginalTo() {
-            return originalTo;
         }
 
         @Override
@@ -124,15 +112,13 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
         public Bucket createBucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             InternalAggregations aggregations,
             boolean keyed,
             DocValueFormat formatter
         ) {
-            return new Bucket(key, from, originalFrom, to, originalTo, docCount, aggregations, keyed, formatter);
+            return new Bucket(key, from, to, docCount, aggregations, keyed, formatter);
         }
 
         @Override
@@ -140,9 +126,7 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
             return new Bucket(
                 prototype.getKey(),
                 prototype.internalGetFrom(),
-                prototype.internalGetOriginalFrom(),
                 prototype.internalGetTo(),
-                prototype.internalGetOriginalTo(),
                 prototype.getDocCount(),
                 aggregations,
                 prototype.getKeyed(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
@@ -23,17 +23,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     static class Bucket extends InternalRange.Bucket {
 
-        Bucket(
-            String key,
-            double from,
-            double originalFrom,
-            double to,
-            double originalTo,
-            long docCount,
-            InternalAggregations aggregations,
-            boolean keyed
-        ) {
-            super(key, from, originalFrom, to, originalTo, docCount, aggregations, keyed, DocValueFormat.RAW);
+        Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed) {
+            super(key, from, to, docCount, aggregations, keyed, DocValueFormat.RAW);
         }
 
         @Override
@@ -77,15 +68,13 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         public Bucket createBucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             InternalAggregations aggregations,
             boolean keyed,
             DocValueFormat format
         ) {
-            return new Bucket(key, from, originalFrom, to, originalTo, docCount, aggregations, keyed);
+            return new Bucket(key, from, to, docCount, aggregations, keyed);
         }
 
         @Override
@@ -93,9 +82,7 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
             return new Bucket(
                 prototype.getKey(),
                 ((Number) prototype.getFrom()).doubleValue(),
-                ((Number) prototype.getOriginalFrom()).doubleValue(),
                 ((Number) prototype.getTo()).doubleValue(),
-                ((Number) prototype.getOriginalTo()).doubleValue(),
                 prototype.getDocCount(),
                 aggregations,
                 prototype.getKeyed()

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -156,7 +156,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
                 out.writeOptionalString(key);
             } else {
                 out.writeString(key == null ? generateKey(from, to, format) : key);
@@ -262,7 +262,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         int size = in.readVInt();
         List<B> ranges = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            String key = in.getVersion().onOrAfter(Version.V_8_1_0) ? in.readOptionalString() : in.readString();
+            String key = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalString() : in.readString();
             double from = in.readDouble();
             if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
                 in.readOptionalDouble();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -36,9 +36,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         protected final transient boolean keyed;
         protected final transient DocValueFormat format;
         protected final double from;
-        protected final double originalFrom;
         protected final double to;
-        protected final double originalTo;
         private final long docCount;
         private final InternalAggregations aggregations;
         private final String key;
@@ -46,9 +44,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         public Bucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             InternalAggregations aggregations,
             boolean keyed,
@@ -56,11 +52,9 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         ) {
             this.keyed = keyed;
             this.format = format;
-            this.key = key != null ? key : generateKey(originalFrom, originalTo, format);
+            this.key = key;
             this.from = from;
-            this.originalFrom = originalFrom;
             this.to = to;
-            this.originalTo = originalTo;
             this.docCount = docCount;
             this.aggregations = aggregations;
         }
@@ -72,7 +66,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public String getKeyAsString() {
-            return key;
+            return this.key == null ? generateKey(this.from, this.to, this.format) : this.key;
         }
 
         @Override
@@ -80,17 +74,9 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             return from;
         }
 
-        public Double getOriginalFrom() {
-            return originalFrom;
-        }
-
         @Override
         public Object getTo() {
             return to;
-        }
-
-        public Double getOriginalTo() {
-            return originalTo;
         }
 
         public boolean getKeyed() {
@@ -103,19 +89,19 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public String getFromAsString() {
-            if (Double.isInfinite(originalFrom)) {
+            if (Double.isInfinite(from)) {
                 return null;
             } else {
-                return format.format(originalFrom).toString();
+                return format.format(from).toString();
             }
         }
 
         @Override
         public String getToAsString() {
-            if (Double.isInfinite(originalTo)) {
+            if (Double.isInfinite(to)) {
                 return null;
             } else {
-                return format.format(originalTo).toString();
+                return format.format(to).toString();
             }
         }
 
@@ -136,22 +122,23 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            final String key = getKeyAsString();
             if (keyed) {
                 builder.startObject(key);
             } else {
                 builder.startObject();
                 builder.field(CommonFields.KEY.getPreferredName(), key);
             }
-            if (Double.isInfinite(originalFrom) == false) {
-                builder.field(CommonFields.FROM.getPreferredName(), originalFrom);
+            if (Double.isInfinite(from) == false) {
+                builder.field(CommonFields.FROM.getPreferredName(), from);
                 if (format != DocValueFormat.RAW) {
-                    builder.field(CommonFields.FROM_AS_STRING.getPreferredName(), format.format(originalFrom));
+                    builder.field(CommonFields.FROM_AS_STRING.getPreferredName(), format.format(from));
                 }
             }
-            if (Double.isInfinite(originalTo) == false) {
-                builder.field(CommonFields.TO.getPreferredName(), originalTo);
+            if (Double.isInfinite(to) == false) {
+                builder.field(CommonFields.TO.getPreferredName(), to);
                 if (format != DocValueFormat.RAW) {
-                    builder.field(CommonFields.TO_AS_STRING.getPreferredName(), format.format(originalTo));
+                    builder.field(CommonFields.TO_AS_STRING.getPreferredName(), format.format(to));
                 }
             }
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
@@ -169,14 +156,18 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(key);
+            if (out.getVersion().onOrAfter(Version.V_8_1_0)) {
+                out.writeOptionalString(key);
+            } else {
+                out.writeString(key == null ? generateKey(from, to, format) : key);
+            }
             out.writeDouble(from);
             if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
-                out.writeOptionalDouble(originalFrom);
+                out.writeOptionalDouble(from);
             }
             out.writeDouble(to);
             if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
-                out.writeOptionalDouble(originalTo);
+                out.writeOptionalDouble(to);
             }
             out.writeVLong(docCount);
             aggregations.writeTo(out);
@@ -222,15 +213,13 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         public B createBucket(
             String key,
             double from,
-            double originalFrom,
             double to,
-            double originalTo,
             long docCount,
             InternalAggregations aggregations,
             boolean keyed,
             DocValueFormat format
         ) {
-            return (B) new Bucket(key, from, originalFrom, to, originalTo, docCount, aggregations, keyed, format);
+            return (B) new Bucket(key, from, to, docCount, aggregations, keyed, format);
         }
 
         @SuppressWarnings("unchecked")
@@ -243,9 +232,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             return (B) new Bucket(
                 prototype.getKey(),
                 prototype.from,
-                prototype.originalFrom,
                 prototype.to,
-                prototype.originalTo,
                 prototype.getDocCount(),
                 aggregations,
                 prototype.keyed,
@@ -275,25 +262,18 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         int size = in.readVInt();
         List<B> ranges = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            String key = in.readString();
+            String key = in.getVersion().onOrAfter(Version.V_8_1_0) ? in.readOptionalString() : in.readString();
             double from = in.readDouble();
-            Double originalFrom = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalDouble() : Double.valueOf(from);
+            if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
+                in.readOptionalDouble();
+            }
             double to = in.readDouble();
-            Double originalTo = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalDouble() : Double.valueOf(to);
+            if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
+                in.readOptionalDouble();
+            }
             long docCount = in.readVLong();
-            ranges.add(
-                getFactory().createBucket(
-                    key,
-                    from,
-                    originalFrom,
-                    to,
-                    originalTo,
-                    docCount,
-                    InternalAggregations.readFrom(in),
-                    keyed,
-                    format
-                )
-            );
+            InternalAggregations aggregations = InternalAggregations.readFrom(in);
+            ranges.add(getFactory().createBucket(key, from, to, docCount, aggregations, keyed, format));
         }
         this.ranges = ranges;
     }
@@ -369,17 +349,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         }
         final InternalAggregations aggs = InternalAggregations.reduce(aggregationsList, context);
         Bucket prototype = buckets.get(0);
-        return getFactory().createBucket(
-            prototype.key,
-            prototype.from,
-            prototype.originalFrom,
-            prototype.to,
-            prototype.originalTo,
-            docCount,
-            aggs,
-            keyed,
-            format
-        );
+        return getFactory().createBucket(prototype.key, prototype.from, prototype.to, docCount, aggs, keyed, format);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
@@ -163,18 +163,9 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
         Range[] ranges = processRanges(range -> {
             DocValueFormat parser = config.format();
             assert parser != null;
-            Double from = fixPrecision.applyAsDouble(range.from);
-            Double to = fixPrecision.applyAsDouble(range.to);
-            if (range.fromAsStr != null) {
-                from = parser.parseDouble(range.fromAsStr, false, context::nowInMillis);
-            }
-            if (range.toAsStr != null) {
-                to = parser.parseDouble(range.toAsStr, false, context::nowInMillis);
-            }
-            double originalFrom = range.fromAsStr != null ? from : range.from;
-            double originalTo = range.toAsStr != null ? to : range.to;
-            String key = range.key != null ? range.key : generateKey(originalFrom, originalTo, config.format());
-            return new Range(key, from, originalFrom, range.fromAsStr, to, originalTo, range.toAsStr);
+            double from = range.fromAsStr != null ? parser.parseDouble(range.fromAsStr, false, context::nowInMillis) : range.from;
+            double to = range.toAsStr != null ? parser.parseDouble(range.toAsStr, false, context::nowInMillis) : range.to;
+            return new Range(range.key, from, range.fromAsStr, to, range.toAsStr, fixPrecision);
         });
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -472,8 +472,6 @@ public class SearchResponseMergerTests extends ESTestCase {
             InternalDateRange.Bucket bucket = factory.createBucket(
                 "bucket",
                 0D,
-                0D,
-                10000D,
                 10000D,
                 count,
                 InternalAggregations.EMPTY,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -81,7 +81,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalDateRange.Bucket("range_" + i, from, from, to, to, docCount, aggregations, keyed, format));
+            buckets.add(new InternalDateRange.Bucket("range_" + i, from, to, docCount, aggregations, keyed, format));
         }
         return new InternalDateRange(name, buckets, format, keyed, metadata);
     }
@@ -116,17 +116,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
                 double from = randomDouble();
                 double to = from + randomDouble();
                 buckets.add(
-                    new InternalDateRange.Bucket(
-                        "range_a",
-                        from,
-                        from,
-                        to,
-                        to,
-                        randomNonNegativeLong(),
-                        InternalAggregations.EMPTY,
-                        false,
-                        format
-                    )
+                    new InternalDateRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false, format)
                 );
             }
             case 3 -> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -63,7 +63,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalGeoDistance.Bucket("range_" + i, from, from, to, to, docCount, aggregations, keyed));
+            buckets.add(new InternalGeoDistance.Bucket("range_" + i, from, to, docCount, aggregations, keyed));
         }
         return new InternalGeoDistance(name, buckets, keyed, metadata);
     }
@@ -97,16 +97,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
                 double from = randomDouble();
                 double to = from + randomDouble();
                 buckets.add(
-                    new InternalGeoDistance.Bucket(
-                        "range_a",
-                        from,
-                        from,
-                        to,
-                        to,
-                        randomNonNegativeLong(),
-                        InternalAggregations.EMPTY,
-                        false
-                    )
+                    new InternalGeoDistance.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false)
                 );
             }
             case 3 -> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -76,7 +76,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalRange.Bucket("range_" + i, from, from, to, to, docCount, aggregations, keyed, format));
+            buckets.add(new InternalRange.Bucket("range_" + i, from, to, docCount, aggregations, keyed, format));
         }
         return new InternalRange<>(name, buckets, format, keyed, metadata);
     }
@@ -111,17 +111,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
                 double from = randomDouble();
                 double to = from + randomDouble();
                 buckets.add(
-                    new InternalRange.Bucket(
-                        "range_a",
-                        from,
-                        from,
-                        to,
-                        to,
-                        randomNonNegativeLong(),
-                        InternalAggregations.EMPTY,
-                        false,
-                        format
-                    )
+                    new InternalRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false, format)
                 );
             }
             case 3 -> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -121,7 +121,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         );
     }
 
-    public void testFloatRangeKeys() throws IOException {
+    public void testFloatRangeFromAndToValues() throws IOException {
         final String fieldName = "test";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.FLOAT);
         testCase(
@@ -138,15 +138,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                 assertEquals(2, ranges.size());
                 assertEquals("5.0-6.0", ranges.get(0).getKeyAsString());
                 assertEquals("6.0-10.6", ranges.get(1).getKeyAsString());
+                assertEquals(5.0D, ranges.get(0).getFrom());
+                assertEquals(6.0D, ranges.get(0).getTo());
+                assertEquals(6.0D, ranges.get(1).getFrom());
+                assertEquals(10.6D, ranges.get(1).getTo());
                 assertEquals("5.0", ranges.get(0).getFromAsString());
                 assertEquals("6.0", ranges.get(0).getToAsString());
                 assertEquals("6.0", ranges.get(1).getFromAsString());
                 assertEquals("10.6", ranges.get(1).getToAsString());
-                // NOTE: `getOriginalFrom` and `getOriginalTo` return double
-                assertEquals(5.0D, ranges.get(0).getOriginalFrom(), 0.0000000000001);
-                assertEquals(6.0D, ranges.get(0).getOriginalTo(), 0.0000000000001);
-                assertEquals(6.0D, ranges.get(1).getOriginalFrom(), 0.0000000000001);
-                assertEquals(10.6D, ranges.get(1).getOriginalTo(), 0.0000000000001);
                 assertEquals(1, ranges.get(0).getDocCount());
                 assertEquals(2, ranges.get(1).getDocCount());
             },
@@ -154,7 +153,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         );
     }
 
-    public void testDoubleRangeKeys() throws IOException {
+    public void testDoubleRangeFromAndToValues() throws IOException {
         final String fieldName = "test";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.DOUBLE);
         testCase(
@@ -171,14 +170,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                 assertEquals(2, ranges.size());
                 assertEquals("5.0-6.0", ranges.get(0).getKeyAsString());
                 assertEquals("6.0-10.6", ranges.get(1).getKeyAsString());
+                assertEquals(5.0D, ranges.get(0).getFrom());
+                assertEquals(6.0D, ranges.get(0).getTo());
+                assertEquals(6.0D, ranges.get(1).getFrom());
+                assertEquals(10.6D, ranges.get(1).getTo());
                 assertEquals("5.0", ranges.get(0).getFromAsString());
                 assertEquals("6.0", ranges.get(0).getToAsString());
                 assertEquals("6.0", ranges.get(1).getFromAsString());
                 assertEquals("10.6", ranges.get(1).getToAsString());
-                assertEquals(5.0D, ranges.get(0).getOriginalFrom(), 0.0000000000001);
-                assertEquals(6.0D, ranges.get(0).getOriginalTo(), 0.0000000000001);
-                assertEquals(6.0D, ranges.get(1).getOriginalFrom(), 0.0000000000001);
-                assertEquals(10.6D, ranges.get(1).getOriginalTo(), 0.0000000000001);
                 assertEquals(1, ranges.get(0).getDocCount());
                 assertEquals(2, ranges.get(1).getDocCount());
             },
@@ -574,9 +573,11 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             }
         }, (InternalRange<?, ?> r, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
             assertThat(
-                r.getBuckets().stream().map(InternalRange.Bucket::getKey).collect(toList()),
+                r.getBuckets().stream().map(InternalRange.Bucket::getKeyAsString).collect(toList()),
                 equalTo(List.of("0.0-1.0", "1.0-2.0", "2.0-3.0"))
             );
+            assertThat(r.getBuckets().stream().map(InternalRange.Bucket::getFrom).collect(toList()), equalTo(List.of(0.0, 1.0, 2.0)));
+            assertThat(r.getBuckets().stream().map(InternalRange.Bucket::getTo).collect(toList()), equalTo(List.of(1.0, 2.0, 3.0)));
             assertThat(
                 r.getBuckets().stream().map(InternalRange.Bucket::getDocCount).collect(toList()),
                 equalTo(List.of(totalDocs, 0L, 0L))
@@ -610,9 +611,11 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             },
             (InternalRange<?, ?> r, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
                 assertThat(
-                    r.getBuckets().stream().map(InternalRange.Bucket::getKey).collect(toList()),
+                    r.getBuckets().stream().map(InternalRange.Bucket::getKeyAsString).collect(toList()),
                     equalTo(List.of("0.0-1.0", "1.0-2.0", "2.0-3.0"))
                 );
+                assertThat(r.getBuckets().stream().map(InternalRange.Bucket::getFrom).collect(toList()), equalTo(List.of(0.0, 1.0, 2.0)));
+                assertThat(r.getBuckets().stream().map(InternalRange.Bucket::getTo).collect(toList()), equalTo(List.of(1.0, 2.0, 3.0)));
                 assertThat(
                     r.getBuckets().stream().map(InternalRange.Bucket::getDocCount).collect(toList()),
                     equalTo(List.of(totalDocs, 0L, 0L))


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #83262

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
