### PR TITLE
Fix flaky testMaxBytesPerSecOnNonDataNodeWithIndicesRecoveryMaxBytesPerSec

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
@@ -109,7 +109,7 @@ public class RecoverySettingsTests extends ESTestCase {
     public void testDefaultMaxBytesPerSecOnNonDataNode() {
         assertThat(
             "Non-data nodes have a default 40mb rate limit",
-            nodeRecoverySettings().withRole(randomFrom("master", "ingest", "ml")).withRandomMemory().build().getMaxBytesPerSec(),
+            nodeRecoverySettings().withRole(randomFrom("master", "ingest")).withRandomMemory().build().getMaxBytesPerSec(),
             equalTo(DEFAULT_MAX_BYTES_PER_SEC)
         );
     }
@@ -118,7 +118,7 @@ public class RecoverySettingsTests extends ESTestCase {
         final ByteSizeValue random = randomByteSizeValue();
         assertThat(
             "Non-data nodes should use the defined rate limit when set",
-            nodeRecoverySettings().withRole(randomFrom("master", "ingest", "ml"))
+            nodeRecoverySettings().withRole(randomFrom("master", "ingest"))
                 .withIndicesRecoveryMaxBytesPerSec(random)
                 .withRandomMemory()
                 .build()


### PR DESCRIPTION
The test is failing as it could randomly select
ml role that is not a build in role in 7.17

Closes: #83352 
