### PR TITLE
Adding a critical warning for low watermark exceeded to the deprecation info API

### DIFF
--- a/docs/changelog/83544.yaml
+++ b/docs/changelog/83544.yaml
@@ -1,0 +1,7 @@
+pr: 83544
+summary: Adding a critical warning for low watermark exceeded to the deprecation info
+  API
+area: Other
+type: feature
+issues:
+ - 82807

--- a/docs/changelog/83544.yaml
+++ b/docs/changelog/83544.yaml
@@ -1,7 +1,0 @@
-pr: 83544
-summary: Adding a critical warning for low watermark exceeded to the deprecation info
-  API
-area: Other
-type: feature
-issues:
- - 82807

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -30,10 +30,8 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -143,17 +143,11 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
         if (usage != null) {
             long freeBytes = usage.getFreeBytes();
             double freeDiskPercentage = usage.getFreeDiskAsPercentage();
-            final Map<String, Object> meta;
             final boolean emitWarning;
-            if (exceedsLowWatermark(clusterSettings, freeBytes, freeDiskPercentage)) {
-                // TODO: Do the metadata thing
-                meta = new HashMap<>();
-                emitWarning = true;
-            } else if (exceedsLowWatermark(nodeSettings, freeBytes, freeDiskPercentage)) {
-                meta = null;
+            if (exceedsLowWatermark(nodeSettings, freeBytes, freeDiskPercentage)
+                || exceedsLowWatermark(clusterSettings, freeBytes, freeDiskPercentage)) {
                 emitWarning = true;
             } else {
-                meta = null;
                 emitWarning = false;
             }
             if (emitWarning) {
@@ -169,7 +163,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
                             CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey()
                         ),
                         false,
-                        meta
+                        null
                     )
                 );
             }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -58,6 +59,7 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         Mockito.when(transportService.getLocalNode()).thenReturn(node);
         PluginsService pluginsService = Mockito.mock(PluginsService.class);
         ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
+        ClusterInfoService clusterInfoService = Mockito.mock(ClusterInfoService.class);
         TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
             nodeSettings,
             threadPool,
@@ -65,7 +67,8 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
             clusterService,
             transportService,
             pluginsService,
-            actionFilters
+            actionFilters,
+            clusterInfoService
         );
         NodesDeprecationCheckAction.NodeRequest nodeRequest = null;
         AtomicReference<Settings> visibleNodeSettings = new AtomicReference<>();

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -13,10 +13,13 @@ import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.List;
 import org.elasticsearch.core.Set;
@@ -29,6 +32,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.junit.Assert;
 import org.mockito.Mockito;
 
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
@@ -132,4 +136,93 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         );
     }
 
+    public void testNodeOperationWatermark() {
+        Settings nodeSettings = Settings.EMPTY;
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put("cluster.routing.allocation.disk.watermark.low", "10%");
+        Settings settingsWithLowWatermark = settingsBuilder.build();
+        Settings dynamicSettings = settingsWithLowWatermark;
+        ThreadPool threadPool = null;
+        final XPackLicenseState licenseState = null;
+        Metadata metadata = Metadata.builder().transientSettings(dynamicSettings).build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
+        ClusterService clusterService = Mockito.mock(ClusterService.class);
+        Mockito.when(clusterService.state()).thenReturn(clusterState);
+        final java.util.Set<Setting<?>> settingsSet = new HashSet<>();
+        settingsSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        settingsSet.add(DeprecationChecks.SKIP_DEPRECATIONS_SETTING);
+        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, settingsSet);
+        Mockito.when((clusterService.getClusterSettings())).thenReturn(clusterSettings);
+        DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
+        String nodeId = "123";
+        Mockito.when(node.getId()).thenReturn(nodeId);
+        TransportService transportService = Mockito.mock(TransportService.class);
+        Mockito.when(transportService.getLocalNode()).thenReturn(node);
+        PluginsService pluginsService = Mockito.mock(PluginsService.class);
+        ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
+        ClusterInfoService clusterInfoService = Mockito.mock(ClusterInfoService.class);
+        ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableSpaceUsageBuilder = ImmutableOpenMap.builder();
+        long totalBytesOnMachine = 100;
+        long totalBytesFree = 70;
+        mostAvailableSpaceUsageBuilder.put(nodeId, new DiskUsage(nodeId, "", "", totalBytesOnMachine, totalBytesFree));
+        ClusterInfo clusterInfo = new ClusterInfo(
+            ImmutableOpenMap.of(),
+            mostAvailableSpaceUsageBuilder.build(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of()
+        );
+        Mockito.when(clusterInfoService.getClusterInfo()).thenReturn(clusterInfo);
+        TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
+            nodeSettings,
+            threadPool,
+            licenseState,
+            clusterService,
+            transportService,
+            pluginsService,
+            actionFilters,
+            clusterInfoService
+        );
+        NodesDeprecationCheckAction.NodeRequest nodeRequest = null;
+        java.util.List<
+            DeprecationChecks.NodeDeprecationCheck<
+                Settings,
+                PluginsAndModules,
+                ClusterState,
+                XPackLicenseState,
+                DeprecationIssue>> nodeSettingsChecks = List.of();
+        NodesDeprecationCheckAction.NodeResponse response = transportNodeDeprecationCheckAction.nodeOperation(
+            nodeRequest,
+            nodeSettingsChecks
+        );
+        java.util.List<DeprecationIssue> issues = response.getDeprecationIssues();
+        assertEquals(1, issues.size());
+        assertEquals("Disk usage exceeds low watermark", issues.get(0).getMessage());
+
+        // Making sure there's no warning when we clear out the cluster settings:
+        dynamicSettings = Settings.EMPTY;
+        metadata = Metadata.builder().transientSettings(dynamicSettings).build();
+        clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
+        Mockito.when(clusterService.state()).thenReturn(clusterState);
+        response = transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
+        assertEquals(0, response.getDeprecationIssues().size());
+
+        // And make sure there is a warning when the setting is in the node settings but not the cluster settings:
+        nodeSettings = settingsWithLowWatermark;
+        transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
+            nodeSettings,
+            threadPool,
+            licenseState,
+            clusterService,
+            transportService,
+            pluginsService,
+            actionFilters,
+            clusterInfoService
+        );
+        response = transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
+        issues = response.getDeprecationIssues();
+        assertEquals(1, issues.size());
+        assertEquals("Disk usage exceeds low watermark", issues.get(0).getMessage());
+    }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -60,6 +61,8 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         PluginsService pluginsService = Mockito.mock(PluginsService.class);
         ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
         ClusterInfoService clusterInfoService = Mockito.mock(ClusterInfoService.class);
+        ClusterInfo clusterInfo = ClusterInfo.EMPTY;
+        Mockito.when(clusterInfoService.getClusterInfo()).thenReturn(clusterInfo);
         TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
             nodeSettings,
             threadPool,


### PR DESCRIPTION
Running out of disk space can cause problems during an upgrade. This commit emits a critical warning if disk usage on
any node exceeds the low watermark. It checks both node settings and dynamic settings.
Closes #82807