### PR TITLE
[DOCS] Update multi-target syntax refs

### DIFF
--- a/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
@@ -55,4 +55,4 @@ fails and returns an error. Defaults to `30s`.
 `indices`::
 (Required, string)
 A comma-separated list of indices to include in the snapshot.
-<<multi-index,Multi-index syntax>> is supported.
+<<multi-index,multi-target syntax>> is supported.

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -113,7 +113,7 @@ include::restore-snapshot-api.asciidoc[tag=cluster-state-contents]
 `indices`::
 (Optional, string or array of strings)
 Comma-separated list of data streams and indices to include in the snapshot.
-Supports <<api-multi-index,multi-index syntax>>. Defaults to an empty array
+Supports <<api-multi-index,multi-target syntax>>. Defaults to an empty array
 (`[]`), which includes all regular data streams and regular indices. To exclude
 all data streams and indices, use `-*`.
 +

--- a/docs/reference/sql/language/indices.asciidoc
+++ b/docs/reference/sql/language/indices.asciidoc
@@ -6,7 +6,7 @@
 
 [[sql-index-patterns-multi]]
 [discrete]
-==== {es} multi-index
+==== {es} multi-target syntax
 
 The {es} notation for enumerating, including or excluding <<api-multi-index,multi-target syntax>>
 is supported _as long_ as it is quoted or escaped as a table identifier.

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -71,15 +71,15 @@ The following table lists all available settings for the search
 | `request.indices_options.expand_wildcards`    | no        | `open`            | Determines how to expand indices wildcards. An array
                                                                                   consisting of a combination of `open`, `closed`,
                                                                                   and `hidden`. Alternatively a value of `none` or `all`.
-                                                                                  (see <<multi-index,multi-index support>>)
+                                                                                  (see <<multi-index,multi-target syntax>>)
 
 | `request.indices_options.ignore_unavailable`  | no        | `true`            | A boolean value that determines whether the search
                                                                                   should leniently ignore unavailable indices
-                                                                                  (see <<multi-index,multi-index support>>)
+                                                                                  (see <<multi-index,multi-target syntax>>)
 
 | `request.indices_options.allow_no_indices`    | no        | `true`            | A boolean value that determines whether the search
                                                                                   should leniently return no results when no indices
-                                                                                  are resolved (see <<multi-index,multi-index support>>)
+                                                                                  are resolved (see <<multi-index,multi-target syntax>>)
 
 | `request.template`                            | no        | -                 | The body of the search template. See
                                                                                   <<templates,configure templates>> for more information.


### PR DESCRIPTION
With the introduction of data streams, "multi-index syntax" is now "multi-target syntax." This updates a few outstanding references.