### PR TITLE
[8.1] [DOCS] Remove major release references from migration guide (#83555)

### DIFF
--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -21,13 +21,6 @@ and prevent them from operating normally.
 Before upgrading to ${majorDotMinor}, review these changes and take the described steps
 to mitigate the impact.
 
-NOTE: Breaking changes introduced in minor versions are
-normally limited to security and bug fixes.
-Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
-To find out if you are using any deprecated functionality,
-enable <<deprecation-logging, deprecation logging>>.
-
 <%
     [true, false].each { isNotable ->
         def breakingByArea = breakingByNotabilityByArea.getOrDefault(isNotable, [])
@@ -78,8 +71,6 @@ While this won't have an immediate impact on your applications,
 we strongly encourage you take the described steps to update your code
 after upgrading to ${majorDotMinor}.
 
-NOTE: Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.generateMigrationFile.asciidoc
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.generateMigrationFile.asciidoc
@@ -21,13 +21,6 @@ and prevent them from operating normally.
 Before upgrading to 8.4, review these changes and take the described steps
 to mitigate the impact.
 
-NOTE: Breaking changes introduced in minor versions are
-normally limited to security and bug fixes.
-Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
-To find out if you are using any deprecated functionality,
-enable <<deprecation-logging, deprecation logging>>.
-
 // NOTE: The notable-breaking-changes tagged regions are re-used in the
 // Installation and Upgrade Guide
 // tag::notable-breaking-changes[]
@@ -99,8 +92,6 @@ While this won't have an immediate impact on your applications,
 we strongly encourage you take the described steps to update your code
 after upgrading to 8.4.
 
-NOTE: Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 

--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -5,19 +5,16 @@ This section discusses the changes that you need to be aware of to migrate
 your application to {version}. For more information about what's new in this
 release, see the <<release-highlights>> and <<es-release-notes>>.
 
-As {es} introduces new features and improves existing ones,
-the changes sometimes make older settings, APIs, and parameters obsolete.
-The obsolete functionality is typically deprecated in a minor release and
-removed in the subsequent major release.
-This enables applications to continue working unchanged
-across most minor version upgrades.
-Breaking changes introduced in minor releases are
-generally limited to critical security fixes
-and bug fixes that correct unintended behavior.
+As {es} introduces new features and improves existing ones, the changes
+sometimes make older settings, APIs, and parameters obsolete. We typically
+deprecate obsolete functionality as part of a release. If possible, we support
+the deprecated functionality for several subsequent releases before removing it.
+This enables applications to continue working unchanged while you prepare to
+migrate away from the deprecated functionality.
 
-To get the most out of {es} and facilitate future upgrades,
-we strongly encourage migrating
-away from using deprecated functionality as soon as possible.
+To get the most out of {es} and facilitate future upgrades, we strongly
+encourage migrating away from using deprecated functionality as soon as
+possible.
 
 To give you insight into what deprecated features you're using, {es}:
 

--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -20,13 +20,6 @@ and prevent them from operating normally.
 Before upgrading to 8.0, review these changes and take the described steps
 to mitigate the impact.
 
-NOTE: Breaking changes introduced in minor versions are
-normally limited to security and bug fixes.
-Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
-To find out if you are using any deprecated functionality,
-enable <<deprecation-logging, deprecation logging>>.
-
 include::migrate_8_0/cluster-node-setting-changes.asciidoc[]
 include::migrate_8_0/command-line-tool-changes.asciidoc[]
 include::migrate_8_0/index-setting-changes.asciidoc[]
@@ -52,8 +45,6 @@ While this won't have an immediate impact on your applications,
 we strongly encourage you take the described steps to update your code
 after upgrading to 8.0.
 
-NOTE: Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 

--- a/docs/reference/migration/migrate_8_1.asciidoc
+++ b/docs/reference/migration/migrate_8_1.asciidoc
@@ -21,16 +21,10 @@ and prevent them from operating normally.
 Before upgrading to 8.1, review these changes and take the described steps
 to mitigate the impact.
 
-NOTE: Breaking changes introduced in minor versions are
-normally limited to security and bug fixes.
-Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
-To find out if you are using any deprecated functionality,
-enable <<deprecation-logging, deprecation logging>>.
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
 
-// NOTE: The notable-breaking-changes tagged regions are re-used in the
-// Installation and Upgrade Guide
-// tag::notable-breaking-changes[]
+//tag::notable-breaking-changes[]
 [discrete]
 [[breaking_81_rest_api_changes]]
 ==== REST API changes
@@ -62,8 +56,6 @@ While this won't have an immediate impact on your applications,
 we strongly encourage you take the described steps to update your code
 after upgrading to 8.1.
 
-NOTE: Significant changes in behavior are deprecated in a minor release and
-the old behavior is supported until the next major release.
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #83555

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)