### PR TITLE
Clarify data, logs, plugins, and config locations for the Homebrew installation

### DIFF
--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -24,7 +24,7 @@ brew install elastic/tap/elasticsearch-full
 ==== Directory layout for Homebrew installs
 
 When you install {es} with `brew install` the config files, logs,
-and data directory are stored in the following locations.
+and data directory are stored in the following locations (you can alternatively find these locations by running `brew info elasticsearch-full`).
 
 [cols="<h,<,<m,<m",options="header",]
 |=======================================================================


### PR DESCRIPTION
The specific locations in the table ([here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/brew.html)) do not correspond to my, and I assume other users', installations. Running `brew info elasticsearch-full` gives the user the precise, and correct, locations for Data, Logs, Plugins and Config.

Please accept my change so other people don't spend hours trying to figure out what's wrong.
