### PR TITLE
Shrink slow log for rank_feature query

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java
@@ -32,6 +32,7 @@ import java.util.Objects;
  * Query to run on a [rank_feature] field.
  */
 public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeatureQueryBuilder> {
+    private static final ScoreFunction DEFAULT_SCORE_FUNCTION = new ScoreFunction.Saturation();
 
     /**
      * Scoring function for a [rank_feature] field.
@@ -309,7 +310,7 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
         if (numNonNulls > 1) {
             throw new IllegalArgumentException("Can only specify one of [log], [saturation], [sigmoid] and [linear]");
         } else if (numNonNulls == 0) {
-            query = new RankFeatureQueryBuilder(field, new ScoreFunction.Saturation());
+            query = new RankFeatureQueryBuilder(field, DEFAULT_SCORE_FUNCTION);
         } else {
             ScoreFunction scoreFunction = (ScoreFunction) Arrays.stream(args, 3, args.length).filter(Objects::nonNull).findAny().get();
             query = new RankFeatureQueryBuilder(field, scoreFunction);
@@ -368,8 +369,10 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
         builder.field("field", field);
-        scoreFunction.doXContent(builder);
-        printBoostAndQueryName(builder);
+        if (false == scoreFunction.equals(DEFAULT_SCORE_FUNCTION)) {
+            scoreFunction.doXContent(builder);
+        }
+        boostAndQueryNameToXContent(builder);
         builder.endObject();
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilderTests.java
@@ -147,4 +147,21 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
             e.getMessage()
         );
     }
+
+    public void testParseDefaultsRemoved() throws IOException {
+        String json = """
+            {
+              "rank_feature" : {
+                "field": "foo",
+                "boost": 1,
+                "saturation": {}
+              }
+            }""";
+        checkGeneratedJson("""
+            {
+              "rank_feature": {
+                "field": "foo"
+              }
+            }""", parseQuery(json));
+    }
 }


### PR DESCRIPTION
This removes the `boost` from the `toXContent` of `rank_feature` if it
is the default. It also removes the score function if it is the default.

Relates to #76515
