### PR TITLE
Use more Efficient Immutable Maps in Mapping Lookups

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -25,8 +25,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.unmodifiableMap;
-
 /**
  * Wrapper around everything that defines a mapping, without references to
  * utility classes like MapperService, ...
@@ -45,26 +43,22 @@ public final class Mapping implements ToXContentFragment {
     private final Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap;
     private final Map<String, MetadataFieldMapper> metadataMappersByName;
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Mapping(RootObjectMapper rootObjectMapper, MetadataFieldMapper[] metadataMappers, Map<String, Object> meta) {
         this.metadataMappers = metadataMappers;
-        Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap = new HashMap<>();
-        Map<String, MetadataFieldMapper> metadataMappersByName = new HashMap<>();
-        for (MetadataFieldMapper metadataMapper : metadataMappers) {
-            metadataMappersMap.put(metadataMapper.getClass(), metadataMapper);
-            metadataMappersByName.put(metadataMapper.name(), metadataMapper);
+        Map.Entry<Class<? extends MetadataFieldMapper>, MetadataFieldMapper>[] metadataMappersMap = new Map.Entry[metadataMappers.length];
+        Map.Entry<String, MetadataFieldMapper>[] metadataMappersByName = new Map.Entry[metadataMappers.length];
+        for (int i = 0; i < metadataMappers.length; i++) {
+            MetadataFieldMapper metadataMapper = metadataMappers[i];
+            metadataMappersMap[i] = Map.entry(metadataMapper.getClass(), metadataMapper);
+            metadataMappersByName[i] = Map.entry(metadataMapper.name(), metadataMapper);
         }
         this.root = rootObjectMapper;
         // keep root mappers sorted for consistent serialization
-        Arrays.sort(metadataMappers, new Comparator<Mapper>() {
-            @Override
-            public int compare(Mapper o1, Mapper o2) {
-                return o1.name().compareTo(o2.name());
-            }
-        });
-        this.metadataMappersMap = unmodifiableMap(metadataMappersMap);
-        this.metadataMappersByName = unmodifiableMap(metadataMappersByName);
+        Arrays.sort(metadataMappers, Comparator.comparing(Mapper::name));
+        this.metadataMappersMap = Map.ofEntries(metadataMappersMap);
+        this.metadataMappersByName = Map.ofEntries(metadataMappersByName);
         this.meta = meta;
-
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -134,7 +133,7 @@ public class NestedObjectMapper extends ObjectMapper {
     }
 
     public Map<String, Mapper> getChildren() {
-        return Collections.unmodifiableMap(this.mappers);
+        return this.mappers;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -307,9 +307,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
         this.enabled = enabled;
         this.dynamic = dynamic;
         if (mappers == null) {
-            this.mappers = new HashMap<>();
+            this.mappers = Map.of();
         } else {
-            this.mappers = new HashMap<>(mappers);
+            this.mappers = Map.copyOf(mappers);
         }
     }
 
@@ -321,7 +321,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
-        clone.mappers = new HashMap<>(clone.mappers);
+        clone.mappers = Map.copyOf(clone.mappers);
         return clone;
     }
 
@@ -410,8 +410,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
         }
 
+        Map<String, Mapper> mergedMappers = null;
         for (Mapper mergeWithMapper : mergeWith) {
-            Mapper mergeIntoMapper = mappers.get(mergeWithMapper.simpleName());
+            Mapper mergeIntoMapper = (mergedMappers == null ? mappers : mergedMappers).get(mergeWithMapper.simpleName());
 
             Mapper merged;
             if (mergeIntoMapper == null) {
@@ -434,7 +435,13 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     merged = mergeIntoMapper.merge(mergeWithMapper);
                 }
             }
-            mappers.put(merged.simpleName(), merged);
+            if (mergedMappers == null) {
+                mergedMappers = new HashMap<>(mappers);
+            }
+            mergedMappers.put(merged.simpleName(), merged);
+        }
+        if (mergedMappers != null) {
+            mappers = Map.copyOf(mergedMappers);
         }
     }
 


### PR DESCRIPTION
Both of these maps are very hot in benchmarking and seem to not get a lot of
inlining of the unmodifiable wrapper etc.
=> use the more efficient immutable maps for both to speed things up a little.
