### PR TITLE
[DOCS] Remove unneeded callouts from snippets

### DIFF
--- a/docs/reference/aggregations/metrics/max-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/max-aggregation.asciidoc
@@ -137,8 +137,8 @@ PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
-      "values" : [0.1, 0.2, 0.3, 0.4, 0.5], <1>
-      "counts" : [3, 7, 23, 12, 6] <2>
+      "values" : [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [3, 7, 23, 12, 6]
    }
 }
 
@@ -146,8 +146,8 @@ PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
-      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5], <1>
-      "counts" : [8, 17, 8, 7, 6] <2>
+      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [8, 17, 8, 7, 6]
    }
 }
 

--- a/docs/reference/aggregations/metrics/min-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/min-aggregation.asciidoc
@@ -137,8 +137,8 @@ PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
-      "values" : [0.1, 0.2, 0.3, 0.4, 0.5], <1>
-      "counts" : [3, 7, 23, 12, 6] <2>
+      "values" : [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [3, 7, 23, 12, 6]
    }
 }
 
@@ -146,8 +146,8 @@ PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
-      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5], <1>
-      "counts" : [8, 17, 8, 7, 6] <2>
+      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [8, 17, 8, 7, 6]
    }
 }
 


### PR DESCRIPTION
These callouts aren't referenced anywhere. Leaving them in can be confusing.