### PR TITLE
[DOCS] Fix min/max agg snippets for histograms

### DIFF
--- a/docs/reference/aggregations/metrics/max-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/max-aggregation.asciidoc
@@ -123,8 +123,17 @@ of all elements in the `values` array. Note, that the `counts` array of the hist
 For example, for the following index that stores pre-aggregated histograms with latency metrics for different networks:
 
 [source,console]
---------------------------------------------------
-PUT metrics_index/_doc/1
+----
+PUT metrics_index
+{
+  "mappings": {
+    "properties": {
+      "latency_histo": { "type": "histogram" }
+    }
+  }
+}
+
+PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
@@ -133,7 +142,7 @@ PUT metrics_index/_doc/1
    }
 }
 
-PUT metrics_index/_doc/2
+PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
@@ -142,25 +151,23 @@ PUT metrics_index/_doc/2
    }
 }
 
-POST /metrics_index/_search?size=0
+POST /metrics_index/_search?size=0&filter_path=aggregations
 {
   "aggs" : {
-    "min_latency" : { "min" : { "field" : "latency_histo" } }
+    "max_latency" : { "max" : { "field" : "latency_histo" } }
   }
 }
---------------------------------------------------
+----
 
 The `max` aggregation will return the maximum value of all histogram fields:
 
 [source,console-result]
---------------------------------------------------
+----
 {
-  ...
   "aggregations": {
-    "min_latency": {
+    "max_latency": {
       "value": 0.5
     }
   }
 }
---------------------------------------------------
-// TESTRESPONSE[skip:test not setup]
+----

--- a/docs/reference/aggregations/metrics/min-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/min-aggregation.asciidoc
@@ -123,8 +123,17 @@ of all elements in the `values` array. Note, that the `counts` array of the hist
 For example, for the following index that stores pre-aggregated histograms with latency metrics for different networks:
 
 [source,console]
---------------------------------------------------
-PUT metrics_index/_doc/1
+----
+PUT metrics_index
+{
+  "mappings": {
+    "properties": {
+      "latency_histo": { "type": "histogram" }
+    }
+  }
+}
+
+PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
@@ -133,7 +142,7 @@ PUT metrics_index/_doc/1
    }
 }
 
-PUT metrics_index/_doc/2
+PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
@@ -142,25 +151,23 @@ PUT metrics_index/_doc/2
    }
 }
 
-POST /metrics_index/_search?size=0
+POST /metrics_index/_search?size=0&filter_path=aggregations
 {
   "aggs" : {
     "min_latency" : { "min" : { "field" : "latency_histo" } }
   }
 }
---------------------------------------------------
+----
 
 The `min` aggregation will return the minimum value of all histogram fields:
 
 [source,console-result]
---------------------------------------------------
+----
 {
-  ...
   "aggregations": {
     "min_latency": {
       "value": 0.1
     }
   }
 }
---------------------------------------------------
-// TESTRESPONSE[skip:test not setup]
+----


### PR DESCRIPTION
* Updates the `min` and `max` snippets for histograms. These should now run as docs integration tests.
* Fixes a copy/paste error in the `max` aggregation snippet for histograms.

Relates to https://github.com/elastic/elasticsearch/pull/83384

### Preview docs
* max agg: https://elasticsearch_83695.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-max-aggregation.html#search-aggregations-metrics-max-aggregation-histogram-fields
* min agg: https://elasticsearch_83695.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-min-aggregation.html#search-aggregations-metrics-min-aggregation-histogram-fields