### PR TITLE
[7.17][ML] Retry anomaly detection job recovery during relocation (#8…

### DIFF
--- a/docs/changelog/83456.yaml
+++ b/docs/changelog/83456.yaml
@@ -1,0 +1,5 @@
+pr: 83456
+summary: Retry anomaly detection job recovery during relocation
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
…3456)

When an anomaly detection job is relocating to a new node, we revert
the job to its current snapshot if it exists, or we reset the job.
Both these actions may fail if ML indices are not available. A job
relocation is often triggered because of a rolling upgrade. During
a rolling upgrade it is probably that data nodes containing shards
of the ML indices may be temporarily unavailable which causes this
operation to fail.

In order not to leave the job in a reverting/resetting state in such
a scenario, this commit adds retrying logic. We retry reverting/resetting
the job for up to 15 minutes which should be enough for the cluster to
manage to delete any intervening ML data for the job.

Backport of #83456
