### PR TITLE
[7.17] Change date range format which fails to parse in some clients (#83397)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -399,7 +399,9 @@ setup:
               range:
                 field: date
                 ranges:
-                  { from: 2021-05-01T00:00:00Z, to: 2021-05-05T00:00:00Z }
+                 -
+                   from: 2021-05-01T00:00:00Z
+                   to: 2021-05-05T00:00:00Z
 
   - match: { hits.total.value: 5 }
   - length: { aggregations.date_range.buckets: 1 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Change date range format which fails to parse in some clients (#83397)