### PR TITLE
Moving ScoreFunctionBuilders under VersionedNamedWriteable

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
@@ -132,6 +133,11 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
         @Override
         public DecayFunction getDecayFunction() {
             return decayFunction;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_EMPTY;
         }
 
         private static final DecayFunction decayFunction = new LinearMultScoreFunction();

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 
@@ -79,5 +80,10 @@ public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder<Expone
             }
             return obj != null && getClass() != obj.getClass();
         }
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -128,6 +129,11 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldV
     @Override
     protected int doHashCode() {
         return Objects.hash(this.field, this.factor, this.missing, this.modifier);
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/GaussDecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/GaussDecayFunctionBuilder.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xcontent.ParseField;
@@ -48,6 +49,11 @@ public class GaussDecayFunctionBuilder extends DecayFunctionBuilder<GaussDecayFu
     @Override
     public DecayFunction getDecayFunction() {
         return GAUSS_DECAY_FUNCTION;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     private static final class GaussScoreFunction implements DecayFunction {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/LinearDecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/LinearDecayFunctionBuilder.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 
@@ -46,6 +47,11 @@ public class LinearDecayFunctionBuilder extends DecayFunctionBuilder<LinearDecay
     @Override
     public DecayFunction getDecayFunction() {
         return LINEAR_DECAY_FUNCTION;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     private static final class LinearDecayScoreFunction implements DecayFunction {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.index.query.functionscore;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -171,6 +172,11 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
 
     private static int hash(long value) {
         return Long.hashCode(value);
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     public static RandomScoreFunctionBuilder fromXContent(XContentParser parser) throws IOException, ParsingException {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilder.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.index.query.functionscore;
 
-import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -20,7 +20,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> implements ToXContentFragment, NamedWriteable {
+public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> implements ToXContentFragment, VersionedNamedWriteable {
 
     private Float weight;
 

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -77,6 +78,11 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder<ScriptScore
     @Override
     protected int doHashCode() {
         return Objects.hash(this.script);
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/WeightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/WeightBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
@@ -53,6 +54,11 @@ public class WeightBuilder extends ScoreFunctionBuilder<WeightBuilder> {
     @Override
     protected int doHashCode() {
         return 0;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 
     @Override


### PR DESCRIPTION
In #81809 we introduced a mechanism to check searializability of search request
to earlier version nodes already on the coordinating node. This requires
knowledge about the version that NamedWritable classes have been introduced,
which is why we started moving classes that are used inside the search request
under the VersionedNamedWriteable interface to make sure future additions
implement the mthod that provides the version information.
This change moves ScoreFunctionBuilders which are used in function score queries
under that interface. Since all these builders have been around before 7.0 we
return the empty version constant for them.