### PR TITLE
Speedup ByteArray.indexOf

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -56,6 +56,16 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     @Override
+    public int indexOf(byte marker, int from) {
+        for (int i = offset + from; i < offset + length; i++) {
+            if (bytes[i] == marker) {
+                return i - offset;
+            }
+        }
+        return -1;
+    }
+
+    @Override
     public int length() {
         return length;
     }


### PR DESCRIPTION
We can do a faster indexOf on a bytes array by implementing a tight array loop.