### PR TITLE
[DOCS] Add release highlight for REST API compatibility

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -16,6 +16,23 @@ For detailed information about this release, see the <<es-release-notes>> and
 
 // tag::notable-highlights[] 
 [discrete]
+=== 7.x REST API compatibility
+
+8.0 introduces several breaking changes to the {es} REST APIs. While it's
+important to update your application to account for these changes, finding and
+updating every API call in a single upgrade can be painful and error-prone. To
+make this process easier, we've added support for 7.x compatibility headers to
+our REST APIs. When provided, these optional headers let you make 7.x-compatible
+requests to an 8.0 cluster and receive 7.x-compatible responses.
+
+While we still recommend you update your application to use native 8.0 requests
+and responses, the 7.x API compatibility headers let you safely make these
+changes and over a longer period of time.
+
+For more information about the headers and how to use them, see
+{ref}/rest-api-compatibility.html[REST API compatibility].
+
+[discrete]
 === Security features are enabled and configured by default
 
 Running {es} without security leaves your cluster exposed to anyone who can send

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -22,8 +22,8 @@ For detailed information about this release, see the <<es-release-notes>> and
 important to update your application to account for these changes, finding and
 updating every API call in a single upgrade can be painful and error-prone. To
 make this process easier, we've added support for 7.x compatibility headers to
-our REST APIs. These optional headers let you make 7.x-compatible
-requests to an 8.0 cluster and receive 7.x-compatible responses.
+our REST APIs. In many cases, these optional headers let you make
+7.x-compatible requests to an 8.0 cluster and receive 7.x-compatible responses.
 
 While we still recommend you update your application to use native 8.0 requests
 and responses, the 7.x API compatibility headers let you safely make these

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -22,12 +22,12 @@ For detailed information about this release, see the <<es-release-notes>> and
 important to update your application to account for these changes, finding and
 updating every API call in a single upgrade can be painful and error-prone. To
 make this process easier, we've added support for 7.x compatibility headers to
-our REST APIs. When provided, these optional headers let you make 7.x-compatible
+our REST APIs. These optional headers let you make 7.x-compatible
 requests to an 8.0 cluster and receive 7.x-compatible responses.
 
 While we still recommend you update your application to use native 8.0 requests
 and responses, the 7.x API compatibility headers let you safely make these
-changes and over a longer period of time.
+changes over a longer period of time.
 
 For more information about the headers and how to use them, see
 {ref}/rest-api-compatibility.html[REST API compatibility].


### PR DESCRIPTION
Adds a release highlight for the 7.x REST API compatibility headers.

Relates to https://github.com/elastic/elasticsearch/issues/51816 and https://github.com/elastic/elasticsearch/pull/83487

### Preview
https://elasticsearch_83614.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.0/release-highlights.html#_7_x_rest_api_compatibility