### PR TITLE
[ML] fix random sampling background query consistency

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplingQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplingQuery.java
@@ -32,7 +32,6 @@ import java.util.function.IntSupplier;
 public final class RandomSamplingQuery extends Query {
 
     private final double p;
-    private final SplittableRandom splittableRandom;
     private final int seed;
     private final int hash;
 
@@ -49,7 +48,6 @@ public final class RandomSamplingQuery extends Query {
         this.p = p;
         this.seed = seed;
         this.hash = hash;
-        this.splittableRandom = new SplittableRandom(BitMixer.mix(hash, seed));
     }
 
     @Override
@@ -78,7 +76,7 @@ public final class RandomSamplingQuery extends Query {
 
             @Override
             public Scorer scorer(LeafReaderContext context) {
-                final SplittableRandom random = splittableRandom.split();
+                final SplittableRandom random = new SplittableRandom(BitMixer.mix(hash, seed));
                 int maxDoc = context.reader().maxDoc();
                 return new ConstantScoreScorer(
                     this,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomDocIDSetIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomDocIDSetIteratorTests.java
@@ -11,7 +11,11 @@ package org.elasticsearch.search.aggregations.bucket.sampler.random;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SplittableRandom;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class RandomDocIDSetIteratorTests extends ESTestCase {
 
@@ -40,6 +44,28 @@ public class RandomDocIDSetIteratorTests extends ESTestCase {
                         + p
                 );
             }
+        }
+    }
+
+    public void testRandomSamplerConsistency() {
+        int maxDoc = 10000;
+        int seed = randomInt();
+
+        for (int i = 1; i < 100; i++) {
+            double p = i / 100.0;
+            SplittableRandom random = new SplittableRandom(seed);
+            List<Integer> iterationOne = new ArrayList<>();
+            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, random::nextInt);
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                iterationOne.add(iter.docID());
+            }
+            random = new SplittableRandom(seed);
+            List<Integer> iterationTwo = new ArrayList<>();
+            iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, random::nextInt);
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                iterationTwo.add(iter.docID());
+            }
+            assertThat(iterationOne, equalTo(iterationTwo));
         }
     }
 


### PR DESCRIPTION
There was a consistency bug where the documents returned by the created scorer could change while looking at the same shard. This can occur if multiple weights are created from the same query. 

For scenarios like Significant Terms/Text, we need a consistent view of each shard when using the same probability and seed.

This commit ensures this by creating a new random value supplier seeded by the shard hash & seed. 