### PR TITLE
[8.1] [DOCS] Remove beta admon for security-on-by-default (#83600)

### DIFF
--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -1,8 +1,6 @@
 [[configuring-stack-security]]
 == Start the Elastic Stack with security enabled
 
-beta::[This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.]
-
 When you start {es} for the first time, the following security configuration
 occurs automatically:
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Remove beta admon for security-on-by-default (#83600)