### PR TITLE
backport: update version after backporting to 7.17.1

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -220,8 +220,8 @@ setup:
 ---
 "Double range on long field":
   - skip:
-      version: " - 8.0.99"
-      reason: Bug fixed in 8.1.0
+      version: " - 7.17.0"
+      reason: Bug fixed in 8.1.0 and backported to 7.17.1
   - do:
       search:
         index: test
@@ -473,8 +473,8 @@ setup:
 ---
 "Min and max long range bounds":
   - skip:
-      version: " - 8.0.99"
-      reason: Bug fixed in 8.1.0
+      version: " - 7.17.0"
+      reason: Bug fixed in 8.1.0 and backported to 7.17.1
   - do:
       search:
         index: long_value_test


### PR DESCRIPTION
Update yaml test skip version after backporting to `7.17.1`.