### PR TITLE
[8.0] Update system index metadata if `_meta` is null (#83896)

### DIFF
--- a/docs/changelog/83896.yaml
+++ b/docs/changelog/83896.yaml
@@ -1,0 +1,6 @@
+pr: 83896
+summary: Update system index mappings if `_meta` is null
+area: Infra/Core
+type: bug
+issues:
+ - 83890

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
@@ -52,7 +52,7 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
     }
 
     /**
-     * Check that if the the SystemIndexManager finds a managed index with out-of-date mappings, then
+     * Check that if the SystemIndexManager finds a managed index with out-of-date mappings, then
      * the manager updates those mappings.
      */
     public void testSystemIndexManagerUpgradesMappings() throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.SystemIndexManager.UpgradeStatus;
@@ -218,6 +219,19 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     /**
+     * Check that the manager will try to upgrade indices where the mappings metadata is null or absent.
+     */
+    public void testManagerProcessesIndicesWithNullMetadata() {
+        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
+
+        assertThat(
+            manager.getUpgradeStatus(markShardsAvailable(createClusterState(Strings.toString(getMappings(builder -> {})))), DESCRIPTOR),
+            equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
+        );
+    }
+
+    /**
      * Check that the manager will try to upgrade indices where the version in the metadata is null or absent.
      */
     public void testManagerProcessesIndicesWithNullVersionMetadata() {
@@ -225,7 +239,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(
-            manager.getUpgradeStatus(markShardsAvailable(createClusterState(Strings.toString(getMappings(null)))), DESCRIPTOR),
+            manager.getUpgradeStatus(markShardsAvailable(createClusterState(Strings.toString(getMappings((String) null)))), DESCRIPTOR),
             equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
         );
     }
@@ -385,42 +399,21 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static XContentBuilder getMappings(String version) {
-        try {
-            final XContentBuilder builder = jsonBuilder();
-
-            builder.startObject();
-            {
-                builder.startObject("_meta");
-                builder.field("version", version);
-                builder.endObject();
-
-                builder.field("dynamic", "strict");
-                builder.startObject("properties");
-                {
-                    builder.startObject("completed");
-                    builder.field("type", "boolean");
-                    builder.endObject();
-                }
-                builder.endObject();
-            }
-
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to build " + SYSTEM_INDEX_NAME + " index mappings", e);
-        }
+        return getMappings(builder -> builder.object("_meta", meta -> meta.field("version", version)));
     }
 
     // Prior to 7.12.0, .tasks had _meta.version: 3 so we need to be sure we can handle that
     private static XContentBuilder getMappings(int version) {
+        return getMappings(builder -> builder.object("_meta", meta -> meta.field("version", version)));
+    }
+
+    private static XContentBuilder getMappings(CheckedConsumer<XContentBuilder, IOException> metaCallback) {
         try {
             final XContentBuilder builder = jsonBuilder();
 
             builder.startObject();
             {
-                builder.startObject("_meta");
-                builder.field("version", version);
-                builder.endObject();
+                metaCallback.accept(builder);
 
                 builder.field("dynamic", "strict");
                 builder.startObject("properties");
@@ -438,4 +431,5 @@ public class SystemIndexManagerTests extends ESTestCase {
             throw new UncheckedIOException("Failed to build " + SYSTEM_INDEX_NAME + " index mappings", e);
         }
     }
+
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Update system index metadata if `_meta` is null (#83896)