### PR TITLE
[ML] Fix submit after shutdown in process worker service

### DIFF
--- a/docs/changelog/83645.yaml
+++ b/docs/changelog/83645.yaml
@@ -1,0 +1,6 @@
+pr: 83645
+summary: Fix submit after shutdown in process worker service
+area: Machine Learning
+type: bug
+issues:
+ - 83633

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -95,6 +95,7 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(processName + " worker service has shutdown", true);
             if (command instanceof AbstractRunnable runnable) {
                 runnable.onRejection(rejected);
+                return;
             } else {
                 throw rejected;
             }


### PR DESCRIPTION
Runnables submitted after shutdown should not be executed. 

Closes #83633