### PR TITLE
Allow doc-values only search on geo_point fields

### DIFF
--- a/docs/changelog/83395.yaml
+++ b/docs/changelog/83395.yaml
@@ -1,5 +1,5 @@
 pr: 83395
-summary: Date script doc values
+summary: Allow doc-values only search on geo_point fields
 area: Mapping
 type: enhancement
 issues: []

--- a/docs/changelog/83395.yaml
+++ b/docs/changelog/83395.yaml
@@ -1,0 +1,5 @@
+pr: 83395
+summary: Date script doc values
+area: Mapping
+type: enhancement
+issues: []

--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -18,7 +18,7 @@ sorting and aggregations. Doc values are supported on almost all field types,
 with the __notable exception of `text` and `annotated_text` fields__.
 
 <<number,Numeric types>>, <<date,date types>>, the <<boolean,boolean type>>,
-the <<ip,ip type>> and the <<keyword,keyword type>>
+<<ip,ip type>>, <<geo-point,geo_point type>> and the <<keyword,keyword type>>
 can also be queried using term or range-based queries
 when they are not <<mapping-index,indexed>> but only have doc values enabled.
 Query performance on doc values is much slower than on index structures, but

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -137,7 +137,9 @@ The following parameters are accepted by `geo_point` fields:
 
 <<mapping-index,`index`>>::
 
-    Should the field be searchable? Accepts `true` (default) and `false`.
+    Should the field be quickly searchable? Accepts `true` (default) and
+    `false`. Fields that only have <<doc-values,`doc_values`>>
+    enabled can still be queried, albeit slower.
 
 <<null-value,`null_value`>>::
 

--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -33,7 +33,8 @@ the stability of the cluster. Those queries can be categorised as follows:
 
 * Queries that need to do linear scans to identify matches:
 ** <<query-dsl-script-query,`script` queries>>
-** queries on <<number,numeric>>, <<date,date>>, <<boolean,boolean>>, <<ip,ip>> or <<keyword,keyword>> fields
+** queries on <<number,numeric>>, <<date,date>>, <<boolean,boolean>>, <<ip,ip>>,
+   <<geo-point,geo_point>> or <<keyword,keyword>> fields
    that are not indexed but have <<doc-values,doc values>> enabled
 
 * Queries that have a high up-front cost:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -95,6 +95,9 @@ setup:
                   non_indexed_ip:
                     type:     ip
                     index:    false
+                  non_indexed_geo_point:
+                    type:     geo_point
+                    index:    false
                   geo:
                     type:     keyword
                   object:
@@ -269,6 +272,19 @@ setup:
         fields: non_indexed_ip
 
   - match: {fields.non_indexed_ip.ip.searchable:                          true}
+
+---
+"Field caps for geo_point field with only doc values":
+  - skip:
+      version: " - 8.1.99"
+      reason: "doc values search was added in 8.2.0"
+  - do:
+      field_caps:
+        index: 'test1,test2,test3'
+        fields: non_indexed_geo_point
+
+  - match: {fields.non_indexed_geo_point.geo_point.searchable:            true}
+
 
 ---
 "Get object and nested field caps":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -276,8 +276,8 @@ setup:
 ---
 "Field caps for geo_point field with only doc values":
   - skip:
-      version: " - 8.1.99"
-      reason: "doc values search was added in 8.2.0"
+      version: " - 8.0.99"
+      reason: "doc values search was added in 8.1.0"
   - do:
       field_caps:
         index: 'test1,test2,test3'

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
@@ -45,6 +45,9 @@ setup:
               ip:
                 type: ip
                 index: false
+              geo_point:
+                type: geo_point
+                index: false
 
   - do:
       index:
@@ -62,6 +65,7 @@ setup:
           keyword: "key1"
           boolean: "false"
           ip: "192.168.0.1"
+          geo_point: [13.5, 34.89]
 
   - do:
       index:
@@ -79,6 +83,7 @@ setup:
           keyword: "key2"
           boolean: "true"
           ip: "192.168.0.2"
+          geo_point : [-63.24, 31.0]
 
   - do:
       indices.refresh: {}
@@ -238,6 +243,9 @@ setup:
 
 ---
 "Test distance_feature query on date field where only doc values are enabled":
+  - skip:
+      version: " - 8.1.99"
+      reason: "doc values search was added in 8.2.0"
 
   - do:
       search:
@@ -334,3 +342,42 @@ setup:
         index: test
         body: { query: { range: { ip: { gte: "192.168.0.1" } } } }
   - length:   { hits.hits: 2  }
+
+---
+"Test geo shape query on geo_point field where only doc values are enabled":
+  - skip:
+      version: " - 8.1.99"
+      reason: "doc values search was added in 8.2.0"
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            geo_shape:
+              geo_point:
+                shape:
+                  type: "envelope"
+                  coordinates: [ [ -70, 32 ], [ -50, 30 ] ]
+  - match: {hits.total.value: 1}
+
+---
+"Test distance_feature query on geo_point field where only doc values are enabled":
+  - skip:
+      version: " - 8.1.99"
+      reason: "doc values search was added in 8.2.0"
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: geo_point
+                  pivot: "1000km"
+                  origin: [0.0, 0.0]
+  - length:   { hits.hits: 2  }
+  - match: {hits.hits.0._id: "1" }
+  - match: {hits.hits.1._id: "2" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
@@ -244,8 +244,8 @@ setup:
 ---
 "Test distance_feature query on date field where only doc values are enabled":
   - skip:
-      version: " - 8.1.99"
-      reason: "doc values search was added in 8.2.0"
+      version: " - 8.0.99"
+      reason: "doc values search was added in 8.1.0"
 
   - do:
       search:
@@ -346,8 +346,8 @@ setup:
 ---
 "Test geo shape query on geo_point field where only doc values are enabled":
   - skip:
-      version: " - 8.1.99"
-      reason: "doc values search was added in 8.2.0"
+      version: " - 8.0.99"
+      reason: "doc values search was added in 8.1.0"
 
   - do:
       search:
@@ -364,8 +364,8 @@ setup:
 ---
 "Test distance_feature query on geo_point field where only doc values are enabled":
   - skip:
-      version: " - 8.1.99"
-      reason: "doc values search was added in 8.2.0"
+      version: " - 8.0.99"
+      reason: "doc values search was added in 8.1.0"
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/390_doc_values_search.yml
@@ -237,6 +237,24 @@ setup:
   - length:   { hits.hits: 2  }
 
 ---
+"Test distance_feature query on date field where only doc values are enabled":
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: "date"
+                  pivot: "7d"
+                  origin: "now"
+  - length:   { hits.hits: 2  }
+  - match: {hits.hits.0._id: "2" }
+  - match: {hits.hits.1._id: "1" }
+
+---
 "Test match query on keyword field where only doc values are enabled":
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -609,8 +609,13 @@ public final class DateFieldMapper extends FieldMapper {
             if (isIndexed()) {
                 return LongPoint.newDistanceFeatureQuery(name(), 1.0f, originLong, pivotLong);
             } else {
-                return new LongScriptFieldDistanceFeatureQuery(new Script(""),
-                    ctx -> new SortedNumericDocValuesLongFieldScript(name(), context.lookup(), ctx), name(), originLong, pivotLong);
+                return new LongScriptFieldDistanceFeatureQuery(
+                    new Script(""),
+                    ctx -> new SortedNumericDocValuesLongFieldScript(name(), context.lookup(), ctx),
+                    name(),
+                    originLong,
+                    pivotLong
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.fielddata.DateScriptFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -160,7 +161,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public DateScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
+    public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
         return new DateScriptFieldData.Builder(name(), leafFactory(lookup.get()), Resolution.MILLISECONDS.getDefaultToScriptField());
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.fielddata.DateScriptFieldData;
-import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -161,7 +160,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
+    public DateScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
         return new DateScriptFieldData.Builder(name(), leafFactory(lookup.get()), Resolution.MILLISECONDS.getDefaultToScriptField());
     }
 

--- a/server/src/main/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScript.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.script.AbstractLongFieldScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class SortedNumericDocValuesLongFieldScript extends AbstractLongFieldScript {
+
+    final LongDocValuesField longDocValuesField;
+
+    public SortedNumericDocValuesLongFieldScript(String fieldName, SearchLookup lookup, LeafReaderContext ctx) {
+        super(fieldName, Map.of(), lookup, ctx);
+        try {
+            longDocValuesField = new LongDocValuesField(DocValues.getSortedNumeric(ctx.reader(), fieldName), fieldName);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load doc values", e);
+        }
+    }
+
+    @Override
+    protected void emitFromObject(Object v) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDocument(int docID) {
+        try {
+            longDocValuesField.setNextDocId(docID);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load doc values", e);
+        }
+    }
+
+    @Override
+    public void execute() {
+        for (long value : longDocValuesField) {
+            emit(value);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScript.java
@@ -31,6 +31,7 @@ public class SortedNumericDocValuesLongFieldScript extends AbstractLongFieldScri
 
     @Override
     protected void emitFromObject(Object v) {
+        // we only use doc-values, not _source, so no need to implement this method
         throw new UnsupportedOperationException();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -198,7 +198,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
         Mapper fieldMapper = mapper.mappers().getMapper("field");
         assertThat(fieldMapper, instanceOf(GeoPointFieldMapper.class));
         assertThat(((GeoPointFieldMapper) fieldMapper).fieldType().isIndexed(), equalTo(false));
-        assertThat(((GeoPointFieldMapper) fieldMapper).fieldType().isSearchable(), equalTo(false));
+        assertThat(((GeoPointFieldMapper) fieldMapper).fieldType().isSearchable(), equalTo(true));
     }
 
     public void testMultiField() throws Exception {


### PR DESCRIPTION
Similar to #82409, but for geo_point fields.

Allows searching on geo_point fields when those fields are not indexed (index: false) but just doc values are enabled.

Also adds distance feature query support for date fields (bringing date field to feature parity with runtime fields)

This enables searches on archive data, which has access to doc values but not index structures. When combined with searchable snapshots, it allows downloading only data for a given (doc value) field to quickly filter down to a select set of documents.

Relates #81210 and #52728