### PR TITLE
Remove CSTL#onNoLongerMaster

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.health;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -159,18 +160,14 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                 }
 
                 @Override
-                public void onNoLongerMaster() {
-                    logger.trace("stopped being master while waiting for events with priority [{}]. retrying.", request.waitForEvents());
-                    // TransportMasterNodeAction implements the retry logic, which is triggered by passing a NotMasterException
-                    listener.onFailure(new NotMasterException("no longer master. source: [" + source + "]"));
-                }
-
-                @Override
                 public void onFailure(Exception e) {
                     if (e instanceof ProcessClusterEventTimeoutException) {
                         listener.onResponse(getResponse(request, clusterService.state(), waitCount, TimeoutState.TIMED_OUT));
                     } else {
-                        logger.error(() -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+                        final Level level = e instanceof NotMasterException ? Level.TRACE : Level.ERROR;
+                        assert e instanceof NotMasterException : e; // task cannot fail, nor will it trigger a publication which fails
+                        logger.log(level, () -> new ParameterizedMessage("unexpected failure during [{}]", source), e);
+                        // TransportMasterNodeAction implements the retry logic, which is triggered by passing a NotMasterException
                         listener.onFailure(e);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -18,13 +18,12 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -207,7 +206,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                     @Override
                     public void onFailure(Exception e) {
                         logger.debug(new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
-                        if (e instanceof NotMasterException || e instanceof FailedToCommitClusterStateException) {
+                        if (MasterService.isPublishFailureException(e)) {
                             listener.onResponse(
                                 new ClusterUpdateSettingsResponse(
                                     updateSettingsAcked,

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -20,15 +20,14 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.MasterNodeChangePredicate;
-import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
@@ -196,7 +195,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                         }
                     } else {
                         ActionListener<Response> delegate = listener.delegateResponse((delegatedListener, t) -> {
-                            if (t instanceof FailedToCommitClusterStateException || t instanceof NotMasterException) {
+                            if (MasterService.isPublishFailureException(t)) {
                                 logger.debug(
                                     () -> new ParameterizedMessage(
                                         "master could not publish cluster state or "

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -7,29 +7,29 @@
  */
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
+import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
+import org.elasticsearch.cluster.service.MasterService;
+
 import java.util.List;
 
 public interface ClusterStateTaskListener {
 
     /**
-     * A callback for when task execution fails.
-     *
+     * A callback for when task execution fails. May receive a {@link NotMasterException} if this node stopped being the master before this
+     * task was executed or a {@link ProcessClusterEventTimeoutException} if the task timed out before it was executed. If the task fails
+     * during execution then this method receives the corresponding exception. If the task executes successfully but the resulting cluster
+     * state publication fails then this method receives a {@link FailedToCommitClusterStateException}. If publication fails then a new
+     * master is elected and the update might or might not take effect, depending on whether or not the newly-elected master accepted the
+     * published state that failed to be committed.
+     * <p>
+     * Use {@link MasterService#isPublishFailureException} to detect the "expected" master failure cases if needed.
+     * <p>
      * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the master service at {@code ERROR}
      * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
      * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
     void onFailure(Exception e);
-
-    /**
-     * A callback for when the task was rejected because the processing node is no longer the elected master.
-     *
-     * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the master service at {@code ERROR}
-     * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
-     * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
-     */
-    default void onNoLongerMaster() {
-        onFailure(new NotMasterException("no longer master"));
-    }
 
     /**
      * Called when the result of the {@link ClusterStateTaskExecutor#execute(ClusterState, List)} method have been processed properly by all

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
+import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -47,7 +50,14 @@ public abstract class ClusterStateUpdateTask implements ClusterStateTaskConfig, 
     public abstract ClusterState execute(ClusterState currentState) throws Exception;
 
     /**
-     * A callback for when task execution fails.
+     * A callback for when task execution fails. May receive a {@link NotMasterException} if this node stopped being the master before this
+     * task was executed or a {@link ProcessClusterEventTimeoutException} if the task timed out before it was executed. If the task fails
+     * during execution then this method receives the corresponding exception. If the task executes successfully but the resulting cluster
+     * state publication fails then this method receives a {@link FailedToCommitClusterStateException}. If publication fails then a new
+     * master is elected and the update might or might not take effect, depending on whether or not the newly-elected master accepted the
+     * published state that failed to be committed.
+     * <p>
+     * Use {@link MasterService#isPublishFailureException} to detect the "expected" master failure cases if needed.
      * <p>
      * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
      * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically

--- a/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
@@ -13,9 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.IOException;
 
 /**
- * Thrown when a node join request or a master ping reaches a node which is not
- * currently acting as a master or when a cluster state update task is to be executed
- * on a node that is no longer master.
+ * Exception which indicates that an operation failed because the node stopped being the elected master.
  */
 public class NotMasterException extends ElasticsearchException {
 

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.action.shard;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -34,6 +35,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.StaleShard;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -557,13 +559,11 @@ public class ShardStateAction {
 
         @Override
         public void onFailure(Exception e) {
-            if (e instanceof NotMasterException) {
-                logger.debug(() -> new ParameterizedMessage("{} no longer master while failing shard [{}]", entry.shardId, entry));
-            } else if (e instanceof FailedToCommitClusterStateException) {
-                logger.debug(() -> new ParameterizedMessage("{} unexpected failure while failing shard [{}]", entry.shardId, entry), e);
-            } else {
-                logger.error(() -> new ParameterizedMessage("{} unexpected failure while failing shard [{}]", entry.shardId, entry), e);
-            }
+            logger.log(
+                MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.ERROR,
+                () -> new ParameterizedMessage("{} unexpected failure while failing shard [{}]", entry.shardId, entry),
+                e
+            );
             listener.onFailure(e);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
@@ -13,7 +13,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.IOException;
 
 /**
- * Thrown when failing to publish a cluster state. See {@link ClusterStatePublisher} for more details.
+ * Thrown when a cluster state publication fails to commit the new cluster state. If publication fails then a new master is elected but the
+ * update might or might not take effect, depending on whether or not the newly-elected master accepted the published state that failed to
+ * be committed.
+ *
+ * See {@link ClusterStatePublisher} for more details.
  */
 public class FailedToCommitClusterStateException extends ElasticsearchException {
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
-import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.coordination.Coordinator.Mode;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RerouteService;
@@ -188,8 +187,7 @@ public class JoinHelper {
         static Level getLogLevel(TransportException e) {
             Throwable cause = e.unwrapCause();
             if (cause instanceof CoordinationStateRejectedException
-                || cause instanceof FailedToCommitClusterStateException
-                || cause instanceof NotMasterException) {
+                || (cause instanceof Exception causeException && MasterService.isPublishFailureException(causeException))) {
                 return Level.DEBUG;
             }
             return Level.INFO;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -16,6 +17,7 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 
 import java.util.List;
@@ -30,12 +32,7 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
 
         @Override
         public void onFailure(final Exception e) {
-            logger.error("unexpected failure during [node-left]", e);
-        }
-
-        @Override
-        public void onNoLongerMaster() {
-            logger.debug("no longer master while processing node removal [node-left]");
+            logger.log(MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.ERROR, "unexpected failure during [node-left]", e);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
@@ -120,17 +121,6 @@ public class BatchedRerouteService implements RerouteService {
                 }
 
                 @Override
-                public void onNoLongerMaster() {
-                    synchronized (mutex) {
-                        if (pendingRerouteListeners == currentListeners) {
-                            pendingRerouteListeners = null;
-                        }
-                    }
-                    ActionListener.onFailure(currentListeners, new NotMasterException("delayed reroute [" + reason + "] cancelled"));
-                    // no big deal, the new master will reroute again
-                }
-
-                @Override
                 public void onFailure(Exception e) {
                     synchronized (mutex) {
                         if (pendingRerouteListeners == currentListeners) {
@@ -138,7 +128,13 @@ public class BatchedRerouteService implements RerouteService {
                         }
                     }
                     final ClusterState state = clusterService.state();
-                    if (logger.isTraceEnabled()) {
+                    if (MasterService.isPublishFailureException(e)) {
+                        logger.debug(
+                            () -> new ParameterizedMessage("unexpected failure during [{}], current state:\n{}", source, state),
+                            e
+                        );
+                        // no big deal, the new master will reroute again
+                    } else if (logger.isTraceEnabled()) {
                         logger.error(
                             () -> new ParameterizedMessage("unexpected failure during [{}], current state:\n{}", source, state),
                             e

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gateway;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -22,6 +23,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -225,14 +227,12 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
         }
 
         @Override
-        public void onNoLongerMaster() {
-            logger.debug("stepped down as master before recovering state [{}]", TASK_SOURCE);
-            resetRecoveredFlags();
-        }
-
-        @Override
         public void onFailure(final Exception e) {
-            logger.info(() -> new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE), e);
+            logger.log(
+                MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.INFO,
+                () -> new ParameterizedMessage("unexpected failure during [{}]", TASK_SOURCE),
+                e
+            );
             resetRecoveredFlags();
         }
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.snapshots;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -45,6 +46,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -1060,13 +1062,11 @@ public class RestoreService implements ClusterStateApplier {
             @Override
             public void onFailure(final Exception e) {
                 cleanupInProgress = false;
-                logger.warn(() -> new ParameterizedMessage("failed to remove completed restores from cluster state"), e);
-            }
-
-            @Override
-            public void onNoLongerMaster() {
-                cleanupInProgress = false;
-                logger.debug("no longer master while removing completed restores from cluster state");
+                logger.log(
+                    MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.WARN,
+                    "failed to remove completed restores from cluster state",
+                    e
+                );
             }
 
             @Override


### PR DESCRIPTION
Implementations of `ClusterStateTaskListener#onNoLongerMaster` almost
universally do the same thing as `CSTL#onFailure` except for differences
in logging. In most cases for logging purposes we should treat not being
the master the same as failing to commit the cluster state, but we don't
do so and this can generate a lot of log noise on a master failure. In
other places we rely on the default implementation of `onNoLongerMaster`
and react to the type of the exception in the `onFailure` handler as
needed.

To simplify the situation, this commit combines `onNoLongerMaster` and
`onFailure` everywhere and harmonises the logging behaviour for
`FailedToCommitClusterStateException` and `NotMasterException`.