### PR TITLE
Render Mappings more Compact in GET /_cluster/state

### DIFF
--- a/docs/changelog/83846.yaml
+++ b/docs/changelog/83846.yaml
@@ -1,0 +1,5 @@
+pr: 83846
+summary: Render Mappings more Compact in GET /_cluster/state
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -126,7 +127,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
      */
     @SuppressWarnings("unchecked")
     public Map<String, Object> sourceAsMap() throws ElasticsearchParseException {
-        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).v2();
+        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
         if (mapping.size() == 1 && mapping.containsKey(type())) {
             // the type name is the root value, reduce it
             mapping = (Map<String, Object>) mapping.get(type());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -94,6 +94,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public static final String ALL = "_all";
     public static final String UNKNOWN_CLUSTER_UUID = "_na_";
 
+    public static final String MAPPINGS_BY_HASH_PARAM = "mappings_by_hash";
+
     public enum XContentContext {
         /* Custom metadata should be returns as part of API call */
         API,
@@ -2124,6 +2126,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             builder.endObject();
 
             if (context == XContentContext.API) {
+                if (params.paramAsBoolean(MAPPINGS_BY_HASH_PARAM, true)) {
+                    builder.startObject("mappings");
+                    for (Map.Entry<String, MappingMetadata> mappingEntry : metadata.getMappingsByHash().entrySet()) {
+                        builder.startObject(mappingEntry.getKey());
+                        builder.mapContents(mappingEntry.getValue().sourceAsMap());
+                        builder.endObject();
+                    }
+                    builder.endObject();
+                }
                 builder.startObject("indices");
                 for (IndexMetadata indexMetadata : metadata) {
                     IndexMetadata.Builder.toXContent(indexMetadata, builder, params);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -30,18 +30,18 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
-import static java.util.Collections.singletonMap;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestClusterStateAction extends BaseRestHandler {
 
+    public static final Map<String, String> TO_XCONTENT_PARAMS = Map.of(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API);
     private final SettingsFilter settingsFilter;
 
     private final ThreadPool threadPool;
@@ -116,10 +116,7 @@ public class RestClusterStateAction extends BaseRestHandler {
             ) {
                 @Override
                 protected ToXContent.Params getParams() {
-                    return new ToXContent.DelegatingMapParams(
-                        singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API),
-                        request
-                    );
+                    return new ToXContent.DelegatingMapParams(TO_XCONTENT_PARAMS, request);
                 }
             }.map(response -> new RestClusterStateResponse(clusterStateRequest, response, threadPool::relativeTimeInMillis))
         );
@@ -130,8 +127,9 @@ public class RestClusterStateAction extends BaseRestHandler {
     static {
         final Set<String> responseParams = new HashSet<>();
         responseParams.add("metric");
+        responseParams.add(Metadata.MAPPINGS_BY_HASH_PARAM);
         responseParams.addAll(Settings.FORMAT_PARAMS);
-        RESPONSE_PARAMS = Collections.unmodifiableSet(responseParams);
+        RESPONSE_PARAMS = Set.copyOf(responseParams);
     }
 
     @Override


### PR DESCRIPTION
This deduplicates index mappings in the `/_cluster/state` response by grouping them by the sha256 hash of the mapping.
This significantly reduces the response size for large cluster states,
making this debug API easier to read for humans (because understanding
whether or not mappings are duplicated across indices might be valuable)
and more importantly less ressource hungry as far as serialization goes.

Adds an undocumented parameter to get back to the old format if we actually have to in an unforeseen instance.


New rendering of an index:

```json
      "my-index-000001" : {
        "version" : 5,
        "mapping_version" : 2,
        "settings_version" : 1,
        "aliases_version" : 1,
        "routing_num_shards" : 1024,
        "state" : "open",
        "settings" : {
          "index" : {
            "routing" : {
              "allocation" : {
                "include" : {
                  "_tier_preference" : "data_content"
                }
              }
            },
            "number_of_shards" : "1",
            "provided_name" : "my-index-000001",
            "creation_date" : "1644601309989",
            "number_of_replicas" : "1",
            "uuid" : "9m19TP4DRsevoKkSG3DC0g",
            "version" : {
              "created" : "8020099"
            }
          }
        },
        "mappings" : "XinOY78Sl3l55aaFJrhIKDlniKVodszNHRmKhONrR/o=",
```

and then mappings at the same level as "indices":


```json
  "mappings" : {
      "5jySc/VOXLKC1itGKeilXwF6kCFL0i5Xe0DqJ0eDgwk=" : {
        "dynamic" : "strict",
        "_meta" : {
          "version" : "8.2.0"
        },
        "properties" : {
          "chunk" : {
            "type" : "integer"
          },
          "data" : {
            "type" : "binary"
          },
          "name" : {
            "type" : "keyword"
          }
        }
      },
      "XinOY78Sl3l55aaFJrhIKDlniKVodszNHRmKhONrR/o=" : {
        "properties" : {
          "@timestamp" : {
            "type" : "date"
          },
          "message" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "user" : {
            "properties" : {
              "id" : {
                "type" : "text",
                "fields" : {
                  "keyword" : {
                    "type" : "keyword",
                    "ignore_above" : 256
                  }
                }
              }
            }
          }
        }
      }
    }
```

relates #77466 