### PR TITLE
SQL: List unsigned_long type as supported SQL type

### DIFF
--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -18,6 +18,7 @@ s|SQL precision
 | <<number, `short`>>                      | short           | SMALLINT    | 5
 | <<number, `integer`>>                    | integer         | INTEGER     | 10
 | <<number, `long`>>                       | long            | BIGINT      | 19
+| <<number, `unsigned_long`>>              | experimental:[] unsigned_long   | BIGINT      | 20
 | <<number, `double`>>                     | double          | DOUBLE      | 15
 | <<number, `float`>>                      | float           | REAL        | 7
 | <<number, `half_float`>>                 | half_float      | FLOAT       | 3

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -155,7 +155,7 @@ FROM (SELECT ...) WHERE [simple_condition]`, this is currently **un-supported**.
 
 Using `FIRST` and `LAST` in the `HAVING` clause is not supported. The same applies to
 <<sql-functions-aggs-min,`MIN`>> and <<sql-functions-aggs-max,`MAX`>> when their target column
-is of type <<keyword, `keyword`>> as they are internally translated to `FIRST` and `LAST`.
+is of type <<keyword, `keyword`>> or <<number, `unsigned_long`>> as they are internally translated to `FIRST` and `LAST`.
 
 [discrete]
 [[group-by-time]]


### PR DESCRIPTION
Add unsigned_long as an (experimentally) supported SQL type and its limitations.
