### PR TITLE
[8.0] Tolerate empty types array in Watch definitions (#83524)

### DIFF
--- a/docs/changelog/83524.yaml
+++ b/docs/changelog/83524.yaml
@@ -1,0 +1,6 @@
+pr: 83524
+summary: Tolerate empty types array in Watch definitions
+area: Watcher
+type: bug
+issues:
+ - 83235

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -42,6 +44,10 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
     private final Script template;
     private final BytesReference searchSource;
     private boolean restTotalHitsAsInt = true;
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(WatcherSearchTemplateRequest.class);
+    static final String TYPES_DEPRECATION_MESSAGE =
+        "[types removal] Specifying empty types array in a watcher search request is deprecated.";
 
     public WatcherSearchTemplateRequest(
         String[] indices,
@@ -190,6 +196,17 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                             );
                         }
                     }
+                } else if (TYPES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    // Tolerate an empty types array, because some watches created internally in 6.x have
+                    // an empty types array in their search, and it's clearly equivalent to typeless.
+                    if (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        throw new ElasticsearchParseException(
+                            "could not read search request. unsupported non-empty array field [" + currentFieldName + "]"
+                        );
+                    }
+                    // Empty types arrays still generate the same deprecation warning they did in 7.x.
+                    // Ideally they should be removed from the definition.
+                    deprecationLogger.critical(DeprecationCategory.PARSING, "watcher_search_input", TYPES_DEPRECATION_MESSAGE);
                 } else {
                     throw new ElasticsearchParseException(
                         "could not read search request. unexpected array field [" + currentFieldName + "]"
@@ -272,6 +289,7 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
     }
 
     private static final ParseField INDICES_FIELD = new ParseField("indices");
+    private static final ParseField TYPES_FIELD = new ParseField("types");
     private static final ParseField BODY_FIELD = new ParseField("body");
     private static final ParseField SEARCH_TYPE_FIELD = new ParseField("search_type");
     private static final ParseField INDICES_OPTIONS_FIELD = new ParseField("indices_options");


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Tolerate empty types array in Watch definitions (#83524)