### PR TITLE
Document removal of custom REST wrappers in 8.0

### DIFF
--- a/docs/reference/migration/migrate_8_0/plugin-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/plugin-changes.asciidoc
@@ -45,4 +45,26 @@ If you run {es} using Docker and you are managing plugins using a
 they already installed. If any of these plugins are specified in your
 configuration file, {es} will ignore them and emit a warning log message.
 ====
+
+.Third party plugins can no longer intercept REST requests (RestHandlerWrapper)
+[%collapsible]
+====
+*Details* +
+In previous versions of {es}, plugins were able to implement the 
+`getRestHandlerWrapper` method which would allow the plugin to intercept all
+REST requests to the node.  One of the common uses of this feature was to
+implement custom security plugins that replaced the built-in
+{security-features}. This extension point is no longer available to 
+third-party plugins.
+
+*Impact* +
+Some third party plugins that existed for earlier versions of {es} may not be
+compatible with {es} version 8.0 or higher.
+
+If you depend on any third-party plugins (that is, plugins that are not
+produced and supported by Elastic) then you should check with the plugin author
+and ensure that the plugin is available for your target version of {es} before
+you upgrade.
+====
+
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/plugin-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/plugin-changes.asciidoc
@@ -46,25 +46,25 @@ they already installed. If any of these plugins are specified in your
 configuration file, {es} will ignore them and emit a warning log message.
 ====
 
-.Third party plugins can no longer intercept REST requests (RestHandlerWrapper)
+.Third party plugins can no longer intercept REST requests (`RestHandlerWrapper`)
 [%collapsible]
 ====
 *Details* +
-In previous versions of {es}, plugins were able to implement the 
-`getRestHandlerWrapper` method which would allow the plugin to intercept all
-REST requests to the node.  One of the common uses of this feature was to
-implement custom security plugins that replaced the built-in
-{security-features}. This extension point is no longer available to 
-third-party plugins.
+In previous versions of {es}, third-party plugins could implement the 
+`getRestHandlerWrapper` method to intercept all REST requests to the node. A 
+common use of this feature was to implement custom security plugins to replace
+the built-in {security-features}. This extension point is no longer available
+to third-party plugins.
+
 
 *Impact* +
-Some third party plugins that existed for earlier versions of {es} may not be
-compatible with {es} version 8.0 or higher.
+Some third-party plugins that were designed to work with earlier versions of
+{es} might not be compatible with {es} version 8.0 or later.
 
-If you depend on any third-party plugins (that is, plugins that are not
-produced and supported by Elastic) then you should check with the plugin author
-and ensure that the plugin is available for your target version of {es} before
-you upgrade.
+If you depend on any plugins that are not produced and supported by Elastic,
+check with the plugin author and ensure that the plugin is available for your
+target version of {es} before upgrading.
+
 ====
 
 //end::notable-breaking-changes[]


### PR DESCRIPTION
In #71061 we removed support for custom REST Handler Wrappers.

This change adds that information to the migration guide under the
"Plugin changes" section
