### PR TITLE
[DOCS] Fix 7.17 mapping deprecations

### DIFF
--- a/docs/reference/migration/migrate_7_17.asciidoc
+++ b/docs/reference/migration/migrate_7_17.asciidoc
@@ -34,7 +34,7 @@ enable <<deprecation-logging, deprecation logging>>.
 // tag::notable-breaking-changes[]
 [discrete]
 [[breaking_717_packaging_changes]]
-=== Packaging changes
+==== Packaging changes
 
 .The Windows MSI installer package is no longer available.
 [%collapsible]
@@ -66,7 +66,7 @@ logging>>.
 // tag::notable-breaking-changes[]
 [discrete]
 [[breaking_717_mapping_deprecations]]
-=== Mapping deprecations
+==== Mapping deprecations
 
 .Camel case date formats are deprecated.
 [%collapsible]

--- a/docs/reference/migration/migrate_7_17.asciidoc
+++ b/docs/reference/migration/migrate_7_17.asciidoc
@@ -68,7 +68,6 @@ logging>>.
 [[breaking_717_mapping_deprecations]]
 === Mapping deprecations
 
-[[717_camel_case_date_format_deprecation]]
 .Camel case date formats are deprecated.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_17.asciidoc
+++ b/docs/reference/migration/migrate_7_17.asciidoc
@@ -46,24 +46,8 @@ were previously released in beta and didn't receive widespread adoption.
 To install {es} on Windows, use the {ref}/zip-windows.html[`.zip` archive
 package] instead.
 ====
-
-=== Mappings changes
-.Camel case date formats are deprecated.
-[%collapsible]
-====
-*Details* +
-The use of camel case patterns on date formats is deprecated
-and will be removed in {es} 8.0.0.
-
-The corresponding snake case pattern should be used instead.
-
-*Impact* +
-To avoid deprecation warnings, discontinue use of the camel case pattern.
-
-====
 // end::notable-breaking-changes[]
 
-////
 [discrete]
 [[deprecated-7.17]]
 === Deprecations
@@ -79,5 +63,19 @@ using any deprecated functionality, enable <<deprecation-logging, deprecation
 logging>>.
 
 // tag::notable-breaking-changes[]
+[discrete]
+[[breaking_717_mapping_deprecations]]
+=== Mapping deprecations
+.Camel case date formats are deprecated.
+[%collapsible]
+====
+*Details* +
+The use of camel case patterns on date formats is deprecated and will be removed
+in {es} 8.0.0.
+
+The corresponding snake case pattern should be used instead.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of the camel case pattern.
+====
 // end::notable-breaking-changes[]
-////

--- a/docs/reference/migration/migrate_7_17.asciidoc
+++ b/docs/reference/migration/migrate_7_17.asciidoc
@@ -10,6 +10,7 @@ your application to {es} 7.17.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_717_packaging_changes>>
+* <<breaking_717_mapping_deprecations>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -66,6 +67,8 @@ logging>>.
 [discrete]
 [[breaking_717_mapping_deprecations]]
 === Mapping deprecations
+
+[[717_camel_case_date_format_deprecation]]
 .Camel case date formats are deprecated.
 [%collapsible]
 ====


### PR DESCRIPTION
* Relocates the "Camel case date formats are deprecated" deprecation to the deprecation section.
* Adds a `[discrete]` tag so the content displays on the same page.

### Preview
https://elasticsearch_83910.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/migrating-7.17.html#breaking_717_mapping_deprecations