### PR TITLE
MetadataIndexStateService cleanups

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -631,6 +631,10 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             return nodes;
         }
 
+        public Builder routingTable(RoutingTable.Builder routingTableBuilder) {
+            return routingTable(routingTableBuilder.build());
+        }
+
         public Builder routingTable(RoutingTable routingTable) {
             this.routingTable = routingTable;
             return this;

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -300,6 +300,13 @@ public class ClusterBlocks implements SimpleDiffable<ClusterBlocks> {
         return new Builder();
     }
 
+    /**
+     * Convenience method, equivalent to: {@code builder().blocks(blocks)}
+     */
+    public static Builder builder(ClusterBlocks blocks) {
+        return builder().blocks(blocks);
+    }
+
     public static class Builder {
 
         private final Set<ClusterBlock> global = new HashSet<>();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -269,11 +269,9 @@ public class MetadataIndexStateService {
         final Map<Index, ClusterBlock> blockedIndices,
         final ClusterState currentState
     ) {
-        final Metadata.Builder metadata = Metadata.builder(currentState.metadata());
-
         final Set<Index> indicesToClose = new HashSet<>();
         for (Index index : indices) {
-            final IndexMetadata indexMetadata = metadata.getSafe(index);
+            final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
             if (indexMetadata.getState() != IndexMetadata.State.CLOSE) {
                 indicesToClose.add(index);
             } else {
@@ -331,7 +329,7 @@ public class MetadataIndexStateService {
                 blockedIndices.keySet().stream().map(Object::toString).collect(Collectors.joining(","))
             )
         );
-        return ClusterState.builder(currentState).blocks(blocks).metadata(metadata).build();
+        return ClusterState.builder(currentState).blocks(blocks).build();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -300,7 +300,7 @@ public class MetadataIndexStateService {
             );
         }
 
-        final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+        final ClusterBlocks.Builder blocks = ClusterBlocks.builder(currentState.blocks());
 
         for (Index index : indicesToClose) {
             ClusterBlock indexBlock = null;
@@ -361,7 +361,7 @@ public class MetadataIndexStateService {
             return Tuple.tuple(currentState, Collections.emptyMap());
         }
 
-        final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+        final ClusterBlocks.Builder blocks = ClusterBlocks.builder(currentState.blocks());
         final Map<Index, ClusterBlock> blockedIndices = new HashMap<>();
 
         for (Index index : indicesToAddBlock) {
@@ -785,7 +785,7 @@ public class MetadataIndexStateService {
         final Map<Index, IndexResult> verifyResult
     ) {
         final Metadata.Builder metadata = Metadata.builder(currentState.metadata());
-        final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+        final ClusterBlocks.Builder blocks = ClusterBlocks.builder(currentState.blocks());
         final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());
 
         final Set<String> closedIndices = new HashSet<>();
@@ -929,7 +929,7 @@ public class MetadataIndexStateService {
         final Map<Index, AddBlockResult> verifyResult,
         final APIBlock block
     ) {
-        final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+        final ClusterBlocks.Builder blocks = ClusterBlocks.builder(currentState.blocks());
 
         final Set<String> effectivelyBlockedIndices = new HashSet<>();
         Map<Index, AddBlockResult> blockingResults = new HashMap<>(verifyResult);
@@ -1113,7 +1113,7 @@ public class MetadataIndexStateService {
             });
 
             final Metadata.Builder metadata = Metadata.builder(currentState.metadata());
-            final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+            final ClusterBlocks.Builder blocks = ClusterBlocks.builder(currentState.blocks());
             final Version minIndexCompatibilityVersion = currentState.getNodes().getMaxNodeVersion().minimumIndexCompatibilityVersion();
 
             for (IndexMetadata indexMetadata : indicesToOpen) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -871,7 +871,7 @@ public class MetadataIndexStateService {
         }
         logger.info("completed closing of indices {}", closedIndices);
         return Tuple.tuple(
-            ClusterState.builder(currentState).blocks(blocks).metadata(metadata).routingTable(routingTable.build()).build(),
+            ClusterState.builder(currentState).blocks(blocks).metadata(metadata).routingTable(routingTable).build(),
             closingResults.values()
         );
     }
@@ -1152,7 +1152,7 @@ public class MetadataIndexStateService {
                     routingTable.addAsFromCloseToOpen(updatedState.metadata().getIndexSafe(previousIndexMetadata.getIndex()));
                 }
             }
-            return ClusterState.builder(updatedState).routingTable(routingTable.build()).build();
+            return ClusterState.builder(updatedState).routingTable(routingTable).build();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -225,10 +225,8 @@ public class MetadataIndexStateService {
                                                                     );
                                                                 }
                                                                 // acknowledged maybe be false but some indices may have been correctly
-                                                                // closed, so
-                                                                // we maintain a kind of coherency by overriding the shardsAcknowledged
-                                                                // value
-                                                                // (see ShardsAcknowledgedResponse constructor)
+                                                                // closed, so we maintain a kind of coherency by overriding the
+                                                                // shardsAcknowledged value (see ShardsAcknowledgedResponse constructor)
                                                                 boolean shardsAcked = acknowledged ? shardsAcknowledged : false;
                                                                 listener.onResponse(
                                                                     new CloseIndexResponse(acknowledged, shardsAcked, indices)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -793,7 +793,6 @@ public class MetadataIndexStateService {
         final Map<Index, ClusterBlock> blockedIndices,
         final Map<Index, IndexResult> verifyResult
     ) {
-
         final Metadata.Builder metadata = Metadata.builder(currentState.metadata());
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
         final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -303,7 +303,6 @@ public class MetadataIndexStateService {
         }
 
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-        final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());
 
         for (Index index : indicesToClose) {
             ClusterBlock indexBlock = null;
@@ -332,7 +331,7 @@ public class MetadataIndexStateService {
                 blockedIndices.keySet().stream().map(Object::toString).collect(Collectors.joining(","))
             )
         );
-        return ClusterState.builder(currentState).blocks(blocks).metadata(metadata).routingTable(routingTable.build()).build();
+        return ClusterState.builder(currentState).blocks(blocks).metadata(metadata).build();
     }
 
     /**
@@ -365,7 +364,6 @@ public class MetadataIndexStateService {
         }
 
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-        final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());
         final Map<Index, ClusterBlock> blockedIndices = new HashMap<>();
 
         for (Index index : indicesToAddBlock) {
@@ -403,10 +401,7 @@ public class MetadataIndexStateService {
             block.name,
             blockedIndices.keySet().stream().map(Object::toString).collect(Collectors.toList())
         );
-        return Tuple.tuple(
-            ClusterState.builder(currentState).blocks(blocks).metadata(metadata).routingTable(routingTable.build()).build(),
-            blockedIndices
-        );
+        return Tuple.tuple(ClusterState.builder(currentState).blocks(blocks).metadata(metadata).build(), blockedIndices);
     }
 
     /**
@@ -936,10 +931,7 @@ public class MetadataIndexStateService {
         final Map<Index, AddBlockResult> verifyResult,
         final APIBlock block
     ) {
-
-        final Metadata.Builder metadata = Metadata.builder(currentState.metadata());
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-        final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());
 
         final Set<String> effectivelyBlockedIndices = new HashSet<>();
         Map<Index, AddBlockResult> blockingResults = new HashMap<>(verifyResult);
@@ -992,10 +984,7 @@ public class MetadataIndexStateService {
             }
         }
         logger.info("completed adding block {} to indices {}", block.name, effectivelyBlockedIndices);
-        return Tuple.tuple(
-            ClusterState.builder(currentState).blocks(blocks).metadata(metadata).routingTable(routingTable.build()).build(),
-            blockingResults.values()
-        );
+        return Tuple.tuple(ClusterState.builder(currentState).blocks(blocks).build(), blockingResults.values());
     }
 
     /**


### PR DESCRIPTION
Related to #81627

Just a cleanup PR, some things I noticed while I was working on understanding some of the parts of this class to do the actual work of #81627. Individual commits are meant to be independent, if you object to anything, I can revert things piecemeal pretty easily.