### PR TITLE
[DOCS] Add deprecation notice for system indices

### DIFF
--- a/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
@@ -6,6 +6,23 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[deprecation-system-indices]]
+.Direct access to system indices is deprecated.
+[%collapsible]
+====
+*Details* +
+Directly accessing system indices is deprecated, and may be prevented in a
+future version. If you must access a system index, create a security role with
+an index permission that targets the specific index and set the
+`allow_restricted_indices` permission to `true`. Refer to 
+{ref}/defining-roles.html#roles-indices-priv[indices privileges] for
+information on adding this permission to an index privilege.
+*Impact* +
+Accessing system indices directly results in warnings in the header of API
+responses. If available, use {kib} or the associated feature's {es} APIs to manage the data
+that you want to access.
+====
+
 [[deprecate-max-merge-at-once-explicit-setting]]
 .`index.merge.policy.max_merge_at_once_explicit` is deprecated and has no effect.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/index-setting-changes.asciidoc
@@ -17,10 +17,11 @@ an index permission that targets the specific index and set the
 `allow_restricted_indices` permission to `true`. Refer to 
 {ref}/defining-roles.html#roles-indices-priv[indices privileges] for
 information on adding this permission to an index privilege.
+
 *Impact* +
 Accessing system indices directly results in warnings in the header of API
-responses. If available, use {kib} or the associated feature's {es} APIs to manage the data
-that you want to access.
+responses. If available, use {kib} or the associated feature's {es} APIs to
+manage the data that you want to access.
 ====
 
 [[deprecate-max-merge-at-once-explicit-setting]]


### PR DESCRIPTION
Applies the changes from #80028 to the 8.0 Migration Guide. 

Preview: https://elasticsearch_83688.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_index_setting_changes