### PR TITLE
[DOCS] Add 8.0 release highlight for kNN search API

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -7,14 +7,14 @@ For detailed information about this release, see the <<es-release-notes>> and
 <<breaking-changes>>.
 
 // Add previous release to the list
-// Other versions: 
-// {ref-bare}/7.last/release-highlights.html[7.last] 
+// Other versions:
+// {ref-bare}/7.last/release-highlights.html[7.last]
 // | {ref-bare}/8.0/release-highlights.html[8.0]
 
-// Use the notable-highlights tag to mark entries that 
+// Use the notable-highlights tag to mark entries that
 // should be featured in the Stack Installation and Upgrade Guide:
 
-// tag::notable-highlights[] 
+// tag::notable-highlights[]
 [discrete]
 === 7.x REST API compatibility
 
@@ -36,17 +36,17 @@ For more information about the headers and how to use them, see
 === Security features are enabled and configured by default
 
 Running {es} without security leaves your cluster exposed to anyone who can send
-network traffic to {es}. In previous versions, you had to explicitly enable the 
+network traffic to {es}. In previous versions, you had to explicitly enable the
 {es} security features such as authentication, authorization, and network
 encryption (TLS). Starting in {es} 8.0, security is
 {ref}/configuring-stack-security.html[enabled and configured by default] when
-you start {es} for the first time. 
+you start {es} for the first time.
 
-At startup, we generate enrollment tokens that you use to connect a {kib} 
-instance or enroll additional nodes in your secured {es} cluster, without having 
-to generate security certificates or update YAML configuration files. Just use 
-the generated enrollment token when starting new nodes or {kib} instances, and 
-the {stack} handles all of the security configuration for you. Out of the box, 
+At startup, we generate enrollment tokens that you use to connect a {kib}
+instance or enroll additional nodes in your secured {es} cluster, without having
+to generate security certificates or update YAML configuration files. Just use
+the generated enrollment token when starting new nodes or {kib} instances, and
+the {stack} handles all of the security configuration for you. Out of the box,
 you'll get:
 
 * User authentication
@@ -54,8 +54,8 @@ you'll get:
 * Encrypted internode communication with TLS
 * Encrypted communication between {es} and {kib} with TLS
 
-Need a new enrollment token? Use the 
-{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] 
+Need a new enrollment token? Use the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`]
 tool to create enrollment tokens for {es} nodes and {kib} instances.
 
 [discrete]
@@ -81,7 +81,7 @@ rather than accessing a system index. If you attempt to directly access a system
 logs.
 
 [discrete]
-=== kNN search API
+=== New kNN search API
 
 With 8.0, we're introducing a technical preview of the
 {ref}/knn-search-api.html[kNN search API].
@@ -93,9 +93,9 @@ relevancy based on natural language processing (NLP) algorithms.
 
 Previously, {es} only supported exact kNN searches using a `script_score` query
 with a vector function. While this method guarantees accurate results, it often
-results in slow searches and doesn’t scale well with large datasets. The new kNN
-search API lets you run approximate kNN searches on larger datasets and at faster
-speeds—at the cost of slower indexing and imperfect accuracy.
+results in slow searches and doesn’t scale well with large datasets. In exchange
+for slower indexing and imperfect accuracy, the new kNN search API lets you run
+approximate kNN searches on larger datasets and at faster speeds.
 
 [discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
@@ -122,9 +122,9 @@ improvements to indexing speed.
 [discrete]
 === PyTorch model support for {nlp} (NLP)
 
-Now it is possible to upload https://pytorch.org/[PyTorch] models that are 
-trained outside {es} and use them for {infer} at ingest time. Third party model 
-support brings modern {ml-docs}/ml-nlp-overview.html[{nlp} (NLP)] and search use 
+Now it is possible to upload https://pytorch.org/[PyTorch] models that are
+trained outside {es} and use them for {infer} at ingest time. Third party model
+support brings modern {ml-docs}/ml-nlp-overview.html[{nlp} (NLP)] and search use
 cases to the {stack} such as:
 
 * Fill-mask
@@ -136,7 +136,7 @@ cases to the {stack} such as:
 // end::notable-highlights[]
 
 // Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [discrete] 
+// [discrete]
 // === Heading
 //
-// Description. 
+// Description.

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -81,6 +81,23 @@ rather than accessing a system index. If you attempt to directly access a system
 logs.
 
 [discrete]
+=== kNN search API
+
+With 8.0, we're introducing a technical preview of the
+{ref}/knn-search-api.html[kNN search API].
+
+Using `dense_vector` fields, a {ref}/knn-search.html[_k-nearest neighbor_ (kNN)
+search] finds the _k_ nearest vectors to a query vector, as measured by a
+similarity metric. kNN is commonly used to power recommendation engines and rank
+relevancy based on natural language processing (NLP) algorithms.
+
+Previously, {es} only supported exact kNN searches using a `script_score` query
+with a vector function. While this method guarantees accurate results, it often
+results in slow searches and doesn’t scale well with large datasets. The new kNN
+search API lets you run approximate kNN searches on larger datasets and at faster
+speeds—at the cost of slower indexing and imperfect accuracy.
+
+[discrete]
 === Storage savings for `keyword`, `match_only_text`, and `text` fields
 
 We've updated inverted indices, an internal data structure, to use a more


### PR DESCRIPTION
Adds a release highlight for the kNN search API.

Relates to https://github.com/elastic/elasticsearch/issues/78473 and https://github.com/elastic/elasticsearch/pull/79013

### Preview
https://elasticsearch_83755.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.0/release-highlights.html#_knn_search_api