### PR TITLE
[8.0] [DOCS] Fix get snapshot status API parameters (#81818)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -73,13 +73,17 @@ PUT _snapshot/my_repository/snapshot_2?wait_for_completion=true
 
 [source,console]
 ----
-GET /_snapshot/my_repository/my_snapshot/_status
+GET _snapshot/_status
 ----
 
 [[get-snapshot-status-api-request]]
 ==== {api-request-title}
 
-`GET /_snapshot/<repository>/<snapshot>/_status`
+`GET _snapshot/_status`
+
+`GET _snapshot/<repository>/_status`
+
+`GET _snapshot/<repository>/<snapshot>/_status`
 
 [[get-snapshot-status-api-prereqs]]
 ==== {api-prereq-title}
@@ -91,9 +95,14 @@ GET /_snapshot/my_repository/my_snapshot/_status
 [[get-snapshot-status-api-desc]]
 ==== {api-description-title}
 
-Use the get snapshot status API to retrieve detailed information about snapshots currently running in the cluster.
+Use the get snapshot status API to get detailed information about the shards
+participating in a snapshot.
 
-If you specify both the repository name and snapshot, the request retrieves detailed status information for the given snapshot, even if not currently running.
+If you omit the `<snapshot>` request path parameter, the request only retrieves
+information for currently running snapshots. This usage is preferred.
+
+If needed, you can specify `<repository>` and `<snapshot>` to retrieve
+information for specific snapshots, even if they're not currently running.
 
 [WARNING]
 ====
@@ -112,18 +121,14 @@ and, when using cloud storage, incur high processing costs.
 ==== {api-path-parms-title}
 
 `<repository>`::
-(Required, string)
-Snapshot repository name used to limit the request. Wildcard (`*`) expressions are supported.
-+
-Use `_current` after the repository name to limit the request only to the currently running snapshots. This usage is preferred to return only snapshots that are currently running and not degrade response time.
+(Optional, string)
+Snapshot repository name used to limit the request. Supports wildcards (`*`) if
+`<snapshot>` isn't specified.
 
 `<snapshot>`::
-(Required, string)
-Comma-separated list of snapshot names to retrieve status for.
-+
-To retrieve a list of all snapshots in a specified repository, omit this parameter.
-+
-NOTE: Wildcard (`*`) expressions are not supported for `<snapshot>`.
+(Optional, string)
+Comma-separated list of snapshots to retrieve status for. Defaults to
+currently running snapshots. Wildcards (`*`) are not supported.
 
 [role="child_attributes"]
 [[get-snapshot-status-api-query-params]]
@@ -325,7 +330,7 @@ The following request returns detailed status information for `snapshot_2` in th
 
 [source,console]
 ----
-GET /_snapshot/my_repository/snapshot_2/_status
+GET _snapshot/my_repository/snapshot_2/_status
 ----
 
 [source,console-result]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #81818

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)