### PR TITLE
[8.1] Mute ClientYamlTestSuiteIT "Get all aliases via /_alias" and "Get aliases via /_all/_alias/" (#83510)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -18,6 +18,9 @@ setup:
 
 ---
 "Get all aliases via /_alias":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/83256"
 
   - do:
       indices.create:
@@ -79,6 +82,10 @@ setup:
 
 ---
 "Get aliases via /_all/_alias/":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/83256"
+
   - do:
       indices.create:
         index: myindex


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Mute ClientYamlTestSuiteIT "Get all aliases via /_alias" and "Get aliases via /_all/_alias/" (#83510)