### PR TITLE
Document and test operator-only node bandwidth recovery settings

### DIFF
--- a/docs/reference/modules/indices/recovery.asciidoc
+++ b/docs/reference/modules/indices/recovery.asciidoc
@@ -109,6 +109,7 @@ Do not increase this setting without carefully verifying that your cluster has
 the resources available to handle the extra load that will result.
 
 [discrete]
+[[recovery-settings-for-managed-services]]
 ==== Recovery settings for managed services
 
 NOTE: {cloud-only}

--- a/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
@@ -27,7 +27,7 @@ given {es} version.
 ==== Operator-only dynamic cluster settings
 
 * All <<ip-filtering,IP filtering>> settings
-* The following the dynamic <<ml-settings,machine learning settings>>:
+* The following dynamic <<ml-settings,machine learning settings>>:
   - `xpack.ml.node_concurrent_job_allocations`
   - `xpack.ml.max_machine_memory_percent`
   - `xpack.ml.use_auto_machine_memory_percent`
@@ -38,3 +38,9 @@ given {es} version.
   - `xpack.ml.enable_config_migration`
   - `xpack.ml.persist_results_max_retries`
 * The <<cluster-routing-disk-threshold,`cluster.routing.allocation.disk.threshold_enabled` setting>>
+* The following <<recovery-settings-for-managed-services,recovery settings for managed services>>:
+  - `node.bandwidth.recovery.operator.factor`
+  - `node.bandwidth.recovery.operator.factor.read`
+  - `node.bandwidth.recovery.operator.factor.write`
+  - `node.bandwidth.recovery.operator.factor.max_overcommit`
+


### PR DESCRIPTION
This commit updates the _Operator-only functionality_ doc to mention the operator only settings introduced in #82819.

It also adds an integration test for those operator only settings that would have caught #83359.