### PR TITLE
Returns valid PIT when no index matched

### DIFF
--- a/docs/changelog/83424.yaml
+++ b/docs/changelog/83424.yaml
@@ -1,0 +1,5 @@
+pr: 83424
+summary: Returns valid PIT when no index matched
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -193,18 +193,9 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                 : request.source().trackTotalHitsUpTo();
             // total hits is null in the response if the tracking of total hits is disabled
             boolean withTotalHits = trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_DISABLED;
-            listener.onResponse(
-                new SearchResponse(
-                    withTotalHits ? InternalSearchResponse.EMPTY_WITH_TOTAL_HITS : InternalSearchResponse.EMPTY_WITHOUT_TOTAL_HITS,
-                    null,
-                    0,
-                    0,
-                    0,
-                    buildTookInMillis(),
-                    ShardSearchFailure.EMPTY_ARRAY,
-                    clusters,
-                    null
-                )
+            sendSearchResponse(
+                withTotalHits ? InternalSearchResponse.EMPTY_WITH_TOTAL_HITS : InternalSearchResponse.EMPTY_WITHOUT_TOTAL_HITS,
+                new AtomicArray<>(0)
             );
             return;
         }

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -318,4 +318,47 @@ public class FrozenIndexIT extends ESIntegTestCase {
             client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest(pitId)).actionGet();
         }
     }
+
+    public void testOpenPointInTimeWithNoIndexMatched() {
+        createIndex("test-index");
+
+        int numDocs = randomIntBetween(10, 50);
+        for (int i = 0; i < numDocs; i++) {
+            String id = Integer.toString(i);
+            client().prepareIndex("test-index").setId(id).setSource("value", i).get();
+        }
+        assertAcked(client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest("test-index")).actionGet());
+        // include the frozen indices
+        {
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(TimeValue.timeValueMinutes(2));
+            final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
+            try {
+                SearchResponse resp = client().prepareSearch()
+                    .setPreference(null)
+                    .setPointInTime(new PointInTimeBuilder(pitId))
+                    .get();
+                assertNoFailures(resp);
+                assertHitCount(resp, numDocs);
+            } finally {
+                client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest(pitId)).actionGet();
+            }
+        }
+        // exclude the frozen indices
+        {
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*")
+                .indicesOptions(IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled())
+                .keepAlive(TimeValue.timeValueMinutes(2));
+            final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
+            try {
+                SearchResponse resp = client().prepareSearch()
+                    .setPreference(null)
+                    .setPointInTime(new PointInTimeBuilder(pitId))
+                    .get();
+                assertNoFailures(resp);
+                assertHitCount(resp, 0);
+            } finally {
+                client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest(pitId)).actionGet();
+            }
+        }
+    }
 }

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -330,13 +330,12 @@ public class FrozenIndexIT extends ESIntegTestCase {
         assertAcked(client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest("test-index")).actionGet());
         // include the frozen indices
         {
-            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(TimeValue.timeValueMinutes(2));
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(
+                TimeValue.timeValueMinutes(2)
+            );
             final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
             try {
-                SearchResponse resp = client().prepareSearch()
-                    .setPreference(null)
-                    .setPointInTime(new PointInTimeBuilder(pitId))
-                    .get();
+                SearchResponse resp = client().prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
                 assertNoFailures(resp);
                 assertHitCount(resp, numDocs);
             } finally {
@@ -345,15 +344,12 @@ public class FrozenIndexIT extends ESIntegTestCase {
         }
         // exclude the frozen indices
         {
-            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*")
-                .indicesOptions(IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled())
-                .keepAlive(TimeValue.timeValueMinutes(2));
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").indicesOptions(
+                IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled()
+            ).keepAlive(TimeValue.timeValueMinutes(2));
             final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
             try {
-                SearchResponse resp = client().prepareSearch()
-                    .setPreference(null)
-                    .setPointInTime(new PointInTimeBuilder(pitId))
-                    .get();
+                SearchResponse resp = client().prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
                 assertNoFailures(resp);
                 assertHitCount(resp, 0);
             } finally {


### PR DESCRIPTION
We should return a valid PIT instead of tripping an assertion when the index wildcard matches no index.
