### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Elasticsearch Changlog
+
+Please see the [release notes](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html) in the reference manual.


### PR DESCRIPTION
Having a `CHANGELOG.md` file in the root of a code repository is a very common practice. Elasticsearch doesn't follow this for good reasons, and publishes extensive release notes on the website. However we can be more helpful to users browsing the repository by pointing them to the release notes.