### PR TITLE
fix flaky of tsdb/30_snapshot.yml it

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -101,6 +101,8 @@ teardown:
         repository: test_repo
         snapshot: test_restore_tsdb
         wait_for_completion: true
+        body:
+          indices: test_index
 
   - match: { snapshot.snapshot: test_restore_tsdb }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
This test performs snapshot and verifies it has exactly 2 successful
shards. It could fail when additional indices might be added (such as
system .task index).

Closes: #83390
