### PR TITLE
Remove LegacyCTRAListener from open-indices batching

### DIFF
--- a/docs/changelog/83760.yaml
+++ b/docs/changelog/83760.yaml
@@ -1,5 +1,5 @@
 pr: 83760
-summary: Batch open-indices
+summary: Batch open-indices cluster state updates
 area: Indices APIs
 type: enhancement
 issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1081,7 +1081,7 @@ public class MetadataIndexStateService {
                     builder.success(task, new ActionListener<>() {
                         @Override
                         public void onResponse(ClusterState clusterState) {
-                            // no-op
+                            task.onPublicationComplete();
                         }
 
                         @Override
@@ -1201,5 +1201,12 @@ public class MetadataIndexStateService {
         public TimeValue ackTimeout() {
             return request.ackTimeout();
         }
+
+        @Override
+        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
+            assert false : "not called";
+        }
+
+        protected void onPublicationComplete() {}
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1081,7 +1081,7 @@ public class MetadataIndexStateService {
                     builder.success(task, new ActionListener<>() {
                         @Override
                         public void onResponse(ClusterState clusterState) {
-                            task.onPublicationComplete();
+                            // listener is notified at the end of acking
                         }
 
                         @Override
@@ -1206,7 +1206,5 @@ public class MetadataIndexStateService {
         public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
             assert false : "not called";
         }
-
-        protected void onPublicationComplete() {}
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1078,7 +1078,17 @@ public class MetadataIndexStateService {
                 state = allocationService.reroute(state, "indices opened");
 
                 for (OpenIndicesTask task : tasks) {
-                    builder.success(task, new LegacyClusterTaskResultActionListener(task, currentState));
+                    builder.success(task, new ActionListener<>() {
+                        @Override
+                        public void onResponse(ClusterState clusterState) {
+                            // no-op
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            task.onFailure(e);
+                        }
+                    });
                 }
             } catch (Exception e) {
                 for (OpenIndicesTask task : tasks) {


### PR DESCRIPTION
Follow up to #83760, related to https://github.com/elastic/elasticsearch/issues/83784

Also, fixed the changelog from that PR while I was here (I changed the title on the previous PR, but the changelog caught the old description).
