### PR TITLE
Moving Smoothing models under VersionedNamedWriteable

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/Laplace.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/Laplace.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest.phrase;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.suggest.phrase.WordScorer.WordScorerFactory;
@@ -116,5 +117,10 @@ public final class Laplace extends SmoothingModel {
             separator,
             alpha
         );
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest.phrase;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -173,5 +174,10 @@ public final class LinearInterpolation extends SmoothingModel {
                 bigramLambda,
                 unigramLambda
             );
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/SmoothingModel.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/SmoothingModel.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.search.suggest.phrase;
 
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.search.suggest.phrase.WordScorer.WordScorerFactory;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public abstract class SmoothingModel implements NamedWriteable, ToXContentFragment {
+public abstract class SmoothingModel implements VersionedNamedWriteable, ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoff.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoff.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest.phrase;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.suggest.phrase.WordScorer.WordScorerFactory;
@@ -119,5 +120,10 @@ public final class StupidBackoff extends SmoothingModel {
             separator,
             discount
         );
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_EMPTY;
     }
 }


### PR DESCRIPTION
This change moves the three existing smoothing models which are used in suggesters
under the VersionedNamedWriteable interface.

Relates to #81809, #83358