### PR TITLE
[8.0] SQL: Fix txt format for empty result sets (#83376)

### DIFF
--- a/docs/changelog/83376.yaml
+++ b/docs/changelog/83376.yaml
@@ -1,0 +1,5 @@
+pr: 83376
+summary: Fix txt format for empty result sets
+area: SQL
+type: bug
+issues: []

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
@@ -79,6 +79,9 @@ enum TextFormat implements MediaType {
             } else if (response.hasId()) {
                 // an async request has no results yet
                 return StringUtils.EMPTY;
+            } else if (response.rows().isEmpty()) {
+                // no data and no headers to return
+                return StringUtils.EMPTY;
             }
             // if this code is reached, it means it's a next page without cursor wrapping
             throw new SqlIllegalArgumentException("Cannot find text formatter - this is likely a bug");

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.sql.action.SqlQueryResponse;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xpack.sql.plugin.TextFormat.CSV;
+import static org.elasticsearch.xpack.sql.plugin.TextFormat.PLAIN_TEXT;
 import static org.elasticsearch.xpack.sql.plugin.TextFormat.TSV;
 import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VERSION;
 
@@ -163,9 +165,26 @@ public class TextFormatTests extends ESTestCase {
         }
     }
 
+    public void testPlainTextEmptyCursorWithColumns() {
+        assertEquals("""
+                 name     \s
+            ---------------
+            """, PLAIN_TEXT.format(req(), emptyData()));
+    }
+
+    public void testPlainTextEmptyCursorWithoutColumns() {
+        assertEquals(
+            StringUtils.EMPTY,
+            PLAIN_TEXT.format(
+                req(),
+                new SqlQueryResponse(StringUtils.EMPTY, Mode.JDBC, DATE_NANOS_SUPPORT_VERSION, false, null, emptyList())
+            )
+        );
+    }
+
     private static SqlQueryResponse emptyData() {
         return new SqlQueryResponse(
-            null,
+            StringUtils.EMPTY,
             Mode.JDBC,
             DATE_NANOS_SUPPORT_VERSION,
             false,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - SQL: Fix txt format for empty result sets (#83376)