### PR TITLE
Document that awareness attributes override custom preferences

### DIFF
--- a/docs/reference/search/search-your-data/search-shard-routing.asciidoc
+++ b/docs/reference/search/search-your-data/search-shard-routing.asciidoc
@@ -89,10 +89,12 @@ GET /my-index-000001/_search?preference=my-custom-shard-string
 // TEST[setup:my_index]
 
 WARNING: If a node has <<shard-allocation-awareness,shard allocation awareness>>
-attributes, it will ignore custom `preference` values and instead prefer shards
-with the same awareness attribute values. You can disable routing based on
-awareness attributes by enabling the `es.search.ignore_awareness_attributes`
-system property on every node in the cluster.
+attributes, then it will prefer shards with the same awareness attribute values.
+So even if a search specifies the same custom `preference` values, different
+coordinating nodes may route it differently because of their awareness
+attributes. You can disable routing based on awareness attributes entirely by
+enabling the `es.search.ignore_awareness_attributes` system property on every
+node in the cluster.
 
 NOTE: If the cluster state or selected shards change, the same `preference`
 string may not route searches to the same shards in the same order. This can

--- a/docs/reference/search/search-your-data/search-shard-routing.asciidoc
+++ b/docs/reference/search/search-your-data/search-shard-routing.asciidoc
@@ -90,9 +90,9 @@ GET /my-index-000001/_search?preference=my-custom-shard-string
 
 WARNING: If a node has <<shard-allocation-awareness,shard allocation awareness>>
 attributes, then it will prefer shards with the same awareness attribute values.
-Because of these attributes, different coordinating nodes may route same search
-differently, even if the searches use the same custom `preference` values. To
-disable routing based on awareness attributes, set the
+Because of these attributes, different coordinating nodes may route the same
+search differently, even if the searches use the same custom `preference`
+values. To disable routing based on awareness attributes, set the
 `es.search.ignore_awareness_attributes` system property to `true` in the
 <<set-jvm-options,JVM options>> of every node in the cluster.
 

--- a/docs/reference/search/search-your-data/search-shard-routing.asciidoc
+++ b/docs/reference/search/search-your-data/search-shard-routing.asciidoc
@@ -90,11 +90,11 @@ GET /my-index-000001/_search?preference=my-custom-shard-string
 
 WARNING: If a node has <<shard-allocation-awareness,shard allocation awareness>>
 attributes, then it will prefer shards with the same awareness attribute values.
-So even if a search specifies the same custom `preference` values, different
-coordinating nodes may route it differently because of their awareness
-attributes. You can disable routing based on awareness attributes entirely by
-enabling the `es.search.ignore_awareness_attributes` system property on every
-node in the cluster.
+Because of these attributes, different coordinating nodes may route same search
+differently, even if the searches use the same custom `preference` values. To
+disable routing based on awareness attributes, set the
+`es.search.ignore_awareness_attributes` system property to `true` in the
+<<set-jvm-options,JVM options>> of every node in the cluster.
 
 NOTE: If the cluster state or selected shards change, the same `preference`
 string may not route searches to the same shards in the same order. This can

--- a/docs/reference/search/search-your-data/search-shard-routing.asciidoc
+++ b/docs/reference/search/search-your-data/search-shard-routing.asciidoc
@@ -88,6 +88,12 @@ GET /my-index-000001/_search?preference=my-custom-shard-string
 ----
 // TEST[setup:my_index]
 
+WARNING: If a node has <<shard-allocation-awareness,shard allocation awareness>>
+attributes, it will ignore custom `preference` values and instead prefer shards
+with the same awareness attribute values. You can disable routing based on
+awareness attributes by enabling the `es.search.ignore_awareness_attributes`
+system property on every node in the cluster.
+
 NOTE: If the cluster state or selected shards change, the same `preference`
 string may not route searches to the same shards in the same order. This can
 occur for a number of reasons, including shard relocations and shard failures. A


### PR DESCRIPTION
When selecting replicas in a search, the coordinating node prefers nodes with
the same shard allocation awareness attributes. So even if a search specifies
the same custom `preference` values, different coordinating nodes may route it
differently because of their awareness attributes.

In 8.0, allocation awareness attributes no longer influence search replica
selection. So although this is a bug, we do not intend to fix it in 7.x or 6.x.
Instead, we document the behavior as a 'warning' and mention a system property
that can be used to disable the behavior.

Addresses #53054.