### PR TITLE
Fix version variable in docker-compose.yml

### DIFF
--- a/docs/reference/setup/install/docker-compose.yml
+++ b/docs/reference/setup/install/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     depends_on:
       setup:
         condition: service_healthy
-    image: {docker-repo}:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata01:/usr/share/elasticsearch/data
@@ -109,7 +109,7 @@ services:
   es02:
     depends_on:
       - es01
-    image: {docker-repo}:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata02:/usr/share/elasticsearch/data
@@ -149,7 +149,7 @@ services:
   es03:
     depends_on:
       - es02
-    image: {docker-repo}${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata03:/usr/share/elasticsearch/data

--- a/docs/reference/setup/install/docker-compose.yml
+++ b/docs/reference/setup/install/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   setup:
-    image: docker.elastic.co/elasticsearch/elasticsearch:{version}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
     user: "0"
@@ -66,7 +66,7 @@ services:
     depends_on:
       setup:
         condition: service_healthy
-    image: {docker-repo}:{version}
+    image: {docker-repo}:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata01:/usr/share/elasticsearch/data
@@ -109,7 +109,7 @@ services:
   es02:
     depends_on:
       - es01
-    image: {docker-repo}:{version}
+    image: {docker-repo}:${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata02:/usr/share/elasticsearch/data
@@ -149,7 +149,7 @@ services:
   es03:
     depends_on:
       - es02
-    image: {docker-repo}:{version}
+    image: {docker-repo}${STACK_VERSION}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata03:/usr/share/elasticsearch/data
@@ -194,7 +194,7 @@ services:
         condition: service_healthy
       es03:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:{version}
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
     volumes:
       - certs:/usr/share/kibana/config/certs
       - kibanadata:/usr/share/kibana/data


### PR DESCRIPTION
The `docker-compose.yml` file used in our docs has been modified to use a `{version}` placeholder rather than the original `${STACK_VERSION}` variable.

This creates problems as it doesn't honor the variable value set in the `.env` file.
The scope to have this variable is that users can change the `.env` file while keeping the `docker-compose.yml` file untouched.

This PR restores the original `docker-compose.yml` content to honor the variable.