### PR TITLE
Optimize SnapshotsInProgress#obsoleteGenerations

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -130,8 +130,14 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         return entries.values().stream().flatMap(Collection::stream);
     }
 
+    @Nullable
     public Entry snapshot(final Snapshot snapshot) {
-        for (Entry entry : forRepo(snapshot.getRepository())) {
+        return findInList(snapshot, forRepo(snapshot.getRepository()));
+    }
+
+    @Nullable
+    private static Entry findInList(Snapshot snapshot, List<Entry> forRepo) {
+        for (Entry entry : forRepo) {
             final Snapshot curr = entry.snapshot();
             if (curr.equals(snapshot)) {
                 return entry;
@@ -147,9 +153,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
      */
     public Map<RepositoryShardId, Set<ShardGeneration>> obsoleteGenerations(String repository, SnapshotsInProgress old) {
         final Map<RepositoryShardId, Set<ShardGeneration>> obsoleteGenerations = new HashMap<>();
+        final List<Entry> updatedSnapshots = forRepo(repository);
         for (Entry entry : old.forRepo(repository)) {
-            final Entry updatedEntry = snapshot(entry.snapshot());
-            if (updatedEntry == null) {
+            final Entry updatedEntry = findInList(entry.snapshot(), updatedSnapshots);
+            if (updatedEntry == null || updatedEntry == entry) {
                 continue;
             }
             for (Map.Entry<RepositoryShardId, ShardSnapshotStatus> oldShardAssignment : entry.shardsByRepoShardId().entrySet()) {


### PR DESCRIPTION
This method turns out to be the most expensive part of snapshot finalization
if many snapshots are finalized concurrently (and in fact takes more time than any repo IO).
This was never optimized much because we wouldn't expect to have all that many snapshots running in parallel.
Even with this change is quadratic in the number of snapshots that are in-flight but it's far faster
and helps us run many-shards benchmarks more efficiently.
Also, it's a huge help for the simulated case of running a very large number of single index snapshots in parallel which could be a real world ILM scenario.

relates https://github.com/elastic/elasticsearch/issues/77466