### PR TITLE
[8.1] Move internal APIs into their own namespace '_internal'

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
@@ -1,10 +1,10 @@
 {
-  "desired_nodes.delete_desired_nodes":{
+  "_internal.delete_desired_nodes":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-desired-nodes.html",
       "description": "Deletes the desired nodes. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_nodes.json
@@ -1,10 +1,10 @@
 {
-  "desired_nodes.get_desired_nodes":{
+  "_internal.get_desired_nodes":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-desired-nodes.html",
       "description": "Gets the latest desired nodes. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
@@ -1,10 +1,10 @@
 {
-  "desired_nodes.update_desired_nodes":{
+  "_internal.update_desired_nodes":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/update-desired-nodes.html",
       "description": "Updates the desired nodes. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -6,12 +6,12 @@
         "Api": {
             "type": "object",
             "propertyNames": {
-                "pattern": "^[a-z]+?(_[a-z]+)*(\\.[a-z]+?(_[a-z]+)*)?$"
+                "pattern": "^(?:[a-z]+?(_[a-z]+)*(\\.[a-z]+?(_[a-z]+)*)?|_internal\\.[a-z]+?(_[a-z]+)*)$"
             },
             "minProperties": 1,
             "maxProperties": 1,
             "patternProperties": {
-                "^[a-z]+?(_[a-z]+)*(\\.[a-z]+?(_[a-z]+)*)?$": {
+                "^(?:[a-z]+?(_[a-z]+)*(\\.[a-z]+?(_[a-z]+)*)?|_internal\\.[a-z]+?(_[a-z]+)*)$": {
                     "$ref": "#/definitions/Components"
                 }
             },

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_nodes/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_nodes/10_basic.yml
@@ -6,7 +6,7 @@ setup:
 ---
 teardown:
   - do:
-      desired_nodes.delete_desired_nodes: {}
+      _internal.delete_desired_nodes: {}
 ---
 "Test update desired nodes":
   - do:
@@ -20,7 +20,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -29,7 +29,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -38,7 +38,7 @@ teardown:
           - { settings: { node: { name: "instance-000187" } }, processors: 8, memory: "64gb", storage: "128gb", node_version: $es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 2
         body:
@@ -48,7 +48,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -68,7 +68,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -77,7 +77,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -86,7 +86,7 @@ teardown:
           - { settings: { node: { external_id: "instance-000187" } }, processors: 8, memory: "64gb", storage: "128gb", node_version: $es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "new_history"
         version: 1
         body:
@@ -96,7 +96,7 @@ teardown:
   - match: { replaced_existing_history_id: true }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "new_history"
@@ -116,7 +116,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -125,7 +125,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -134,11 +134,11 @@ teardown:
           - { settings: { node: { external_id: "instance-000187" } }, processors: 8, memory: "64gb", storage: "128gb", node_version: $es_version }
 
   - do:
-      desired_nodes.delete_desired_nodes: {}
+      _internal.delete_desired_nodes: {}
 
   - do:
       catch: missing
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match: { status: 404 }
 ---
 "Test update desired nodes is idempotent":
@@ -152,7 +152,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -161,7 +161,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -170,7 +170,7 @@ teardown:
           - { settings: { node: { external_id: "instance-000187" } }, processors: 8, memory: "64gb", storage: "128gb", node_version: $es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -179,7 +179,7 @@ teardown:
   - match: { replaced_existing_history_id: false }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -198,7 +198,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 2
         body:
@@ -208,7 +208,7 @@ teardown:
 
   - do:
       catch: conflict
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -219,7 +219,7 @@ teardown:
   - match: { error.reason: "version [1] has been superseded by version [2] for history [test]" }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -238,7 +238,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -248,7 +248,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -259,7 +259,7 @@ teardown:
   - match: { error.reason: "Desired nodes with history [test] and version [1] already exists with a different definition" }
 
   - do:
-      desired_nodes.get_desired_nodes: {}
+      _internal.get_desired_nodes: {}
   - match:
       $body:
         history_id: "test"
@@ -279,7 +279,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -302,7 +302,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -315,7 +315,7 @@ teardown:
 ---
 "Test unknown settings are allowed in future versions":
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -334,7 +334,7 @@ teardown:
   - set: { nodes.$master.version: es_version }
 
   - do:
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -354,7 +354,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -377,7 +377,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -400,7 +400,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -423,7 +423,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: "asa"
         body:
@@ -445,7 +445,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: -1
         body:
@@ -458,7 +458,7 @@ teardown:
 "Test node version must be at least the current master version":
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -482,7 +482,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "    "
         version: 1
         body:
@@ -495,7 +495,7 @@ teardown:
 "Test at least one node must be sent":
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -516,7 +516,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -538,7 +538,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -559,7 +559,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -580,7 +580,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -601,7 +601,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -622,7 +622,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -643,7 +643,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -664,7 +664,7 @@ teardown:
 
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -676,7 +676,7 @@ teardown:
 "Test node version is required":
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -688,7 +688,7 @@ teardown:
 "Test node version must have content":
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:
@@ -700,7 +700,7 @@ teardown:
 "Test node version can not be null":
   - do:
       catch: bad_request
-      desired_nodes.update_desired_nodes:
+      _internal.update_desired_nodes:
         history_id: "test"
         version: 1
         body:


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/83554