### PR TITLE
[8.0] [DOCS] Fix typo (#83426)

### DIFF
--- a/docs/reference/release-notes/8.0.0-rc1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc1.asciidoc
@@ -15,7 +15,7 @@ a pre-release of {es} 8.0 and is intended for testing purposes only.
 +
 Upgrades from pre-release builds are not supported and could result in errors or
 data loss. If you upgrade from a released version, such as 7.16, to a
-pre-release verion for testing, discard the contents of the cluster when you are
+pre-release version for testing, discard the contents of the cluster when you are
 done. Do not attempt to upgrade to the final 8.0 release.
 
 * For {es} 8.0.0-rc1, the {ref}/sql-jdbc.html[{es} SQL JDBC driver] requires


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix typo (#83426)