### PR TITLE
[8.1] Optimize calculating the presence of a quorum (#83638)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -346,9 +346,13 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         }
 
         public boolean hasQuorum(Collection<String> votes) {
-            final HashSet<String> intersection = new HashSet<>(nodeIds);
-            intersection.retainAll(votes);
-            return intersection.size() * 2 > nodeIds.size();
+            int votedNodesCount = 0;
+            for (String nodeId : nodeIds) {
+                if (votes.contains(nodeId)) {
+                    votedNodesCount++;
+                }
+            }
+            return votedNodesCount * 2 > nodeIds.size();
         }
 
         public Set<String> getNodeIds() {


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Optimize calculating the presence of a quorum (#83638)