### PR TITLE
SQL: Add range checks to interval multiplication operation

### DIFF
--- a/docs/changelog/83478.yaml
+++ b/docs/changelog/83478.yaml
@@ -1,0 +1,6 @@
+pr: 83478
+summary: Add range checks to interval multiplication operation
+area: SQL
+type: bug
+issues:
+ - 83336

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Arithmetics;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Arithmetics.NumericArithmetic;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.BinaryArithmeticOperation;
+import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.sql.expression.literal.interval.Interval;
 import org.elasticsearch.xpack.sql.expression.literal.interval.IntervalArithmetics;
 import org.elasticsearch.xpack.sql.expression.literal.interval.IntervalDayTime;
@@ -23,6 +24,8 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.function.BiFunction;
+
+import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToLong;
 
 public enum SqlBinaryArithmeticOperation implements BinaryArithmeticOperation {
 
@@ -85,17 +88,17 @@ public enum SqlBinaryArithmeticOperation implements BinaryArithmeticOperation {
         if (l instanceof Number && r instanceof Number) {
             return Arithmetics.mul((Number) l, (Number) r);
         }
-        if (l instanceof Number && r instanceof IntervalYearMonth) {
-            return ((IntervalYearMonth) r).mul(((Number) l).intValue());
+        if (l instanceof Number number && r instanceof IntervalYearMonth) {
+            return ((IntervalYearMonth) r).mul(safeToLong(number));
         }
-        if (r instanceof Number && l instanceof IntervalYearMonth) {
-            return ((IntervalYearMonth) l).mul(((Number) r).intValue());
+        if (r instanceof Number number && l instanceof IntervalYearMonth) {
+            return ((IntervalYearMonth) l).mul(safeToLong(number));
         }
-        if (l instanceof Number && r instanceof IntervalDayTime) {
-            return ((IntervalDayTime) r).mul(((Number) l).longValue());
+        if (l instanceof Number number && r instanceof IntervalDayTime) {
+            return ((IntervalDayTime) r).mul(safeToLong(number));
         }
-        if (r instanceof Number && l instanceof IntervalDayTime) {
-            return ((IntervalDayTime) l).mul(((Number) r).longValue());
+        if (r instanceof Number number && l instanceof IntervalDayTime) {
+            return ((IntervalDayTime) l).mul(safeToLong(number));
         }
 
         throw new QlIllegalArgumentException(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Arithmetics;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Arithmetics.NumericArithmetic;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.BinaryArithmeticOperation;
-import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.sql.expression.literal.interval.Interval;
 import org.elasticsearch.xpack.sql.expression.literal.interval.IntervalArithmetics;
 import org.elasticsearch.xpack.sql.expression.literal.interval.IntervalDayTime;


### PR DESCRIPTION
This adds range checks on the multiplication operation of intervals with integers.

Fixes #83336