### PR TITLE
[8.0] Wait for license generation before REST test (#83563)

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.plugins.MetadataUpgrader;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.elasticsearch.xpack.core.ml.integration.MlRestTestStateCleaner;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
@@ -90,6 +91,20 @@ public class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     }
 
     /**
+     * Waits for the cluster's self-generated license to be created and installed
+     */
+    protected void waitForLicense() {
+        // GET _licence returns a 404 status up until the license exists
+        awaitCallApi(
+            "license.get",
+            Map.of(),
+            List.of(),
+            response -> true,
+            () -> "Exception when waiting for initial license to be generated"
+        );
+    }
+
+    /**
      * Cleanup after tests.
      *
      * Feature-specific cleanup methods should be called from here rather than using
@@ -130,10 +145,16 @@ public class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
         try {
             final AtomicReference<ClientYamlTestResponse> response = new AtomicReference<>();
             assertBusy(() -> {
-                // The actual method call that sends the API requests returns a Future, but we immediately
-                // call .get() on it so there's no need for this method to do any other awaiting.
-                response.set(callApi(apiName, params, bodies, getApiCallHeaders()));
-                assertEquals(HttpStatus.SC_OK, response.get().getStatusCode());
+                try {
+                    // The actual method call that sends the API requests returns a Future, but we immediately
+                    // call .get() on it so there's no need for this method to do any other awaiting.
+                    response.set(callApi(apiName, params, bodies, getApiCallHeaders()));
+                    assertEquals(HttpStatus.SC_OK, response.get().getStatusCode());
+                } catch (ClientYamlTestResponseException e) {
+                    // Convert to an AssertionError so that "assertBusy" treats it as a failed assertion (and tries again)
+                    // rather than a runtime failure (which terminates the loop)
+                    throw new AssertionError("Failed to call API " + apiName, e);
+                }
             });
             success.apply(response.get());
         } catch (Exception e) {

--- a/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.test.rest;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.junit.Before;
 
 public class XPackRestIT extends AbstractXPackRestTest {
 
@@ -20,5 +21,13 @@ public class XPackRestIT extends AbstractXPackRestTest {
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return createParameters();
+    }
+
+    /**
+     * Some rest tests depend on the trial license being generated before they run
+     */
+    @Before
+    public void setupLicense() {
+        super.waitForLicense();
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/license/20_put_license.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/license/20_put_license.yml
@@ -127,6 +127,12 @@ teardown:
 ---
 "Current license is trial means not eligle to start trial":
 
+  # Check the current state of the license. If this is not a trail, then the rest of the test will fail (but the failure is hard to diagnose without this assertion)
+  - do:
+      license.get: {}
+
+  - match: { license.type: "trial" }
+
   - do:
       license.get_trial_status: {}
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Wait for license generation before REST test (#83563)