### PR TITLE
[ML] Fix submit after shutdown in process worker service

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectWorkerExecutorService.java
@@ -75,6 +75,7 @@ class AutodetectWorkerExecutorService extends AbstractExecutorService {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException("autodetect worker service has shutdown", true);
             if (command instanceof AbstractRunnable) {
                 ((AbstractRunnable) command).onRejection(rejected);
+                return;
             } else {
                 throw rejected;
             }


### PR DESCRIPTION
AbstractRunnables submitted after shutdown should not be executed.

Backport of #83645