### PR TITLE
[8.1] Add docs for elasticsearch-reconfigure-node (#83605)

### DIFF
--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -13,6 +13,7 @@ tasks from the command line:
 * <<elasticsearch-croneval>>
 * <<elasticsearch-keystore>>
 * <<node-tool>>
+* <<reconfigure-node>>
 * <<reset-password>>
 * <<saml-metadata>>
 * <<setup-passwords>>
@@ -28,6 +29,7 @@ include::create-enrollment-token.asciidoc[]
 include::croneval.asciidoc[]
 include::keystore.asciidoc[]
 include::node-tool.asciidoc[]
+include::reconfigure-node.asciidoc[]
 include::reset-password.asciidoc[]
 include::saml-metadata.asciidoc[]
 include::service-tokens-command.asciidoc[]

--- a/docs/reference/commands/reconfigure-node.asciidoc
+++ b/docs/reference/commands/reconfigure-node.asciidoc
@@ -1,0 +1,64 @@
+[[reconfigure-node]]
+== elasticsearch-reconfigure-node
+
+The `elasticsearch-reconfigure-node` tool reconfigures an {es} node that was installed
+through an RPM or DEB package to join an existing cluster with security features enabled.
+
+[discrete]
+=== Synopsis
+
+[source,shell]
+-----------------------------------------------------
+bin/elasticsearch-reconfigure-node
+[--enrollment-token] [-h, --help] [-E <KeyValuePair>]
+[-s, --silent] [-v, --verbose]
+-----------------------------------------------------
+
+
+[discrete]
+=== Description
+
+When installing {es} with a DEB or RPM package, the current node is assumed to
+be the first node in the cluster. {es} enables and configures security 
+features on the node, generates a password for the `elastic` superuser, and 
+configures TLS for the HTTP and transport layers.
+
+Rather than form a single-node cluster, you can add a node to an existing 
+cluster where security features are already enabled and configured. Before 
+starting your new node, run the 
+<<create-enrollment-token,`elasticsearch-create-enrollment-token`>> tool
+with the `-s node` option to generate an enrollment token on any node in your
+existing cluster. On your new node, run the the
+`elasticsearch-reconfigure-node` tool and pass the enrollment token as a
+parameter.
+
+NOTE: This tool is intended only for use on DEB or RPM distributions of {es}.
+
+You must run this tool with `sudo` so that it can edit the necessary
+files in your {es} installation configuration directory that are owned by
+`root:elasticsearch`.
+
+
+[discrete]
+[[reconfigure-node-parameters]]
+=== Parameters
+
+`--enrollment-token`:: The enrollment token, which can be generated on any of the
+nodes in an existing, secured cluster.
+
+`-E <KeyValuePair>`:: Configures a standard {es} or {xpack} setting.
+
+`-h, --help`:: Shows help information.
+
+`-s, --silent`:: Shows minimal output.
+
+`-v, --verbose`:: Shows verbose output.
+
+[discrete]
+=== Examples
+
+The following example reconfigures an installed {es} node so that it can join an existing cluster when it starts for the first time.
+[source,shell]
+----
+sudo /usr/share/elasticsearch/elasticsearch-reconfigure-node --enrollment-token eyJ2ZXIiOiI4LjAuMCIsImFkciI6WyIxOTIuMTY4LjEuMTY6OTIwMCJdLCJmZ3IiOiI4NGVhYzkyMzAyMWQ1MjcyMmQxNTFhMTQwZmM2ODI5NmE5OWNiNmU0OGVhZjYwYWMxYzljM2I3ZDJjOTg2YTk3Iiwia2V5IjoiUy0yUjFINEJrNlFTMkNEY1dVV1g6QS0wSmJxM3hTRy1haWxoQTdPWVduZyJ9
+----


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Add docs for elasticsearch-reconfigure-node (#83605)