### PR TITLE
Add Alma Linux 8 ARM to CI

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
@@ -14,6 +14,7 @@
           type: label-expression
           name: os
           values:
+            - "almalinux-8-aarch64&&immutable"
             - "ubuntu-1804-aarch64&&immutable"
     builders:
       - inject:


### PR DESCRIPTION
Since CentOS 8 on ARM is defunct, add Alma Linux 8 on ARM into the CI config.