### PR TITLE
Speed up ContentPath

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -8,46 +8,34 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.Strings;
+
 public final class ContentPath {
 
     private static final char DELIMITER = '.';
 
-    private final StringBuilder sb;
+    private static final ThreadLocal<StringBuilder> stringBuilder = ThreadLocal.withInitial(StringBuilder::new);
 
-    private final int offset;
+    private int index;
 
-    private int index = 0;
-
-    private String[] path = new String[10];
+    private String[] path = Strings.EMPTY_ARRAY;
 
     public ContentPath() {
-        this(0);
-    }
-
-    /**
-     * Constructs a json path with an offset. The offset will result an {@code offset}
-     * number of path elements to not be included in {@link #pathAsText(String)}.
-     */
-    public ContentPath(int offset) {
-        this.sb = new StringBuilder();
-        this.offset = offset;
         this.index = 0;
     }
 
     public ContentPath(String path) {
-        this.sb = new StringBuilder();
-        this.offset = 0;
         this.index = 0;
         add(path);
     }
 
     public void add(String name) {
-        path[index++] = name;
         if (index == path.length) { // expand if needed
             String[] newPath = new String[path.length + 10];
             System.arraycopy(path, 0, newPath, 0, path.length);
             path = newPath;
         }
+        path[index++] = name;
     }
 
     public void remove() {
@@ -55,8 +43,12 @@ public final class ContentPath {
     }
 
     public String pathAsText(String name) {
+        if (index == 0) {
+            return name;
+        }
+        final StringBuilder sb = stringBuilder.get();
         sb.setLength(0);
-        for (int i = offset; i < index; i++) {
+        for (int i = 0; i < index; i++) {
             sb.append(path[i]).append(DELIMITER);
         }
         sb.append(name);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -719,7 +719,7 @@ public final class DocumentParser {
      * and how they are stored in the lucene index.
      */
     private static class InternalDocumentParserContext extends DocumentParserContext {
-        private final ContentPath path = new ContentPath(0);
+        private final ContentPath path = new ContentPath();
         private final XContentParser parser;
         private final LuceneDocument document;
         private final List<LuceneDocument> documents = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -292,7 +292,7 @@ public abstract class DocumentParserContext {
      * @param doc           the document to target
      */
     public final DocumentParserContext createCopyToContext(String copyToField, LuceneDocument doc) throws IOException {
-        ContentPath path = new ContentPath(0);
+        ContentPath path = new ContentPath();
         XContentParser parser = DotExpandingXContentParser.expandDots(new CopyToParser(copyToField, parser()));
         return new Wrapper(this) {
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1355,7 +1355,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         protected static ContentPath parentPath(String name) {
             int endPos = name.lastIndexOf(".");
             if (endPos == -1) {
-                return new ContentPath(0);
+                return new ContentPath();
             }
             return new ContentPath(name.substring(0, endPos));
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestDocumentParserContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestDocumentParserContext.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
  */
 public class TestDocumentParserContext extends DocumentParserContext {
     private final LuceneDocument document = new LuceneDocument();
-    private final ContentPath contentPath = new ContentPath(0);
+    private final ContentPath contentPath = new ContentPath();
 
     /**
      * The shortest and easiest way to create a context, to be used when none of the constructor arguments are needed.


### PR DESCRIPTION
This class shows up as 2%+ on some write threads in many-shards benchmarks
during indexing. We can at least make it a little faster by short-circuiting
the empty path array case, reusing the string builder as thread-local (did not put a limit on this as we don't have a field name length limit by default) and removing the redundant `offset` field that's always `0` (the last one probably
won't do much for performance though).
