### PR TITLE
Optimize calculating the presence of a quorum

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -346,13 +346,13 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         }
 
         public boolean hasQuorum(Collection<String> votes) {
-            int votedNodes = 0;
+            int votedNodesCount = 0;
             for (String nodeId : nodeIds) {
                 if (votes.contains(nodeId)) {
-                    votedNodes++;
+                    votedNodesCount++;
                 }
             }
-            return votedNodes * 2 > nodeIds.size();
+            return votedNodesCount * 2 > nodeIds.size();
         }
 
         public Set<String> getNodeIds() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -346,9 +346,13 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         }
 
         public boolean hasQuorum(Collection<String> votes) {
-            final HashSet<String> intersection = new HashSet<>(nodeIds);
-            intersection.retainAll(votes);
-            return intersection.size() * 2 > nodeIds.size();
+            int votedNodes = 0;
+            for (String nodeId : nodeIds) {
+                if (votes.contains(nodeId)) {
+                    votedNodes++;
+                }
+            }
+            return votedNodes * 2 > nodeIds.size();
         }
 
         public Set<String> getNodeIds() {


### PR DESCRIPTION
We don't need to create new `HashSet` and remove elements from just to get an intersection set.
We only care about the amount of notes that have voted.