### PR TITLE
Optimize spliterator for ImmutableOpenMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -241,7 +241,7 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
         }
 
         public Spliterator<Map.Entry<Integer, VType>> spliterator() {
-            return Spliterators.spliteratorUnknownSize(iterator(), 0);
+            return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
         }
 
         public void forEach(Consumer<? super Map.Entry<Integer, VType>> action) {

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -209,7 +209,7 @@ public final class ImmutableOpenMap<KType, VType> implements Iterable<ObjectObje
         }
 
         public Spliterator<Map.Entry<KType, VType>> spliterator() {
-            return Spliterators.spliteratorUnknownSize(iterator(), 0);
+            return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
         }
 
         public void forEach(Consumer<? super Map.Entry<KType, VType>> action) {


### PR DESCRIPTION
We know the exact amount of nodes, so we can return a sized spliterator
which allows the Stream pipeline to allocate memory more granularly.
