### PR TITLE
Shrink slow log for has_child query

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -60,6 +60,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
      * The default minimum number of children that are required to match for the parent to be considered a match.
      */
     public static final int DEFAULT_MIN_CHILDREN = 1;
+    private static final ScoreMode DEFAULT_SCORE_MODE = ScoreMode.None;
 
     /**
      * The default value for ignore_unmapped.
@@ -80,7 +81,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     private InnerHitBuilder innerHitBuilder;
     private int minChildren = DEFAULT_MIN_CHILDREN;
     private int maxChildren = DEFAULT_MAX_CHILDREN;
-    private boolean ignoreUnmapped = false;
+    private boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
 
     public HasChildQueryBuilder(String type, QueryBuilder query, ScoreMode scoreMode) {
         this(type, query, DEFAULT_MIN_CHILDREN, DEFAULT_MAX_CHILDREN, scoreMode, null);
@@ -224,11 +225,19 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
         builder.field(QUERY_FIELD.getPreferredName());
         query.toXContent(builder, params);
         builder.field(TYPE_FIELD.getPreferredName(), type);
-        builder.field(SCORE_MODE_FIELD.getPreferredName(), NestedQueryBuilder.scoreModeAsString(scoreMode));
-        builder.field(MIN_CHILDREN_FIELD.getPreferredName(), minChildren);
-        builder.field(MAX_CHILDREN_FIELD.getPreferredName(), maxChildren);
-        builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
-        printBoostAndQueryName(builder);
+        if (false == scoreMode.equals(DEFAULT_SCORE_MODE)) {
+            builder.field(SCORE_MODE_FIELD.getPreferredName(), NestedQueryBuilder.scoreModeAsString(scoreMode));
+        }
+        if (minChildren != DEFAULT_MIN_CHILDREN) {
+            builder.field(MIN_CHILDREN_FIELD.getPreferredName(), minChildren);
+        }
+        if (maxChildren != DEFAULT_MAX_CHILDREN) {
+            builder.field(MAX_CHILDREN_FIELD.getPreferredName(), maxChildren);
+        }
+        if (ignoreUnmapped != DEFAULT_IGNORE_UNMAPPED) {
+            builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
+        }
+        boostAndQueryNameToXContent(builder);
         if (innerHitBuilder != null) {
             builder.field(INNER_HITS_FIELD.getPreferredName(), innerHitBuilder, params);
         }
@@ -238,7 +247,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     public static HasChildQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String childType = null;
-        ScoreMode scoreMode = ScoreMode.None;
+        ScoreMode scoreMode = DEFAULT_SCORE_MODE;
         int minChildren = HasChildQueryBuilder.DEFAULT_MIN_CHILDREN;
         int maxChildren = HasChildQueryBuilder.DEFAULT_MAX_CHILDREN;
         boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.join.ParentJoinPlugin;
+import org.elasticsearch.join.query.HasChildQueryBuilder.LateParsingQuery;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -55,7 +56,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.join.query.HasChildQueryBuilder.LateParsingQuery;
 import static org.elasticsearch.join.query.JoinQueryBuilders.hasChildQuery;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -245,7 +245,14 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
               }
             }""";
         HasChildQueryBuilder queryBuilder = (HasChildQueryBuilder) parseQuery(query);
-        checkGeneratedJson(query, queryBuilder);
+        checkGeneratedJson(
+            /*
+             * Ignoring unampped is the default and we don't dump it and can't
+             * change it if we're going to use inner_hits.
+             */
+            query.replaceFirst("\"ignore_unmapped\" : false,", ""),
+            queryBuilder
+        );
         assertEquals(query, queryBuilder.maxChildren(), 1217235442);
         assertEquals(query, queryBuilder.minChildren(), 883170873);
         assertEquals(query, queryBuilder.boost(), 2.0f, 0.0f);
@@ -257,6 +264,74 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
             .setSize(100)
             .addSort(new FieldSortBuilder("mapped_string").order(SortOrder.ASC));
         assertEquals(query, queryBuilder.innerHit(), expected);
+    }
+
+    public void testParseDefaultsRemoved() throws IOException {
+        String query = """
+            {
+              "has_child" : {
+                "query" : {
+                  "range" : {
+                    "mapped_string" : {
+                      "gte" : "agJhRET",
+                      "lte" : "zvqIq",
+                      "boost" : 1.0
+                    }
+                  }
+                },
+                "type" : "child",
+                "score_mode" : "none",
+                "min_children" : 1,
+                "max_children" : MAX_CHILDREN,
+                "ignore_unmapped" : false,
+                "boost" : 1.0,
+                "inner_hits" : {
+                  "name" : "inner_hits_name",
+                  "ignore_unmapped" : false,
+                  "from" : 0,
+                  "size" : 100,
+                  "version" : false,
+                  "seq_no_primary_term" : false,
+                  "explain" : false,
+                  "track_scores" : false,
+                  "sort" : [ {
+                    "mapped_string" : {
+                      "order" : "asc"
+                    }
+                  } ]
+                }
+              }
+            }""".replaceAll("MAX_CHILDREN", Integer.toString(Integer.MAX_VALUE));
+        checkGeneratedJson("""
+            {
+              "has_child" : {
+                "query" : {
+                  "range" : {
+                    "mapped_string" : {
+                      "gte" : "agJhRET",
+                      "lte" : "zvqIq",
+                      "boost" : 1.0
+                    }
+                  }
+                },
+                "type" : "child",
+                "inner_hits" : {
+                  "name" : "inner_hits_name",
+                  "ignore_unmapped" : false,
+                  "from" : 0,
+                  "size" : 100,
+                  "version" : false,
+                  "seq_no_primary_term" : false,
+                  "explain" : false,
+                  "track_scores" : false,
+                  "sort" : [ {
+                    "mapped_string" : {
+                      "order" : "asc"
+                    }
+                  } ]
+                }
+              }
+            }""", parseQuery(query));
     }
 
     public void testToQueryInnerQueryType() throws IOException {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -247,7 +247,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         HasChildQueryBuilder queryBuilder = (HasChildQueryBuilder) parseQuery(query);
         checkGeneratedJson(
             /*
-             * Ignoring unampped is the default and we don't dump it and can't
+             * Ignoring unmapped is the default and we don't dump it and can't
              * change it if we're going to use inner_hits.
              */
             query.replaceFirst("\"ignore_unmapped\" : false,", ""),


### PR DESCRIPTION
This removes the defaults from the `toXContent` of the `has_child` query
so slow logs that contain it are marginally easier to read.

Relates to #76515
