### PR TITLE
[8.1] Add 8.0.0-rc2 release notes (#83412)

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -105,5 +105,33 @@ user password is already configured.
 ====
 //end::notable-breaking-changes[]
 
+
+[[deprecate-max-merge-at-once-explicit-setting]]
+.The setting `max_merge_at_once_explicit` is deprecated.
+[%collapsible]
+====
+*Details* +
+The setting `max_merge_at_once_explicit` is removed in Lucene 9.
+
+
+*Impact* +
+Remove the setting `max_merge_at_once_explicit` from your
+configuration.
+====
+
+[[deprecate-indices-query-bool-max-clause-count-setting]]
+.The setting `indices.query.bool.max_clause_count` is deprecated.
+[%collapsible]
+====
+*Details* +
+The setting `indices.query.bool.max_clause_count` is deprecated. Instead,
+{es} configures the maximum clause count for Lucene based on the available
+heap and the size of the thread pool.
+
+*Impact* +
+Remove the setting `indices.query.bool.max_clause_count` from
+your configuration.
+====
+
 include::migrate_8_0/migrate_to_java_time.asciidoc[]
 include::transient-settings-migration-guide.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.0.0-rc2>>
 * <<release-notes-8.0.0-rc1>>
 * <<release-notes-8.0.0-beta1>>
 * <<release-notes-8.0.0-alpha2>>
@@ -13,6 +14,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.0.0-rc2.asciidoc[]
 include::release-notes/8.0.0-rc1.asciidoc[]
 include::release-notes/8.0.0-beta1.asciidoc[]
 include::release-notes/8.0.0-alpha2.asciidoc[]

--- a/docs/reference/release-notes/8.0.0-rc1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc1.asciidoc
@@ -1,6 +1,3 @@
-:es-issue: https://github.com/elastic/elasticsearch/issues/
-:es-pull:  https://github.com/elastic/elasticsearch/pull/
-
 [[release-notes-8.0.0-rc1]]
 == {es} version 8.0.0-rc1
 

--- a/docs/reference/release-notes/8.0.0-rc2.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc2.asciidoc
@@ -1,0 +1,107 @@
+[[release-notes-8.0.0-rc2]]
+== {es} version 8.0.0-rc2
+
+Also see <<breaking-changes-8.0,Breaking changes in 8.0>>.
+
+[[known-issues-8.0.0-rc2]]
+[float]
+=== Known issues
+
+* **Do not upgrade production clusters to {es} 8.0.0-rc2.** {es} 8.0.0-rc2 is
+a pre-release of {es} 8.0 and is intended for testing purposes only.
++
+Upgrades from pre-release builds are not supported and could result in errors or
+data loss. If you upgrade from a released version, such as 7.16, to a
+pre-release version for testing, discard the contents of the cluster when you are
+done. Do not attempt to upgrade to the final 8.0 release.
+
+[[deprecation-8.0.0-rc2]]
+[float]
+=== Deprecations
+
+Engine::
+* Deprecate setting `max_merge_at_once_explicit` {es-pull}80574[#80574]
+
+Search::
+* Configure `IndexSearcher.maxClauseCount()` based on node characteristics {es-pull}81525[#81525] (issue: {es-issue}46433[#46433])
+
+
+[[feature-8.0.0-rc2]]
+[float]
+=== New features
+
+Snapshot/Restore::
+* Support IAM roles for Kubernetes service accounts {es-pull}81255[#81255] (issue: {es-issue}52625[#52625])
+
+Watcher::
+* Use `startsWith` rather than exact matches for Watcher history template names {es-pull}82396[#82396]
+
+
+[[enhancement-8.0.0-rc2]]
+[float]
+=== Enhancements
+
+Cluster Coordination::
+* Make `TaskBatcher` less lock-heavy {es-pull}82227[#82227] (issue: {es-issue}77466[#77466])
+
+ILM+SLM::
+* Avoid unnecessary `LifecycleExecutionState` recalculation {es-pull}81558[#81558] (issues: {es-issue}77466[#77466], {es-issue}79692[#79692])
+* Make unchanged ILM policy updates into no-op {es-pull}82240[#82240] (issue: {es-issue}82065[#82065])
+
+Infra/Core::
+* Prevent upgrades to 8.0 without first upgrading to the last 7.x release {es-pull}82321[#82321] (issue: {es-issue}81865[#81865])
+
+Machine Learning::
+* Add `deployment_stats` to trained model stats {es-pull}80531[#80531]
+* The setting `use_auto_machine_memory_percent` now defaults to `max_model_memory_limit` {es-pull}80532[#80532] (issue: {es-issue}80415[#80415])
+
+Network::
+* Improve slow inbound handling to include response type {es-pull}80425[#80425]
+
+Search::
+* Check nested fields earlier in kNN search {es-pull}80516[#80516] (issue: {es-issue}78473[#78473])
+
+
+[[bug-8.0.0-rc2]]
+[float]
+=== Bug fixes
+
+Autoscaling::
+* Use adjusted total memory instead of total memory {es-pull}80528[#80528] (issue: {es-issue}78750[#78750])
+
+Infra/Scripting::
+* Fix duplicated allow lists upon script engine creation {es-pull}82820[#82820] (issue: {es-issue}82778[#82778])
+
+Ingest::
+* Adjust default geoip logging to be less verbose {es-pull}81404[#81404] (issue: {es-issue}81356[#81356])
+
+Machine Learning::
+* Check that `total_definition_length` is consistent before starting a deployment {es-pull}80553[#80553]
+* Fail inference processor more consistently on certain error types {es-pull}81475[#81475]
+* Optimize the job stats call to do fewer searches {es-pull}82362[#82362] (issue: {es-issue}82255[#82255])
+
+Recovery::
+* Make shard started response handling only return after the cluster state update completes {es-pull}82790[#82790] (issue: {es-issue}81628[#81628])
+
+Search::
+* Reject zero-length vectors when using cosine similarity {es-pull}82241[#82241] (issue: {es-issue}81167[#81167])
+
+Security::
+* Auto-generated TLS files under fixed config path {es-pull}81547[#81547] (issue: {es-issue}81057[#81057])
+* Bind to non-localhost for transport in some cases {es-pull}82973[#82973]
+* Correct file ownership on node reconfiguration {es-pull}82789[#82789] (issue: {es-issue}80990[#80990])
+* Display security auto-configuration with fancy unicode {es-pull}82740[#82740] (issue: {es-issue}82364[#82364])
+
+Snapshot/Restore::
+* Remove custom metadata if there is nothing to restore {es-pull}81373[#81373] (issues: {es-issue}81247[#81247], {es-issue}82019[#82019])
+
+
+[[upgrade-8.0.0-rc2]]
+[float]
+=== Upgrades
+
+Infra/Logging::
+* Upgrade ECS logging layout to latest version {es-pull}80500[#80500]
+
+Search::
+* Upgrade to released lucene 9.0.0 {es-pull}81426[#81426]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #83412

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)