### PR TITLE
Accept only single tasks at master service

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -28,8 +28,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.List;
-
 public class ClusterService extends AbstractLifecycleComponent {
     private final MasterService masterService;
 
@@ -259,7 +257,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         ClusterStateTaskConfig config,
         ClusterStateTaskExecutor<T> executor
     ) {
-        masterService.submitStateUpdateTasks(source, List.of(task), config, executor);
+        masterService.submitStateUpdateTask(source, task, config, executor);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/TaskBatcher.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/TaskBatcher.java
@@ -19,15 +19,12 @@ import org.elasticsearch.core.TimeValue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Batching support for {@link PrioritizedEsThreadPoolExecutor}
@@ -45,86 +42,50 @@ public abstract class TaskBatcher {
         this.threadExecutor = threadExecutor;
     }
 
-    public void submitTasks(List<? extends BatchedTask> tasks, @Nullable TimeValue timeout) throws EsRejectedExecutionException {
-        if (tasks.isEmpty()) {
-            return;
-        }
-        final BatchedTask firstTask = tasks.get(0);
-        assert tasks.stream().allMatch(t -> t.batchingKey == firstTask.batchingKey)
-            : "tasks submitted in a batch should share the same batching key: " + tasks;
-        // convert to an identity map to check for dups based on task identity
-
-        tasksPerBatchingKey.compute(firstTask.batchingKey, (k, existingTasks) -> {
-            assert assertNoDuplicateTasks(tasks, existingTasks);
+    public void submitTask(BatchedTask task, @Nullable TimeValue timeout) throws EsRejectedExecutionException {
+        tasksPerBatchingKey.compute(task.batchingKey, (k, existingTasks) -> {
             if (existingTasks == null) {
-                return Collections.synchronizedSet(new LinkedHashSet<>(tasks));
+                existingTasks = Collections.synchronizedSet(new LinkedHashSet<>());
+            } else {
+                assert assertNoDuplicateTasks(task, existingTasks);
             }
-            existingTasks.addAll(tasks);
+            existingTasks.add(task);
             return existingTasks;
         });
 
         if (timeout != null) {
-            threadExecutor.execute(firstTask, timeout, () -> onTimeoutInternal(tasks, timeout));
+            threadExecutor.execute(task, timeout, () -> onTimeoutInternal(task, timeout));
         } else {
-            threadExecutor.execute(firstTask);
+            threadExecutor.execute(task);
         }
     }
 
-    private static boolean assertNoDuplicateTasks(List<? extends BatchedTask> tasks, Set<BatchedTask> existingTasks) {
-        final Map<Object, BatchedTask> tasksIdentity = tasks.stream()
-            .collect(
-                Collectors.toMap(
-                    BatchedTask::getTask,
-                    Function.identity(),
-                    (a, b) -> { throw new AssertionError("cannot add duplicate task: " + a); },
-                    IdentityHashMap::new
-                )
-            );
-        if (existingTasks == null) {
-            return true;
-        }
-        for (BatchedTask existing : existingTasks) {
-            // check that there won't be two tasks with the same identity for the same batching key
-            BatchedTask duplicateTask = tasksIdentity.get(existing.getTask());
-            assert duplicateTask == null
-                : "task ["
-                    + duplicateTask.describeTasks(Collections.singletonList(existing))
-                    + "] with source ["
-                    + duplicateTask.source
-                    + "] is already queued";
+    private static boolean assertNoDuplicateTasks(BatchedTask task, Set<BatchedTask> existingTasks) {
+        for (final var existingTask : existingTasks) {
+            assert existingTask.getTask() != task.getTask()
+                : "task [" + task.describeTasks(List.of(task)) + "] with source [" + task.source + "] is already queued";
         }
         return true;
     }
 
-    private void onTimeoutInternal(List<? extends BatchedTask> tasks, TimeValue timeout) {
-        final ArrayList<BatchedTask> toRemove = new ArrayList<>();
-        for (BatchedTask task : tasks) {
-            if (task.processed.getAndSet(true) == false) {
-                logger.debug("task [{}] timed out after [{}]", task.source, timeout);
-                toRemove.add(task);
-            }
+    private void onTimeoutInternal(BatchedTask task, TimeValue timeout) {
+        if (task.processed.getAndSet(true)) {
+            return;
         }
-        if (toRemove.isEmpty() == false) {
-            BatchedTask firstTask = toRemove.get(0);
-            Object batchingKey = firstTask.batchingKey;
-            assert tasks.stream().allMatch(t -> t.batchingKey == batchingKey)
-                : "tasks submitted in a batch should share the same batching key: " + tasks;
-            tasksPerBatchingKey.computeIfPresent(batchingKey, (key, existingTasks) -> {
-                toRemove.forEach(existingTasks::remove);
-                if (existingTasks.isEmpty()) {
-                    return null;
-                }
-                return existingTasks;
-            });
-            onTimeout(toRemove, timeout);
-        }
+
+        logger.debug("task [{}] timed out after [{}]", task.source, timeout);
+        tasksPerBatchingKey.computeIfPresent(task.batchingKey, (key, existingTasks) -> {
+            existingTasks.remove(task);
+            return existingTasks.isEmpty() ? null : existingTasks;
+        });
+        onTimeout(task, timeout);
     }
 
     /**
      * Action to be implemented by the specific batching implementation.
      * All tasks have the same batching key.
      */
-    protected abstract void onTimeout(List<? extends BatchedTask> tasks, TimeValue timeout);
+    protected abstract void onTimeout(BatchedTask task, TimeValue timeout);
 
     void runIfNotProcessed(BatchedTask updateTask) {
         // if this task is already processed, it shouldn't execute other tasks with same batching key that arrived later,
@@ -135,6 +96,7 @@ public abstract class TaskBatcher {
             final Set<BatchedTask> pending = tasksPerBatchingKey.remove(updateTask.batchingKey);
             if (pending != null) {
                 // pending is a java.util.Collections.SynchronizedSet so we can safely iterate holding its mutex
+                // noinspection SynchronizationOnLocalVariableOrMethodParameter
                 synchronized (pending) {
                     for (BatchedTask task : pending) {
                         if (task.processed.getAndSet(true) == false) {

--- a/server/src/test/java/org/elasticsearch/cluster/service/TaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TaskExecutorTests.java
@@ -70,9 +70,9 @@ public class TaskExecutorTests extends ESTestCase {
     }
 
     protected interface TestListener {
-        void onFailure(String source, Exception e);
+        void onFailure(Exception e);
 
-        default void processed(String source) {
+        default void processed() {
             // do nothing by default
         }
     }
@@ -129,7 +129,7 @@ public class TaskExecutorTests extends ESTestCase {
         public void run() {
             logger.trace("will process {}", source);
             testTask.execute(Collections.singletonList(testTask));
-            testTask.processed(source);
+            testTask.processed();
         }
     }
 
@@ -140,7 +140,7 @@ public class TaskExecutorTests extends ESTestCase {
         if (timeout != null) {
             threadExecutor.execute(task, timeout, () -> threadPool.generic().execute(() -> {
                 logger.debug("task [{}] timed out after [{}]", task, timeout);
-                testTask.onFailure(source, new ProcessClusterEventTimeoutException(timeout, source));
+                testTask.onFailure(new ProcessClusterEventTimeoutException(timeout, source));
             }));
         } else {
             threadExecutor.execute(task);
@@ -163,7 +163,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new RuntimeException(e);
             }
         };
@@ -178,7 +178,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 block2.countDown();
             }
 
@@ -207,7 +207,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new RuntimeException(e);
             }
         };
@@ -228,7 +228,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 timedOut.countDown();
             }
         };
@@ -245,7 +245,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(Exception e) {
                 throw new RuntimeException(e);
             }
         };
@@ -312,7 +312,7 @@ public class TaskExecutorTests extends ESTestCase {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {}
+        public void onFailure(Exception e) {}
 
         @Override
         public Priority priority() {
@@ -349,7 +349,7 @@ public class TaskExecutorTests extends ESTestCase {
         }
 
         @Override
-        public void onFailure(String source, Exception e) {
+        public void onFailure(Exception e) {
             latch.countDown();
         }
     }


### PR DESCRIPTION
Today `MasterService` (and `TaskBatcher`) allow callers to submit a
collection of tasks that will be executed all at once. Support for
batches of tasks makes things more complicated than they need to be,
noting that (since #83803) in production code we only ever submit single
tasks. This commit specializes things to accept only single tasks.