### PR TITLE
Adds known issue for aarch64 pwd generation

### DIFF
--- a/docs/reference/release-notes/8.0.0-rc2.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc2.asciidoc
@@ -15,7 +15,7 @@ data loss. If you upgrade from a released version, such as 7.16, to a
 pre-release version for testing, discard the contents of the cluster when you are
 done. Do not attempt to upgrade to the final 8.0 release.
 
-* If you installed {es} from an archive on Linux aarch64 or macOS aarch64, the
+* If you installed {es} from an archive on an aarch64 platform like Linux ARM or macOS M1, the
 `elastic` user password and {kib} enrollment token are not generated
 automatically when starting your node for the first time.
 +

--- a/docs/reference/release-notes/8.0.0-rc2.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc2.asciidoc
@@ -15,13 +15,27 @@ data loss. If you upgrade from a released version, such as 7.16, to a
 pre-release version for testing, discard the contents of the cluster when you are
 done. Do not attempt to upgrade to the final 8.0 release.
 
-* `elastic` user password and {kib} enrollment token are not generated on node first startup
-when elasticsearch is installed from archive on Linux aarch64 and macOS aarch64 platforms.
+* If you installed {es} from an archive on Linux aarch64 or macOS aarch64, the
+`elastic` user password and {kib} enrollment token are not generated
+automatically when starting your node for the first time.
 +
-You can still generate the `elastic` password with `bin/elasticsearch-reset-password -u elastic` and
-get a {kib} enrollment token with `bin/elasticsearch-create-enrollment-token -s kibana` after the
-node has started.
+--
+After the node starts, generate the `elastic` password with the
+<<reset-password,`bin/elasticsearch-reset-password`>> tool:
 
+[source,bash]
+----
+bin/elasticsearch-reset-password -u elastic
+----
+
+Then, create an enrollment token for {kib} with the
+<<create-enrollment-token,`bin/elasticsearch-create-enrollment-token`>> tool:
+
+[source,bash]
+----
+bin/elasticsearch-create-enrollment-token -s kibana
+----
+--
 [[deprecation-8.0.0-rc2]]
 [float]
 === Deprecations

--- a/docs/reference/release-notes/8.0.0-rc2.asciidoc
+++ b/docs/reference/release-notes/8.0.0-rc2.asciidoc
@@ -15,6 +15,13 @@ data loss. If you upgrade from a released version, such as 7.16, to a
 pre-release version for testing, discard the contents of the cluster when you are
 done. Do not attempt to upgrade to the final 8.0 release.
 
+* `elastic` user password and {kib} enrollment token are not generated on node first startup
+when elasticsearch is installed from archive on Linux aarch64 and macOS aarch64 platforms.
++
+You can still generate the `elastic` password with `bin/elasticsearch-reset-password -u elastic` and
+get a {kib} enrollment token with `bin/elasticsearch-create-enrollment-token -s kibana` after the
+node has started.
+
 [[deprecation-8.0.0-rc2]]
 [float]
 === Deprecations


### PR DESCRIPTION
We figured out that on Linux and macOS aarch64, we can't
determine whether a terminal is attached to elasticsearch and as
such we don't print the elastic password and enrollment token on
node first startup. This is resolved in #83566 by updating the
underlying library we use to detect the terminal.
