### PR TITLE
[ML] Remove uses of ML HLRC classes

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCauseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCauseTests.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.core.ml.job.results;
 
-import org.elasticsearch.client.ml.job.config.DetectorFunction;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.job.config.DetectorFunction;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecordTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecordTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.job.results;
 
-import org.elasticsearch.client.ml.job.config.DetectorFunction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -16,6 +15,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
+import org.elasticsearch.xpack.core.ml.job.config.DetectorFunction;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 
 import java.io.IOException;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/NamedXContentObjectHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/NamedXContentObjectHelperTests.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.utils;
 
-import org.elasticsearch.client.ml.inference.NamedXContentObject;
-import org.elasticsearch.client.ml.inference.NamedXContentObjectHelper;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -7,28 +7,17 @@
 
 package org.elasticsearch.xpack.deprecation;
 
-import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.WarningsHandler;
-import org.elasticsearch.client.ml.PutJobRequest;
-import org.elasticsearch.client.ml.job.config.AnalysisConfig;
-import org.elasticsearch.client.ml.job.config.DataDescription;
-import org.elasticsearch.client.ml.job.config.Detector;
-import org.elasticsearch.client.ml.job.config.Job;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,12 +32,6 @@ public class MlDeprecationIT extends ESRestTestCase {
     private static final RequestOptions REQUEST_OPTIONS = RequestOptions.DEFAULT.toBuilder()
         .setWarningsHandler(WarningsHandler.PERMISSIVE)
         .build();
-
-    private static class HLRC extends RestHighLevelClient {
-        HLRC(RestClient restClient) {
-            super(restClient, RestClient::close, new ArrayList<>());
-        }
-    }
 
     @After
     public void resetFeatures() throws IOException {
@@ -69,32 +52,21 @@ public class MlDeprecationIT extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testMlDeprecationChecks() throws Exception {
-        HLRC hlrc = new HLRC(client());
         String jobId = "deprecation_check_job";
-        hlrc.machineLearning()
-            .putJob(
-                new PutJobRequest(
-                    Job.builder(jobId)
-                        .setAnalysisConfig(
-                            AnalysisConfig.builder(Collections.singletonList(Detector.builder().setFunction("count").build()))
-                        )
-                        .setDataDescription(new DataDescription.Builder().setTimeField("time"))
-                        .build()
-                ),
-                REQUEST_OPTIONS
-            );
+        buildAndPutJob(jobId);
 
-        IndexRequest indexRequest = new IndexRequest(".ml-anomalies-.write-" + jobId).id(jobId + "_model_snapshot_1")
-            .source("{\"job_id\":\"deprecation_check_job\",\"snapshot_id\":\"1\", \"snapshot_doc_count\":1}", XContentType.JSON);
-        hlrc.index(indexRequest, REQUEST_OPTIONS);
+        indexDoc(
+            ".ml-anomalies-.write-" + jobId,
+            jobId + "_model_snapshot_1",
+            "{\"job_id\":\"deprecation_check_job\",\"snapshot_id\":\"1\", \"snapshot_doc_count\":1}"
+        );
 
-        indexRequest = new IndexRequest(".ml-anomalies-.write-" + jobId).id(jobId + "_model_snapshot_2")
-            .source(
-                "{\"job_id\":\"deprecation_check_job\",\"snapshot_id\":\"2\",\"snapshot_doc_count\":1,\"min_version\":\"8.0.0\"}",
-                XContentType.JSON
-            );
-        hlrc.index(indexRequest, REQUEST_OPTIONS);
-        hlrc.indices().refresh(new RefreshRequest(".ml-anomalies-*"), REQUEST_OPTIONS);
+        indexDoc(
+            ".ml-anomalies-.write-" + jobId,
+            jobId + "_model_snapshot_2",
+            "{\"job_id\":\"deprecation_check_job\",\"snapshot_id\":\"2\",\"snapshot_doc_count\":1,\"min_version\":\"8.0.0\"}"
+        );
+        client().performRequest(new Request("POST", "/.ml-anomalies-*/_refresh"));
 
         // specify an index so that deprecation checks don't run against any accidentally existing indices
         Request getDeprecations = new Request("GET", "/does-not-exist-*/_migration/deprecations");
@@ -106,6 +78,32 @@ public class MlDeprecationIT extends ESRestTestCase {
             containsString("Model snapshot [1] for job [deprecation_check_job] has an obsolete minimum version")
         );
         assertThat(mlSettingsDeprecations.get(0).get("_meta"), equalTo(Map.of("job_id", jobId, "snapshot_id", "1")));
+    }
+
+    private Response buildAndPutJob(String jobId) throws Exception {
+        String jobConfig = """
+            {
+                "analysis_config" : {
+                    "bucket_span": "3600s",
+                    "detectors" :[{"function":"count"}]
+                },
+                "data_description" : {
+                    "time_field":"time",
+                    "time_format":"yyyy-MM-dd HH:mm:ssX"
+                }
+            }""";
+
+        Request request = new Request("PUT", "/_ml/anomaly_detectors/" + jobId);
+        request.setOptions(REQUEST_OPTIONS);
+        request.setJsonEntity(jobConfig);
+        return client().performRequest(request);
+    }
+
+    private Response indexDoc(String index, String docId, String source) throws IOException {
+        Request request = new Request("PUT", "/" + index + "/_doc/" + docId);
+        request.setOptions(REQUEST_OPTIONS);
+        request.setJsonEntity(source);
+        return client().performRequest(request);
     }
 
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -10,12 +10,11 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.ml.GetTrainedModelsStatsResponse;
-import org.elasticsearch.client.ml.inference.TrainedModelStats;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ExternalTestCluster;
@@ -24,9 +23,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.InferenceDefinitionTests;
 import org.elasticsearch.xpack.core.ml.integration.MlRestTestStateCleaner;
@@ -36,6 +33,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -185,6 +183,7 @@ public class InferenceIngestIT extends ESRestTestCase {
         }, 30, TimeUnit.SECONDS);
     }
 
+    @SuppressWarnings("unchecked")
     public void testPipelineIngestWithModelAliases() throws Exception {
         String regressionModelId = "test_regression_1";
         putModel(regressionModelId, REGRESSION_CONFIG);
@@ -255,17 +254,13 @@ public class InferenceIngestIT extends ESRestTestCase {
         assertThat(EntityUtils.toString(searchResponse.getEntity()), not(containsString("\"value\":0")));
 
         assertBusy(() -> {
-            try (
-                XContentParser parser = createParser(
-                    JsonXContent.jsonXContent,
-                    client().performRequest(new Request("GET", "_ml/trained_models/" + modelAlias + "/_stats")).getEntity().getContent()
-                )
-            ) {
-                GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
-                assertThat(response.toString(), response.getTrainedModelStats(), hasSize(1));
-                TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
-                assertThat(trainedModelStats.getModelId(), equalTo(regressionModelId2));
-                assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
+            try {
+                Response response = client().performRequest(new Request("GET", "_ml/trained_models/" + modelAlias + "/_stats"));
+                var responseMap = entityAsMap(response);
+                assertThat((List<?>) responseMap.get("trained_model_stats"), hasSize(1));
+                var stats = ((List<Map<String, Object>>) responseMap.get("trained_model_stats")).get(0);
+                assertThat(stats.get("model_id"), equalTo(regressionModelId2));
+                assertThat(stats.get("inference_stats"), is(notNullValue()));
             } catch (ResponseException ex) {
                 // this could just mean shard failures.
                 fail(ex.getMessage());
@@ -273,16 +268,15 @@ public class InferenceIngestIT extends ESRestTestCase {
         });
     }
 
+    @SuppressWarnings("unchecked")
     public void assertStatsWithCacheMisses(String modelId, long inferenceCount) throws IOException {
         Response statsResponse = client().performRequest(new Request("GET", "_ml/trained_models/" + modelId + "/_stats"));
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, statsResponse.getEntity().getContent())) {
-            GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
-            assertThat(response.getTrainedModelStats(), hasSize(1));
-            TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
-            assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
-            assertThat(trainedModelStats.getInferenceStats().getInferenceCount(), equalTo(inferenceCount));
-            assertThat(trainedModelStats.getInferenceStats().getCacheMissCount(), greaterThan(0L));
-        }
+        var responseMap = entityAsMap(statsResponse);
+        assertThat((List<?>) responseMap.get("trained_model_stats"), hasSize(1));
+        var stats = ((List<Map<String, Object>>) responseMap.get("trained_model_stats")).get(0);
+        assertThat(stats.get("inference_stats"), is(notNullValue()));
+        assertThat(XContentMapValues.extractValue(stats, "inference_stats.inference_count"), equalTo(inferenceCount));
+        assertThat((Long) XContentMapValues.extractValue(stats, "inference_stats.cache_miss_count"), greaterThan(0L));
     }
 
     public void testSimulate() throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -116,8 +116,8 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         Response getSnapshotsResponse = getModelSnapshots(JOB_ID);
         List<Map<String, Object>> snapshots = (List<Map<String, Object>>) entityAsMap(getSnapshotsResponse).get("model_snapshots");
         assertThat(snapshots, hasSize(2));
-        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int)UPGRADE_FROM_VERSION.major));
-        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int)UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
 
         Map<String, Object> snapshotToUpgrade = snapshots.stream()
             .filter(s -> s.get("snapshot_id").equals(currentSnapshotId) == false)
@@ -146,10 +146,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         List<Map<String, Object>> upgradedSnapshot = (List<Map<String, Object>>) entityAsMap(getModelSnapshots(JOB_ID, snapshotToUpgradeId))
             .get("model_snapshots");
         assertThat(upgradedSnapshot, hasSize(1));
-        assertThat(
-            upgradedSnapshot.get(0).get("latest_record_time_stamp"),
-            equalTo(snapshotToUpgrade.get("latest_record_time_stamp"))
-        );
+        assertThat(upgradedSnapshot.get(0).get("latest_record_time_stamp"), equalTo(snapshotToUpgrade.get("latest_record_time_stamp")));
 
         // Does the snapshot still work?
         var stats = entityAsMap(getJobStats(JOB_ID));
@@ -228,8 +225,8 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         var modelSnapshots = entityAsMap(getModelSnapshots(JOB_ID));
         var snapshots = (List<Map<String, Object>>) modelSnapshots.get("model_snapshots");
         assertThat(snapshots, hasSize(2));
-        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int)UPGRADE_FROM_VERSION.major));
-        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int)UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
     }
 
     private Response buildAndPutJob(String jobId, TimeValue bucketSpan) throws Exception {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -8,47 +8,24 @@ package org.elasticsearch.upgrades;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.client.MachineLearningClient;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.ml.CloseJobRequest;
-import org.elasticsearch.client.ml.CloseJobResponse;
-import org.elasticsearch.client.ml.FlushJobRequest;
-import org.elasticsearch.client.ml.FlushJobResponse;
-import org.elasticsearch.client.ml.GetJobRequest;
-import org.elasticsearch.client.ml.GetJobResponse;
-import org.elasticsearch.client.ml.GetJobStatsRequest;
-import org.elasticsearch.client.ml.GetModelSnapshotsRequest;
-import org.elasticsearch.client.ml.GetModelSnapshotsResponse;
-import org.elasticsearch.client.ml.OpenJobRequest;
-import org.elasticsearch.client.ml.OpenJobResponse;
-import org.elasticsearch.client.ml.PostDataRequest;
-import org.elasticsearch.client.ml.PostDataResponse;
-import org.elasticsearch.client.ml.PutJobRequest;
-import org.elasticsearch.client.ml.PutJobResponse;
-import org.elasticsearch.client.ml.RevertModelSnapshotRequest;
-import org.elasticsearch.client.ml.UpgradeJobModelSnapshotRequest;
 import org.elasticsearch.client.ml.job.config.AnalysisConfig;
 import org.elasticsearch.client.ml.job.config.DataDescription;
 import org.elasticsearch.client.ml.job.config.Detector;
 import org.elasticsearch.client.ml.job.config.Job;
-import org.elasticsearch.client.ml.job.process.DataCounts;
-import org.elasticsearch.client.ml.job.process.ModelSnapshot;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +37,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -67,14 +45,6 @@ import static org.hamcrest.Matchers.is;
 public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-snapshots-upgrade-job";
-
-    private static class HLRC extends RestHighLevelClient {
-        HLRC(RestClient restClient) {
-            super(restClient, RestClient::close, new ArrayList<>());
-        }
-    }
-
-    private MachineLearningClient hlrc;
 
     @Override
     protected Collection<String> templatesToWaitFor() {
@@ -95,7 +65,6 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
     public void testSnapshotUpgrader() throws Exception {
-        hlrc = new HLRC(client()).machineLearning();
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
         adjustLoggingLevels.setJsonEntity("""
             {"persistent": {"logger.org.elasticsearch.xpack.ml": "trace"}}""");
@@ -125,57 +94,51 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void testSnapshotUpgradeFailsOnMixedCluster() throws Exception {
-        Job job = getJob(JOB_ID).jobs().get(0);
-        String currentSnapshot = job.getModelSnapshotId();
-        GetModelSnapshotsResponse modelSnapshots = getModelSnapshots(job.getId());
-        assertThat(modelSnapshots.snapshots(), hasSize(2));
+        Map<String, Object> jobs = entityAsMap(getJob(JOB_ID));
 
-        ModelSnapshot snapshot = modelSnapshots.snapshots()
-            .stream()
-            .filter(s -> s.getSnapshotId().equals(currentSnapshot) == false)
+        String currentSnapshot = ((List<String>) XContentMapValues.extractValue("jobs.model_snapshot_id", jobs)).get(0);
+        Response getResponse = getModelSnapshots(JOB_ID);
+        List<Map<String, Object>> snapshots = (List<Map<String, Object>>) entityAsMap(getResponse).get("model_snapshots");
+        assertThat(snapshots, hasSize(2));
+
+        Map<String, Object> snapshot = snapshots.stream()
+            .filter(s -> s.get("snapshot_id").equals(currentSnapshot) == false)
             .findFirst()
             .orElseThrow(() -> new ElasticsearchException("Not found snapshot other than " + currentSnapshot));
 
-        Exception ex = expectThrows(
-            Exception.class,
-            () -> hlrc.upgradeJobSnapshot(
-                new UpgradeJobModelSnapshotRequest(JOB_ID, snapshot.getSnapshotId(), null, true),
-                RequestOptions.DEFAULT
-            )
-        );
+        Exception ex = expectThrows(Exception.class, () -> upgradeJobSnapshot(JOB_ID, (String) snapshot.get("snapshot_id"), true));
         assertThat(ex.getMessage(), containsString("All nodes must be the same version"));
     }
 
+    @SuppressWarnings("unchecked")
     private void testSnapshotUpgrade() throws Exception {
-        Job job = getJob(JOB_ID).jobs().get(0);
-        String currentSnapshot = job.getModelSnapshotId();
+        Map<String, Object> jobs = entityAsMap(getJob(JOB_ID));
+        String currentSnapshotId = ((List<String>) XContentMapValues.extractValue("jobs.model_snapshot_id", jobs)).get(0);
 
-        GetModelSnapshotsResponse modelSnapshots = getModelSnapshots(job.getId());
-        assertThat(modelSnapshots.snapshots(), hasSize(2));
-        assertThat(modelSnapshots.snapshots().get(0).getMinVersion().major, equalTo(UPGRADE_FROM_VERSION.major));
-        assertThat(modelSnapshots.snapshots().get(1).getMinVersion().major, equalTo(UPGRADE_FROM_VERSION.major));
+        Response getSnapshotsResponse = getModelSnapshots(JOB_ID);
+        List<Map<String, Object>> snapshots = (List<Map<String, Object>>) entityAsMap(getSnapshotsResponse).get("model_snapshots");
+        assertThat(snapshots, hasSize(2));
+        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo(UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo(UPGRADE_FROM_VERSION.major));
 
-        ModelSnapshot snapshot = modelSnapshots.snapshots()
-            .stream()
-            .filter(s -> s.getSnapshotId().equals(currentSnapshot) == false)
+        Map<String, Object> snapshotToUpgrade = snapshots.stream()
+            .filter(s -> s.get("snapshot_id").equals(currentSnapshotId) == false)
             .findFirst()
-            .orElseThrow(() -> new ElasticsearchException("Not found snapshot other than " + currentSnapshot));
+            .orElseThrow(() -> new ElasticsearchException("Not found snapshot other than " + currentSnapshotId));
 
         // Don't wait for completion in the initial upgrade call, but instead poll for status
         // using the stats endpoint - this mimics what the Kibana upgrade assistant does
-        String snapshotToUpgrade = snapshot.getSnapshotId();
-        assertThat(
-            hlrc.upgradeJobSnapshot(new UpgradeJobModelSnapshotRequest(JOB_ID, snapshotToUpgrade, null, false), RequestOptions.DEFAULT)
-                .isCompleted(),
-            is(false)
-        );
+        String snapshotToUpgradeId = (String) snapshotToUpgrade.get("snapshot_id");
+        Map<String, Object> upgradeResponse = entityAsMap(upgradeJobSnapshot(JOB_ID, snapshotToUpgradeId, false));
+        assertFalse((boolean) upgradeResponse.get("completed"));
 
         // Wait for completion by waiting for the persistent task to disappear
         assertBusy(() -> {
             try {
                 Response response = client().performRequest(
-                    new Request("GET", "_ml/anomaly_detectors/" + JOB_ID + "/model_snapshots/" + snapshotToUpgrade + "/_upgrade/_stats")
+                    new Request("GET", "_ml/anomaly_detectors/" + JOB_ID + "/model_snapshots/" + snapshotToUpgradeId + "/_upgrade/_stats")
                 );
                 // Doing this instead of using expectThrows() on the line above means we get better diagnostics if the test fails
                 fail("Upgrade still in progress: " + entityAsMap(response));
@@ -184,78 +147,96 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
             }
         }, 30, TimeUnit.SECONDS);
 
-        List<ModelSnapshot> snapshots = getModelSnapshots(job.getId(), snapshotToUpgrade).snapshots();
-        assertThat(snapshots, hasSize(1));
-        snapshot = snapshots.get(0);
-        assertThat(snapshot.getLatestRecordTimeStamp(), equalTo(snapshots.get(0).getLatestRecordTimeStamp()));
+        List<Map<String, Object>> upgradedSnapshot = (List<Map<String, Object>>) entityAsMap(getModelSnapshots(JOB_ID, snapshotToUpgradeId))
+            .get("model_snapshots");
+        assertThat(upgradedSnapshot, hasSize(1));
+        assertThat(
+            (long) upgradedSnapshot.get(0).get("latest_record_time_stamp"),
+            equalTo(snapshotToUpgrade.get("latest_record_time_stamp"))
+        );
 
         // Does the snapshot still work?
+        var stats = entityAsMap(getJobStats(JOB_ID));
+        List<Map<String, Object>> jobStats = (List<Map<String, Object>>) XContentMapValues.extractValue("jobs", stats);
         assertThat(
-            hlrc.getJobStats(new GetJobStatsRequest(JOB_ID), RequestOptions.DEFAULT)
-                .jobStats()
-                .get(0)
-                .getDataCounts()
-                .getLatestRecordTimeStamp(),
-            greaterThan(snapshot.getLatestRecordTimeStamp())
+            (long) XContentMapValues.extractValue("data_counts.latest_record_timestamp", jobStats.get(0)),
+            greaterThan((long) snapshots.get(0).get("latest_record_time_stamp"))
         );
-        RevertModelSnapshotRequest revertModelSnapshotRequest = new RevertModelSnapshotRequest(JOB_ID, snapshotToUpgrade);
-        revertModelSnapshotRequest.setDeleteInterveningResults(true);
+
+        var revertResponse = entityAsMap(revertModelSnapshot(JOB_ID, snapshotToUpgradeId, true));
+        assertThat((String) XContentMapValues.extractValue(revertResponse, "model.snapshot_id"), equalTo(snapshotToUpgradeId));
+        assertThat(entityAsMap(openJob(JOB_ID)).get("opened"), is(true));
+
+        stats = entityAsMap(getJobStats(JOB_ID));
+        jobStats = (List<Map<String, Object>>) XContentMapValues.extractValue("jobs", stats);
         assertThat(
-            hlrc.revertModelSnapshot(revertModelSnapshotRequest, RequestOptions.DEFAULT).getModel().getSnapshotId(),
-            equalTo(snapshotToUpgrade)
-        );
-        assertThat(openJob(JOB_ID).isOpened(), is(true));
-        assertThat(
-            hlrc.getJobStats(new GetJobStatsRequest(JOB_ID), RequestOptions.DEFAULT)
-                .jobStats()
-                .get(0)
-                .getDataCounts()
-                .getLatestRecordTimeStamp(),
-            equalTo(snapshot.getLatestRecordTimeStamp())
+            (long) XContentMapValues.extractValue("data_counts.latest_record_timestamp", jobStats.get(0)),
+            equalTo((long) upgradedSnapshot.get(0).get("latest_record_time_stamp"))
         );
         closeJob(JOB_ID);
     }
 
+    @SuppressWarnings("unchecked")
     private void createJobAndSnapshots() throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueHours(1);
         long startTime = 1491004800000L;
 
-        PutJobResponse jobResponse = buildAndPutJob(JOB_ID, bucketSpan);
-        Job job = jobResponse.getResponse();
-        openJob(job.getId());
-        DataCounts dataCounts = postData(
-            job.getId(),
-            generateData(startTime, bucketSpan, 10, Arrays.asList("foo"), (bucketIndex, series) -> bucketIndex == 5 ? 100.0 : 10.0).stream()
-                .collect(Collectors.joining())
-        ).getDataCounts();
-        assertThat(dataCounts.getInvalidDateCount(), equalTo(0L));
-        assertThat(dataCounts.getBucketCount(), greaterThan(0L));
-        final long lastCount = dataCounts.getBucketCount();
-        flushJob(job.getId());
-        closeJob(job.getId());
+        buildAndPutJob(JOB_ID, bucketSpan);
+        openJob(JOB_ID);
+        var dataCounts = entityAsMap(
+            postData(
+                JOB_ID,
+                String.join(
+                    "",
+                    generateData(
+                        startTime,
+                        bucketSpan,
+                        10,
+                        Collections.singletonList("foo"),
+                        (bucketIndex, series) -> bucketIndex == 5 ? 100.0 : 10.0
+                    )
+                )
+            )
+        );
+
+        assertThat((Long) dataCounts.get("invalid_date_count"), equalTo(0L));
+        assertThat((Long) dataCounts.get("bucket_count"), greaterThan(0L));
+        final long lastCount = (long) dataCounts.get("bucket_count");
+        flushJob(JOB_ID);
+        closeJob(JOB_ID);
 
         // We need to wait a second to ensure the second time around model snapshot will have a different ID (it depends on epoch seconds)
         waitUntil(() -> false, 2, TimeUnit.SECONDS);
 
-        openJob(job.getId());
-        dataCounts = postData(
-            job.getId(),
-            generateData(startTime + 10 * bucketSpan.getMillis(), bucketSpan, 10, Arrays.asList("foo"), (bucketIndex, series) -> 10.0)
-                .stream()
-                .collect(Collectors.joining())
-        ).getDataCounts();
-        assertThat(dataCounts.getInvalidDateCount(), equalTo(0L));
-        assertThat(dataCounts.getBucketCount(), greaterThan(lastCount));
-        flushJob(job.getId());
-        closeJob(job.getId());
+        openJob(JOB_ID);
+        dataCounts = entityAsMap(
+            postData(
+                JOB_ID,
+                String.join(
+                    "",
+                    generateData(
+                        startTime + 10 * bucketSpan.getMillis(),
+                        bucketSpan,
+                        10,
+                        Collections.singletonList("foo"),
+                        (bucketIndex, series) -> 10.0
+                    )
+                )
+            )
+        );
+        assertThat((Long) dataCounts.get("invalid_date_count"), equalTo(0L));
+        assertThat((Long) dataCounts.get("bucket_count"), greaterThan(lastCount));
+        flushJob(JOB_ID);
+        closeJob(JOB_ID);
 
-        GetModelSnapshotsResponse modelSnapshots = getModelSnapshots(job.getId());
-        assertThat(modelSnapshots.snapshots(), hasSize(2));
-        assertThat(modelSnapshots.snapshots().get(0).getMinVersion().major, equalTo(UPGRADE_FROM_VERSION.major));
-        assertThat(modelSnapshots.snapshots().get(1).getMinVersion().major, equalTo(UPGRADE_FROM_VERSION.major));
+        var modelSnapshots = entityAsMap(getModelSnapshots(JOB_ID));
+        var snapshots = (List<Map<String, Object>>) modelSnapshots.get("model_snapshots");
+        assertThat(snapshots, hasSize(2));
+        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo(UPGRADE_FROM_VERSION.major));
+        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo(UPGRADE_FROM_VERSION.major));
     }
 
-    private PutJobResponse buildAndPutJob(String jobId, TimeValue bucketSpan) throws Exception {
+    private Response buildAndPutJob(String jobId, TimeValue bucketSpan) throws Exception {
         Detector.Builder detector = new Detector.Builder("mean", "value");
         detector.setPartitionFieldName("series");
         List<Detector> detectors = new ArrayList<>();
@@ -305,19 +286,25 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         return data;
     }
 
-    protected GetJobResponse getJob(String jobId) throws IOException {
-        return hlrc.getJob(new GetJobRequest(jobId), RequestOptions.DEFAULT);
+    protected Response getJob(String jobId) throws IOException {
+        return client().performRequest(new Request("GET", "/_ml/anomaly_detectors/" + jobId));
     }
 
-    protected PutJobResponse putJob(Job job) throws IOException {
-        return hlrc.putJob(new PutJobRequest(job), RequestOptions.DEFAULT);
+    protected Response getJobStats(String jobId) throws IOException {
+        return client().performRequest(new Request("GET", "/_ml/anomaly_detectors/" + jobId + "/_stats"));
     }
 
-    protected OpenJobResponse openJob(String jobId) throws IOException {
-        return hlrc.openJob(new OpenJobRequest(jobId), RequestOptions.DEFAULT);
+    protected Response putJob(Job job) throws IOException {
+        Request request = new Request("PUT", "/_ml/anomaly_detectors/" + job.getId());
+        request.setJsonEntity(Strings.toString(job));
+        return client().performRequest(request);
     }
 
-    protected PostDataResponse postData(String jobId, String data) throws IOException {
+    protected Response openJob(String jobId) throws IOException {
+        return client().performRequest(new Request("POST", "/_ml/anomaly_detectors/" + jobId + "/_open"));
+    }
+
+    protected Response postData(String jobId, String data) throws IOException {
         // Post data is deprecated, so a deprecation warning is possible (depending on the old version)
         RequestOptions postDataOptions = RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
             if (warnings.isEmpty()) {
@@ -332,25 +319,52 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
                         + "in a future major version it will be compulsory to use a datafeed"
                 ) == false;
         }).build();
-        return hlrc.postData(new PostDataRequest(jobId, XContentType.JSON, new BytesArray(data)), postDataOptions);
+
+        Request postDataRequest = new Request("POST", "/_ml/anomaly_detectors/" + jobId + "/_data");
+        // Post data is deprecated, so expect a deprecation warning
+        postDataRequest.setOptions(postDataOptions);
+        postDataRequest.setJsonEntity(data);
+        return client().performRequest(postDataRequest);
     }
 
-    protected FlushJobResponse flushJob(String jobId) throws IOException {
-        return hlrc.flushJob(new FlushJobRequest(jobId), RequestOptions.DEFAULT);
+    protected void flushJob(String jobId) throws IOException {
+        client().performRequest(new Request("POST", "/_ml/anomaly_detectors/" + jobId + "/_flush"));
     }
 
-    protected CloseJobResponse closeJob(String jobId) throws IOException {
-        return hlrc.closeJob(new CloseJobRequest(jobId), RequestOptions.DEFAULT);
+    private void closeJob(String jobId) throws IOException {
+        Response closeResponse = client().performRequest(new Request("POST", "/_ml/anomaly_detectors/" + jobId + "/_close"));
+        assertThat(entityAsMap(closeResponse), hasEntry("closed", true));
     }
 
-    protected GetModelSnapshotsResponse getModelSnapshots(String jobId) throws IOException {
+    protected Response getModelSnapshots(String jobId) throws IOException {
         return getModelSnapshots(jobId, null);
     }
 
-    protected GetModelSnapshotsResponse getModelSnapshots(String jobId, String snapshotId) throws IOException {
-        GetModelSnapshotsRequest getModelSnapshotsRequest = new GetModelSnapshotsRequest(jobId);
-        getModelSnapshotsRequest.setSnapshotId(snapshotId);
-        return hlrc.getModelSnapshots(getModelSnapshotsRequest, RequestOptions.DEFAULT);
+    protected Response getModelSnapshots(String jobId, String snapshotId) throws IOException {
+        String url = "_ml/anomaly_detectors/" + jobId + "/model_snapshots/";
+        if (snapshotId != null) {
+            url = url + snapshotId;
+        }
+        return client().performRequest(new Request("GET", url));
+    }
+
+    private Response revertModelSnapshot(String jobId, String snapshotId, boolean deleteIntervening) throws IOException {
+        String url = "_ml/anomaly_detectors/" + jobId + "/model_snapshots/" + snapshotId + "/_revert";
+
+        if (deleteIntervening) {
+            url = url + "?delete_intervening_results=true";
+        }
+        Request request = new Request("POST", url);
+        return client().performRequest(request);
+    }
+
+    private Response upgradeJobSnapshot(String jobId, String snapshotId, boolean waitForCompletion) throws IOException {
+        String url = "_ml/anomaly_detectors/" + jobId + "/model_snapshots/" + snapshotId;
+        if (waitForCompletion) {
+            url = url + "?wait_for_completion=true";
+        }
+        Request request = new Request("POST", url);
+        return client().performRequest(request);
     }
 
     protected static String createJsonRecord(Map<String, Object> keyValueMap) throws IOException {


### PR DESCRIPTION
Removes all references to the ML HLRC classes in preparation for removal of those classes. Mostly this means converting tests that use the HLRC to use the low level client.

For #83423