### PR TITLE
Remove CentOS from the CI matrix

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
@@ -13,6 +13,7 @@
           type: label-expression
           name: os
           values:
+            - centos-7-packaging
             - debian-10-packaging
             - debian-11-packaging
             - opensuse-15-1-packaging

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
@@ -13,8 +13,6 @@
           type: label-expression
           name: os
           values:
-            - centos-7-packaging
-            - centos-8-packaging
             - debian-10-packaging
             - debian-11-packaging
             - opensuse-15-1-packaging

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-upgrade.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-upgrade.yml
@@ -13,7 +13,7 @@
           type: label-expression
           name: os
           values:
-            - centos-8-packaging
+            - rocky-linux-8-packaging
             - ubuntu-20.04-packaging
       - axis:
           type: yaml

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
@@ -14,7 +14,6 @@
           type: label-expression
           name: os
           values:
-            - "centos-8-aarch64&&immutable"
             - "ubuntu-1804-aarch64&&immutable"
     builders:
       - inject:

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
@@ -13,8 +13,6 @@
           type: label-expression
           name: os
           values:
-            - "centos-7&&immutable"
-            - "centos-8&&immutable"
             - "amazon&&immutable"
             - "debian-10&&immutable"
             - "debian-11&&immutable"

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
@@ -13,6 +13,7 @@
           type: label-expression
           name: os
           values:
+            - "centos-7&&immutable"
             - "amazon&&immutable"
             - "debian-10&&immutable"
             - "debian-11&&immutable"

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
@@ -31,7 +31,7 @@
           type: label-expression
           name: os
           values:
-            - centos-8-packaging
+            - rocky-linux-8-packaging
             - ubuntu-20.04-packaging
       - axis:
           type: user-defined

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -32,8 +32,6 @@
           type: label-expression
           name: os
           values:
-            - centos-7-packaging
-            - centos-8-packaging
             - debian-9-packaging
             - debian-10-packaging
             - debian-11-packaging

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -32,6 +32,7 @@
           type: label-expression
           name: os
           values:
+            - centos-7-packaging
             - debian-9-packaging
             - debian-10-packaging
             - debian-11-packaging

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
@@ -33,7 +33,7 @@
           type: label-expression
           name: os
           values:
-            - centos-8-packaging
+            - rocky-linux-8-packaging
             - ubuntu-20.04-packaging
       - axis:
           type: yaml


### PR DESCRIPTION
The CentOS repositories are disabled, making it impossible to test on CentOS now. Remove them from CI, and use Rocky Linux where possible.