### PR TITLE
Clean up field caps test after fix

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -31,9 +31,6 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
       numberOfNodes = 4
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
-      // extra logger settings to help debug https://github.com/elastic/elasticsearch/issues/80335
-      setting 'logger.org.elasticsearch.transport.TransportService.tracer', 'TRACE'
-      setting 'transport.tracer.include', '"indices:data/read/field_caps*"'
     }
 
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
[AFAICS](https://gradle-enterprise.elastic.co/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe/Luxembourg&tests.container=org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT&tests.sortField=FAILED&tests.test=test%20%7Bp0%3Dfield_caps/10_basic/Get%20simple%20field%20caps%7D&tests.unstableOnly=true), since pushing  #82716, the tests in #80335 have only failed on the 7.16 branch, i.e. the branch that did not get the fix. I think we can backport the fix and close the issue (so that it can be reopened when another failure occurs).

Closes #80335