### PR TITLE
fix: update version after backporting to 7.17.1

### DIFF
--- a/docs/changelog/83709.yaml
+++ b/docs/changelog/83709.yaml
@@ -1,0 +1,5 @@
+pr: 83709
+summary: "Fix: update version after backporting to 7.17.1"
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -142,8 +142,8 @@ setup:
 ---
 "Float range":
   - skip:
-      version: " - 7.16.99"
-      reason: Bug fixed in 8.1.0 and backported to 7.17.0
+      version: " - 8.2.0"
+      reason: Temporarily disabling the test before backporting fix to 8.1
   - do:
       search:
         index: test

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -163,11 +163,11 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
                 out.writeString(key == null ? generateKey(from, to, format) : key);
             }
             out.writeDouble(from);
-            if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_17_1)) {
                 out.writeOptionalDouble(from);
             }
             out.writeDouble(to);
-            if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_17_1)) {
                 out.writeOptionalDouble(to);
             }
             out.writeVLong(docCount);
@@ -265,11 +265,11 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         for (int i = 0; i < size; i++) {
             String key = in.getVersion().onOrAfter(Version.V_7_17_1) ? in.readOptionalString() : in.readString();
             double from = in.readDouble();
-            if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_17_1)) {
                 in.readOptionalDouble();
             }
             double to = in.readDouble();
-            if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_17_1)) {
                 in.readOptionalDouble();
             }
             long docCount = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -162,8 +162,8 @@ public abstract class RangeAggregator extends BucketsAggregator {
             toAsStr = in.readOptionalString();
             from = in.readDouble();
             to = in.readDouble();
-            originalFrom = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalDouble() : Double.valueOf(from);
-            originalTo = in.getVersion().onOrAfter(Version.V_7_17_0) ? in.readOptionalDouble() : Double.valueOf(to);
+            originalFrom = in.getVersion().onOrAfter(Version.V_7_17_1) ? in.readOptionalDouble() : Double.valueOf(from);
+            originalTo = in.getVersion().onOrAfter(Version.V_7_17_1) ? in.readOptionalDouble() : Double.valueOf(to);
         }
 
         @Override
@@ -173,7 +173,7 @@ public abstract class RangeAggregator extends BucketsAggregator {
             out.writeOptionalString(toAsStr);
             out.writeDouble(from);
             out.writeDouble(to);
-            if (out.getVersion().onOrAfter(Version.V_7_17_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_17_1)) {
                 out.writeOptionalDouble(originalFrom);
                 out.writeOptionalDouble(originalTo);
             }


### PR DESCRIPTION
PR #83339 was meant to be included in version 7.17.0 but didn't happen.
It landed in version 7.17.1. As a result version checks are incorrect.
Instead of checking against version 7.17.0 we need to check against
version 7.17.1.