### PR TITLE
Remove LegacyCTRAListener from MetadataMappingService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -111,7 +111,17 @@ public class MetadataMappingService {
                             }
                         }
                         currentState = applyRequest(currentState, request, indexMapperServices);
-                        builder.success(task, new LegacyClusterTaskResultActionListener(task, originalState));
+                        builder.success(task, new ActionListener<>() {
+                            @Override
+                            public void onResponse(ClusterState clusterState) {
+                                // listener is notified at the end of acking
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                task.onFailure(e);
+                            }
+                        });
                     } catch (Exception e) {
                         builder.failure(task, e);
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -57,15 +57,10 @@ public class MetadataMappingService {
         this.indicesService = indicesService;
     }
 
-    static class PutMappingClusterStateUpdateTask implements ClusterStateTaskListener, ClusterStateAckListener {
-
-        private final PutMappingClusterStateUpdateRequest request;
-        private final ActionListener<AcknowledgedResponse> listener;
-
-        PutMappingClusterStateUpdateTask(PutMappingClusterStateUpdateRequest request, ActionListener<AcknowledgedResponse> listener) {
-            this.request = request;
-            this.listener = listener;
-        }
+    record PutMappingClusterStateUpdateTask(PutMappingClusterStateUpdateRequest request, ActionListener<AcknowledgedResponse> listener)
+        implements
+            ClusterStateTaskListener,
+            ClusterStateAckListener {
 
         @Override
         public void onFailure(Exception e) {


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/83784

Same resolution as https://github.com/elastic/elasticsearch/pull/83807, and I'm waiting on CI there anyway.