### PR TITLE
[8.1] [DOCS] Remove 8.0.0 coming tag (#83757)

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -9,8 +9,6 @@ your application to {es} 8.0.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.0.0]
-
 [discrete]
 [[breaking-changes-8.0]]
 === Breaking changes

--- a/docs/reference/release-notes/8.0.0.asciidoc
+++ b/docs/reference/release-notes/8.0.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.0.0]]
 == {es} version 8.0.0
 
-coming::[8.0.0]
-
 The following list are changes in 8.0.0 as compared to 7.17.0, and combines
 release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Remove 8.0.0 coming tag (#83757)