### PR TITLE
[8.1] [DOCS] Link to the 7.17 upgrade assistant docs (#83613)

### DIFF
--- a/docs/reference/migration/migrate_8_0/migrate_to_java_time.asciidoc
+++ b/docs/reference/migration/migrate_8_0/migrate_to_java_time.asciidoc
@@ -30,7 +30,7 @@ Most custom date formats are compatible. However, several require
 an update.
 
 To see if your date format is impacted, use the <<migration-api-deprecation,deprecation info API>>
-or the {kibana-ref}/upgrade-assistant.html[Kibana upgrade assistant].
+or the {kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Kibana Upgrade Assistant].
 
 [discrete]
 [[java-time-migration-incompatible-date-formats]]

--- a/docs/reference/rest-api/rest-api-compatibility.asciidoc
+++ b/docs/reference/rest-api/rest-api-compatibility.asciidoc
@@ -85,7 +85,7 @@ To leverage REST API compatibility during an upgrade from 7.17 to {version}:
 
 1. Upgrade your https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]
 to the latest 7.x version and enable REST API compatibility.
-2. Use the {kibana-ref}/upgrade-assistant.html[Upgrade Assistant]
+2. Use the {kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Upgrade Assistant]
 to review all critical issues and explore the deprecation logs.
 Some critical issues might be mitigated by REST API compatibility.
 3. Resolve all critical issues before proceeding with the upgrade.


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #83613

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)