### PR TITLE
[8.1] Do not allow safelisted media types on Content-Type (#83448)

### DIFF
--- a/docs/changelog/83448.yaml
+++ b/docs/changelog/83448.yaml
@@ -1,0 +1,5 @@
+pr: 83448
+summary: Do not allow safelisted media types on Content-Type
+area: Infra/REST API
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Do not allow safelisted media types on Content-Type (#83448)