### PR TITLE
SQL: Compress Cursors

### DIFF
--- a/docs/changelog/83591.yaml
+++ b/docs/changelog/83591.yaml
@@ -1,0 +1,5 @@
+pr: 83591
+summary: Compress Cursors
+area: SQL
+type: enhancement
+issues: []

--- a/docs/changelog/83591.yaml
+++ b/docs/changelog/83591.yaml
@@ -2,4 +2,5 @@ pr: 83591
 summary: Compress Cursors
 area: SQL
 type: enhancement
-issues: []
+issues:
+ - 83284

--- a/docs/changelog/83591.yaml
+++ b/docs/changelog/83591.yaml
@@ -2,5 +2,4 @@ pr: 83591
 summary: Compress Cursors
 area: SQL
 type: enhancement
-issues:
- - 83284
+issues: []

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -1437,20 +1437,22 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
     }
 
     public void testCompressCursor() throws IOException {
-        String doc = IntStream.range(0, 1000).mapToObj(i -> String.format("\"field%d\": %d", i, i)).collect(Collectors.joining(","));
+        String doc = IntStream.range(0, 1000)
+            .mapToObj(i -> String.format(Locale.ROOT, "\"field%d\": %d", i, i))
+            .collect(Collectors.joining(","));
         index("{" + doc + "}");
 
         String mode = randomMode();
-        Map<String, Object> resp = toMap(runSql(query("SHOW COLUMNS FROM test").fetchSize(1).mode(mode)), mode);
+        Map<String, Object> resp = toMap(runSql(query("SHOW COLUMNS FROM " + indexPattern("test")).fetchSize(1).mode(mode)), mode);
 
-        // without compression, the cursor is at least <avg. fieldname length> * 1000 bytes (effectively ~35kb)
+        // without compression, the cursor is at least <avg. fieldname length> * 1000 bytes (in fact it is ~35kb)
         assertThat(resp.get("cursor").toString().length(), lessThan(5000));
     }
 
     static Map<String, Object> runSql(RequestObjectBuilder builder, String mode) throws IOException {
         return toMap(runSql(builder.mode(mode)), mode);
     }
- 
+
     static Response runSql(RequestObjectBuilder builder) throws IOException {
         return runSqlAsTextWithFormat(builder, null);
     }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -74,6 +76,7 @@ import static org.elasticsearch.xpack.sql.proto.CoreProtocol.URL_PARAM_DELIMITER
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.URL_PARAM_FORMAT;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.WAIT_FOR_COMPLETION_TIMEOUT_NAME;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  * Integration test for the rest sql action. The one that speaks json directly to a
@@ -1433,10 +1436,21 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         }
     }
 
+    public void testCompressCursor() throws IOException {
+        String doc = IntStream.range(0, 1000).mapToObj(i -> String.format("\"field%d\": %d", i, i)).collect(Collectors.joining(","));
+        index("{" + doc + "}");
+
+        String mode = randomMode();
+        Map<String, Object> resp = toMap(runSql(query("SHOW COLUMNS FROM test").fetchSize(1).mode(mode)), mode);
+
+        // without compression, the cursor is at least <avg. fieldname length> * 1000 bytes (effectively ~35kb)
+        assertThat(resp.get("cursor").toString().length(), lessThan(5000));
+    }
+
     static Map<String, Object> runSql(RequestObjectBuilder builder, String mode) throws IOException {
         return toMap(runSql(builder.mode(mode)), mode);
     }
-
+ 
     static Response runSql(RequestObjectBuilder builder) throws IOException {
         return runSqlAsTextWithFormat(builder, null);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamInput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamInput.java
@@ -8,11 +8,14 @@
 package org.elasticsearch.xpack.sql.common.io;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Base64;
@@ -30,7 +33,10 @@ public class SqlStreamInput extends NamedWriteableAwareStreamInput {
     }
 
     public SqlStreamInput(byte[] input, NamedWriteableRegistry namedWriteableRegistry, Version version) throws IOException {
-        super(StreamInput.wrap(input), namedWriteableRegistry);
+        super(
+            new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(new ByteArrayInputStream(input))),
+            namedWriteableRegistry
+        );
 
         // version check first
         Version ver = Version.readVersion(delegate);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamInput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamInput.java
@@ -34,11 +34,8 @@ public class SqlStreamInput extends NamedWriteableAwareStreamInput {
             throw new SqlIllegalArgumentException("Unsupported cursor version [{}], expected [{}]", inVersion, version);
         }
 
-        boolean compressed = in.readBoolean();
-        if (compressed) {
-            in = new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(in));
-        }
-        return new SqlStreamInput(in, namedWriteableRegistry, inVersion);
+        InputStreamStreamInput uncompressingIn = new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(in));
+        return new SqlStreamInput(uncompressingIn, namedWriteableRegistry, inVersion);
     }
 
     private final ZoneId zoneId;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.sql.common.io;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 
 import java.io.ByteArrayOutputStream;
@@ -25,9 +26,8 @@ public class SqlStreamOutput extends OutputStreamStreamOutput {
     }
 
     private SqlStreamOutput(ByteArrayOutputStream bytes, Version version, ZoneId zoneId) throws IOException {
-        super(Base64.getEncoder().wrap(new OutputStreamStreamOutput(bytes)));
+        super(new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(Base64.getEncoder().wrap(bytes))));
         this.bytes = bytes;
-
         Version.writeVersion(version, this);
         writeZoneId(zoneId);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
@@ -9,34 +9,88 @@ package org.elasticsearch.xpack.sql.common.io;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
 import java.time.ZoneId;
 import java.util.Base64;
 
-public class SqlStreamOutput extends OutputStreamStreamOutput {
+/**
+ * Output stream for writing SQL cursors. The output is compressed if it would become larger than {@code compressionThreshold}
+ * bytes otherwise (see {@code DEFAULT_COMPRESSION_THRESHOLD}).
+ */
+public class SqlStreamOutput extends StreamOutput {
 
-    private final ByteArrayOutputStream bytes;
+    public static final byte HEADER_UNCOMPRESSED = 0;
+    public static final byte HEADER_COMPRESSED = 1;
+    private static final int DEFAULT_COMPRESSION_THRESHOLD = 1000;
+
+    private ByteArrayOutputStream bytes;
+    private OutputStream out;
+    private boolean compressing;
+    private final int compressionThreshold;
 
     public SqlStreamOutput(Version version, ZoneId zoneId) throws IOException {
-        this(new ByteArrayOutputStream(), version, zoneId);
+        this(version, zoneId, DEFAULT_COMPRESSION_THRESHOLD);
     }
 
-    private SqlStreamOutput(ByteArrayOutputStream bytes, Version version, ZoneId zoneId) throws IOException {
-        super(new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(Base64.getEncoder().wrap(bytes))));
-        this.bytes = bytes;
+    public SqlStreamOutput(Version version, ZoneId zoneId, int compressionThreshold) throws IOException {
+        this.bytes = new ByteArrayOutputStream();
+        this.out = bytes;
+        this.compressing = false;
+        this.compressionThreshold = compressionThreshold;
         Version.writeVersion(version, this);
-        writeZoneId(zoneId);
+        this.writeZoneId(zoneId);
+    }
+
+    @Override
+    public void writeByte(byte b) throws IOException {
+        out.write(b);
+        maybeSwitchToCompression();
+    }
+
+    @Override
+    public void writeBytes(byte[] b, int offset, int length) throws IOException {
+        out.write(b, offset, length);
+        maybeSwitchToCompression();
+    }
+
+    private void maybeSwitchToCompression() throws IOException {
+        if (compressing == false && bytes.size() > compressionThreshold) {
+            ByteArrayOutputStream oldBytes = bytes;
+            bytes = new ByteArrayOutputStream(bytes.size());
+            out = CompressorFactory.COMPRESSOR.threadLocalOutputStream(bytes);
+            out.write(oldBytes.toByteArray());
+            compressing = true;
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     /**
      * Should be called _after_ closing the stream - there are no guarantees otherwise.
      */
     public String streamAsString() {
-        // Base64 uses this encoding instead of UTF-8
-        return bytes.toString(StandardCharsets.ISO_8859_1);
+        byte header = compressing ? HEADER_COMPRESSED : HEADER_UNCOMPRESSED;
+        byte[] bytesWithHeader = new byte[bytes.size() + 1];
+        bytesWithHeader[0] = header;
+        System.arraycopy(bytes.toByteArray(), 0, bytesWithHeader, 1, bytes.size());
+        return Base64.getEncoder().encodeToString(bytesWithHeader);
     }
+
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
@@ -26,8 +26,6 @@ import java.util.Base64;
  */
 public class SqlStreamOutput extends StreamOutput {
 
-    public static final byte HEADER_UNCOMPRESSED = 0;
-    public static final byte HEADER_COMPRESSED = 1;
     private static final int DEFAULT_COMPRESSION_THRESHOLD = 1000;
 
     private Version version;
@@ -94,7 +92,7 @@ public class SqlStreamOutput extends StreamOutput {
         ByteArrayOutputStream bytesWithHeader = new ByteArrayOutputStream();
         StreamOutput out = new OutputStreamStreamOutput(bytesWithHeader);
         Version.writeVersion(version, out);
-        out.writeByte(compressing ? HEADER_COMPRESSED : HEADER_UNCOMPRESSED);
+        out.writeBoolean(compressing);
         out.writeBytes(bytes.toByteArray());
         return Base64.getEncoder().encodeToString(bytesWithHeader.toByteArray());
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
@@ -91,7 +91,7 @@ public final class Cursors {
         if (base64.isEmpty()) {
             return new Tuple<>(Cursor.EMPTY, null);
         }
-        try (SqlStreamInput in = new SqlStreamInput(base64, WRITEABLE_REGISTRY, VERSION)) {
+        try (SqlStreamInput in = SqlStreamInput.fromString(base64, WRITEABLE_REGISTRY, VERSION)) {
             Cursor cursor = in.readNamedWriteable(Cursor.class);
             return new Tuple<>(cursor, in.zoneId());
         } catch (IOException ex) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
@@ -74,7 +74,7 @@ public final class Cursors {
         if (info == Cursor.EMPTY) {
             return StringUtils.EMPTY;
         }
-        try (SqlStreamOutput output = new SqlStreamOutput(version, zoneId)) {
+        try (SqlStreamOutput output = SqlStreamOutput.create(version, zoneId)) {
             output.writeNamedWriteable(info);
             output.close();
             // return the string only after closing the resource

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.sql;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireTestCase;
@@ -23,14 +22,12 @@ public abstract class AbstractSqlWireSerializingTestCase<T extends Writeable> ex
 
     @Override
     protected T copyInstance(T instance, Version version) throws IOException {
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            ZoneId zoneId = instanceZoneId(instance);
-            SqlStreamOutput out = new SqlStreamOutput(version, zoneId);
-            instance.writeTo(out);
-            out.close();
-            try (SqlStreamInput in = new SqlStreamInput(out.streamAsString(), getNamedWriteableRegistry(), version)) {
-                return instanceReader().read(in);
-            }
+        ZoneId zoneId = instanceZoneId(instance);
+        SqlStreamOutput out = new SqlStreamOutput(version, zoneId);
+        instance.writeTo(out);
+        out.close();
+        try (SqlStreamInput in = SqlStreamInput.fromString(out.streamAsString(), getNamedWriteableRegistry(), version)) {
+            return instanceReader().read(in);
         }
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
@@ -23,7 +23,7 @@ public abstract class AbstractSqlWireSerializingTestCase<T extends Writeable> ex
     @Override
     protected T copyInstance(T instance, Version version) throws IOException {
         ZoneId zoneId = instanceZoneId(instance);
-        SqlStreamOutput out = new SqlStreamOutput(version, zoneId);
+        SqlStreamOutput out = SqlStreamOutput.create(version, zoneId);
         instance.writeTo(out);
         out.close();
         try (SqlStreamInput in = SqlStreamInput.fromString(out.streamAsString(), getNamedWriteableRegistry(), version)) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/common/io/SqlStreamTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/common/io/SqlStreamTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.common.io;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+public class SqlStreamTests extends ESTestCase {
+
+    public void testWriteAndRead() throws IOException {
+        BytesRef payload = new BytesRef(randomByteArrayOfLength(randomIntBetween(10, 1000)));
+        int threshold = randomIntBetween(10, 1000);
+
+        SqlStreamOutput out = new SqlStreamOutput(Version.CURRENT, randomZone(), threshold);
+        out.writeBytesRef(payload);
+        out.close();
+        String encoded = out.streamAsString();
+
+        SqlStreamInput in = SqlStreamInput.fromString(encoded, new NamedWriteableRegistry(List.of()), Version.CURRENT);
+        BytesRef read = in.readBytesRef();
+
+        assertArrayEquals(payload.bytes, read.bytes);
+    }
+
+    public void testSmallPayloadIsUncompressed() throws IOException {
+        SqlStreamOutput out = new SqlStreamOutput(Version.CURRENT, randomZone(), 1000);
+        writeUniformPayload(out, 200);
+        out.close();
+
+        String result = out.streamAsString();
+        assertThat(result.length(), greaterThan(200));
+    }
+
+    public void testSmallPayloadIsCompressedWhenUsingLowThreshold() throws IOException {
+        SqlStreamOutput out = new SqlStreamOutput(Version.CURRENT, randomZone(), 200);
+        writeUniformPayload(out, 200);
+        out.close();
+
+        String result = out.streamAsString();
+        assertThat(result.length(), lessThan(200));
+    }
+
+    public void testLargePayloadIsCompressed() throws IOException {
+        SqlStreamOutput out = new SqlStreamOutput(Version.CURRENT, randomZone(), 1000);
+        writeUniformPayload(out, 1000);
+        out.close();
+
+        String result = out.streamAsString();
+        assertThat(result.length(), lessThan(1000));
+    }
+
+    private void writeUniformPayload(StreamOutput out, int length) throws IOException {
+        byte[] payload = new byte[length];
+        Arrays.fill(payload, (byte) 0);
+        out.write(payload);
+    }
+
+    public void testOldCursorProducesVersionMismatchError() {
+        SqlIllegalArgumentException ex = expectThrows(
+            SqlIllegalArgumentException.class,
+            () -> SqlStreamInput.fromString(
+                // some cursor produced by ES 7.15.1
+                "97S0AwFaAWMBCHRlc3RfZW1whgEBAQljb21wb3NpdGUHZ3JvdXBieQEDbWF4CDJkMTBjNGJhAAD/AQls"
+                    + "YW5ndWFnZXMAAAD/AAD/AQAIYmRlZjg4ZTUBBmdlbmRlcgAAAQAAAQEKAQhiZGVmODhlNf8AAgEAAAAA"
+                    + "AP////8PAAAAAAAAAAAAAAAAAVoDAAICAAAAAAAAAAAKAP////8PAgFtCDJkMTBjNGJhBXZhbHVlAAEE"
+                    + "QllURQFrCGJkZWY4OGU1AAABAwA=",
+                new NamedWriteableRegistry(List.of()),
+                Version.V_8_2_0
+            )
+        );
+
+        assertThat(ex.getMessage(), containsString("Unsupported cursor version [7.15.1], expected [8.2.0]"));
+    }
+
+    public void testVersionCanBeReadByOldNodes() throws IOException {
+        Version version = randomFrom(Version.V_7_0_0, Version.V_7_2_1, Version.V_8_1_0);
+        SqlStreamOutput out = new SqlStreamOutput(version, randomZone());
+        out.writeString("payload");
+        out.close();
+        String encoded = out.streamAsString();
+
+        byte[] bytes = Base64.getDecoder().decode(encoded);
+        InputStreamStreamInput in = new InputStreamStreamInput(new ByteArrayInputStream(bytes));
+
+        assertEquals(version, Version.readVersion(in));
+    }
+
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
@@ -30,7 +30,7 @@ public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingT
         }
 
         return new CompositeAggCursor(
-            new byte[randomInt(256)],
+            new byte[randomInt(1024)],
             extractors,
             randomBitSet(extractorsSize),
             randomIntBetween(10, 1024),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ListCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ListCursorTests.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class ListCursorTests extends AbstractSqlWireSerializingTestCase<ListCursor> {
     public static ListCursor randomPagingListCursor() {
-        int size = between(1, 20);
+        int size = between(1, 100);
         int depth = between(1, 20);
 
         List<List<?>> values = new ArrayList<>(size);


### PR DESCRIPTION
Partially addresses #83284

It looks like compressing cursors is a low hanging fruit to address issues around cursor size that seems to pay off pretty nicely (thanks @costin for the pointer). This is especially relevant for queries using the `ListCursor` (e.g. `SHOW COLUMNS` or queries sorting on aggregated columns) but might also benefit queries that store `SearchSourceBuilder` in the cursor.

Some anecdata for the potential savings in cursor size with `big` being an index with 1000 long fields `field1`, `field2`, ...:

| Request | Cursor size before | after | % |
|---------|--------------------|-----|----|
| `http post "localhost:9200/_sql?format=txt" query="SHOW COLUMNS IN big" fetch_size=1` | 34528b | 3208b | 9% |
| `http post "localhost:9200/_sql?format=csv" query="SHOW COLUMNS IN big" fetch_size=1` | 34508b | 3188b | 9% |
| `http post "localhost:9200/_sql?format=txt" query="SHOW COLUMNS IN test_emp" fetch_size=1` | 720b | 336b | 47% |
| `http post "localhost:9200/_sql?format=txt" query="SELECT emp_no, COUNT(*) FROM test_emp GROUP BY 1 ORDER BY 2" fetch_size=1` | 2672b | 352b | 13% |
| `http post "localhost:9201/_sql?format=csv" query="select max(languages), gender from test_emp group by 2" fetch_size=1` | 268b | 224b | 84% |

The format only has an impact on cursor size for the `txt` format. Hence, I'd also expect similar savings for the binary protocols.