### PR TITLE
Make BulkShardRequest.ramBytesUsed a little cheaper

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
@@ -25,8 +25,8 @@ public class BulkItemRequest implements Writeable, Accountable {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BulkItemRequest.class);
 
-    private int id;
-    private DocWriteRequest<?> request;
+    private final int id;
+    private final DocWriteRequest<?> request;
     private volatile BulkItemResponse primaryResponse;
 
     BulkItemRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -147,8 +147,7 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> i
     public long ramBytesUsed() {
         long sum = SHALLOW_SIZE;
         for (BulkItemRequest item : items) {
-            long ramBytesUsed = item.ramBytesUsed();
-            sum += ramBytesUsed;
+            sum += item.ramBytesUsed();
         }
         return sum;
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -23,7 +23,6 @@ import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Stream;
 
 public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> implements Accountable, RawIndexingDataTransportRequest {
 
@@ -146,6 +145,11 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> i
 
     @Override
     public long ramBytesUsed() {
-        return SHALLOW_SIZE + Stream.of(items).mapToLong(Accountable::ramBytesUsed).sum();
+        long sum = SHALLOW_SIZE;
+        for (BulkItemRequest item : items) {
+            long ramBytesUsed = item.ramBytesUsed();
+            sum += ramBytesUsed;
+        }
+        return sum;
     }
 }


### PR DESCRIPTION
Weirdly enough this shows up in profiling (as in ~5% of the time taken to dispatch the request to the write executor)
on the transport thread when benchmarking large bulk requests. It's not too important but this change removes it from
profiling and it's always nice to save some cycles on transport threads.
