### PR TITLE
Add note about base_path and ECE to the snapshot repository docs

### DIFF
--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -159,9 +159,9 @@ The Azure repository supports following settings:
     Specifies the path within container to repository data. Defaults to empty
     (root directory).
 +
-NOTE: {ECE} generates the `base_path` for each deployment so that multiple
-deployments may share the same bucket. Do not set `base_path` when
-configuring a snapshot repository for {ECE}.
+NOTE: Don't set `base_path` when configuring a snapshot repository for {ECE}.
+{ECE} automatically generates the `base_path` for each deployment so that
+multiple deployments may share the same bucket.
 
 `chunk_size`::
 

--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -158,6 +158,10 @@ The Azure repository supports following settings:
 
     Specifies the path within container to repository data. Defaults to empty
     (root directory).
++
+NOTE: {ECE} generates the `base_path` for each deployment so that multiple
+deployments may share the same bucket. Do not set `base_path` when
+configuring a snapshot repository for {ECE}.
 
 `chunk_size`::
 

--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -228,9 +228,9 @@ The following settings are supported:
     Specifies the path within bucket to repository data. Defaults to
     the root of the bucket.
 +
-NOTE: {ECE} generates the `base_path` for each deployment so that multiple
-deployments may share the same bucket. Do not set `base_path` when
-configuring a snapshot repository for {ECE}.
+NOTE: Don't set `base_path` when configuring a snapshot repository for {ECE}.
+{ECE} automatically generates the `base_path` for each deployment so that
+multiple deployments may share the same bucket.
 
 `chunk_size`::
 

--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -227,6 +227,10 @@ The following settings are supported:
 
     Specifies the path within bucket to repository data. Defaults to
     the root of the bucket.
++
+NOTE: {ECE} generates the `base_path` for each deployment so that multiple
+deployments may share the same bucket. Do not set `base_path` when
+configuring a snapshot repository for {ECE}.
 
 `chunk_size`::
 

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -276,6 +276,10 @@ bucket naming rules].
     Specifies the path to the repository data within its bucket. Defaults to an
     empty string, meaning that the repository is at the root of the bucket. The
     value of this setting should not start or end with a `/`.
++
+NOTE: {ECE} generates the `base_path` for each deployment so that multiple
+deployments may share the same bucket. Do not set `base_path` when
+configuring a snapshot repository for {ECE}.
 
 `chunk_size`::
 

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -277,9 +277,9 @@ bucket naming rules].
     empty string, meaning that the repository is at the root of the bucket. The
     value of this setting should not start or end with a `/`.
 +
-NOTE: {ECE} generates the `base_path` for each deployment so that multiple
-deployments may share the same bucket. Do not set `base_path` when
-configuring a snapshot repository for {ECE}.
+NOTE: Don't set `base_path` when configuring a snapshot repository for {ECE}.
+{ECE} automatically generates the `base_path` for each deployment so that
+multiple deployments may share the same bucket.
 
 `chunk_size`::
 


### PR DESCRIPTION
Because Elastic Cloud Enterprise (ECE) shares snapshot repositories across multiple deployments the `base_path` is generated by ECE, and the `base_path` setting is not allowed.  This PR adds a note to the S3, Azure, and GCS snapshot repository docs:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/25182304/152547381-e74819a4-b504-4d9e-ad8d-0f01f181b47f.png">

@111andre111 can provide more information from support if needed.

I did not add labels for back porting as the pages I edited are not published in current.  Please let me know if I should also submit a PR for the 7.17 pages in the plugin area of the docs (I don't think that we need to edit those).