### PR TITLE
[8.0] Update setting deprecation messages to remove major release references (#83528)

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -55,7 +55,7 @@ PUT _cluster/settings
   }
 }
 ----------------------------------
-// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.]
 
 Alternatively, you can enable this setting in {kib}. In the side navigation,
 click *Monitoring*. If data collection is disabled, you are prompted to turn it

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -36,7 +36,7 @@ PUT _cluster/settings
   }
 }
 ----------------------------------
-// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.]
 
 If {es} {security-features} are enabled, you must have `monitor` cluster privileges to 
 view the cluster settings and `manage` cluster privileges to change them.
@@ -204,7 +204,7 @@ PUT _cluster/settings
   }
 }
 ----------------------------------
-// TEST[warning:[xpack.monitoring.elasticsearch.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[warning:[xpack.monitoring.elasticsearch.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.]
 
 If {es} {security-features} are enabled, you must have `monitor` cluster
 privileges to view the cluster settings and `manage` cluster privileges

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -337,7 +337,7 @@ PUT _cluster/settings
   }
 }
 ----
-// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.]
 
 * Watcher
 +
@@ -462,7 +462,7 @@ PUT _cluster/settings
   }
 }
 ----
-// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
+// TEST[warning:[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.]
 // TEST[s/true/false/]
 
 * Watcher

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -207,8 +207,7 @@ public class EvilLoggerTests extends ESTestCase {
                 deprecationEvents.get(0),
                 DeprecationLogger.CRITICAL,
                 "org.elasticsearch.common.logging.DeprecationLogger.lambda\\$doPrivilegedLog\\$0",
-                "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                    + "See the breaking changes documentation for the next major version."
+                "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release."
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -579,8 +579,7 @@ public class Setting<T> implements ToXContentObject {
             final String key = getKey();
             List<String> skipTheseDeprecations = settings.getAsList("deprecation.skip_deprecated_settings");
             if (Regex.simpleMatch(skipTheseDeprecations, key) == false) {
-                String message = "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                    + "See the breaking changes documentation for the next major version.";
+                String message = "[{}] setting was deprecated in Elasticsearch and will be removed in a future release.";
                 if (this.isDeprecatedWarningOnly()) {
                     Settings.DeprecationLoggerHolder.deprecationLogger.warn(DeprecationCategory.SETTINGS, key, message, key);
                 } else {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -205,10 +205,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     protected List<String> filteredWarnings() {
         return Stream.concat(
             super.filteredWarnings().stream(),
-            List.of(
-                "[index.data_path] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                    + "See the breaking changes documentation for the next major version."
-            ).stream()
+            List.of("[index.data_path] setting was deprecated in Elasticsearch and will be removed in a future release.").stream()
         ).collect(Collectors.toList());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -493,8 +493,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         assertWarnings(true, Stream.concat(Arrays.stream(settings).map(setting -> {
             String warningMessage = String.format(
                 Locale.ROOT,
-                "[%s] setting was deprecated in Elasticsearch and will be "
-                    + "removed in a future release! See the breaking changes documentation for the next major version.",
+                "[%s] setting was deprecated in Elasticsearch and will be removed in a future release.",
                 setting.getKey()
             );
             return new DeprecationWarning(

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
@@ -152,7 +152,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ccr.stats.timeout] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+                + "a future release."
         );
     }
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -149,12 +149,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                 TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2
             )) {
                 headerMatchers.add(
-                    equalTo(
-                        "["
-                            + setting.getKey()
-                            + "] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                            + "See the breaking changes documentation for the next major version."
-                    )
+                    equalTo("[" + setting.getKey() + "] setting was deprecated in Elasticsearch and will be removed in a future release.")
                 );
             }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -492,9 +492,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         assertWarnings(
             "[script.context.field.max_compilations_rate] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release! See the breaking changes documentation for the next major version.",
-            "[script.context.score.max_compilations_rate] setting was deprecated in Elasticsearch and will be removed in a future"
-                + " release! See the breaking changes documentation for the next major version."
+                + " removed in a future release.",
+            "[script.context.score.max_compilations_rate] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -527,9 +526,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         assertWarnings(
             "[script.context.update.max_compilations_rate] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release! See the breaking changes documentation for the next major version.",
-            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future"
-                + " release! See the breaking changes documentation for the next major version."
+                + " removed in a future release.",
+            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -562,10 +560,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         assertWarnings(
-            "[script.context.update.cache_max_size] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release! See the breaking changes documentation for the next major version.",
-            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future"
-                + " release! See the breaking changes documentation for the next major version."
+            "[script.context.update.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -598,10 +594,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         assertWarnings(
-            "[script.context.interval.cache_expire] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release! See the breaking changes documentation for the next major version.",
-            "[script.context.moving-function.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future"
-                + " release! See the breaking changes documentation for the next major version."
+            "[script.context.interval.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[script.context.moving-function.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -655,8 +649,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             true,
             new DeprecationWarning(
                 Level.WARN,
-                "[indices.lifecycle.step.master_timeout] setting was deprecated in Elasticsearch and will be removed in a future release!"
-                    + " See the breaking changes documentation for the next major version."
+                "[indices.lifecycle.step.master_timeout] setting was deprecated in Elasticsearch and will be removed in a future release."
             )
         );
     }
@@ -678,8 +671,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             true,
             new DeprecationWarning(
                 Level.WARN,
-                "[xpack.eql.enabled] setting was deprecated in Elasticsearch and will be removed in a future release!"
-                    + " See the breaking changes documentation for the next major version."
+                "[xpack.eql.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
             )
         );
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
@@ -143,7 +143,7 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.enrich.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringHistoryDurationSettingsTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringHistoryDurationSettingsTests.java
@@ -21,8 +21,7 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
         // Note: this verifies the semantics because this is taken for granted that it never returns null!
         assertEquals(sevenDays, MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), null)));
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future "
-                + "release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -33,8 +32,7 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
             MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), "24h"))
         );
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future "
-                + "release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -46,8 +44,7 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
             () -> MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), oneSecondEarly))
         );
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future "
-                + "release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -114,8 +114,7 @@ public class MonitoringServiceTests extends ESTestCase {
         // take down threads
         monitoringService.setMonitoringActive(false);
         assertWarnings(
-            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -140,10 +139,8 @@ public class MonitoringServiceTests extends ESTestCase {
 
         assertThat(exporter.getExportsCount(), equalTo(1));
         assertWarnings(
-            "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -60,8 +60,7 @@ public class CleanerServiceTests extends ESTestCase {
             new CleanerService(settings, clusterSettings, threadPool, licenseState);
         } finally {
             assertWarnings(
-                "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in "
-                    + "a future release! See the breaking changes documentation for the next major version."
+                "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
             );
         }
     }
@@ -73,8 +72,7 @@ public class CleanerServiceTests extends ESTestCase {
         assertEquals(expected, new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
 
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
@@ -296,7 +296,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -367,7 +367,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -432,7 +432,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
@@ -171,11 +171,10 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.recovery.timeout] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release! See the breaking changes documentation for the next major version.",
+                + "removed in a future release.",
             "[xpack.monitoring.collection.index.recovery.active_only] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+                + "in a future release.",
+            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -233,7 +232,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.recovery.timeout] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release! See the breaking changes documentation for the next major version."
+                + "removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -174,7 +174,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -217,7 +217,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
@@ -144,7 +144,7 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ml.job.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -181,7 +181,7 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ml.job.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
@@ -70,7 +70,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -128,7 +128,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -162,7 +162,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
@@ -123,8 +123,7 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
         }
 
         assertWarnings(
-            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a"
-                + " future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
@@ -117,7 +117,7 @@ public class ClusterAlertsUtilTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._random.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release! See the breaking changes documentation for the next major version."
+                + "and will be removed in a future release."
         );
     }
 
@@ -128,7 +128,7 @@ public class ClusterAlertsUtilTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters.any.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release! See the breaking changes documentation for the next major version."
+                + "and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -122,7 +122,7 @@ public class ExportersTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("host list for [" + prefix + ".host] is empty")));
         assertWarnings(
             "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version."
+                + "future release."
         );
     }
 
@@ -140,7 +140,7 @@ public class ExportersTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("Unknown pattern letter: j")));
         assertWarnings(
             "[xpack.monitoring.exporters.example.index.name.time_format] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release! See the breaking changes documentation for the next major version."
+                + "be removed in a future release."
         );
     }
 
@@ -198,7 +198,7 @@ public class ExportersTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._name.enabled] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version."
+                + "future release."
         );
     }
 
@@ -294,14 +294,12 @@ public class ExportersTests extends ESTestCase {
         assertEquals(settings.get("xpack.monitoring.exporters._name1.cluster_alerts.management.blacklist"), "false");
 
         assertWarnings(
-            "[xpack.monitoring.exporters._name1.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._name0.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
+            "[xpack.monitoring.exporters._name1.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._name0.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
             "[xpack.monitoring.exporters._name0.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release! See the breaking changes documentation for the next major version.",
+                + "be removed in a future release.",
             "[xpack.monitoring.exporters._name1.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release! See the breaking changes documentation for the next major version."
+                + "be removed in a future release."
         );
     }
 
@@ -348,7 +346,7 @@ public class ExportersTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters.explicitly_disabled.enabled] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release! See the breaking changes documentation for the next major version."
+                + "removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -397,9 +397,9 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
 
         assertWarnings(
             "[xpack.monitoring.migration.decommission_alerts] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release! See the breaking changes documentation for the next major version.",
+                + "removed in a future release.",
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch and "
-                + "will be removed in a future release! See the breaking changes documentation for the next major version."
+                + "will be removed in a future release."
         );
     }
 
@@ -469,7 +469,7 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
 
         assertWarnings(
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release! See the breaking changes documentation for the next major version."
+                + "and will be removed in a future release."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -104,7 +104,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.putList(prefix + ".host", Collections.emptyList());
             expectedWarnings.add(
                 "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed "
-                    + "in a future release! See the breaking changes documentation for the next major version."
+                    + "in a future release."
             );
         }
         final Settings settings = builder.build();
@@ -117,7 +117,7 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("host list for [" + prefix + ".host] is empty")));
         expectedWarnings.add(
             "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
         assertWarnings(expectedWarnings.toArray(new String[0]));
     }
@@ -141,7 +141,7 @@ public class HttpExporterTests extends ESTestCase {
         HttpExporter.HOST_SETTING.getConcreteSetting(prefix + ".host").get(settings);
         assertWarnings(
             "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version."
+                + "future release."
         );
     }
 
@@ -154,10 +154,8 @@ public class HttpExporterTests extends ESTestCase {
         final SettingsException e = expectThrows(SettingsException.class, () -> clusterSettings.validate(settings, true));
         assertThat(e, hasToString(containsString("[" + prefix + ".host] is set but type is [local]")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -180,10 +178,9 @@ public class HttpExporterTests extends ESTestCase {
         final SettingsException e = expectThrows(SettingsException.class, () -> clusterSettings.validate(settings, true));
         assertThat(e, hasToString(containsString("[" + prefix + settingName + "] is set but type is [local]")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
             "[xpack.monitoring.exporters.example.auth.secure_password] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version."
+                + "future release."
         );
     }
 
@@ -201,10 +198,8 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getCause(), hasToString(containsString("HttpHosts do not use paths [/].")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -229,10 +224,8 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), instanceOf(SettingsException.class));
         assertThat(e.getCause(), hasToString(containsString("[" + prefix + ".host] must use a consistent scheme: http or https")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -260,10 +253,8 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(exception.getMessage(), equalTo(expected));
 
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -289,10 +280,8 @@ public class HttpExporterTests extends ESTestCase {
 
         assertThat(exception.getMessage(), equalTo(expected));
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -332,9 +321,9 @@ public class HttpExporterTests extends ESTestCase {
         );
         assertWarnings(
             "[xpack.monitoring.exporters._http.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch"
-                + " and will be removed in a future release! See the breaking changes documentation for the next major version.",
+                + " and will be removed in a future release.",
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch"
-                + " and will be removed in a future release! See the breaking changes documentation for the next major version."
+                + " and will be removed in a future release."
         );
     }
 
@@ -351,10 +340,8 @@ public class HttpExporterTests extends ESTestCase {
 
         new HttpExporter(config, sslService, threadContext, coordinator).close();
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -382,7 +369,7 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString(expected)));
         assertWarnings(
             "[xpack.monitoring.exporters._http.proxy.base_path] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version."
+                + "in a future release."
         );
     }
 
@@ -396,12 +383,10 @@ public class HttpExporterTests extends ESTestCase {
             .put("xpack.monitoring.exporters._http.type", "http")
             .put("xpack.monitoring.exporters._http.host", "http://localhost:9200");
         expectedWarnings.add(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
         expectedWarnings.add(
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
 
         // use basic auth
@@ -413,7 +398,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.setSecureSettings(mockSecureSettings);
             expectedWarnings.add(
                 "[xpack.monitoring.exporters._http.auth.username] setting was deprecated in Elasticsearch and will be "
-                    + "removed in a future release! See the breaking changes documentation for the next major version."
+                    + "removed in a future release."
             );
         }
 
@@ -444,8 +429,7 @@ public class HttpExporterTests extends ESTestCase {
         assertNull(provider);
 
         assertWarnings(
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release! See the breaking changes documentation for the next major version."
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -488,11 +472,9 @@ public class HttpExporterTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._http.sniff.enabled] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release! See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release!"
-                + " See the breaking changes documentation for the next major version.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release!"
-                + " See the breaking changes documentation for the next major version."
+                + "in a future release.",
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
 
@@ -507,8 +489,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.put("xpack.monitoring.exporters._http.cluster_alerts.management.enabled", true);
             warningsExpected.add(
                 "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in "
-                    + "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major "
-                    + "version."
+                    + "Elasticsearch and will be removed in a future release."
             );
         }
 
@@ -516,8 +497,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.put("xpack.monitoring.exporters._http.index.template.master_timeout", templateTimeout.getStringRep());
             warningsExpected.add(
                 "[xpack.monitoring.exporters._http.index.template.master_timeout] setting was deprecated in "
-                    + "Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major "
-                    + "version."
+                    + "Elasticsearch and will be removed in a future release."
             );
         }
 
@@ -590,7 +570,7 @@ public class HttpExporterTests extends ESTestCase {
             assertThat(parameters.remove("timeout"), equalTo(bulkTimeout.toString()));
             assertWarnings(
                 "[xpack.monitoring.exporters._http.bulk.timeout] setting was deprecated in Elasticsearch and will be removed "
-                    + "in a future release! See the breaking changes documentation for the next major version."
+                    + "in a future release."
             );
         } else {
             assertNull(parameters.remove("timeout"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -149,10 +149,7 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
         assertThat(response.getNodesAddresses(), hasSize(numberOfNodes));
         assertThat(nodesInfoRequests, hasSize(1));
 
-        assertWarnings(
-            "[keystore.password] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version."
-        );
+        assertWarnings("[keystore.password] setting was deprecated in Elasticsearch and will be removed in a future release.");
     }
 
     private void assertSameCertificate(String cert, Path original, char[] originalPassword, boolean isCa) throws Exception {


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #83528

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)