### PR TITLE
[7.17] [DOCS] Update dynamic mapping docs to clarify supported match_mapping_type (#83274)

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -15,19 +15,19 @@ explicitly map all other data types.
 
 [[dynamic-field-mapping-types]]
 // tag::dynamic-field-mapping-types-tag[]
-[cols="3"]
+[cols="3",frame=all]
 |===
+h|                2+^h|{es} data type
 h| JSON data type h| `"dynamic":"true"` h| `"dynamic":"runtime"`
  |`null` 2*| No field added
  |`true` or `false` 2*| `boolean`
  |`double` | `float` | `double`
- |`integer` 2*| `long`
+ |`long` 2*| `long`
  |`object` | `object` | No field added
  |`array` 2*|  Depends on the first non-`null` value in the array
  |`string` that passes <<date-detection,date detection>> 2*| `date`
  |`string` that passes <<numeric-detection,numeric detection>> | `float` or `long` | `double` or `long`
  |`string` that doesn't pass `date` detection or `numeric` detection | `text` with a `.keyword` sub-field | `keyword`
-3+|
 |===
 // end::dynamic-field-mapping-types-tag[]
 

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -120,8 +120,13 @@ to map `string` fields as either indexed fields or runtime fields.
 
 The `match_mapping_type` is the data type detected by the JSON parser. Because
 JSON doesn't distinguish a `long` from an `integer` or a `double` from
-a `float`, it always chooses the wider data type such as `long` for integers
-and `double` for floating-point numbers.
+a `float`, any parsed floating point number is considered a `double` JSON data
+type, while any parsed `integer` number is considered a `long`.
+
+NOTE: With dynamic mappings, {es} will always choose the wider data type. The
+one exception is `float`, which requires less storage space than `double` and
+is precise enough for most applications. Runtime fields do not support `float`,
+which is why `"dynamic":"runtime"` uses `double`.
 
 {es} automatically detects the following data types:
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Update dynamic mapping docs to clarify supported match_mapping_type (#83274)