### PR TITLE
[8.1] fix: backward compatibility with version 7.17.0 (#83715)

### DIFF
--- a/docs/changelog/83715.yaml
+++ b/docs/changelog/83715.yaml
@@ -1,0 +1,5 @@
+pr: 83715
+summary: "Fix: backward compatibility with version 7.17.0"
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -142,8 +142,8 @@ setup:
 ---
 "Float range":
   - skip:
-      version: " - 7.16.99"
-      reason: Bug fixed in 8.1.0 and backported to 7.17.0
+      version: " - 7.17.0"
+      reason: Bug fixed in 8.1.0 and backported to 7.17.1
   - do:
       search:
         index: test

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -266,11 +266,21 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             String key = in.getVersion().onOrAfter(Version.V_7_17_1) ? in.readOptionalString() : in.readString();
             double from = in.readDouble();
             if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
-                in.readOptionalDouble();
+                final Double originalFrom = in.readOptionalDouble();
+                if (originalFrom != null) {
+                    from = originalFrom;
+                } else {
+                    from = Double.NEGATIVE_INFINITY;
+                }
             }
             double to = in.readDouble();
             if (in.getVersion().onOrAfter(Version.V_7_17_0)) {
-                in.readOptionalDouble();
+                final Double originalTo = in.readOptionalDouble();
+                if (originalTo != null) {
+                    to = originalTo;
+                } else {
+                    to = Double.POSITIVE_INFINITY;
+                }
             }
             long docCount = in.readVLong();
             InternalAggregations aggregations = InternalAggregations.readFrom(in);


### PR DESCRIPTION
Backports the following commits to 8.1:
 - fix: backward compatibility with version 7.17.0 (#83715)