### PR TITLE
[DOCS] Adds disclaimer to cat APIs

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or the 
 {kib} console. They are _not_ intended for use by applications. For application 
-consumption, use the <<aliases>> API.
+consumption, use the <<aliases,aliases API>>.
 ====
 
 Retrieves the cluster's <<aliases,index aliases>>, including filter and routing

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat aliases</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<aliases>> API.
+====
+
 Retrieves the cluster's <<aliases,index aliases>>, including filter and routing
 information. The API does not return data stream aliases.
 

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<aliases>> API.
+cat APIs are only intended for human consumption using the command line or the 
+{kib} console. They are _not_ intended for use by applications. For application 
+consumption, use the <<aliases>> API.
 ====
 
 Retrieves the cluster's <<aliases,index aliases>>, including filter and routing

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat allocation</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications.
+====
 
 Provides a snapshot of the number of shards allocated to each data node
 and their disk space.

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -6,9 +6,8 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications.
 ====
 
 Provides a snapshot of the number of shards allocated to each data node

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -5,6 +5,14 @@
 <titleabbrev>cat anomaly detectors</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<ml-get-job-stats>>.
+====
+
 Returns configuration and usage information about {anomaly-jobs}.
 
 [[cat-anomaly-detectors-request]]

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -9,7 +9,8 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<ml-get-job-stats>>.
+consumption, use the 
+<<ml-get-job-stats,get anomaly detection job statistics API>>.
 ====
 
 Returns configuration and usage information about {anomaly-jobs}.

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<ml-get-job-stats>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<ml-get-job-stats>>.
 ====
 
 Returns configuration and usage information about {anomaly-jobs}.

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<search-count>> API.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<search-count>> API.
 ====
 
 Provides quick access to a document count for a data stream, an index, or an

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat count</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<search-count>> API.
+====
+
 Provides quick access to a document count for a data stream, an index, or an
 entire cluster.
 

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<search-count>> API.
+consumption, use the <<search-count,count API>>.
 ====
 
 Provides quick access to a document count for a data stream, an index, or an

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -9,7 +9,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<ml-get-datafeed-stats>>.
+consumption, use the <<ml-get-datafeed-stats,get datafeed statistics API>>.
 ====
 
 Returns configuration and usage information about {dfeeds}.

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<ml-get-datafeed-stats>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<ml-get-datafeed-stats>>.
 ====
 
 Returns configuration and usage information about {dfeeds}.

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -5,6 +5,14 @@
 <titleabbrev>cat {dfeeds}</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<ml-get-datafeed-stats>>.
+====
+
 Returns configuration and usage information about {dfeeds}.
 
 [[cat-datafeeds-request]]

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -5,6 +5,14 @@
 <titleabbrev>cat {dfanalytics}</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<get-dfanalytics-stats>>.
+====
+
 Returns configuration and usage information about {dfanalytics-jobs}.
 
 

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<get-dfanalytics-stats>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<get-dfanalytics-stats>>.
 ====
 
 Returns configuration and usage information about {dfanalytics-jobs}.

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -9,7 +9,8 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<get-dfanalytics-stats>>.
+consumption, use the 
+<<get-dfanalytics-stats,get data frame analytics jobs statistics API>>.
 ====
 
 Returns configuration and usage information about {dfanalytics-jobs}.

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-stats>>.
+consumption, use the <<cluster-nodes-stats,nodes stats API>>.
 ====
 
 Returns the amount of heap memory currently used by the

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat fielddata</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-stats>>.
+====
+
 Returns the amount of heap memory currently used by the
 <<modules-fielddata, field data cache>> on every data node in the cluster.
 

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-stats>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-stats>>.
 ====
 
 Returns the amount of heap memory currently used by the

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-health>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, we use the <<cluster-health>>.
 ====
 
 Returns the health status of a cluster, similar to the <<cluster-health,cluster

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat health</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-health>>.
+====
+
 Returns the health status of a cluster, similar to the <<cluster-health,cluster
 health>> API.
 

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, we use the <<cluster-health>>.
+consumption, use the <<cluster-health,cluster health API>>.
 ====
 
 Returns the health status of a cluster, similar to the <<cluster-health,cluster

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-get-index>>.
+consumption, use the <<indices-get-index,get index API>>.
 ====
 
 Returns high-level information about indices in a cluster, including backing

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<indices-get-index>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<indices-get-index>>.
 ====
 
 Returns high-level information about indices in a cluster, including backing

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat indices</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<indices-get-index>>.
+====
+
 Returns high-level information about indices in a cluster, including backing
 indices for data streams.
 

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat master</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-info>>.
+====
+
 Returns information about the master node, including the ID, bound IP address,
 and name.
 

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-info>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-info>>.
 ====
 
 Returns information about the master node, including the ID, bound IP address,

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-info>>.
+consumption, use the <<cluster-nodes-info,nodes info API>>.
 ====
 
 Returns information about the master node, including the ID, bound IP address,

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat nodeattrs</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-info>>.
+====
+
 Returns information about custom node attributes.
 
 [[cat-nodeattrs-api-request]]

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-info>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-info>>.
 ====
 
 Returns information about custom node attributes.

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-info>>.
+consumption, use the <<cluster-nodes-info,nodes info API>>.
 ====
 
 Returns information about custom node attributes.

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat nodes</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-info>>.
+====
+
 Returns information about a cluster's nodes.
 
 [[cat-nodes-api-request]]

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-info>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-info>>.
 ====
 
 Returns information about a cluster's nodes.

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-info>>.
+consumption, use the <<cluster-nodes-info,nodes info API>>.
 ====
 
 Returns information about a cluster's nodes.

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-pending>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-pending>>.
 ====
 
 Returns cluster-level changes that have not yet been executed, similar to the

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat pending tasks</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-pending>>.
+====
+
 Returns cluster-level changes that have not yet been executed, similar to the
 <<cluster-pending, pending cluster tasks>> API.
 

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-pending>>.
+consumption, use the <<cluster-pending,pending cluster tasks API>>.
 ====
 
 Returns cluster-level changes that have not yet been executed, similar to the

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -4,6 +4,15 @@
 <titleabbrev>cat plugins</titleabbrev>
 ++++
 
+
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-info>>.
+====
+
 Returns a list of plugins running on each node of a cluster.
 
 

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -9,7 +9,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-info>>.
+consumption, use the <<cluster-nodes-info,nodes info API>>.
 ====
 
 Returns a list of plugins running on each node of a cluster.

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-info>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-info>>.
 ====
 
 Returns a list of plugins running on each node of a cluster.

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -4,6 +4,13 @@
 <titleabbrev>cat recovery</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<indices-recovery>>.
+====
 
 Returns information about ongoing and completed shard recoveries,
 similar to the <<indices-recovery, index recovery>> API.

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<indices-recovery>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<indices-recovery>>.
 ====
 
 Returns information about ongoing and completed shard recoveries,

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-recovery>>.
+consumption, use the <<indices-recovery,index recovery API>>.
 ====
 
 Returns information about ongoing and completed shard recoveries,

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat repositories</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<indices-recovery>>.
+====
+
 Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.
 
 

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-recovery,index recovery API>>.
+consumption, use the <<get-snapshot-repo-api,get snapshot repository API>>.
 ====
 
 Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<indices-recovery>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<indices-recovery>>.
 ====
 
 Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-recovery>>.
+consumption, use the <<indices-recovery,index recovery API>>.
 ====
 
 Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat segments</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<indices-segments>>.
+====
+
 Returns low-level information about the https://lucene.apache.org/core/[Lucene]
 segments in index shards, similar to the <<indices-segments, indices segments>>
 API.

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-segments>>.
+consumption, use the <<indices-segments,index segments API>>.
 ====
 
 Returns low-level information about the https://lucene.apache.org/core/[Lucene]

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<indices-segments>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<indices-segments>>.
 ====
 
 Returns low-level information about the https://lucene.apache.org/core/[Lucene]

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -4,6 +4,13 @@
 <titleabbrev>cat shards</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications.
+====
+
 The `shards` command is the detailed view of what nodes contain which
 shards. It will tell you if it's a primary or replica, the number of
 docs, the bytes it takes on disk, and the node where it's located.

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -6,9 +6,8 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications.
 ====
 
 The `shards` command is the detailed view of what nodes contain which

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<get-snapshot-api>>.
+consumption, use the <<get-snapshot-api,get snapshot API>>.
 ====
 
 Returns information about the <<modules-snapshots,snapshots>> stored in one or

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat snapshots</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<get-snapshot-api>>.
+====
+
 Returns information about the <<modules-snapshots,snapshots>> stored in one or
 more repositories. A snapshot is a backup of an index or running {es} cluster.
 

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<get-snapshot-api>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<get-snapshot-api>>.
 ====
 
 Returns information about the <<modules-snapshots,snapshots>> stored in one or

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -8,10 +8,9 @@ beta::["The cat task management API is new and should still be considered a beta
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<tasks>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<tasks>>.
 ====
 
 Returns information about tasks currently executing in the cluster,

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -10,7 +10,7 @@ beta::["The cat task management API is new and should still be considered a beta
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<tasks>>.
+consumption, use the <<tasks,task management API>>.
 ====
 
 Returns information about tasks currently executing in the cluster,

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -6,6 +6,14 @@
 
 beta::["The cat task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{es-issue}51628]
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<tasks>>.
+====
+
 Returns information about tasks currently executing in the cluster,
 similar to the <<tasks,task management>> API.
 

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<indices-get-template>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<indices-get-template>>.
 ====
 
 Returns information about <<index-templates,index templates>> in a cluster.

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<indices-get-template>>.
+consumption, use the <<indices-get-template,get index template API>>.
 ====
 
 Returns information about <<index-templates,index templates>> in a cluster.

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat templates</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<indices-get-template>>.
+====
+
 Returns information about <<index-templates,index templates>> in a cluster.
 You can use index templates to apply <<index-modules-settings,index settings>>
 and <<mapping,field mappings>> to new indices at creation.

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>cat thread pool</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<cluster-nodes-info>>.
+====
+
 Returns thread pool statistics for each node in a cluster. Returned information
 includes all <<modules-threadpool,built-in thread pools>> and custom thread
 pools.

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -6,10 +6,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<cluster-nodes-info>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<cluster-nodes-info>>.
 ====
 
 Returns thread pool statistics for each node in a cluster. Returned information

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -8,7 +8,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<cluster-nodes-info>>.
+consumption, use the <<cluster-nodes-info,nodes info API>>.
 ====
 
 Returns thread pool statistics for each node in a cluster. Returned information

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<get-trained-models>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<get-trained-models>>.
 ====
 
 Returns configuration and usage information about {infer} trained models.

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -9,7 +9,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<get-trained-models>>.
+consumption, use the <<get-trained-models,get trained models API>>.
 ====
 
 Returns configuration and usage information about {infer} trained models.

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -5,6 +5,14 @@
 <titleabbrev>cat trained model</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<get-trained-models>>.
+====
+
 Returns configuration and usage information about {infer} trained models.
 
 

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -5,6 +5,14 @@
 <titleabbrev>cat transforms</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using the <<get-transform>>.
+====
+
 Returns configuration and usage information about {transforms}.
 
 [[cat-transforms-api-request]]

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -9,7 +9,7 @@
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 
 console. They are _not_ intended for use by applications. For application 
-consumption, use the <<get-transform>>.
+consumption, use the <<get-transform,get transforms API>>.
 ====
 
 Returns configuration and usage information about {transforms}.

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -7,10 +7,9 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the
-{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
-intended for use by applications. For application consumption, we recommend
-using the <<get-transform>>.
+cat APIs are only intended for human consumption using the command line or {kib} 
+console. They are _not_ intended for use by applications. For application 
+consumption, use the <<get-transform>>.
 ====
 
 Returns configuration and usage information about {transforms}.


### PR DESCRIPTION
## Overview

This PR adds a disclaimer to every cat API docs page. The disclaimer states that cat APIs are intended for human consumption. The disclaimers name the corresponding APIs that are recommended to use for application consumption.