### PR TITLE
[8.1] fix: ip prefix bucket reduction (#83637)

### DIFF
--- a/docs/changelog/83637.yaml
+++ b/docs/changelog/83637.yaml
@@ -1,0 +1,5 @@
+pr: 83637
+summary: "Fix: ip prefix bucket reduction"
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/450_ip_prefix.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/450_ip_prefix.yml
@@ -22,31 +22,31 @@ setup:
         refresh: true
         body:
           - { "index": { } }
-          - { "ipv4": "192.168.1.10", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f10", "value": 10, ip: "192.168.1.10" }
+          - { "ipv4": "192.168.1.10", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f10", "value": 10, "ip": "192.168.1.10" }
           - { "index": { } }
-          - { "ipv4": "192.168.1.12", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f12", "value": 20, ip: "2001:db8:a4f8:112a:6001:0:12:7f12" }
+          - { "ipv4": "192.168.1.12", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f12", "value": 20, "ip": "2001:db8:a4f8:112a:6001:0:12:7f12" }
           - { "index": { } }
-          - { "ipv4": "192.168.1.33", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f33", "value": 40, ip: "192.168.1.33" }
+          - { "ipv4": "192.168.1.33", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f33", "value": 40, "ip": "192.168.1.33" }
           - { "index": { } }
-          - { "ipv4": "192.168.1.10", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f10", "value": 20, ip: "2001:db8:a4f8:112a:6001:0:12:7f10" }
+          - { "ipv4": "192.168.1.10", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f10", "value": 20, "ip": "2001:db8:a4f8:112a:6001:0:12:7f10" }
           - { "index": { } }
-          - { "ipv4": "192.168.1.33", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f33", "value": 70, ip: "192.168.1.33" }
+          - { "ipv4": "192.168.1.33", "ipv6": "2001:db8:a4f8:112a:6001:0:12:7f33", "value": 70, "ip": "192.168.1.33" }
           - { "index": { } }
-          - { "ipv4": "192.168.2.41", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f41", "value": 20, ip: "2001:db8:a4f8:112c:6001:0:12:7f41" }
+          - { "ipv4": "192.168.2.41", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f41", "value": 20, "ip": "2001:db8:a4f8:112c:6001:0:12:7f41" }
           - { "index": { } }
-          - { "ipv4": "192.168.2.10", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f10", "value": 30, ip: "192.168.2.10" }
+          - { "ipv4": "192.168.2.10", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f10", "value": 30, "ip": "192.168.2.10" }
           - { "index": { } }
-          - { "ipv4": "192.168.2.23", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f23", "value": 50, ip: "2001:db8:a4f8:112c:6001:0:12:7f23" }
+          - { "ipv4": "192.168.2.23", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f23", "value": 50, "ip": "2001:db8:a4f8:112c:6001:0:12:7f23" }
           - { "index": { } }
-          - { "ipv4": "192.168.2.41", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f41", "value": 60, ip: "192.168.2.41" }
+          - { "ipv4": "192.168.2.41", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f41", "value": 60, "ip": "192.168.2.41" }
           - { "index": { } }
-          - { "ipv4": "192.168.2.10", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f10", "value": 10, ip: "2001:db8:a4f8:112c:6001:0:12:7f10" }
+          - { "ipv4": "192.168.2.10", "ipv6": "2001:db8:a4f8:112c:6001:0:12:7f10", "value": 10, "ip": "2001:db8:a4f8:112c:6001:0:12:7f10" }
 
 ---
 "IPv4 prefix":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -79,8 +79,8 @@ setup:
 # network part will just 0s.
 "IPv4 prefix with incorrect is_ipv6":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -104,8 +104,8 @@ setup:
 ---
 "IPv4 short prefix":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -141,8 +141,8 @@ setup:
 ---
 "IPv6 prefix":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -175,8 +175,8 @@ setup:
 # with everything else being 0s.
 "IPv6 prefix with incorrect is_ipv6":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -201,8 +201,8 @@ setup:
 ---
 "Invalid IPv4 prefix":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       catch: /\[prefix_length\] must be in range \[0, 32\] while value is \[44\]/
       search:
@@ -219,8 +219,8 @@ setup:
 ---
 "Invalid IPv6 prefix":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       catch: /\[prefix_length] must be in range \[0, 128\] while value is \[170]/
       search:
@@ -236,8 +236,8 @@ setup:
 ---
 "IPv4 prefix sub aggregation":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -278,8 +278,8 @@ setup:
 ---
 "IPv6 prefix sub aggregation":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -319,8 +319,8 @@ setup:
 ---
 "IPv6 prefix metric sub aggregation":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -356,8 +356,8 @@ setup:
 ---
 "IPv4 prefix appended":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -388,8 +388,8 @@ setup:
 ---
 "IPv6 prefix appended":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -420,8 +420,8 @@ setup:
 ---
 "Mixed IPv4 and IPv6 with is_ipv6 false":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:
@@ -451,8 +451,8 @@ setup:
 ---
 "Mixed IPv4 and IPv6 with is_ipv6 true":
   - skip:
-      version: " - 8.0.99"
-      reason: "added in 8.1.0"
+      version: " - 8.2.0"
+      reason: "Temporarily skipping preparing to backport to 8.1"
   - do:
       search:
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/450_ip_prefix.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/450_ip_prefix.yml
@@ -45,8 +45,8 @@ setup:
 ---
 "IPv4 prefix":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -79,8 +79,8 @@ setup:
 # network part will just 0s.
 "IPv4 prefix with incorrect is_ipv6":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -104,8 +104,8 @@ setup:
 ---
 "IPv4 short prefix":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -141,8 +141,8 @@ setup:
 ---
 "IPv6 prefix":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -175,8 +175,8 @@ setup:
 # with everything else being 0s.
 "IPv6 prefix with incorrect is_ipv6":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -201,8 +201,8 @@ setup:
 ---
 "Invalid IPv4 prefix":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       catch: /\[prefix_length\] must be in range \[0, 32\] while value is \[44\]/
       search:
@@ -219,8 +219,8 @@ setup:
 ---
 "Invalid IPv6 prefix":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       catch: /\[prefix_length] must be in range \[0, 128\] while value is \[170]/
       search:
@@ -236,8 +236,8 @@ setup:
 ---
 "IPv4 prefix sub aggregation":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -278,8 +278,8 @@ setup:
 ---
 "IPv6 prefix sub aggregation":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -319,8 +319,8 @@ setup:
 ---
 "IPv6 prefix metric sub aggregation":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -356,8 +356,8 @@ setup:
 ---
 "IPv4 prefix appended":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -388,8 +388,8 @@ setup:
 ---
 "IPv6 prefix appended":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -420,8 +420,8 @@ setup:
 ---
 "Mixed IPv4 and IPv6 with is_ipv6 false":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:
@@ -451,8 +451,8 @@ setup:
 ---
 "Mixed IPv4 and IPv6 with is_ipv6 true":
   - skip:
-      version: " - 8.2.0"
-      reason: "Temporarily skipping preparing to backport to 8.1"
+      version: " - 8.0.99"
+      reason: "added in 8.1.0"
   - do:
       search:
         body:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -318,15 +318,30 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         );
     }
 
+    private Bucket createBucket(Bucket prototype, InternalAggregations aggregations, long docCount) {
+        return new Bucket(
+            format,
+            prototype.key,
+            prototype.keyed,
+            prototype.isIpv6,
+            prototype.prefixLength,
+            prototype.appendPrefixLength,
+            docCount,
+            aggregations
+        );
+    }
+
     @Override
     protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.size() > 0;
         List<InternalAggregations> aggregations = new ArrayList<>(buckets.size());
+        long docCount = 0;
         for (InternalIpPrefix.Bucket bucket : buckets) {
+            docCount += bucket.docCount;
             aggregations.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
-        return createBucket(aggs, buckets.get(0));
+        return createBucket(buckets.get(0), aggs, docCount);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregatorTests.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -42,6 +43,10 @@ import java.util.stream.Collectors;
 import static java.util.Collections.singleton;
 
 public class IpPrefixAggregatorTests extends AggregatorTestCase {
+
+    private static final Comparator<InternalIpPrefix.Bucket> IP_ADDRESS_KEY_COMPARATOR = Comparator.comparing(
+        InternalIpPrefix.Bucket::getKeyAsString
+    );
 
     private static final class TestIpDataHolder {
         private final String ipAddressAsString;
@@ -212,6 +217,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(1L, 1L, 4L, 1L)
+            );
         }, fieldType);
     }
 
@@ -261,6 +270,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(2L, 1L, 2L)
+            );
         }, fieldType);
     }
 
@@ -313,6 +326,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of((long) ipAddresses.size())
+            );
         }, fieldType);
     }
 
@@ -365,6 +382,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(1L, 1L, 1L, 2L, 1L, 1L)
+            );
         }, fieldType);
     }
 
@@ -414,6 +435,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(1L, 1L, 1L, 1L, 1L)
+            );
         }, fieldType);
     }
 
@@ -471,6 +496,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(1L, 1L, 4L, 1L)
+            );
         }, fieldTypes);
     }
 
@@ -525,6 +554,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(2L, 1L, 2L)
+            );
         }, fieldTypes);
     }
 
@@ -898,11 +931,12 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         // GIVEN
         final int prefixLength = 16;
         final String field = "ipv4";
+        int minDocCount = 2;
         final IpPrefixAggregationBuilder aggregationBuilder = new IpPrefixAggregationBuilder("ip_prefix").field(field)
             .isIpv6(false)
             .keyed(randomBoolean())
             .appendPrefixLength(false)
-            .minDocCount(2)
+            .minDocCount(minDocCount)
             .prefixLength(prefixLength);
         final MappedFieldType fieldType = new IpFieldMapper.IpFieldType(field);
         final List<TestIpDataHolder> ipAddresses = List.of(
@@ -941,6 +975,13 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertTrue(
+                ipPrefix.getBuckets().stream().map(InternalIpPrefix.Bucket::getDocCount).allMatch(docCount -> docCount >= minDocCount)
+            );
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(4L)
+            );
         }, fieldType);
     }
 
@@ -1002,6 +1043,10 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
+            assertEquals(
+                ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
+                List.of(4L)
+            );
         }, fieldType);
     }
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - fix: ip prefix bucket reduction (#83637)