### PR TITLE
TSDB: improve error message for nested fields

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -52,7 +52,7 @@ add time series mappings:
 can't shadow dimensions:
   - skip:
       version: " - 8.0.99"
-      reason: introduced in 8.1.0 to be backported to 8.0.0
+      reason: introduced in 8.1.0
 
   - do:
       indices.create:
@@ -118,7 +118,7 @@ can't shadow dimensions:
 can't shadow metrics:
   - skip:
       version: " - 8.0.99"
-      reason: introduced in 8.1.0 to be backported to 8.0.0
+      reason: introduced in 8.1.0
 
   - do:
       indices.create:
@@ -214,3 +214,35 @@ no _tsid in standard indices:
   - is_false: fields.metricset.keyword.non_searchable_indices
   - is_false: fields.metricset.keyword.non_aggregatable_indices
   - is_false: fields._tsid  # _tsid metadata field must not exist in non-time-series indices
+
+---
+nested dimensions:
+  - skip:
+      version: " - 8.0.99"
+      reason: introduced in 8.1.0
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                nested:
+                  type: nested
+                  properties:
+                      dim:
+                        type: keyword
+                        time_series_dimension: true
+
+  - do:
+      index:
+        index: test
+        refresh: true
+        body:
+          "@timestamp": "2021-04-28T18:35:24.467Z"
+          nested:
+            - dim: foo
+            - dim: bar
+            - dim: baz

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -271,3 +271,32 @@ runtime field matching routing path:
           - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim": {"foo": {"bar": "a"}}}'
   - match: {items.0.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
   - match: {items.1.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
+
+---
+nested dimensions:
+  - skip:
+      version: " - 8.1.99"
+      reason: message changed in 8.2.0
+
+  - do:
+      catch: /cannot have nested fields when index is in \[index.mode=time_series\]/
+      indices.create:
+          index: test
+          body:
+            settings:
+              index:
+                mode: time_series
+                routing_path: [nested.*]
+                time_series:
+                  start_time: 2021-04-28T00:00:00Z
+                  end_time: 2021-04-29T00:00:00Z
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                nested:
+                  type: nested
+                  properties:
+                      dim:
+                        type: keyword
+                        time_series_dimension: true

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
+import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 
@@ -110,6 +111,9 @@ public enum IndexMode {
 
         @Override
         public void validateMapping(MappingLookup lookup) {
+            if (lookup.nestedLookup() != NestedLookup.EMPTY) {
+                throw new IllegalArgumentException("cannot have nested fields when index is in " + tsdbMode());
+            }
             if (((RoutingFieldMapper) lookup.getMapper(RoutingFieldMapper.NAME)).required()) {
                 throw new IllegalArgumentException(routingRequiredBad());
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -95,6 +95,7 @@ public class DocumentMapper {
                 );
             }
         }
+        settings.getMode().validateMapping(mappingLookup);
         if (settings.getIndexSortConfig().hasIndexSort() && mappers().nestedLookup() != NestedLookup.EMPTY) {
             throw new IllegalArgumentException("cannot have nested fields when index sort is activated");
         }
@@ -117,6 +118,5 @@ public class DocumentMapper {
         if (checkLimits) {
             this.mappingLookup.checkLimits(settings);
         }
-        settings.getMode().validateMapping(mappingLookup);
     }
 }


### PR DESCRIPTION
Nested fields have never been supported in time_series mode but their
error message was something along the lines of "nested fields don't work
when you've enabled index sorting". Which is *true*, but when you put
an index into time_series mode you don't explicitly enable index sorting
- time_series mode does that for you. So the message is confusing. This
gives you a more explicit "nested fields don't work in time_series
mode".

I've also added tests for nested dimensions outside of time series mode.
We didn't have any such tests and it's nice to assert how they currently
work.
