### PR TITLE
[8.1] Add `beats_stats.metrics.apm-server.sampling.tail` to stack monitoring templates (#82401)

### DIFF
--- a/docs/changelog/82401.yaml
+++ b/docs/changelog/82401.yaml
@@ -1,0 +1,5 @@
+pr: 82401
+summary: Add `beats_stats.metrics.apm-server.sampling.tail` to stack monitoring templates
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -18,11 +18,8 @@ public final class MonitoringTemplateUtils {
      * The last version of X-Pack that updated the templates and pipelines.
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
-     *
-     * Note that the templates were last updated in 7.11.0, but the versions were not updated, meaning that upgrades
-     * to 7.11.0 would not have updated the templates. See https://github.com/elastic/elasticsearch/pull/69317.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_7_14_0.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_8_1_0.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -1509,6 +1509,49 @@
                           }
                         }
                       }
+                    },
+                    "sampling": {
+                      "properties": {
+                        "transactions_dropped": {
+                          "type": "long"
+                        },
+                        "tail": {
+                          "properties": {
+                            "dynamic_service_groups": {
+                              "type": "long"
+                            },
+                            "storage": {
+                              "properties": {
+                                "lsm_size": {
+                                  "type": "long"
+                                },
+                                "value_log_size": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "events": {
+                              "properties": {
+                                "processed": {
+                                  "type": "long"
+                                },
+                                "dropped": {
+                                  "type": "long"
+                                },
+                                "stored": {
+                                  "type": "long"
+                                },
+                                "sampled": {
+                                  "type": "long"
+                                },
+                                "head_unsampled": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -697,6 +697,49 @@
                           }
                         }
                       }
+                    },
+                    "sampling": {
+                      "properties": {
+                        "transactions_dropped": {
+                          "type": "long"
+                        },
+                        "tail": {
+                          "properties": {
+                            "dynamic_service_groups": {
+                              "type": "long"
+                            },
+                            "storage": {
+                              "properties": {
+                                "lsm_size": {
+                                  "type": "long"
+                                },
+                                "value_log_size": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "events": {
+                              "properties": {
+                                "processed": {
+                                  "type": "long"
+                                },
+                                "dropped": {
+                                  "type": "long"
+                                },
+                                "stored": {
+                                  "type": "long"
+                                },
+                                "sampled": {
+                                  "type": "long"
+                                },
+                                "head_unsampled": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -50,7 +50,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * continue to use the release version number in this registry, even though this is not standard practice for template
      * registries.
      */
-    public static final int REGISTRY_VERSION = Version.V_7_14_0.id;
+    public static final int REGISTRY_VERSION = Version.V_8_1_0.id;
     private static final String REGISTRY_VERSION_VARIABLE = "xpack.monitoring.template.release.version";
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Add `beats_stats.metrics.apm-server.sampling.tail` to stack monitoring templates (#82401)