### PR TITLE
Make EnrollmentProcessTests more robust v2

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -94,20 +94,12 @@ public class EnrollmentProcessTests extends PackagingTestCase {
         waitForElasticsearch(installation);
         final String node1ContainerId = Docker.getContainerId();
 
-        final AtomicReference<String> enrollmentToken = new AtomicReference<>();
+        Docker.waitForGreenCluster(node1ContainerId);
 
-        assertBusy(() -> {
-            final String tokenValue = installation.executables().createEnrollmentToken.run("-s node")
-                .stdout()
-                .lines()
-                .filter(line -> line.startsWith("WARNING:") == false)
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Failed to find any non-warning output lines"));
-            enrollmentToken.set(tokenValue);
-        }, 30, TimeUnit.SECONDS);
+        String enrollmentToken = getEnrollmentToken();
 
         // installation refers to second node from now on
-        installation = runAdditionalContainer(distribution(), builder().envVar("ENROLLMENT_TOKEN", enrollmentToken.get()), 9201, 9301);
+        installation = runAdditionalContainer(distribution(), builder().envVar("ENROLLMENT_TOKEN", enrollmentToken), 9201, 9301);
 
         // TODO Make our packaging test methods aware of multiple installations, see https://github.com/elastic/elasticsearch/issues/79688
         waitForElasticsearch(installation);
@@ -128,6 +120,35 @@ public class EnrollmentProcessTests extends PackagingTestCase {
 
         // Cleanup the first node that is still running
         removeContainer(node1ContainerId);
+    }
+
+    private String getEnrollmentToken() throws Exception {
+        final AtomicReference<String> enrollmentTokenHolder = new AtomicReference<>();
+
+        assertBusy(() -> {
+            // `assertBusy` only retries on assertion errors, not exceptions, and `Executable#run(String)`
+            // throws a `Shell.ShellException` if the command isn't successful.
+            final Shell.Result result = installation.executables().createEnrollmentToken.run("-s node", null, true);
+
+            if (result.isSuccess() == false) {
+                if (result.stdout().contains("Failed to determine the health of the cluster")) {
+                    throw new AssertionError("Elasticsearch is not ready yet");
+                }
+                throw new Shell.ShellException(
+                    "Command was not successful: [elasticsearch-create-enrollment-token -s node]\n   result: " + result
+                );
+            }
+
+            final String tokenValue = result.stdout()
+                .lines()
+                .filter(line -> line.startsWith("WARNING:") == false)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Failed to find any non-warning output lines"));
+            enrollmentTokenHolder.set(tokenValue);
+        }, 30, TimeUnit.SECONDS);
+
+
+        return enrollmentTokenHolder.get();
     }
 
     private void waitForSecondNode() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -147,7 +147,6 @@ public class EnrollmentProcessTests extends PackagingTestCase {
             enrollmentTokenHolder.set(tokenValue);
         }, 30, TimeUnit.SECONDS);
 
-
         return enrollmentTokenHolder.get();
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -94,7 +94,7 @@ public class EnrollmentProcessTests extends PackagingTestCase {
         waitForElasticsearch(installation);
         final String node1ContainerId = Docker.getContainerId();
 
-        Docker.waitForGreenCluster(node1ContainerId);
+        Docker.waitForNodeStarted(node1ContainerId);
 
         String enrollmentToken = getEnrollmentToken();
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -140,7 +140,7 @@ public class Shell {
         logger.warn("Running command with env: " + env);
         Result result = runScriptIgnoreExitCode(command);
         if (result.isSuccess() == false) {
-            throw new ShellException("Command was not successful: [" + String.join(" ", command) + "]\n   result: " + result.toString());
+            throw new ShellException("Command was not successful: [" + String.join(" ", command) + "]\n   result: " + result);
         }
         return result;
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -745,14 +745,13 @@ public class Docker {
      */
     public static void waitForGreenCluster(String containerId) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        assertBusy(
-            () -> assertTrue(getContainerLogs(containerId).stdout().lines().filter(line -> line.startsWith("{")).map(line -> {
-                try {
-                    return mapper.readTree(line);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
-            }).anyMatch(json -> json.get("message").textValue().contains("Cluster health status changed from [YELLOW] to [GREEN]"))),
+        assertBusy(() -> assertTrue(getContainerLogs(containerId).stdout().lines().filter(line -> line.startsWith("{")).map(line -> {
+            try {
+                return mapper.readTree(line);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }).anyMatch(json -> json.get("message").textValue().contains("Cluster health status changed from [YELLOW] to [GREEN]"))),
             60,
             TimeUnit.SECONDS
         );

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -687,7 +687,6 @@ public class Docker {
         return sh.run("docker logs " + containerId);
     }
 
-
     /**
      * Restarts the current docker container.
      */

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -745,13 +745,14 @@ public class Docker {
      */
     public static void waitForGreenCluster(String containerId) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        assertBusy(() -> assertTrue(getContainerLogs(containerId).stdout().lines().map(line -> {
-            try {
-                return mapper.readTree(line);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
-        }).anyMatch(json -> json.get("message").textValue().contains("Cluster health status changed from [YELLOW] to [GREEN]"))),
+        assertBusy(
+            () -> assertTrue(getContainerLogs(containerId).stdout().lines().filter(line -> line.startsWith("{")).map(line -> {
+                try {
+                    return mapper.readTree(line);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }).anyMatch(json -> json.get("message").textValue().contains("Cluster health status changed from [YELLOW] to [GREEN]"))),
             60,
             TimeUnit.SECONDS
         );


### PR DESCRIPTION
In the Docker test, try to bullet-proof the call to
`elasticsearch-create-enrollment-token` by:

   1. Checking the container logs for the cluster going green
   2. Don't all the CLI call to automatically fail, instead manually
      check the result and throw an assertion failure if the call failed
