### PR TITLE
Cleanup DataTierAllocationDecider

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderService.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
-import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,11 +32,9 @@ public class ProactiveStorageDeciderService implements AutoscalingDeciderService
 
     private final DiskThresholdSettings diskThresholdSettings;
     private final AllocationDeciders allocationDeciders;
-    private final DataTierAllocationDecider dataTierAllocationDecider;
 
     public ProactiveStorageDeciderService(Settings settings, ClusterSettings clusterSettings, AllocationDeciders allocationDeciders) {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
-        this.dataTierAllocationDecider = new DataTierAllocationDecider();
         this.allocationDeciders = allocationDeciders;
     }
 
@@ -64,8 +61,7 @@ public class ProactiveStorageDeciderService implements AutoscalingDeciderService
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             context,
             diskThresholdSettings,
-            allocationDeciders,
-            dataTierAllocationDecider
+            allocationDeciders
         );
         long unassignedBytesBeforeForecast = allocationState.storagePreventsAllocation();
         assert unassignedBytesBeforeForecast >= 0;

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -71,12 +71,10 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     public static final String NAME = "reactive_storage";
 
     private final DiskThresholdSettings diskThresholdSettings;
-    private final DataTierAllocationDecider dataTierAllocationDecider;
     private final AllocationDeciders allocationDeciders;
 
     public ReactiveStorageDeciderService(Settings settings, ClusterSettings clusterSettings, AllocationDeciders allocationDeciders) {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
-        this.dataTierAllocationDecider = new DataTierAllocationDecider();
         this.allocationDeciders = allocationDeciders;
     }
 
@@ -108,12 +106,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return new AutoscalingDeciderResult(null, new ReactiveReason("current capacity not available", -1, -1));
         }
 
-        AllocationState allocationState = new AllocationState(
-            context,
-            diskThresholdSettings,
-            allocationDeciders,
-            dataTierAllocationDecider
-        );
+        AllocationState allocationState = new AllocationState(context, diskThresholdSettings, allocationDeciders);
         long unassignedBytes = allocationState.storagePreventsAllocation();
         long assignedBytes = allocationState.storagePreventsRemainOrMove();
         long maxShardSize = allocationState.maxShardSize();
@@ -177,7 +170,6 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     public static class AllocationState {
         private final ClusterState state;
         private final AllocationDeciders allocationDeciders;
-        private final DataTierAllocationDecider dataTierAllocationDecider;
         private final DiskThresholdSettings diskThresholdSettings;
         private final ClusterInfo info;
         private final SnapshotShardSizeInfo shardSizeInfo;
@@ -189,13 +181,11 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         AllocationState(
             AutoscalingDeciderContext context,
             DiskThresholdSettings diskThresholdSettings,
-            AllocationDeciders allocationDeciders,
-            DataTierAllocationDecider dataTierAllocationDecider
+            AllocationDeciders allocationDeciders
         ) {
             this(
                 context.state(),
                 allocationDeciders,
-                dataTierAllocationDecider,
                 diskThresholdSettings,
                 context.info(),
                 context.snapshotShardSizeInfo(),
@@ -207,7 +197,6 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         AllocationState(
             ClusterState state,
             AllocationDeciders allocationDeciders,
-            DataTierAllocationDecider dataTierAllocationDecider,
             DiskThresholdSettings diskThresholdSettings,
             ClusterInfo info,
             SnapshotShardSizeInfo shardSizeInfo,
@@ -216,7 +205,6 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         ) {
             this.state = state;
             this.allocationDeciders = allocationDeciders;
-            this.dataTierAllocationDecider = dataTierAllocationDecider;
             this.diskThresholdSettings = diskThresholdSettings;
             this.info = info;
             this.shardSizeInfo = shardSizeInfo;
@@ -346,7 +334,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             IndexMetadata indexMetadata = indexMetadata(shard, allocation);
             Set<Decision.Type> decisionTypes = StreamSupport.stream(allocation.routingNodes().spliterator(), false)
                 .map(
-                    node -> dataTierAllocationDecider.shouldFilter(
+                    node -> DataTierAllocationDecider.shouldFilter(
                         indexMetadata,
                         node.node().getRoles(),
                         this::highestPreferenceTier,
@@ -378,7 +366,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
 
         private boolean isAssignedToTier(ShardRouting shard, RoutingAllocation allocation) {
             IndexMetadata indexMetadata = indexMetadata(shard, allocation);
-            return dataTierAllocationDecider.shouldFilter(indexMetadata, roles, this::highestPreferenceTier, allocation) != Decision.NO;
+            return DataTierAllocationDecider.shouldFilter(indexMetadata, roles, this::highestPreferenceTier, allocation) != Decision.NO;
         }
 
         private IndexMetadata indexMetadata(ShardRouting shard, RoutingAllocation allocation) {
@@ -502,7 +490,6 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return new AllocationState(
                 forecastClusterState,
                 allocationDeciders,
-                dataTierAllocationDecider,
                 diskThresholdSettings,
                 forecastInfo,
                 shardSizeInfo,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -178,7 +178,6 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             null,
             null,
             null,
-            null,
             Set.of(),
             Set.of()
         );
@@ -207,7 +206,6 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         state = randomAllocate(state);
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             state,
-            null,
             null,
             null,
             randomClusterInfo(state),
@@ -252,7 +250,6 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
 
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             state,
-            null,
             null,
             null,
             info,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -96,8 +96,6 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
         new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
     );
 
-    private static final DataTierAllocationDecider DATA_TIER_ALLOCATION_DECIDER = new DataTierAllocationDecider();
-
     private ClusterState state;
     private final int hotNodes = randomIntBetween(1, 8);
     private final int warmNodes = randomIntBetween(1, 3);
@@ -366,8 +364,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             createContext(state, Set.of(role)),
             DISK_THRESHOLD_SETTINGS,
-            createAllocationDeciders(allocationDeciders),
-            DATA_TIER_ALLOCATION_DECIDER
+            createAllocationDeciders(allocationDeciders)
         );
         assertThat(subject.invoke(allocationState), equalTo(expected));
     }
@@ -429,7 +426,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
             Collections.emptyList()
         );
         return new AllocationDeciders(
-            Stream.of(Stream.of(extraDeciders), Stream.of(new DataTierAllocationDecider()), systemAllocationDeciders.stream())
+            Stream.of(Stream.of(extraDeciders), Stream.of(DataTierAllocationDecider.INSTANCE), systemAllocationDeciders.stream())
                 .flatMap(s -> s)
                 .collect(Collectors.toList())
         );

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -280,7 +280,6 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             clusterState,
             null,
             null,
-            null,
             info,
             null,
             Set.of(),
@@ -355,7 +354,6 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         SnapshotShardSizeInfo shardSizeInfo = new SnapshotShardSizeInfo(shardSizeBuilder.build());
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,
-            null,
             null,
             null,
             null,
@@ -448,7 +446,6 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,
             null,
-            null,
             thresholdSettings,
             info,
             null,
@@ -521,11 +518,9 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
 
     public boolean canRemainWithNoNodes(ClusterState clusterState, ShardRouting shardRouting, AllocationDecider... deciders) {
         AllocationDeciders allocationDeciders = new AllocationDeciders(Arrays.asList(deciders));
-        DataTierAllocationDecider dataTierAllocationDecider = new DataTierAllocationDecider();
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,
             allocationDeciders,
-            dataTierAllocationDecider,
             new DiskThresholdSettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             ClusterInfo.EMPTY,
             null,
@@ -626,11 +621,9 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         AllocationDecider... deciders
     ) {
         AllocationDeciders allocationDeciders = new AllocationDeciders(Arrays.asList(deciders));
-        DataTierAllocationDecider dataTierAllocationDecider = new DataTierAllocationDecider();
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,
             allocationDeciders,
-            dataTierAllocationDecider,
             new DiskThresholdSettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             ClusterInfo.EMPTY,
             null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -28,11 +28,13 @@ import java.util.Set;
  * {@link org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider}, however it
  * is specific to the {@code _tier} setting for both the cluster and index level.
  */
-public class DataTierAllocationDecider extends AllocationDecider {
+public final class DataTierAllocationDecider extends AllocationDecider {
 
     public static final String NAME = "data_tier";
 
-    public DataTierAllocationDecider() {}
+    public static final DataTierAllocationDecider INSTANCE = new DataTierAllocationDecider();
+
+    private DataTierAllocationDecider() {}
 
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
@@ -58,7 +60,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
         return shouldFilter(allocation.metadata().getIndexSafe(shardRouting.index()), node.getRoles(), allocation);
     }
 
-    public Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, RoutingAllocation allocation) {
+    private static Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, RoutingAllocation allocation) {
         return shouldFilter(indexMd, roles, DataTierAllocationDecider::preferredAvailableTier, allocation);
     }
 
@@ -66,68 +68,65 @@ public class DataTierAllocationDecider extends AllocationDecider {
         Optional<String> apply(List<String> tierPreference, DiscoveryNodes nodes);
     }
 
-    public Decision shouldFilter(
+    private static final Decision YES_PASSES = Decision.single(Decision.YES.type(), NAME, "node passes tier preference filters");
+
+    public static Decision shouldFilter(
         IndexMetadata indexMd,
         Set<DiscoveryNodeRole> roles,
         PreferredTierFunction preferredTierFunction,
         RoutingAllocation allocation
     ) {
-        Decision decision = shouldIndexPreferTier(indexMd, roles, preferredTierFunction, allocation);
-        if (decision != null) {
-            return decision;
+        List<String> tierPreference = indexMd.getTierPreference();
+        if (tierPreference.isEmpty() != false) {
+            return YES_PASSES;
         }
-
-        return allocation.decision(Decision.YES, NAME, "node passes tier preference filters");
+        Optional<String> tier = preferredTierFunction.apply(tierPreference, allocation.nodes());
+        if (tier.isPresent()) {
+            String tierName = tier.get();
+            if (allocationAllowed(tierName, roles)) {
+                if (allocation.debugDecision()) {
+                    return debugYesAllowed(allocation, tierPreference, tierName);
+                }
+                return Decision.YES;
+            }
+            if (allocation.debugDecision()) {
+                return debugNoRequirementsNotMet(allocation, tierPreference, tierName);
+            }
+            return Decision.NO;
+        }
+        if (allocation.debugDecision()) {
+            return debugNoNoNodesAvailable(allocation, tierPreference);
+        }
+        return Decision.NO;
     }
 
-    private Decision shouldIndexPreferTier(
-        IndexMetadata indexMetadata,
-        Set<DiscoveryNodeRole> roles,
-        PreferredTierFunction preferredTierFunction,
-        RoutingAllocation allocation
-    ) {
-        List<String> tierPreference = indexMetadata.getTierPreference();
+    private static Decision debugNoNoNodesAvailable(RoutingAllocation allocation, List<String> tierPreference) {
+        return allocation.decision(
+            Decision.NO,
+            NAME,
+            "index has a preference for tiers [%s], " + "but no nodes for any of those tiers are available in the cluster",
+            String.join(",", tierPreference)
+        );
+    }
 
-        if (tierPreference.isEmpty() == false) {
-            Optional<String> tier = preferredTierFunction.apply(tierPreference, allocation.nodes());
-            if (tier.isPresent()) {
-                String tierName = tier.get();
-                if (allocationAllowed(tierName, roles)) {
-                    if (allocation.debugDecision() == false) {
-                        return Decision.YES;
-                    }
-                    return allocation.decision(
-                        Decision.YES,
-                        NAME,
-                        "index has a preference for tiers [%s] and node has tier [%s]",
-                        String.join(",", tierPreference),
-                        tierName
-                    );
-                } else {
-                    if (allocation.debugDecision() == false) {
-                        return Decision.NO;
-                    }
-                    return allocation.decision(
-                        Decision.NO,
-                        NAME,
-                        "index has a preference for tiers [%s] and node does not meet the required [%s] tier",
-                        String.join(",", tierPreference),
-                        tierName
-                    );
-                }
-            } else {
-                if (allocation.debugDecision() == false) {
-                    return Decision.NO;
-                }
-                return allocation.decision(
-                    Decision.NO,
-                    NAME,
-                    "index has a preference for tiers [%s], " + "but no nodes for any of those tiers are available in the cluster",
-                    String.join(",", tierPreference)
-                );
-            }
-        }
-        return null;
+    private static Decision debugNoRequirementsNotMet(RoutingAllocation allocation, List<String> tierPreference, String tierName) {
+        return allocation.decision(
+            Decision.NO,
+            NAME,
+            "index has a preference for tiers [%s] and node does not meet the required [%s] tier",
+            String.join(",", tierPreference),
+            tierName
+        );
+    }
+
+    private static Decision debugYesAllowed(RoutingAllocation allocation, List<String> tierPreference, String tierName) {
+        return allocation.decision(
+            Decision.YES,
+            NAME,
+            "index has a preference for tiers [%s] and node has tier [%s]",
+            String.join(",", tierPreference),
+            tierName
+        );
     }
 
     /**
@@ -148,12 +147,9 @@ public class DataTierAllocationDecider extends AllocationDecider {
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier)
             : "tier " + singleTier + " is an invalid tier name";
-        for (DiscoveryNode node : nodes.getNodes().values()) {
-            for (DiscoveryNodeRole discoveryNodeRole : node.getRoles()) {
-                String s = discoveryNodeRole.roleName();
-                if (s.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || s.equals(singleTier)) {
-                    return true;
-                }
+        for (DiscoveryNode node : nodes) {
+            if (allocationAllowed(singleTier, node.getRoles())) {
+                return true;
             }
         }
         return false;
@@ -165,13 +161,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
         if (roles.contains(DiscoveryNodeRole.DATA_ROLE)) {
             // generic "data" roles are considered to have all tiers
             return true;
-        } else {
-            for (DiscoveryNodeRole role : roles) {
-                if (tierName.equals(role.roleName())) {
-                    return true;
-                }
-            }
-            return false;
         }
+        for (DiscoveryNodeRole role : roles) {
+            if (tierName.equals(role.roleName())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -104,7 +104,7 @@ public final class DataTierAllocationDecider extends AllocationDecider {
         return allocation.decision(
             Decision.NO,
             NAME,
-            "index has a preference for tiers [%s], " + "but no nodes for any of those tiers are available in the cluster",
+            "index has a preference for tiers [%s], but no nodes for any of those tiers are available in the cluster",
             String.join(",", tierPreference)
         );
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -455,7 +455,7 @@ public class XPackPlugin extends XPackClientPlugin
 
     @Override
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
-        return Collections.singleton(new DataTierAllocationDecider());
+        return Collections.singleton(DataTierAllocationDecider.INSTANCE);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -32,6 +32,8 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
 
     private static final Logger logger = LogManager.getLogger(DataTierMigrationRoutedStep.class);
 
+    private static final AllocationDeciders DECIDERS = new AllocationDeciders(List.of(DataTierAllocationDecider.INSTANCE));
+
     DataTierMigrationRoutedStep(StepKey key, StepKey nextStepKey) {
         super(key, nextStepKey);
     }
@@ -43,7 +45,6 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
 
     @Override
     public Result isConditionMet(Index index, ClusterState clusterState) {
-        AllocationDeciders allocationDeciders = new AllocationDeciders(List.of(new DataTierAllocationDecider()));
         IndexMetadata idxMeta = clusterState.metadata().index(index);
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it
@@ -95,7 +96,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             return new Result(true, null);
         }
 
-        int allocationPendingAllShards = getPendingAllocations(index, allocationDeciders, clusterState);
+        int allocationPendingAllShards = getPendingAllocations(index, DECIDERS, clusterState);
 
         if (allocationPendingAllShards > 0) {
             String statusMessage = availableDestinationTier.map(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
@@ -73,7 +73,7 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
                     clusterState.getMetadata().settings(),
                     new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
                 ),
-                new DataTierAllocationDecider(),
+                DataTierAllocationDecider.INSTANCE,
                 new NodeVersionAllocationDecider(),
                 new NodeShutdownAllocationDecider(),
                 new NodeReplacementAllocationDecider()


### PR DESCRIPTION
Clean this code up a little more as its one of the remaining rather expensive
allocation deciders in profiling:
* Make static what can be made static
* extract cold paths to maybe make this compile a little better
* Use the same logic in `tierNodesPresent` and `allocationAllowed` to have the
`DATA_ROLE` shortcut in both paths.