### PR TITLE
[8.0] [DOCS] Clarify when changes are replicated in CCR (#83863)

### DIFF
--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -216,19 +216,11 @@ To manage how operations are replicated from the leader index, you can
 configure settings when
 <<ccr-getting-started-follower-index,creating the follower index>>.
 
-The follower index automatically retrieves some updates applied to the leader
-index, while other updates are retrieved as needed:
-
-[cols="3"]
-|===
-h| Update type h| Automatic  h| As needed
-| Alias        | {yes-icon} | {no-icon}
-| Mapping      | {no-icon}  | {yes-icon}
-| Settings     | {no-icon}  | {yes-icon}
-|===
-
-For example, changing the number of replicas on the leader index is not
-replicated by the follower index, so that setting might not be retrieved.
+Changes in the index mapping on the leader index are replicated to the
+follower index as soon as possible. This behavior is true for index
+settings as well, except for some settings that are local to the leader
+index. For example, changing the number of replicas on the leader index is
+not replicated by the follower index, so that setting might not be retrieved.
 
 If you apply a non-dynamic settings change to the leader index that is
 needed by the follower index, the follower index closes itself, applies the


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Clarify when changes are replicated in CCR (#83863)