### PR TITLE
Runtime fields core-with-mapped tests support tsdb

### DIFF
--- a/docs/changelog/83577.yaml
+++ b/docs/changelog/83577.yaml
@@ -1,0 +1,5 @@
+pr: 83577
+summary: Runtime fields core-with-mapped tests support tsdb
+area: Mapping
+type: bug
+issues: []

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -99,6 +99,7 @@ subprojects {
           'search/330_fetch_fields/error includes glob pattern',
           // we need a @timestamp field to be defined in index mapping
           'search/380_sort_segments_on_timestamp/*',
+          'field_caps/40_time_series/*',
           /////// NOT SUPPORTED ///////
         ].join(',')
     }

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -79,8 +79,6 @@ subprojects {
           //there is something wrong when using dotted document syntax here, passes in main yaml tests
           'search/330_fetch_fields/Test nested field inside object structure',
 
-          // AwaitsFix: https://github.com/elastic/elasticsearch/issues/83431
-          'search.aggregation/450_time_series/Basic test',
           /////// TO FIX ///////
 
           /////// NOT SUPPORTED ///////
@@ -101,7 +99,6 @@ subprojects {
           'search/330_fetch_fields/error includes glob pattern',
           // we need a @timestamp field to be defined in index mapping
           'search/380_sort_segments_on_timestamp/*',
-          'field_caps/40_time_series/*',
           /////// NOT SUPPORTED ///////
         ].join(',')
     }

--- a/x-pack/qa/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
+++ b/x-pack/qa/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
@@ -290,6 +291,18 @@ public abstract class CoreTestTranslater {
                 }
                 if (propertyMap.containsKey("ignore_malformed")) {
                     // Our source reading script doesn't emulate ignore_malformed
+                    continue;
+                }
+                if (propertyMap.containsKey("time_series_dimension")) {
+                    // time_series_dimension field can't emulate with scripts.
+                    continue;
+                }
+                if (propertyMap.containsKey("time_series_metric")) {
+                    // time_series_metric field can't emulate with scripts.
+                    continue;
+                }
+                if (name.equals(DataStreamTimestampFieldMapper.DEFAULT_PATH)) {
+                    // time_series and data stream indices need timestamp field
                     continue;
                 }
                 if (RUNTIME_TYPES.contains(type) == false) {


### PR DESCRIPTION
As runtime fields not support `time_series_dimension` and `time_series_metric`, it will lead to the failure of tsdb test case. And tsdb indices require the @timestamp field.

So I improve the `runtimeifyMappingProperties` method logic, add some skip rule.

- skip `time_series_dimension` field.
- skip `time_series_metric` field.
- skip `@timestamp` field.

And the PR fixed the failed test in https://github.com/elastic/elasticsearch/issues/83431