### PR TITLE
Add information about removable settings to the deprecation info API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -66,8 +65,6 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
     private final String details;
     private final boolean resolveDuringRollingUpgrade;
     private final Map<String, Object> meta;
-    private final boolean canBeFixedByRemovingDynamicSetting;
-    private final List<String> settingNames;
 
     public DeprecationIssue(
         Level level,
@@ -77,27 +74,12 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         boolean resolveDuringRollingUpgrade,
         @Nullable Map<String, Object> meta
     ) {
-        this(level, message, url, details, resolveDuringRollingUpgrade, meta, false, null);
-    }
-
-    public DeprecationIssue(
-        Level level,
-        String message,
-        String url,
-        @Nullable String details,
-        boolean resolveDuringRollingUpgrade,
-        @Nullable Map<String, Object> meta,
-        boolean canBeFixedByRemovingDynamicSetting,
-        @Nullable List<String> settingNames
-    ) {
         this.level = level;
         this.message = message;
         this.url = url;
         this.details = details;
         this.resolveDuringRollingUpgrade = resolveDuringRollingUpgrade;
         this.meta = meta;
-        this.canBeFixedByRemovingDynamicSetting = canBeFixedByRemovingDynamicSetting;
-        this.settingNames = settingNames;
     }
 
     public DeprecationIssue(StreamInput in) throws IOException {
@@ -107,8 +89,6 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         details = in.readOptionalString();
         resolveDuringRollingUpgrade = in.getVersion().onOrAfter(Version.V_7_15_0) && in.readBoolean();
         meta = in.getVersion().onOrAfter(Version.V_7_14_0) ? in.readMap() : null;
-        canBeFixedByRemovingDynamicSetting = in.getVersion().onOrAfter(Version.V_7_17_0) && in.readBoolean();
-        settingNames = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalStringList() : null;
     }
 
     public Level getLevel() {
@@ -125,15 +105,6 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
 
     public String getDetails() {
         return details;
-    }
-
-    public boolean canBeFixedByRemovingDynamicSetting() {
-        return canBeFixedByRemovingDynamicSetting;
-    }
-
-    @Nullable
-    public List<String> getSettingNames() {
-        return settingNames;
     }
 
     /**
@@ -162,10 +133,6 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         }
         if (out.getVersion().onOrAfter(Version.V_7_14_0)) {
             out.writeMap(meta);
-        }
-        if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
-            out.writeBoolean(canBeFixedByRemovingDynamicSetting);
-            out.writeOptionalStringCollection(settingNames);
         }
     }
 
@@ -197,7 +164,6 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             && Objects.equals(details, that.details)
             && Objects.equals(resolveDuringRollingUpgrade, that.resolveDuringRollingUpgrade)
             && Objects.equals(meta, that.meta);
-//            && Objects.equals(canBeFixedByRemovingDynamicSetting, that.canBeFixedByRemovingDynamicSetting);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -209,7 +209,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         if (similarIssues.size() == 1) {
             return similarIssues.get(0);
         }
-        DeprecationIssue representativeIssue = similarIssues.stream().findAny().get();
+        DeprecationIssue representativeIssue = similarIssues.get(0);
         Optional<Meta> metaIntersection = similarIssues.stream()
             .map(DeprecationIssue::getMetaObject)
             .reduce(
@@ -254,7 +254,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             this.nonActionMetadata = nonActionMetadata;
         }
 
-        public static Meta fromRemovableSettings(List<String> removableSettings) {
+        private static Meta fromRemovableSettings(List<String> removableSettings) {
             List<Action> actions;
             if (removableSettings == null) {
                 actions = null;
@@ -264,7 +264,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             return new Meta(actions, Collections.emptyMap());
         }
 
-        public Map<String, Object> toMetaMap() {
+        private Map<String, Object> toMetaMap() {
             Map<String, Object> metaMap;
             if (actions != null) {
                 metaMap = new HashMap<>(nonActionMetadata);
@@ -282,7 +282,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
          * This method gets the intersection of this Meta with another. It assumes that the Meta objects are identical, except possibly the
          * contents of the removal actions. So the interection is a new Meta object with only the removal actions that appear in both.
          */
-        public Meta getIntersection(Meta another) {
+        private Meta getIntersection(Meta another) {
             final List<Action> actionsIntersection;
             if (actions != null && another.actions != null) {
                 List<Action> combinedActions = this.actions.stream()
@@ -320,7 +320,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
          * present.
          */
         @SuppressWarnings("unchecked")
-        public static Optional<Meta> fromMetaMap(Map<String, Object> metaMap) {
+        private static Optional<Meta> fromMetaMap(Map<String, Object> metaMap) {
             if (metaMap == null) {
                 return Optional.empty();
             }
@@ -371,7 +371,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         }
 
         @SuppressWarnings("unchecked")
-        public static RemovalAction fromActionMap(Map<String, Object> actionMap) {
+        private static RemovalAction fromActionMap(Map<String, Object> actionMap) {
             final List<String> removableSettings;
             Object removableSettingsObject = actionMap.get(OBJECTS_FIELD);
             if (removableSettingsObject == null) {
@@ -382,7 +382,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             return new RemovalAction(removableSettings);
         }
 
-        public Optional<List<String>> getRemovableSettings() {
+        private Optional<List<String>> getRemovableSettings() {
             return removableSettings == null ? Optional.empty() : Optional.of(removableSettings);
         }
 
@@ -410,7 +410,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             this.actionMap = actionMap;
         }
 
-        public static Action fromActionMap(Map<String, Object> actionMap) {
+        private static Action fromActionMap(Map<String, Object> actionMap) {
             return new UnknownAction(actionMap);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -213,8 +213,11 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         boolean hasSettingsThatNeedToBeDeleted = leastCommonRemovableSettingsDeleteSettingsTuple.v2();
         DeprecationIssue representativeIssue = similarIssues.get(0);
         Map<String, Object> representativeMeta = representativeIssue.getMeta();
-        final Map<String, Object> newMeta = buildNewMetaMap(representativeMeta, leastCommonRemovableSettings,
-            hasSettingsThatNeedToBeDeleted);
+        final Map<String, Object> newMeta = buildNewMetaMap(
+            representativeMeta,
+            leastCommonRemovableSettings,
+            hasSettingsThatNeedToBeDeleted
+        );
         return new DeprecationIssue(
             representativeIssue.level,
             representativeIssue.message,
@@ -232,8 +235,11 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
      * copy of the representative map.
      */
     @SuppressWarnings("unchecked")
-    private static Map<String, Object> buildNewMetaMap(Map<String, Object> representativeMeta, List<String> leastCommonRemovableSettings,
-                                                       boolean hasSettingsThatNeedToBeDeleted) {
+    private static Map<String, Object> buildNewMetaMap(
+        Map<String, Object> representativeMeta,
+        List<String> leastCommonRemovableSettings,
+        boolean hasSettingsThatNeedToBeDeleted
+    ) {
         final Map<String, Object> newMeta;
         if (representativeMeta != null) {
             newMeta = new HashMap<>(representativeMeta);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
@@ -18,6 +18,9 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue.Level;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
@@ -82,5 +85,55 @@ public class DeprecationIssueTests extends ESTestCase {
         Map<String, Object> meta = (Map<String, Object>) toXContentMap.get("_meta");
         DeprecationIssue other = new DeprecationIssue(Level.fromString(level), message, url, details, requiresRestart, meta);
         assertThat(issue, equalTo(other));
+    }
+
+    public void testGetIntersectionOfRemovableSettings() {
+        assertNull(DeprecationIssue.getIntersectionOfRemovableSettings(null));
+        assertNull(DeprecationIssue.getIntersectionOfRemovableSettings(Collections.emptyList()));
+        Map<String, Object> randomMeta = randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(4), randomAlphaOfLength(4)));
+        DeprecationIssue issue1 = createTestDeprecationIssue(getTestMetaMap(randomMeta, "setting.1", "setting.2", "setting.3"));
+        assertEquals(issue1, DeprecationIssue.getIntersectionOfRemovableSettings(Collections.singletonList(issue1)));
+        DeprecationIssue issue2 = createTestDeprecationIssue(issue1, getTestMetaMap(randomMeta, "setting.2"));
+        assertNotEquals(issue1, issue2);
+        assertEquals(issue2, DeprecationIssue.getIntersectionOfRemovableSettings(Arrays.asList(issue1, issue2)));
+        DeprecationIssue issue3 = createTestDeprecationIssue(issue1, getTestMetaMap(randomMeta, "setting.2", "setting.4"));
+        assertEquals(issue2, DeprecationIssue.getIntersectionOfRemovableSettings(Arrays.asList(issue1, issue2, issue3)));
+        DeprecationIssue issue4 = createTestDeprecationIssue(issue1, getTestMetaMap(randomMeta, "setting.5"));
+        DeprecationIssue emptySettingsIssue = createTestDeprecationIssue(issue1, getTestMetaMap(randomMeta));
+        assertEquals(
+            emptySettingsIssue,
+            DeprecationIssue.getIntersectionOfRemovableSettings(Arrays.asList(issue1, issue2, issue3, issue4))
+        );
+    }
+
+    private static Map<String, Object> getTestMetaMap(Map<String, Object> baseMap, String... settings) {
+        Map<String, Object> metaMap = new HashMap<>();
+        Map<String, Object> settingsMetaMap = DeprecationIssue.createMetaMapForRemovableSettings(Arrays.asList(settings));
+        metaMap.putAll(settingsMetaMap);
+        metaMap.putAll(baseMap);
+        return metaMap;
+    }
+
+    private static DeprecationIssue createTestDeprecationIssue(Map<String, Object> metaMap) {
+        String details = randomBoolean() ? randomAlphaOfLength(10) : null;
+        return new DeprecationIssue(
+            randomFrom(DeprecationIssue.Level.values()),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            details,
+            randomBoolean(),
+            metaMap
+        );
+    }
+
+    private static DeprecationIssue createTestDeprecationIssue(DeprecationIssue seedIssue, Map<String, Object> metaMap) {
+        return new DeprecationIssue(
+            seedIssue.getLevel(),
+            seedIssue.getMessage(),
+            seedIssue.getUrl(),
+            seedIssue.getDetails(),
+            seedIssue.isResolveDuringRollingUpgrade(),
+            metaMap
+        );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
@@ -110,7 +110,9 @@ public class DeprecationIssueTests extends ESTestCase {
 
     private static Map<String, Object> getTestMetaMap(Map<String, Object> baseMap, String... settings) {
         Map<String, Object> metaMap = new HashMap<>();
-        Map<String, Object> settingsMetaMap = DeprecationIssue.createMetaMapForRemovableSettings(Arrays.asList(settings));
+        Map<String, Object> settingsMetaMap = DeprecationIssue.createMetaMapForRemovableSettings(
+            settings.length == 0 ? null : Arrays.asList(settings)
+        );
         metaMap.putAll(settingsMetaMap);
         metaMap.putAll(baseMap);
         return metaMap;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssueTests.java
@@ -104,6 +104,8 @@ public class DeprecationIssueTests extends ESTestCase {
             emptySettingsIssue,
             DeprecationIssue.getIntersectionOfRemovableSettings(Arrays.asList(issue1, issue2, issue3, issue4))
         );
+        DeprecationIssue issue5 = createTestDeprecationIssue(getTestMetaMap(randomMeta, "setting.1", "setting.2", "setting.3"));
+        assertEquals(issue1, DeprecationIssue.getIntersectionOfRemovableSettings(Arrays.asList(issue1, issue5)));
     }
 
     private static Map<String, Object> getTestMetaMap(Map<String, Object> baseMap, String... settings) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -74,7 +73,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 issueListMap.computeIfAbsent(issue, (key) -> new ArrayList<>()).add(resp.getNode().getName());
             }
         }
-//TODO: if some nodes have a setting in elasticsearch.yml and some don't, don't set canBeFixedByRemovingDynamicSetting to true
+
         return issueListMap.entrySet().stream().map(entry -> {
             DeprecationIssue issue = entry.getKey();
             String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
@@ -84,9 +83,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 issue.getUrl(),
                 details + "(nodes impacted: " + entry.getValue() + ")",
                 issue.isResolveDuringRollingUpgrade(),
-                issue.getMeta(),
-                issue.canBeFixedByRemovingDynamicSetting(),
-                issue.getSettingNames()
+                issue.getMeta()
             );
         }).collect(Collectors.toList());
     }
@@ -168,22 +165,12 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            String[] autoRemovableSettings = Stream.concat(clusterSettingsIssues.stream(), nodeSettingsIssues.stream())
-                .filter(deprecationIssue -> deprecationIssue.canBeFixedByRemovingDynamicSetting())
-                .map(deprecationIssue -> deprecationIssue.getSettingNames()).flatMap(List::stream).toArray(String[]::new);
             return builder.startObject()
                 .array("cluster_settings", clusterSettingsIssues.toArray())
                 .array("node_settings", nodeSettingsIssues.toArray())
                 .field("index_settings")
                 .map(indexSettingsIssues)
                 .mapContents(pluginSettingsIssues)
-                .startObject("_meta")
-                    .startObject("actions")
-                        .startObject("remove_settings")
-                            .array("settings", autoRemovableSettings)
-                        .endObject()
-                    .endObject()
-                .endObject()
                 .endObject();
         }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -76,9 +77,35 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
      * @return
      */
     private static List<DeprecationIssue> mergeNodeIssues(NodesDeprecationCheckResponse response) {
-        // A map whose values are lists of DeprecationIssues that differ only by meta values (if that):
+        // A collection whose values are lists of DeprecationIssues that differ only by meta values (if that):
+        Collection<List<Tuple<DeprecationIssue, String>>> issuesToMerge = getDeprecationIssuesThatDifferOnlyByMeta(response.getNodes());
+        // A map of DeprecationIssues (containing only the intersection of removable settings) to the nodes they are seen on
+        Map<DeprecationIssue, List<String>> issueToListOfNodesMap = getMergedIssuesToNodesMap(issuesToMerge);
+
+        return issueToListOfNodesMap.entrySet().stream().map(entry -> {
+            DeprecationIssue issue = entry.getKey();
+            String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
+            return new DeprecationIssue(
+                issue.getLevel(),
+                issue.getMessage(),
+                issue.getUrl(),
+                details + "(nodes impacted: " + entry.getValue() + ")",
+                issue.isResolveDuringRollingUpgrade(),
+                issue.getMeta()
+            );
+        }).collect(Collectors.toList());
+    }
+
+    /*
+     * This method pulls all of the DeprecationIssues from the given nodeResponses, and buckets them into lists of DeprecationIssues that
+     * differ at most by meta values (if that). The returned tuples also contain the node name the deprecation issue was found on. If all
+     * nodes in the cluster were configured identically then all tuples in a list will differ only by the node name.
+     */
+    private static Collection<List<Tuple<DeprecationIssue, String>>> getDeprecationIssuesThatDifferOnlyByMeta(
+        List<NodesDeprecationCheckAction.NodeResponse> nodeResponses
+    ) {
         Map<DeprecationIssue, List<Tuple<DeprecationIssue, String>>> issuesToMerge = new HashMap<>();
-        for (NodesDeprecationCheckAction.NodeResponse resp : response.getNodes()) {
+        for (NodesDeprecationCheckAction.NodeResponse resp : nodeResponses) {
             for (DeprecationIssue issue : resp.getDeprecationIssues()) {
                 issuesToMerge.computeIfAbsent(
                     new DeprecationIssue(
@@ -93,28 +120,27 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 ).add(new Tuple<>(issue, resp.getNode().getName()));
             }
         }
-        // A map of DeprecationIssues (containing only the intersection of removable settings) to the nodes they are seen on
+        return issuesToMerge.values();
+    }
+
+    /*
+     * At this point we have one DeprecationIssue per node for a given deprecation. This method rolls them up into a single DeprecationIssue
+     * with a list of nodes that they appear on. If two DeprecationIssues on two different nodes differ only by the set of removable
+     * settings (i.e. they have different elasticsearch.yml configurations) then this method takes the intersection of those settings when
+     * it rolls them up.
+     */
+    private static Map<DeprecationIssue, List<String>> getMergedIssuesToNodesMap(
+        Collection<List<Tuple<DeprecationIssue, String>>> issuesToMerge
+    ) {
         Map<DeprecationIssue, List<String>> issueToListOfNodesMap = new HashMap<>();
-        for (List<Tuple<DeprecationIssue, String>> similarIssues : issuesToMerge.values()) {
+        for (List<Tuple<DeprecationIssue, String>> similarIssues : issuesToMerge) {
             DeprecationIssue leastCommonDenominator = DeprecationIssue.getIntersectionOfRemovableSettings(
                 similarIssues.stream().map(Tuple::v1).collect(Collectors.toList())
             );
             issueToListOfNodesMap.computeIfAbsent(leastCommonDenominator, (key) -> new ArrayList<>())
                 .addAll(similarIssues.stream().map(Tuple::v2).collect(Collectors.toList()));
         }
-
-        return issueToListOfNodesMap.entrySet().stream().map(entry -> {
-            DeprecationIssue issue = entry.getKey();
-            String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
-            return new DeprecationIssue(
-                issue.getLevel(),
-                issue.getMessage(),
-                issue.getUrl(),
-                details + "(nodes impacted: " + entry.getValue() + ")",
-                issue.isResolveDuringRollingUpgrade(),
-                issue.getMeta()
-            );
-        }).collect(Collectors.toList());
+        return issueToListOfNodesMap;
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -66,15 +67,43 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         return checks.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
+    /**
+     * This method rolls up DeprecationIssues that are identical but on different nodes. It also roles up DeprecationIssues that are
+     * identical (and on different nodes) except that they differ in the removable settings listed in their meta object. We roll these up
+     * by taking the intersection of all removable settings in otherwise identical DeprecationIssues. That way we don't claim that a
+     * setting can be automatically removed if any node has it in its elasticsearch.yml.
+     * @param response
+     * @return
+     */
     private static List<DeprecationIssue> mergeNodeIssues(NodesDeprecationCheckResponse response) {
-        Map<DeprecationIssue, List<String>> issueListMap = new HashMap<>();
+        // A map whose values are lists of DeprecationIssues that differ only by meta values (if that):
+        Map<DeprecationIssue, List<Tuple<DeprecationIssue, String>>> issuesToMerge = new HashMap<>();
         for (NodesDeprecationCheckAction.NodeResponse resp : response.getNodes()) {
             for (DeprecationIssue issue : resp.getDeprecationIssues()) {
-                issueListMap.computeIfAbsent(issue, (key) -> new ArrayList<>()).add(resp.getNode().getName());
+                issuesToMerge.computeIfAbsent(
+                    new DeprecationIssue(
+                        issue.getLevel(),
+                        issue.getMessage(),
+                        issue.getUrl(),
+                        issue.getDetails(),
+                        issue.isResolveDuringRollingUpgrade(),
+                        null // Intentionally removing meta from the key so that it's not taken into account for equality
+                    ),
+                    (key) -> new ArrayList<>()
+                ).add(new Tuple<>(issue, resp.getNode().getName()));
             }
         }
+        // A map of DeprecationIssues (containing only the intersection of removable settings) to the nodes they are seen on
+        Map<DeprecationIssue, List<String>> issueToListOfNodesMap = new HashMap<>();
+        for (List<Tuple<DeprecationIssue, String>> similarIssues : issuesToMerge.values()) {
+            DeprecationIssue leastCommonDenominator = DeprecationIssue.getIntersectionOfRemovableSettings(
+                similarIssues.stream().map(Tuple::v1).collect(Collectors.toList())
+            );
+            issueToListOfNodesMap.computeIfAbsent(leastCommonDenominator, (key) -> new ArrayList<>())
+                .addAll(similarIssues.stream().map(Tuple::v2).collect(Collectors.toList()));
+        }
 
-        return issueListMap.entrySet().stream().map(entry -> {
+        return issueToListOfNodesMap.entrySet().stream().map(entry -> {
             DeprecationIssue issue = entry.getKey();
             String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
             return new DeprecationIssue(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -577,9 +577,10 @@ class NodeDeprecationChecks {
     private static Map<String, Object> createMetaMapForRemovableSettings(boolean canAutoRemoveSetting, List<String> removableSettings) {
         final Map<String, Object> meta;
         if (canAutoRemoveSetting) {
-            Map<String, List<String>> settingsMap = Collections.singletonMap("settings", removableSettings);
-            Map<String, Map<String, List<String>>> removeSettingsMap = Collections.singletonMap("remove_settings", settingsMap);
-            meta = Collections.singletonMap("actions", removeSettingsMap);
+            Map<String, Object> actionsMap = new HashMap<>();
+            actionsMap.put("action_type", "remove_settings");
+            actionsMap.put("objects", removableSettings);
+            meta = Collections.singletonMap("actions", Collections.singletonList(actionsMap));
         } else {
             meta = null;
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -575,16 +575,7 @@ class NodeDeprecationChecks {
     }
 
     private static Map<String, Object> createMetaMapForRemovableSettings(boolean canAutoRemoveSetting, List<String> removableSettings) {
-        final Map<String, Object> meta;
-        if (canAutoRemoveSetting) {
-            Map<String, Object> actionsMap = new HashMap<>();
-            actionsMap.put("action_type", "remove_settings");
-            actionsMap.put("objects", removableSettings);
-            meta = Collections.singletonMap("actions", Collections.singletonList(actionsMap));
-        } else {
-            meta = null;
-        }
-        return meta;
+        return canAutoRemoveSetting ? DeprecationIssue.createMetaMapForRemovableSettings(removableSettings) : null;
     }
 
     static DeprecationIssue checkRemovedSetting(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -1502,31 +1502,24 @@ class NodeDeprecationChecks {
             .distinct()
             .map(key -> key + "*")
             .collect(Collectors.joining(","));
-        // The actual group setting that are present in the settings object, with full setting name prepended.
-        // String allSubSettings = deprecatedConcreteSettings.stream().map(affixSetting -> {
-        // String groupPrefix = affixSetting.getKey();
-        // Settings groupSettings = affixSetting.get(settings);
-        // Set<String> subSettings = groupSettings.keySet();
-        // return subSettings.stream().map(key -> groupPrefix + key).collect(Collectors.joining(","));
-        // }).collect(Collectors.joining(";"));
-
+        // The actual group setting that are present in the settings objects, with full setting name prepended.
         List<String> allNodeSubSettingKeys = deprecatedConcreteNodeSettings.stream().map(affixSetting -> {
             String groupPrefix = affixSetting.getKey();
             Settings groupSettings = affixSetting.get(nodeSettings);
             Set<String> subSettings = groupSettings.keySet();
             return subSettings.stream().map(key -> groupPrefix + key).collect(Collectors.toList());
-        }).flatMap(List::stream).collect(Collectors.toList());
+        }).flatMap(List::stream).sorted().collect(Collectors.toList());
 
         List<String> allClusterSubSettingKeys = deprecatedConcreteClusterSettings.stream().map(affixSetting -> {
             String groupPrefix = affixSetting.getKey();
             Settings groupSettings = affixSetting.get(clusterSettings);
             Set<String> subSettings = groupSettings.keySet();
             return subSettings.stream().map(key -> groupPrefix + key).collect(Collectors.toList());
-        }).flatMap(List::stream).collect(Collectors.toList());
+        }).flatMap(List::stream).sorted().collect(Collectors.toList());
 
-        // TODO: This used to use commas and semicolons
         final String allSubSettings = Stream.concat(allNodeSubSettingKeys.stream(), allClusterSubSettingKeys.stream())
             .distinct()
+            .sorted()
             .collect(Collectors.joining(","));
 
         final String message = String.format(

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -2224,7 +2224,6 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public void testDynamicSettings() throws JsonProcessingException {
         Settings clusterSettings = Settings.builder()
             .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), randomInt())
@@ -2262,6 +2261,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> buildMetaObjectForRemovableSettings(String... settingNames) throws JsonProcessingException {
         String settingNamesString = Arrays.stream(settingNames)
             .map(settingName -> "\"" + settingName + "\"")

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -2233,7 +2233,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         Collection<Setting<?>> deprecatedSettings = Set.of(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING);
-        String metaString = "{\"actions\":{\"remove_settings\":{\"settings\":[\"discovery.zen.minimum_master_nodes\"]}}}";
+        String metaString = "{\"actions\": [{\"action_type\": \"remove_settings\", \"objects\":[\"discovery.zen.minimum_master_nodes\"]}]}";
         Map<String, Object> meta = new ObjectMapper().readValue(metaString, Map.class);
         for (Setting<?> deprecatedSetting : deprecatedSettings) {
             final DeprecationIssue expected = new DeprecationIssue(

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -2036,7 +2036,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         Settings settings = Settings.builder().put("xpack.monitoring.exporters.test.use_ingest", true).build();
 
         List<DeprecationIssue> issues = Collections.singletonList(
-            NodeDeprecationChecks.checkExporterUseIngestPipelineSettings(settings, null, null, null)
+            NodeDeprecationChecks.checkExporterUseIngestPipelineSettings(settings, null, ClusterState.EMPTY_STATE, null)
         );
 
         final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-exporter-use-ingest-setting";
@@ -2061,7 +2061,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .build();
 
         List<DeprecationIssue> issues = Collections.singletonList(
-            NodeDeprecationChecks.checkExporterPipelineMasterTimeoutSetting(settings, null, null, null)
+            NodeDeprecationChecks.checkExporterPipelineMasterTimeoutSetting(settings, null, ClusterState.EMPTY_STATE, null)
         );
 
         final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-exporter-pipeline-timeout-setting";
@@ -2085,7 +2085,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         Settings settings = Settings.builder().put("xpack.monitoring.exporters.test.index.template.create_legacy_templates", true).build();
 
         List<DeprecationIssue> issues = Collections.singletonList(
-            NodeDeprecationChecks.checkExporterCreateLegacyTemplateSetting(settings, null, null, null)
+            NodeDeprecationChecks.checkExporterCreateLegacyTemplateSetting(settings, null, ClusterState.EMPTY_STATE, null)
         );
 
         final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-exporter-create-legacy-template-setting";

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -1892,7 +1892,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                     DeprecationIssue.Level.WARNING,
                     "The [" + settingKey1 + ".*," + settingKey2 + ".*] settings are deprecated and will be removed after 8.0",
                     expectedUrl,
-                    "Remove the following settings: [" + subSettingKey1 + "," + subSetting1Key2 + "," + subSetting2Key2+ "]",
+                    "Remove the following settings: [" + subSettingKey1 + "," + subSetting1Key2 + "," + subSetting2Key2 + "]",
                     false,
                     meta
                 )
@@ -2263,8 +2263,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     }
 
     private Map<String, Object> buildMetaObjectForRemovableSettings(String... settingNames) throws JsonProcessingException {
-        String settingNamesString =
-            Arrays.stream(settingNames).map(settingName -> "\"" + settingName + "\"").collect(Collectors.joining(","));
+        String settingNamesString = Arrays.stream(settingNames)
+            .map(settingName -> "\"" + settingName + "\"")
+            .collect(Collectors.joining(","));
         String metaString = "{\"actions\": [{\"action_type\": \"remove_settings\", \"objects\":[" + settingNamesString + "]}]}";
         return new ObjectMapper().readValue(metaString, Map.class);
     }


### PR DESCRIPTION
Deprecated settings that are only set dynamically (i.e. not in elasticsearch.yml) could also be removed dynamically. This
PR adds information about these settings to the deprecation info API.
Closes #83116