### PR TITLE
fix naming in health indicators

### DIFF
--- a/docs/changelog/83587.yaml
+++ b/docs/changelog/83587.yaml
@@ -1,0 +1,5 @@
+pr: 83587
+summary: Fix naming in health indicators
+area: Health
+type: enhancement
+issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.health.ServerHealthComponents.DATA;
  */
 public class IlmHealthIndicatorService implements HealthIndicatorService {
 
-    public static final String NAME = "ILM";
+    public static final String NAME = "ilm";
 
     private final ClusterService clusterService;
 
@@ -63,7 +63,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
 
     private static HealthIndicatorDetails createDetails(IndexLifecycleMetadata metadata) {
         return new SimpleHealthIndicatorDetails(
-            Map.of("ilm-status", metadata.getOperationMode(), "policies", metadata.getPolicies().size())
+            Map.of("ilm_status", metadata.getOperationMode(), "policies", metadata.getPolicies().size())
         );
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.health.ServerHealthComponents.SNAPSHOT;
  */
 public class SlmHealthIndicatorService implements HealthIndicatorService {
 
-    public static final String NAME = "SLM";
+    public static final String NAME = "slm";
 
     private final ClusterService clusterService;
 
@@ -63,7 +63,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
 
     private static HealthIndicatorDetails createDetails(SnapshotLifecycleMetadata metadata) {
         return new SimpleHealthIndicatorDetails(
-            Map.of("slm-status", metadata.getOperationMode(), "policies", metadata.getSnapshotConfigurations().size())
+            Map.of("slm_status", metadata.getOperationMode(), "policies", metadata.getSnapshotConfigurations().size())
         );
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorServiceTests.java
@@ -45,7 +45,7 @@ public class IlmHealthIndicatorServiceTests extends ESTestCase {
                     DATA,
                     GREEN,
                     "ILM is running",
-                    new SimpleHealthIndicatorDetails(Map.of("ilm-status", RUNNING, "policies", 1))
+                    new SimpleHealthIndicatorDetails(Map.of("ilm_status", RUNNING, "policies", 1))
                 )
             )
         );
@@ -64,7 +64,7 @@ public class IlmHealthIndicatorServiceTests extends ESTestCase {
                     DATA,
                     YELLOW,
                     "ILM is not running",
-                    new SimpleHealthIndicatorDetails(Map.of("ilm-status", status, "policies", 1))
+                    new SimpleHealthIndicatorDetails(Map.of("ilm_status", status, "policies", 1))
                 )
             )
         );
@@ -83,7 +83,7 @@ public class IlmHealthIndicatorServiceTests extends ESTestCase {
                     DATA,
                     GREEN,
                     "No policies configured",
-                    new SimpleHealthIndicatorDetails(Map.of("ilm-status", status, "policies", 0))
+                    new SimpleHealthIndicatorDetails(Map.of("ilm_status", status, "policies", 0))
                 )
             )
         );
@@ -101,7 +101,7 @@ public class IlmHealthIndicatorServiceTests extends ESTestCase {
                     DATA,
                     GREEN,
                     "No policies configured",
-                    new SimpleHealthIndicatorDetails(Map.of("ilm-status", RUNNING, "policies", 0))
+                    new SimpleHealthIndicatorDetails(Map.of("ilm_status", RUNNING, "policies", 0))
                 )
             )
         );

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
@@ -45,7 +45,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     SNAPSHOT,
                     GREEN,
                     "SLM is running",
-                    new SimpleHealthIndicatorDetails(Map.of("slm-status", RUNNING, "policies", 1))
+                    new SimpleHealthIndicatorDetails(Map.of("slm_status", RUNNING, "policies", 1))
                 )
             )
         );
@@ -64,7 +64,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     SNAPSHOT,
                     YELLOW,
                     "SLM is not running",
-                    new SimpleHealthIndicatorDetails(Map.of("slm-status", status, "policies", 1))
+                    new SimpleHealthIndicatorDetails(Map.of("slm_status", status, "policies", 1))
                 )
             )
         );
@@ -83,7 +83,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     SNAPSHOT,
                     GREEN,
                     "No policies configured",
-                    new SimpleHealthIndicatorDetails(Map.of("slm-status", status, "policies", 0))
+                    new SimpleHealthIndicatorDetails(Map.of("slm_status", status, "policies", 0))
                 )
             )
         );
@@ -101,7 +101,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     SNAPSHOT,
                     GREEN,
                     "No policies configured",
-                    new SimpleHealthIndicatorDetails(Map.of("slm-status", RUNNING, "policies", 0))
+                    new SimpleHealthIndicatorDetails(Map.of("slm_status", RUNNING, "policies", 0))
                 )
             )
         );


### PR DESCRIPTION
fix name cases to fix common convention in elasticsearch (use '_' instead of `-`)

Related to: #83240