### PR TITLE
[8.1] [DOCS] Clean up 8.0 deprecations (#83548)

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -96,33 +96,5 @@ user password is already configured.
 ====
 //end::notable-breaking-changes[]
 
-
-[[deprecate-max-merge-at-once-explicit-setting]]
-.The setting `max_merge_at_once_explicit` is deprecated.
-[%collapsible]
-====
-*Details* +
-The setting `max_merge_at_once_explicit` is removed in Lucene 9.
-
-
-*Impact* +
-Remove the setting `max_merge_at_once_explicit` from your
-configuration.
-====
-
-[[deprecate-indices-query-bool-max-clause-count-setting]]
-.The setting `indices.query.bool.max_clause_count` is deprecated.
-[%collapsible]
-====
-*Details* +
-The setting `indices.query.bool.max_clause_count` is deprecated. Instead,
-{es} configures the maximum clause count for Lucene based on the available
-heap and the size of the thread pool.
-
-*Impact* +
-Remove the setting `indices.query.bool.max_clause_count` from
-your configuration.
-====
-
 include::migrate_8_0/migrate_to_java_time.asciidoc[]
 include::transient-settings-migration-guide.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster-node-setting-changes.asciidoc
@@ -44,7 +44,7 @@ non-frozen node will result in an error on startup.
 ====
 
 [[max_clause_count_change]]
-.The `indices.query.bool.max_clause_count` setting has been deprecated, and no longer has any effect.
+.`indices.query.bool.max_clause_count` is deprecated and has no effect.
 [%collapsible]
 ====
 *Details* +
@@ -66,6 +66,10 @@ In previous versions of Lucene you could get around this limit by nesting
 boolean queries within each other, but the limit is now based on the total
 number of leaf queries within the query as a whole and this workaround will
 no longer help.
+
+Specifying `indices.query.bool.max_clause_count` will have no effect
+but will generate deprecation warnings. To avoid these warnings, remove the
+setting from `elasticsearch.yml` during an upgrade or node restart.
 ====
 
 [[ilm-poll-interval-limit]]

--- a/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
@@ -6,6 +6,41 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[deprecate-max-merge-at-once-explicit-setting]]
+.`index.merge.policy.max_merge_at_once_explicit` is deprecated and has no effect.
+[%collapsible]
+====
+*Details* +
+The `index.merge.policy.max_merge_at_once_explicit` index setting is deprecated
+and has no effect.
+
+Previously, you could specify `index.merge.policy.max_merge_at_once_explicit` to
+set the maximum number of segments to merge at the same time during a force
+merge or when expunging deleted documents. In 8.0, this number is unlimited,
+regardless of the setting.
+
+*Impact* +
+Specifying `index.merge.policy.max_merge_at_once_explicit` will have no effect
+but will generate deprecation warnings.
+
+To avoid these deprecation warnings, discontinue use of the setting. Don't
+specify the setting when creating new indices, and remove the setting from
+index and component templates.
+
+To remove the setting from an existing data stream or index, specify the
+setting's value as `null` using the update index settings API.
+
+[source,console]
+----
+PUT my-index-000001/_settings
+{
+  "index.merge.policy.max_merge_at_once_explicit": null
+}
+----
+// TEST[setup:my_index]
+
+====
+
 [[index-max-adjacency-matrix-filters-removed]]
 .The `index.max_adjacency_matrix_filters` index setting has been removed.
 [%collapsible]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #83548

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)