### PR TITLE
[8.0] fix: reduce float and half-float values to their stored precision (#83213)

### DIFF
--- a/docs/changelog/83213.yaml
+++ b/docs/changelog/83213.yaml
@@ -1,0 +1,5 @@
+pr: 83213
+summary: "Fix: reduce float and half-float values to their stored precision"
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -29,6 +29,17 @@ setup:
                 format: strict_date_time||strict_date
 
   - do:
+      indices.create:
+        index: long_value_test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              long:
+                type: long
+
+  - do:
       cluster.health:
         wait_for_status: yellow
 
@@ -37,15 +48,22 @@ setup:
         index: test
         refresh: true
         body:
-         - {"index": {}}
-         - { "double" : 42.1, "long": 25, "float": 0.01, "half_float": 0.01 }
-         - {"index": {}}
-         - { "double" : 100.7, "long": 80, "float": 0.03, "half_float": 0.0152 }
-         - {"index": {}}
-         - { "double" : 50.5, "long":  75, "float": 0.04, "half_float": 0.04 }
-# For testing missing values
-         - {"index": {}}
-         - {}
+          - {"index": {}}
+          - { "double" : 42.1, "long": 25, "float": 0.01, "half_float": 0.01 }
+          - {"index": {}}
+          - { "double" : 100.7, "long": 80, "float": 0.03, "half_float": 0.0152 }
+          - {"index": {}}
+          - { "double" : 50.5, "long":  75, "float": 0.04, "half_float": 0.04 }
+          # For testing missing values
+          - {"index": {}}
+          - {}
+  - do:
+      bulk:
+        index: long_value_test
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "long": -9223372036854775808 }
 
   - do:
       bulk:
@@ -198,6 +216,46 @@ setup:
   - match: { aggregations.float_range.buckets.2.from: 10.6 }
   - is_false:  aggregations.float_range.buckets.2.to
   - match: { aggregations.float_range.buckets.2.doc_count: 3 }
+
+---
+"Double range on long field":
+  - skip:
+      version: " - 8.0.99"
+      reason: Bug fixed in 8.1.0
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            double_range:
+              range:
+                field: "long"
+                ranges:
+                  -
+                    to: 24.9
+                  -
+                    from: 24.9
+                    to: 79.9
+                  -
+                    from: 79.9
+
+  - match: { hits.total.relation: "eq" }
+  - match: { hits.total.value: 4 }
+  - length: { aggregations.double_range.buckets: 3 }
+  - match: { aggregations.double_range.buckets.0.key: "*-24.9" }
+  - is_false: aggregations.double_range.buckets.0.from
+  - match: { aggregations.double_range.buckets.0.to: 24.9 }
+  - match: { aggregations.double_range.buckets.0.doc_count: 0 }
+  - match: { aggregations.double_range.buckets.1.key: "24.9-79.9" }
+  - match: { aggregations.double_range.buckets.1.from: 24.9 }
+  - match: { aggregations.double_range.buckets.1.to: 79.9 }
+  - match: { aggregations.double_range.buckets.1.doc_count: 2 }
+  - match: { aggregations.double_range.buckets.2.key: "79.9-*" }
+  - match: { aggregations.double_range.buckets.2.from: 79.9 }
+  - is_false:  aggregations.double_range.buckets.2.to
+  - match: { aggregations.double_range.buckets.2.doc_count: 1 }
+
 
 ---
 "Double range no decimal":
@@ -411,3 +469,27 @@ setup:
   - match: { aggregations.date_range.buckets.0.from_as_string: "2021-05-01T00:00:00.000Z" }
   - match: { aggregations.date_range.buckets.0.to: 1620172800000 }
   - match: { aggregations.date_range.buckets.0.to_as_string: "2021-05-05T00:00:00.000Z" }
+
+---
+"Min and max long range bounds":
+  - skip:
+      version: " - 8.0.99"
+      reason: Bug fixed in 8.1.0
+  - do:
+      search:
+        index: long_value_test
+        body:
+          size: 0
+          aggs:
+            long_range:
+              range:
+                field: "long"
+                ranges:
+                  { from: -9223372036854775808, to: 9223372036854775807 }
+  - match: { hits.total.relation: "eq" }
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.long_range.buckets: 1 }
+  - match: { aggregations.long_range.buckets.0.key: "-9.223372036854776E18-9.223372036854776E18" }
+  - match: { aggregations.long_range.buckets.0.from: -9.223372036854776E18 }
+  - match: { aggregations.long_range.buckets.0.to: 9.223372036854776E18 }
+  - match: { aggregations.long_range.buckets.0.doc_count: 1 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -223,6 +223,11 @@ public class NumberFieldMapper extends FieldMapper {
                 return HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(result));
             }
 
+            @Override
+            public double reduceToStoredPrecision(double value) {
+                return parse(value, false).doubleValue();
+            }
+
             /**
              * Parse a query parameter or {@code _source} value to a float,
              * keeping float precision. Used by queries which need more
@@ -346,6 +351,11 @@ public class NumberFieldMapper extends FieldMapper {
                 }
                 validateParsed(result);
                 return result;
+            }
+
+            @Override
+            public double reduceToStoredPrecision(double value) {
+                return parse(value, false).doubleValue();
             }
 
             @Override
@@ -1053,6 +1063,17 @@ public class NumberFieldMapper extends FieldMapper {
             }
             return builder.apply(l, u);
         }
+        /**
+         * Adjusts a value to the value it would have been had it been parsed by that mapper
+         * and then cast up to a double. This is meant to be an entry point to manipulate values
+         * before the actual value is parsed.
+         *
+         * @param value the value to reduce to the field stored value
+         * @return the double value
+         */
+        public double reduceToStoredPrecision(double value) {
+            return ((Number) value).doubleValue();
+        }
     }
 
     public static class NumberFieldType extends SimpleMappedFieldType {
@@ -1123,7 +1144,7 @@ public class NumberFieldMapper extends FieldMapper {
                 // Trying to parse infinite values into ints/longs throws. Understandably.
                 return value;
             }
-            return type.parse(value, false).doubleValue();
+            return type.reduceToStoredPrecision(value);
         }
 
         public NumericType numericType() {


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #83213

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)