### PR TITLE
Improve BWC for persisted authentication headers

### DIFF
--- a/docs/changelog/83913.yaml
+++ b/docs/changelog/83913.yaml
@@ -1,0 +1,5 @@
+pr: 83913
+summary: Improve BWC for persisted authentication headers
+area: Authentication
+type: enhancement
+issues: []

--- a/docs/changelog/83913.yaml
+++ b/docs/changelog/83913.yaml
@@ -2,4 +2,5 @@ pr: 83913
 summary: Improve BWC for persisted authentication headers
 area: Authentication
 type: enhancement
-issues: []
+issues:
+  - 83567

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -146,7 +146,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
 
     private SearchRequest createSearchRequest(SubmitAsyncSearchRequest request, Task submitTask, TimeValue keepAlive) {
         String docID = UUIDs.randomBase64UUID();
-        Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             nodeClient.threadPool().getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -146,7 +146,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
 
     private SearchRequest createSearchRequest(SubmitAsyncSearchRequest request, Task submitTask, TimeValue keepAlive) {
         String docID = UUIDs.randomBase64UUID();
-        Map<String, String> originHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             nodeClient.threadPool().getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -148,7 +148,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
         String docID = UUIDs.randomBase64UUID();
         Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             nodeClient.threadPool().getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
         SearchRequest searchRequest = new SearchRequest(request.getSearchRequest()) {
             @Override

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -43,6 +43,7 @@ import java.util.function.Supplier;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportSubmitAsyncSearchAction extends HandledTransportAction<SubmitAsyncSearchRequest, AsyncSearchResponse> {
+    private final ClusterService clusterService;
     private final NodeClient nodeClient;
     private final BiFunction<Supplier<Boolean>, SearchRequest, AggregationReduceContext> requestToAggReduceContextBuilder;
     private final TransportSearchAction searchAction;
@@ -62,6 +63,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
         BigArrays bigArrays
     ) {
         super(SubmitAsyncSearchAction.NAME, transportService, actionFilters, SubmitAsyncSearchRequest::new);
+        this.clusterService = clusterService;
         this.nodeClient = nodeClient;
         this.requestToAggReduceContextBuilder = (task, request) -> searchService.aggReduceContextBuilder(task, request).forFinalReduction();
         this.searchAction = searchAction;
@@ -144,7 +146,10 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
 
     private SearchRequest createSearchRequest(SubmitAsyncSearchRequest request, Task submitTask, TimeValue keepAlive) {
         String docID = UUIDs.randomBase64UUID();
-        Map<String, String> originHeaders = ClientHelper.filterSecurityHeaders(nodeClient.threadPool().getThreadContext().getHeaders());
+        Map<String, String> originHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            nodeClient.threadPool().getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
         SearchRequest searchRequest = new SearchRequest(request.getSearchRequest()) {
             @Override
             public AsyncSearchTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> taskHeaders) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -398,7 +398,7 @@ public class CcrLicenseChecker {
         if (headers.isEmpty()) {
             return client;
         } else {
-            Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(headers, minNodeVersion);
+            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, minNodeVersion);
             if (filteredHeaders.isEmpty()) {
                 return client;
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -397,7 +397,7 @@ public class CcrLicenseChecker {
         if (headers.isEmpty()) {
             return client;
         } else {
-            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterState);
+            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(headers, clusterState);
             if (filteredHeaders.isEmpty()) {
                 return client;
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -394,11 +393,11 @@ public class CcrLicenseChecker {
         return securityContext.getUser();
     }
 
-    public static Client wrapClient(Client client, Map<String, String> headers, Version minNodeVersion) {
+    public static Client wrapClient(Client client, Map<String, String> headers, ClusterState clusterState) {
         if (headers.isEmpty()) {
             return client;
         } else {
-            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, minNodeVersion);
+            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterState);
             if (filteredHeaders.isEmpty()) {
                 return client;
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -393,11 +394,11 @@ public class CcrLicenseChecker {
         return securityContext.getUser();
     }
 
-    public static Client wrapClient(Client client, Map<String, String> headers) {
+    public static Client wrapClient(Client client, Map<String, String> headers, Version minNodeVersion) {
         if (headers.isEmpty()) {
             return client;
         } else {
-            Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(headers);
+            Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(headers, minNodeVersion);
             if (filteredHeaders.isEmpty()) {
                 return client;
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -304,7 +304,11 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                     Runnable successHandler,
                     Consumer<Exception> failureHandler
                 ) {
-                    Client followerClient = CcrLicenseChecker.wrapClient(client, headers);
+                    Client followerClient = CcrLicenseChecker.wrapClient(
+                        client,
+                        headers,
+                        clusterService.state().nodes().getMinNodeVersion()
+                    );
                     followerClient.execute(
                         PutFollowAction.INSTANCE,
                         request,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -304,11 +304,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                     Runnable successHandler,
                     Consumer<Exception> failureHandler
                 ) {
-                    Client followerClient = CcrLicenseChecker.wrapClient(
-                        client,
-                        headers,
-                        clusterService.state().nodes().getMinNodeVersion()
-                    );
+                    Client followerClient = CcrLicenseChecker.wrapClient(client, headers, clusterService.state());
                     followerClient.execute(
                         PutFollowAction.INSTANCE,
                         request,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -150,7 +150,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
         Map<String, String> headers
     ) {
         ShardFollowTask params = taskInProgress.getParams();
-        Client followerClient = wrapClient(client, params.getHeaders(), clusterService.state().nodes().getMinNodeVersion());
+        Client followerClient = wrapClient(client, params.getHeaders(), clusterService.state());
         BiConsumer<TimeValue, Runnable> scheduler = (delay, command) -> threadPool.scheduleUnlessShuttingDown(
             delay,
             Ccr.CCR_THREAD_POOL_NAME,
@@ -563,11 +563,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
 
     private Client remoteClient(ShardFollowTask params) {
         // TODO: do we need minNodeVersion here since it is for remote cluster
-        return wrapClient(
-            client.getRemoteClusterClient(params.getRemoteCluster()),
-            params.getHeaders(),
-            clusterService.state().nodes().getMinNodeVersion()
-        );
+        return wrapClient(client.getRemoteClusterClient(params.getRemoteCluster()), params.getHeaders(), clusterService.state());
     }
 
     interface FollowerStatsInfoHandler {
@@ -576,7 +572,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
 
     @Override
     protected void nodeOperation(final AllocatedPersistentTask task, final ShardFollowTask params, final PersistentTaskState state) {
-        Client followerClient = wrapClient(client, params.getHeaders(), clusterService.state().nodes().getMinNodeVersion());
+        Client followerClient = wrapClient(client, params.getHeaders(), clusterService.state());
         ShardFollowNodeTask shardFollowNodeTask = (ShardFollowNodeTask) task;
         logger.info("{} Starting to track leader shard {}", params.getFollowShardId(), params.getLeaderShardId());
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -95,7 +95,10 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
             return;
         }
         final Client remoteClient = client.getRemoteClusterClient(request.getRemoteCluster());
-        final Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        final Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
 
         Consumer<ClusterStateResponse> consumer = remoteClusterState -> {
             String[] indices = request.getLeaderIndexPatterns().toArray(new String[0]);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -95,7 +95,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
             return;
         }
         final Client remoteClient = client.getRemoteClusterClient(request.getRemoteCluster());
-        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -95,7 +95,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
             return;
         }
         final Client remoteClient = client.getRemoteClusterClient(request.getRemoteCluster());
-        final Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -97,7 +97,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
         final Client remoteClient = client.getRemoteClusterClient(request.getRemoteCluster());
         final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
 
         Consumer<ClusterStateResponse> consumer = remoteClusterState -> {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -200,7 +200,7 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
         final Client clientWithHeaders = CcrLicenseChecker.wrapClient(
             this.client,
             threadPool.getThreadContext().getHeaders(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
         threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -197,7 +197,11 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
             .masterNodeTimeout(request.masterNodeTimeout())
             .indexSettings(overrideSettings);
 
-        final Client clientWithHeaders = CcrLicenseChecker.wrapClient(this.client, threadPool.getThreadContext().getHeaders());
+        final Client clientWithHeaders = CcrLicenseChecker.wrapClient(
+            this.client,
+            threadPool.getThreadContext().getHeaders(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
         threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
 
             @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -179,7 +179,10 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         validate(request, leaderIndexMetadata, followIndexMetadata, leaderIndexHistoryUUIDs, mapperService);
         final int numShards = followIndexMetadata.getNumberOfShards();
         final ResponseHandler handler = new ResponseHandler(numShards, listener);
-        Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
 
         for (int shardId = 0; shardId < numShards; shardId++) {
             String taskId = followIndexMetadata.getIndexUUID() + "-" + shardId;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -179,7 +179,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         validate(request, leaderIndexMetadata, followIndexMetadata, leaderIndexHistoryUUIDs, mapperService);
         final int numShards = followIndexMetadata.getNumberOfShards();
         final ResponseHandler handler = new ResponseHandler(numShards, listener);
-        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -179,7 +179,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         validate(request, leaderIndexMetadata, followIndexMetadata, leaderIndexHistoryUUIDs, mapperService);
         final int numShards = followIndexMetadata.getNumberOfShards();
         final ResponseHandler handler = new ResponseHandler(numShards, listener);
-        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -181,7 +181,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         final ResponseHandler handler = new ResponseHandler(numShards, listener);
         Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
 
         for (int shardId = 0; shardId < numShards; shardId++) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -89,7 +89,7 @@ public final class ClientHelper {
      * and rewrite them using minNodeVersion so that they are safe to be persisted as index data
      * and loaded by all nodes in the cluster.
      */
-    public static Map<String, String> extractBwcPersistableSafeHeaders(ThreadContext threadContext, Version minNodeVersion) {
+    public static Map<String, String> getPersistableSafeSecurityHeadersForVersion(ThreadContext threadContext, Version minNodeVersion) {
         return maybeRewriteAuthenticationHeadersForVersion(
             filterSecurityHeaders(threadContext.getHeaders()),
             key -> new AuthenticationContextSerializer(key).readFromContext(threadContext),
@@ -98,10 +98,10 @@ public final class ClientHelper {
     }
 
     /**
-     * Similar to {@link #extractBwcPersistableSafeHeaders(ThreadContext, Version)}, but works on a Map of headers instead of
+     * Similar to {@link #getPersistableSafeSecurityHeadersForVersion(ThreadContext, Version)}, but works on a Map of headers instead of
      * ThreadContext.
      */
-    public static Map<String, String> extractBwcPersistableSafeHeaders(Map<String, String> headers, Version minNodeVersion) {
+    public static Map<String, String> getPersistableSafeSecurityHeadersForVersion(Map<String, String> headers, Version minNodeVersion) {
         final CheckedFunction<String, Authentication, IOException> authenticationReader = key -> {
             final String authHeader = headers.get(key);
             return authHeader == null ? null : AuthenticationContextSerializer.decode(authHeader);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.datafeed;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -22,6 +23,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -37,8 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 
 /**
  * A datafeed update contains partial properties to update a {@link DatafeedConfig}.
@@ -334,7 +334,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
      * Applies the update to the given {@link DatafeedConfig}
      * @return a new {@link DatafeedConfig} that contains the update
      */
-    public DatafeedConfig apply(DatafeedConfig datafeedConfig, Map<String, String> headers) {
+    public DatafeedConfig apply(DatafeedConfig datafeedConfig, Map<String, String> headers, Version minNodeVersion) {
         if (id.equals(datafeedConfig.getId()) == false) {
             throw new IllegalArgumentException("Cannot apply update to datafeedConfig with different id");
         }
@@ -384,7 +384,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             builder.setRuntimeMappings(runtimeMappings);
         }
         if (headers.isEmpty() == false) {
-            builder.setHeaders(filterSecurityHeaders(headers));
+            builder.setHeaders(ClientHelper.extractBwcPersistableSafeHeaders(headers, minNodeVersion));
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -384,7 +384,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             builder.setRuntimeMappings(runtimeMappings);
         }
         if (headers.isEmpty() == false) {
-            builder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterState));
+            builder.setHeaders(ClientHelper.getPersistableSafeSecurityHeaders(headers, clusterState));
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -384,7 +384,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             builder.setRuntimeMappings(runtimeMappings);
         }
         if (headers.isEmpty() == false) {
-            builder.setHeaders(ClientHelper.extractBwcPersistableSafeHeaders(headers, minNodeVersion));
+            builder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, minNodeVersion));
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.datafeed;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -334,7 +334,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
      * Applies the update to the given {@link DatafeedConfig}
      * @return a new {@link DatafeedConfig} that contains the update
      */
-    public DatafeedConfig apply(DatafeedConfig datafeedConfig, Map<String, String> headers, Version minNodeVersion) {
+    public DatafeedConfig apply(DatafeedConfig datafeedConfig, Map<String, String> headers, ClusterState clusterState) {
         if (id.equals(datafeedConfig.getId()) == false) {
             throw new IllegalArgumentException("Cannot apply update to datafeedConfig with different id");
         }
@@ -384,7 +384,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             builder.setRuntimeMappings(runtimeMappings);
         }
         if (headers.isEmpty() == false) {
-            builder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, minNodeVersion));
+            builder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterState));
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -22,10 +23,16 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.authc.support.SecondaryAuthentication;
+import org.elasticsearch.xpack.core.security.user.User;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +44,7 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -370,6 +378,89 @@ public class ClientHelperTests extends ESTestCase {
         }
         {  // null
             expectThrows(NullPointerException.class, () -> ClientHelper.filterSecurityHeaders(null));
+        }
+    }
+
+    public void testGetPersistableSafeSecurityHeadersForVersion() throws IOException {
+        // No security header
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final String nonSecurityHeaderKey = "not-a-security-header";
+        if (randomBoolean()) {
+            threadContext.putHeader(nonSecurityHeaderKey, randomAlphaOfLength(8));
+        }
+        assertThat(
+            ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+                threadContext,
+                VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT)
+            ),
+            anEmptyMap()
+        );
+
+        final boolean hasRunAsHeader = randomBoolean();
+        if (hasRunAsHeader) {
+            threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, "run_as_header");
+        }
+
+        final Authentication authentication = Authentication.newRealmAuthentication(
+            new User(randomAlphaOfLength(8)),
+            new Authentication.RealmRef("name", "type", "node")
+        );
+
+        final boolean hasAuthHeader = randomBoolean();
+        // There maybe a secondary header
+        final boolean hasSecondaryAuthHeader = randomFrom(hasAuthHeader == false, true);
+        if (hasAuthHeader) {
+            new AuthenticationContextSerializer().writeToContext(authentication, threadContext);
+        }
+        if (hasSecondaryAuthHeader) {
+            new AuthenticationContextSerializer(SecondaryAuthentication.THREAD_CTX_KEY).writeToContext(authentication, threadContext);
+        }
+
+        // No rewriting for current version
+        final Map<String, String> headers1;
+        if (randomBoolean()) {
+            headers1 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext, Version.CURRENT);
+        } else {
+            headers1 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext.getHeaders(), Version.CURRENT);
+        }
+        assertThat(headers1, not(hasKey(nonSecurityHeaderKey)));
+        if (hasAuthHeader) {
+            assertThat(headers1, hasKey(AuthenticationField.AUTHENTICATION_KEY));
+            assertThat(
+                headers1.get(AuthenticationField.AUTHENTICATION_KEY),
+                equalTo(threadContext.getHeader(AuthenticationField.AUTHENTICATION_KEY))
+            );
+        }
+        if (hasSecondaryAuthHeader) {
+            assertThat(headers1, hasKey(SecondaryAuthentication.THREAD_CTX_KEY));
+            assertThat(
+                headers1.get(SecondaryAuthentication.THREAD_CTX_KEY),
+                equalTo(threadContext.getHeader(SecondaryAuthentication.THREAD_CTX_KEY))
+            );
+        }
+
+        // Rewritten for older version
+        final Version previousVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
+        final Map<String, String> headers2;
+        if (randomBoolean()) {
+            headers2 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext, previousVersion);
+        } else {
+            headers2 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext.getHeaders(), previousVersion);
+        }
+        assertThat(headers2, not(hasKey(nonSecurityHeaderKey)));
+        if (hasAuthHeader) {
+            final Authentication rewrittenAuth = AuthenticationContextSerializer.decode(
+                headers2.get(AuthenticationField.AUTHENTICATION_KEY)
+            );
+            assertThat(rewrittenAuth.getVersion(), equalTo(previousVersion));
+            assertThat(rewrittenAuth.getUser(), equalTo(authentication.getUser()));
+        }
+        if (hasSecondaryAuthHeader) {
+            final Authentication rewrittenSecondaryAuth = AuthenticationContextSerializer.decode(
+                headers2.get(SecondaryAuthentication.THREAD_CTX_KEY)
+            );
+            assertThat(rewrittenSecondaryAuth.getVersion(), equalTo(previousVersion));
+            assertThat(rewrittenSecondaryAuth.getUser(), equalTo(authentication.getUser()));
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -394,7 +394,7 @@ public class ClientHelperTests extends ESTestCase {
         if (randomBoolean()) {
             threadContext.putHeader(nonSecurityHeaderKey, randomAlphaOfLength(8));
         }
-        assertThat(ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext, clusterState), anEmptyMap());
+        assertThat(ClientHelper.getPersistableSafeSecurityHeaders(threadContext, clusterState), anEmptyMap());
 
         final boolean hasRunAsHeader = randomBoolean();
         if (hasRunAsHeader) {
@@ -420,9 +420,9 @@ public class ClientHelperTests extends ESTestCase {
         when(discoveryNodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
         final Map<String, String> headers1;
         if (randomBoolean()) {
-            headers1 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext, clusterState);
+            headers1 = ClientHelper.getPersistableSafeSecurityHeaders(threadContext, clusterState);
         } else {
-            headers1 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext.getHeaders(), clusterState);
+            headers1 = ClientHelper.getPersistableSafeSecurityHeaders(threadContext.getHeaders(), clusterState);
         }
         assertThat(headers1, not(hasKey(nonSecurityHeaderKey)));
         if (hasAuthHeader) {
@@ -445,9 +445,9 @@ public class ClientHelperTests extends ESTestCase {
         when(discoveryNodes.getMinNodeVersion()).thenReturn(previousVersion);
         final Map<String, String> headers2;
         if (randomBoolean()) {
-            headers2 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext, clusterState);
+            headers2 = ClientHelper.getPersistableSafeSecurityHeaders(threadContext, clusterState);
         } else {
-            headers2 = ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadContext.getHeaders(), clusterState);
+            headers2 = ClientHelper.getPersistableSafeSecurityHeaders(threadContext.getHeaders(), clusterState);
         }
         assertThat(headers2, not(hasKey(nonSecurityHeaderKey)));
         if (hasAuthHeader) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -383,7 +383,7 @@ public class ClientHelperTests extends ESTestCase {
         }
     }
 
-    public void testGetPersistableSafeSecurityHeadersForVersion() throws IOException {
+    public void testGetPersistableSafeSecurityHeaders() throws IOException {
         final ClusterState clusterState = mock(ClusterState.class);
         final DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
         when(clusterState.nodes()).thenReturn(discoveryNodes);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
@@ -210,20 +210,23 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
 
     public void testApply_failBecauseTargetDatafeedHasDifferentId() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
-        expectThrows(IllegalArgumentException.class, () -> createRandomized(datafeed.getId() + "_2").apply(datafeed, null));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> createRandomized(datafeed.getId() + "_2").apply(datafeed, null, Version.CURRENT)
+        );
     }
 
     public void testApply_failBecauseJobIdChanged() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
 
         DatafeedUpdate datafeedUpdateWithUnchangedJobId = new DatafeedUpdate.Builder(datafeed.getId()).setJobId("foo").build();
-        DatafeedConfig updatedDatafeed = datafeedUpdateWithUnchangedJobId.apply(datafeed, Collections.emptyMap());
+        DatafeedConfig updatedDatafeed = datafeedUpdateWithUnchangedJobId.apply(datafeed, Collections.emptyMap(), Version.CURRENT);
         assertThat(updatedDatafeed, equalTo(datafeed));
 
         DatafeedUpdate datafeedUpdateWithChangedJobId = new DatafeedUpdate.Builder(datafeed.getId()).setJobId("bar").build();
         ElasticsearchStatusException ex = expectThrows(
             ElasticsearchStatusException.class,
-            () -> datafeedUpdateWithChangedJobId.apply(datafeed, Collections.emptyMap())
+            () -> datafeedUpdateWithChangedJobId.apply(datafeed, Collections.emptyMap(), Version.CURRENT)
         );
         assertThat(ex.status(), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ex.getMessage(), equalTo(DatafeedUpdate.ERROR_MESSAGE_ON_JOB_ID_UPDATE));
@@ -231,7 +234,8 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
 
     public void testApply_givenEmptyUpdate() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
-        DatafeedConfig updatedDatafeed = new DatafeedUpdate.Builder(datafeed.getId()).build().apply(datafeed, Collections.emptyMap());
+        DatafeedConfig updatedDatafeed = new DatafeedUpdate.Builder(datafeed.getId()).build()
+            .apply(datafeed, Collections.emptyMap(), Version.CURRENT);
         assertThat(datafeed, equalTo(updatedDatafeed));
     }
 
@@ -242,7 +246,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
 
         DatafeedUpdate.Builder updated = new DatafeedUpdate.Builder(datafeed.getId());
         updated.setScrollSize(datafeed.getScrollSize() + 1);
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap());
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
 
         DatafeedConfig.Builder expectedDatafeed = new DatafeedConfig.Builder(datafeed);
         expectedDatafeed.setScrollSize(datafeed.getScrollSize() + 1);
@@ -270,7 +274,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         field.put("updated_runtime_field_foo", settings);
         update.setRuntimeMappings(field);
 
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap());
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
 
         assertThat(updatedDatafeed.getJobId(), equalTo("foo-feed"));
         assertThat(updatedDatafeed.getIndices(), equalTo(Collections.singletonList("i_2")));
@@ -303,7 +307,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         );
         update.setAggregations(aggProvider);
 
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap());
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
 
         assertThat(updatedDatafeed.getIndices(), equalTo(Collections.singletonList("i_1")));
         assertThat(updatedDatafeed.getParsedAggregations(xContentRegistry()), equalTo(aggProvider.getParsedAggs()));
@@ -314,7 +318,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
         DatafeedConfig updatedDatafeed = new DatafeedUpdate.Builder(datafeed.getId()).setIndicesOptions(
             IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN
-        ).build().apply(datafeed, Collections.emptyMap());
+        ).build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
         assertThat(datafeed.getIndicesOptions(), is(not(equalTo(updatedDatafeed.getIndicesOptions()))));
         assertThat(updatedDatafeed.getIndicesOptions(), equalTo(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN));
     }
@@ -332,7 +336,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
                 update = createRandomized(datafeed.getId(), datafeed);
             }
 
-            DatafeedConfig updatedDatafeed = update.apply(datafeed, Collections.emptyMap());
+            DatafeedConfig updatedDatafeed = update.apply(datafeed, Collections.emptyMap(), Version.CURRENT);
 
             assertThat("update was " + update, datafeed, not(equalTo(updatedDatafeed)));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
@@ -10,6 +10,8 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -47,6 +49,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig.Mode;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.elasticsearch.xpack.core.ml.utils.XContentObjectTransformer;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -63,8 +66,20 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpdate> {
+
+    private ClusterState clusterState;
+
+    @Before
+    public void init() {
+        clusterState = mock(ClusterState.class);
+        final DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(clusterState.nodes()).thenReturn(discoveryNodes);
+        when(discoveryNodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
+    }
 
     @Override
     protected DatafeedUpdate createTestInstance() {
@@ -210,23 +225,20 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
 
     public void testApply_failBecauseTargetDatafeedHasDifferentId() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> createRandomized(datafeed.getId() + "_2").apply(datafeed, null, Version.CURRENT)
-        );
+        expectThrows(IllegalArgumentException.class, () -> createRandomized(datafeed.getId() + "_2").apply(datafeed, null, clusterState));
     }
 
     public void testApply_failBecauseJobIdChanged() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
 
         DatafeedUpdate datafeedUpdateWithUnchangedJobId = new DatafeedUpdate.Builder(datafeed.getId()).setJobId("foo").build();
-        DatafeedConfig updatedDatafeed = datafeedUpdateWithUnchangedJobId.apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+        DatafeedConfig updatedDatafeed = datafeedUpdateWithUnchangedJobId.apply(datafeed, Collections.emptyMap(), clusterState);
         assertThat(updatedDatafeed, equalTo(datafeed));
 
         DatafeedUpdate datafeedUpdateWithChangedJobId = new DatafeedUpdate.Builder(datafeed.getId()).setJobId("bar").build();
         ElasticsearchStatusException ex = expectThrows(
             ElasticsearchStatusException.class,
-            () -> datafeedUpdateWithChangedJobId.apply(datafeed, Collections.emptyMap(), Version.CURRENT)
+            () -> datafeedUpdateWithChangedJobId.apply(datafeed, Collections.emptyMap(), clusterState)
         );
         assertThat(ex.status(), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ex.getMessage(), equalTo(DatafeedUpdate.ERROR_MESSAGE_ON_JOB_ID_UPDATE));
@@ -235,7 +247,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
     public void testApply_givenEmptyUpdate() {
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
         DatafeedConfig updatedDatafeed = new DatafeedUpdate.Builder(datafeed.getId()).build()
-            .apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+            .apply(datafeed, Collections.emptyMap(), clusterState);
         assertThat(datafeed, equalTo(updatedDatafeed));
     }
 
@@ -246,7 +258,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
 
         DatafeedUpdate.Builder updated = new DatafeedUpdate.Builder(datafeed.getId());
         updated.setScrollSize(datafeed.getScrollSize() + 1);
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), clusterState);
 
         DatafeedConfig.Builder expectedDatafeed = new DatafeedConfig.Builder(datafeed);
         expectedDatafeed.setScrollSize(datafeed.getScrollSize() + 1);
@@ -274,7 +286,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         field.put("updated_runtime_field_foo", settings);
         update.setRuntimeMappings(field);
 
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), clusterState);
 
         assertThat(updatedDatafeed.getJobId(), equalTo("foo-feed"));
         assertThat(updatedDatafeed.getIndices(), equalTo(Collections.singletonList("i_2")));
@@ -307,7 +319,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         );
         update.setAggregations(aggProvider);
 
-        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+        DatafeedConfig updatedDatafeed = update.build().apply(datafeed, Collections.emptyMap(), clusterState);
 
         assertThat(updatedDatafeed.getIndices(), equalTo(Collections.singletonList("i_1")));
         assertThat(updatedDatafeed.getParsedAggregations(xContentRegistry()), equalTo(aggProvider.getParsedAggs()));
@@ -318,7 +330,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
         DatafeedConfig datafeed = DatafeedConfigTests.createRandomizedDatafeedConfig("foo");
         DatafeedConfig updatedDatafeed = new DatafeedUpdate.Builder(datafeed.getId()).setIndicesOptions(
             IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN
-        ).build().apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+        ).build().apply(datafeed, Collections.emptyMap(), clusterState);
         assertThat(datafeed.getIndicesOptions(), is(not(equalTo(updatedDatafeed.getIndicesOptions()))));
         assertThat(updatedDatafeed.getIndicesOptions(), equalTo(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN));
     }
@@ -336,7 +348,7 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
                 update = createRandomized(datafeed.getId(), datafeed);
             }
 
-            DatafeedConfig updatedDatafeed = update.apply(datafeed, Collections.emptyMap(), Version.CURRENT);
+            DatafeedConfig updatedDatafeed = update.apply(datafeed, Collections.emptyMap(), clusterState);
 
             assertThat("update was " + update, datafeed, not(equalTo(updatedDatafeed)));
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -98,7 +98,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
         // same context, and therefore does not have access to the appropriate security headers.
         Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            state.nodes().getMinNodeVersion()
+            state
         );
 
         LifecyclePolicy.validatePolicyName(request.getPolicy().getName());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -96,7 +96,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             state.nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -96,10 +96,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-            threadPool.getThreadContext(),
-            state
-        );
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), state);
 
         LifecyclePolicy.validatePolicyName(request.getPolicy().getName());
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -96,7 +96,10 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            state.nodes().getMinNodeVersion()
+        );
 
         LifecyclePolicy.validatePolicyName(request.getPolicy().getName());
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -80,10 +80,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-            threadPool.getThreadContext(),
-            state
-        );
+        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), state);
         LifecyclePolicy.validatePolicyName(request.getLifecycleId());
         clusterService.submitStateUpdateTask(
             "put-snapshot-lifecycle-" + request.getLifecycleId(),

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -80,7 +80,10 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        final Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        final Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            state.nodes().getMinNodeVersion()
+        );
         LifecyclePolicy.validatePolicyName(request.getLifecycleId());
         clusterService.submitStateUpdateTask(
             "put-snapshot-lifecycle-" + request.getLifecycleId(),

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -80,7 +80,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
         // REST layer and the Transport layer here must be accessed within this thread and not in the
         // cluster state thread in the ClusterStateUpdateTask below since that thread does not share the
         // same context, and therefore does not have access to the appropriate security headers.
-        final Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             state.nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -82,7 +82,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
         // same context, and therefore does not have access to the appropriate security headers.
         final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            state.nodes().getMinNodeVersion()
+            state
         );
         LifecyclePolicy.validatePolicyName(request.getLifecycleId());
         clusterService.submitStateUpdateTask(

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsCRUDIT.java
@@ -40,7 +40,8 @@ public class DataFrameAnalyticsCRUDIT extends MlSingleNodeTestCase {
         configProvider = new DataFrameAnalyticsConfigProvider(
             client(),
             xContentRegistry(),
-            new DataFrameAnalyticsAuditor(client(), getInstanceFromNode(ClusterService.class))
+            new DataFrameAnalyticsAuditor(client(), getInstanceFromNode(ClusterService.class)),
+            getInstanceFromNode(ClusterService.class)
         );
         waitForMlTemplates();
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -52,7 +52,8 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
         configProvider = new DataFrameAnalyticsConfigProvider(
             client(),
             xContentRegistry(),
-            new DataFrameAnalyticsAuditor(client(), getInstanceFromNode(ClusterService.class))
+            new DataFrameAnalyticsAuditor(client(), getInstanceFromNode(ClusterService.class)),
+            getInstanceFromNode(ClusterService.class)
         );
         waitForMlTemplates();
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -25,6 +25,8 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigUpdate;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
@@ -46,6 +48,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
     private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(5);
 
     private DataFrameAnalyticsConfigProvider configProvider;
+    private String dummyAuthenticationHeader;
 
     @Before
     public void createComponents() throws Exception {
@@ -55,6 +58,10 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
             new DataFrameAnalyticsAuditor(client(), getInstanceFromNode(ClusterService.class)),
             getInstanceFromNode(ClusterService.class)
         );
+        dummyAuthenticationHeader = Authentication.newRealmAuthentication(
+            new User("dummy"),
+            new Authentication.RealmRef("name", "type", "node")
+        ).encode();
         waitForMlTemplates();
     }
 
@@ -98,7 +105,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
     public void testPutAndGet_WithSecurityHeaders() throws InterruptedException {
         String configId = "config-id";
         DataFrameAnalyticsConfig config = DataFrameAnalyticsConfigTests.createRandom(configId);
-        Map<String, String> securityHeaders = Collections.singletonMap("_xpack_security_authentication", "dummy");
+        Map<String, String> securityHeaders = Collections.singletonMap("_xpack_security_authentication", dummyAuthenticationHeader);
         {  // Put the config and verify the response
             AtomicReference<DataFrameAnalyticsConfig> configHolder = new AtomicReference<>();
             AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
@@ -276,7 +283,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
             );
         }
         {  // Update that applies security headers
-            Map<String, String> securityHeaders = Collections.singletonMap("_xpack_security_authentication", "dummy");
+            Map<String, String> securityHeaders = Collections.singletonMap("_xpack_security_authentication", dummyAuthenticationHeader);
 
             AtomicReference<DataFrameAnalyticsConfig> updatedConfigHolder = new AtomicReference<>();
             AtomicReference<Exception> exceptionHolder = new AtomicReference<>();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -21,6 +21,10 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+import org.elasticsearch.xpack.core.security.authc.support.SecondaryAuthentication;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.hamcrest.core.IsInstanceOf;
@@ -46,6 +50,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -54,11 +59,16 @@ import static org.hamcrest.core.Is.is;
 
 public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
     private DatafeedConfigProvider datafeedConfigProvider;
+    private String dummyAuthenticationHeader;
 
     @Before
     public void createComponents() throws Exception {
         datafeedConfigProvider = new DatafeedConfigProvider(client(), xContentRegistry(), getInstanceFromNode(ClusterService.class));
         waitForMlTemplates();
+        dummyAuthenticationHeader = Authentication.newRealmAuthentication(
+            new User("dummy"),
+            new Authentication.RealmRef("name", "type", "node")
+        ).encode();
     }
 
     public void testCrud() throws InterruptedException {
@@ -95,10 +105,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         DatafeedUpdate.Builder update = new DatafeedUpdate.Builder(datafeedId);
         List<String> updateIndices = Collections.singletonList("a-different-index");
         update.setIndices(updateIndices);
-        Map<String, String> updateHeaders = new HashMap<>();
-        // Only security headers are updated, grab the first one
-        String securityHeader = ClientHelper.SECURITY_HEADER_FILTERS.iterator().next();
-        updateHeaders.put(securityHeader, "CHANGED");
+        Map<String, String> updateHeaders = createSecurityHeader();
 
         AtomicReference<DatafeedConfig> configHolder = new AtomicReference<>();
         blockingCall(
@@ -114,7 +121,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         );
         assertNull(exceptionHolder.get());
         assertThat(configHolder.get().getIndices(), equalTo(updateIndices));
-        assertThat(configHolder.get().getHeaders().get(securityHeader), equalTo("CHANGED"));
+        updateHeaders.forEach((key, value) -> assertThat(configHolder.get().getHeaders(), hasEntry(key, value)));
 
         // Read the updated config
         configBuilderHolder.set(null);
@@ -125,7 +132,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         );
         assertNull(exceptionHolder.get());
         assertThat(configBuilderHolder.get().build().getIndices(), equalTo(updateIndices));
-        assertThat(configBuilderHolder.get().build().getHeaders().get(securityHeader), equalTo("CHANGED"));
+        updateHeaders.forEach((key, value) -> assertThat(configHolder.get().getHeaders(), hasEntry(key, value)));
 
         // Delete
         AtomicReference<DeleteResponse> deleteResponseHolder = new AtomicReference<>();
@@ -499,7 +506,11 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         Map<String, String> headers = new HashMap<>();
         // Only security headers are updated, grab the first one
         String securityHeader = ClientHelper.SECURITY_HEADER_FILTERS.iterator().next();
-        headers.put(securityHeader, "SECURITY_");
+        if (Set.of(AuthenticationField.AUTHENTICATION_KEY, SecondaryAuthentication.THREAD_CTX_KEY).contains(securityHeader)) {
+            headers.put(securityHeader, dummyAuthenticationHeader);
+        } else {
+            headers.put(securityHeader, "SECURITY_");
+        }
         return headers;
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -56,7 +57,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
 
     @Before
     public void createComponents() throws Exception {
-        datafeedConfigProvider = new DatafeedConfigProvider(client(), xContentRegistry());
+        datafeedConfigProvider = new DatafeedConfigProvider(client(), xContentRegistry(), getInstanceFromNode(ClusterService.class));
         waitForMlTemplates();
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.xcontent.XContentType;
@@ -41,7 +42,7 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
 
     @Before
     public void createComponents() throws Exception {
-        datafeedConfigProvider = new DatafeedConfigProvider(client(), xContentRegistry());
+        datafeedConfigProvider = new DatafeedConfigProvider(client(), xContentRegistry(), getInstanceFromNode(ClusterService.class));
         waitForMlTemplates();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -786,7 +786,7 @@ public class MachineLearning extends Plugin
             anomalyDetectionAuditor
         );
         JobConfigProvider jobConfigProvider = new JobConfigProvider(client, xContentRegistry);
-        DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
+        DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry, clusterService);
         this.datafeedConfigProvider.set(datafeedConfigProvider);
         UpdateJobProcessNotifier notifier = new UpdateJobProcessNotifier(client, clusterService, threadPool);
         JobManager jobManager = new JobManager(
@@ -969,7 +969,8 @@ public class MachineLearning extends Plugin
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(
             client,
             xContentRegistry,
-            dataFrameAnalyticsAuditor
+            dataFrameAnalyticsAuditor,
+            clusterService
         );
         assert client instanceof NodeClient;
         DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
@@ -48,7 +49,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 import static org.elasticsearch.xpack.ml.utils.SecondaryAuthorizationUtils.useSecondaryAuthIfAvailable;
 
 /**
@@ -134,7 +134,10 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    filterSecurityHeaders(threadPool.getThreadContext().getHeaders())
+                    ClientHelper.extractBwcPersistableSafeHeaders(
+                        threadPool.getThreadContext(),
+                        clusterService.state().nodes().getMinNodeVersion()
+                    )
                 ).build();
                 extractedFieldsDetectorFactory.createFromSource(
                     config,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -134,7 +134,7 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.extractBwcPersistableSafeHeaders(
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                         threadPool.getThreadContext(),
                         clusterService.state().nodes().getMinNodeVersion()
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -134,7 +134,7 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
+                    ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), clusterService.state())
                 ).build();
                 extractedFieldsDetectorFactory.createFromSource(
                     config,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -134,10 +134,7 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-                        threadPool.getThreadContext(),
-                        clusterService.state().nodes().getMinNodeVersion()
-                    )
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
                 ).build();
                 extractedFieldsDetectorFactory.createFromSource(
                     config,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
@@ -18,6 +19,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
@@ -37,7 +39,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 import static org.elasticsearch.xpack.ml.utils.SecondaryAuthorizationUtils.useSecondaryAuthIfAvailable;
 
 /**
@@ -50,6 +51,7 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
     private final SecurityContext securityContext;
     private final ThreadPool threadPool;
     private final Settings settings;
+    private final ClusterService clusterService;
 
     @Inject
     public TransportPreviewDataFrameAnalyticsAction(
@@ -58,7 +60,8 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
         NodeClient client,
         XPackLicenseState licenseState,
         Settings settings,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        ClusterService clusterService
     ) {
         super(PreviewDataFrameAnalyticsAction.NAME, transportService, actionFilters, Request::new);
         this.client = Objects.requireNonNull(client);
@@ -68,6 +71,7 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
+        this.clusterService = clusterService;
     }
 
     private static Map<String, Object> mergeRow(DataFrameDataExtractor.Row row, List<String> fieldNames) {
@@ -87,7 +91,10 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    filterSecurityHeaders(threadPool.getThreadContext().getHeaders())
+                    ClientHelper.extractBwcPersistableSafeHeaders(
+                        threadPool.getThreadContext(),
+                        clusterService.state().nodes().getMinNodeVersion()
+                    )
                 ).build();
                 preview(task, config, listener);
             });

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
@@ -91,7 +91,7 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
+                    ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), clusterService.state())
                 ).build();
                 preview(task, config, listener);
             });

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
@@ -91,10 +91,7 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-                        threadPool.getThreadContext(),
-                        clusterService.state().nodes().getMinNodeVersion()
-                    )
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
                 ).build();
                 preview(task, config, listener);
             });

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDataFrameAnalyticsAction.java
@@ -91,7 +91,7 @@ public class TransportPreviewDataFrameAnalyticsAction extends HandledTransportAc
                 // Set the auth headers (preferring the secondary headers) to the caller's.
                 // Regardless if the config was previously stored or not.
                 DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(request.getConfig()).setHeaders(
-                    ClientHelper.extractBwcPersistableSafeHeaders(
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                         threadPool.getThreadContext(),
                         clusterService.state().nodes().getMinNodeVersion()
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -116,10 +116,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
         DatafeedConfig.Builder previewDatafeedBuilder = buildPreviewDatafeed(datafeedConfig);
         useSecondaryAuthIfAvailable(securityContext, () -> {
             previewDatafeedBuilder.setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-                    threadPool.getThreadContext(),
-                    clusterService.state().nodes().getMinNodeVersion()
-                )
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
             );
             // NB: this is using the client from the transport layer, NOT the internal client.
             // This is important because it means the datafeed search will fail if the user

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -116,7 +116,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
         DatafeedConfig.Builder previewDatafeedBuilder = buildPreviewDatafeed(datafeedConfig);
         useSecondaryAuthIfAvailable(securityContext, () -> {
             previewDatafeedBuilder.setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
+                ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), clusterService.state())
             );
             // NB: this is using the client from the transport layer, NOT the internal client.
             // This is important because it means the datafeed search will fail if the user

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.action.PreviewDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
@@ -48,7 +49,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeWithHeadersAsync;
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 import static org.elasticsearch.xpack.ml.utils.SecondaryAuthorizationUtils.useSecondaryAuthIfAvailable;
 
 public class TransportPreviewDatafeedAction extends HandledTransportAction<PreviewDatafeedAction.Request, PreviewDatafeedAction.Response> {
@@ -115,7 +115,12 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
     ) {
         DatafeedConfig.Builder previewDatafeedBuilder = buildPreviewDatafeed(datafeedConfig);
         useSecondaryAuthIfAvailable(securityContext, () -> {
-            previewDatafeedBuilder.setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));
+            previewDatafeedBuilder.setHeaders(
+                ClientHelper.extractBwcPersistableSafeHeaders(
+                    threadPool.getThreadContext(),
+                    clusterService.state().nodes().getMinNodeVersion()
+                )
+            );
             // NB: this is using the client from the transport layer, NOT the internal client.
             // This is important because it means the datafeed search will fail if the user
             // requesting the preview doesn't have permission to search the relevant indices.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -116,7 +116,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
         DatafeedConfig.Builder previewDatafeedBuilder = buildPreviewDatafeed(datafeedConfig);
         useSecondaryAuthIfAvailable(securityContext, () -> {
             previewDatafeedBuilder.setHeaders(
-                ClientHelper.extractBwcPersistableSafeHeaders(
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                     threadPool.getThreadContext(),
                     clusterService.state().nodes().getMinNodeVersion()
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.regex.Regex;
@@ -46,6 +47,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
@@ -71,7 +73,6 @@ import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 
 /**
  * This class implements CRUD operation for the
@@ -87,12 +88,14 @@ public class DatafeedConfigProvider {
     private static final Logger logger = LogManager.getLogger(DatafeedConfigProvider.class);
     private final Client client;
     private final NamedXContentRegistry xContentRegistry;
+    private final ClusterService clusterService;
 
     public static final Map<String, String> TO_XCONTENT_PARAMS = Map.of(ToXContentParams.FOR_INTERNAL_STORAGE, "true");
 
-    public DatafeedConfigProvider(Client client, NamedXContentRegistry xContentRegistry) {
+    public DatafeedConfigProvider(Client client, NamedXContentRegistry xContentRegistry, ClusterService clusterService) {
         this.client = client;
         this.xContentRegistry = xContentRegistry;
+        this.clusterService = clusterService;
     }
 
     /**
@@ -107,7 +110,9 @@ public class DatafeedConfigProvider {
 
         if (headers.isEmpty() == false) {
             // Filter any values in headers that aren't security fields
-            config = new DatafeedConfig.Builder(config).setHeaders(filterSecurityHeaders(headers)).build();
+            config = new DatafeedConfig.Builder(config).setHeaders(
+                ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+            ).build();
         }
 
         final String datafeedId = config.getId();
@@ -299,7 +304,7 @@ public class DatafeedConfigProvider {
 
                 DatafeedConfig updatedConfig;
                 try {
-                    updatedConfig = update.apply(configBuilder.build(), headers);
+                    updatedConfig = update.apply(configBuilder.build(), headers, clusterService.state().nodes().getMinNodeVersion());
                 } catch (Exception e) {
                     delegate.onFailure(e);
                     return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -111,7 +111,7 @@ public class DatafeedConfigProvider {
         if (headers.isEmpty() == false) {
             // Filter any values in headers that aren't security fields
             config = new DatafeedConfig.Builder(config).setHeaders(
-                ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
             ).build();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -111,7 +111,7 @@ public class DatafeedConfigProvider {
         if (headers.isEmpty() == false) {
             // Filter any values in headers that aren't security fields
             config = new DatafeedConfig.Builder(config).setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state())
             ).build();
         }
 
@@ -304,7 +304,7 @@ public class DatafeedConfigProvider {
 
                 DatafeedConfig updatedConfig;
                 try {
-                    updatedConfig = update.apply(configBuilder.build(), headers, clusterService.state().nodes().getMinNodeVersion());
+                    updatedConfig = update.apply(configBuilder.build(), headers, clusterService.state());
                 } catch (Exception e) {
                     delegate.onFailure(e);
                     return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -111,7 +111,7 @@ public class DatafeedConfigProvider {
         if (headers.isEmpty() == false) {
             // Filter any values in headers that aren't security fields
             config = new DatafeedConfig.Builder(config).setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state())
+                ClientHelper.getPersistableSafeSecurityHeaders(headers, clusterService.state())
             ).build();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
@@ -124,7 +124,7 @@ public class DataFrameAnalyticsConfigProvider {
         return headers.isEmpty()
             ? config
             : new DataFrameAnalyticsConfig.Builder(config).setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state())
+                ClientHelper.getPersistableSafeSecurityHeaders(headers, clusterService.state())
             ).build();
     }
 
@@ -195,7 +195,7 @@ public class DataFrameAnalyticsConfigProvider {
             // Merge the original config with the given update object
             DataFrameAnalyticsConfig.Builder updatedConfigBuilder = update.mergeWithConfig(originalConfig);
             if (headers.isEmpty() == false) {
-                updatedConfigBuilder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state()));
+                updatedConfigBuilder.setHeaders(ClientHelper.getPersistableSafeSecurityHeaders(headers, clusterService.state()));
             }
             DataFrameAnalyticsConfig updatedConfig = updatedConfigBuilder.build();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
@@ -124,7 +124,7 @@ public class DataFrameAnalyticsConfigProvider {
         return headers.isEmpty()
             ? config
             : new DataFrameAnalyticsConfig.Builder(config).setHeaders(
-                ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
             ).build();
     }
 
@@ -196,7 +196,7 @@ public class DataFrameAnalyticsConfigProvider {
             DataFrameAnalyticsConfig.Builder updatedConfigBuilder = update.mergeWithConfig(originalConfig);
             if (headers.isEmpty() == false) {
                 updatedConfigBuilder.setHeaders(
-                    ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
                 );
             }
             DataFrameAnalyticsConfig updatedConfig = updatedConfigBuilder.build();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
@@ -41,6 +42,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
@@ -66,7 +68,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
-import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 
 public class DataFrameAnalyticsConfigProvider {
 
@@ -79,11 +80,18 @@ public class DataFrameAnalyticsConfigProvider {
     private final Client client;
     private final NamedXContentRegistry xContentRegistry;
     private final DataFrameAnalyticsAuditor auditor;
+    private final ClusterService clusterService;
 
-    public DataFrameAnalyticsConfigProvider(Client client, NamedXContentRegistry xContentRegistry, DataFrameAnalyticsAuditor auditor) {
+    public DataFrameAnalyticsConfigProvider(
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        DataFrameAnalyticsAuditor auditor,
+        ClusterService clusterService
+    ) {
         this.client = Objects.requireNonNull(client);
         this.xContentRegistry = xContentRegistry;
         this.auditor = Objects.requireNonNull(auditor);
+        this.clusterService = clusterService;
     }
 
     /**
@@ -113,7 +121,11 @@ public class DataFrameAnalyticsConfigProvider {
     }
 
     private DataFrameAnalyticsConfig prepareConfigForIndex(DataFrameAnalyticsConfig config, Map<String, String> headers) {
-        return headers.isEmpty() ? config : new DataFrameAnalyticsConfig.Builder(config).setHeaders(filterSecurityHeaders(headers)).build();
+        return headers.isEmpty()
+            ? config
+            : new DataFrameAnalyticsConfig.Builder(config).setHeaders(
+                ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+            ).build();
     }
 
     private void exists(String jobId, ActionListener<Boolean> listener) {
@@ -183,7 +195,9 @@ public class DataFrameAnalyticsConfigProvider {
             // Merge the original config with the given update object
             DataFrameAnalyticsConfig.Builder updatedConfigBuilder = update.mergeWithConfig(originalConfig);
             if (headers.isEmpty() == false) {
-                updatedConfigBuilder.setHeaders(filterSecurityHeaders(headers));
+                updatedConfigBuilder.setHeaders(
+                    ClientHelper.extractBwcPersistableSafeHeaders(headers, clusterService.state().nodes().getMinNodeVersion())
+                );
             }
             DataFrameAnalyticsConfig updatedConfig = updatedConfigBuilder.build();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
@@ -124,7 +124,7 @@ public class DataFrameAnalyticsConfigProvider {
         return headers.isEmpty()
             ? config
             : new DataFrameAnalyticsConfig.Builder(config).setHeaders(
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state())
             ).build();
     }
 
@@ -195,9 +195,7 @@ public class DataFrameAnalyticsConfigProvider {
             // Merge the original config with the given update object
             DataFrameAnalyticsConfig.Builder updatedConfigBuilder = update.mergeWithConfig(originalConfig);
             if (headers.isEmpty() == false) {
-                updatedConfigBuilder.setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state().nodes().getMinNodeVersion())
-                );
+                updatedConfigBuilder.setHeaders(ClientHelper.getPersistableSafeSecurityHeadersForVersion(headers, clusterService.state()));
             }
             DataFrameAnalyticsConfig updatedConfig = updatedConfigBuilder.build();
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -108,7 +108,7 @@ public class AsyncTaskManagementService<
 
         @Override
         public Task createTask(long id, String type, String actionName, TaskId parentTaskId, Map<String, String> headers) {
-            Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+            Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
                 threadPool.getThreadContext(),
                 clusterService.state()
             );

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -110,7 +110,7 @@ public class AsyncTaskManagementService<
         public Task createTask(long id, String type, String actionName, TaskId parentTaskId, Map<String, String> headers) {
             Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                 threadPool.getThreadContext(),
-                clusterService.state().nodes().getMinNodeVersion()
+                clusterService.state()
             );
             return operation.createTask(
                 request,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -108,7 +108,7 @@ public class AsyncTaskManagementService<
 
         @Override
         public Task createTask(long id, String type, String actionName, TaskId parentTaskId, Map<String, String> headers) {
-            Map<String, String> originHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            Map<String, String> originHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                 threadPool.getThreadContext(),
                 clusterService.state().nodes().getMinNodeVersion()
             );

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -108,7 +108,10 @@ public class AsyncTaskManagementService<
 
         @Override
         public Task createTask(long id, String type, String actionName, TaskId parentTaskId, Map<String, String> headers) {
-            Map<String, String> originHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+            Map<String, String> originHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+                threadPool.getThreadContext(),
+                clusterService.state().nodes().getMinNodeVersion()
+            );
             return operation.createTask(
                 request,
                 id,

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -141,7 +141,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
 
     private RollupJob createRollupJob(RollupJobConfig config, ThreadPool threadPool) {
         // ensure we only filter for the allowed headers
-        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -141,7 +141,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
 
     private RollupJob createRollupJob(RollupJobConfig config, ThreadPool threadPool) {
         // ensure we only filter for the allowed headers
-        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -90,6 +90,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         );
         this.persistentTasksService = persistentTasksService;
         this.client = client;
+
     }
 
     @Override
@@ -138,9 +139,12 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         }
     }
 
-    private static RollupJob createRollupJob(RollupJobConfig config, ThreadPool threadPool) {
+    private RollupJob createRollupJob(RollupJobConfig config, ThreadPool threadPool) {
         // ensure we only filter for the allowed headers
-        Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
         return new RollupJob(config, filteredHeaders);
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -143,7 +143,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         // ensure we only filter for the allowed headers
         Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
         return new RollupJob(config, filteredHeaders);
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -267,7 +267,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             mappings.set(deducedMappings);
             function.preview(
                 client,
-                ClientHelper.extractBwcPersistableSafeHeaders(
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                     threadPool.getThreadContext(),
                     clusterService.state().nodes().getMinNodeVersion()
                 ),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -267,7 +267,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             mappings.set(deducedMappings);
             function.preview(
                 client,
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state()),
+                ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), clusterService.state()),
                 source,
                 deducedMappings,
                 NUMBER_OF_PREVIEW_BUCKETS,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -267,10 +267,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             mappings.set(deducedMappings);
             function.preview(
                 client,
-                ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-                    threadPool.getThreadContext(),
-                    clusterService.state().nodes().getMinNodeVersion()
-                ),
+                ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state()),
                 source,
                 deducedMappings,
                 NUMBER_OF_PREVIEW_BUCKETS,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -267,7 +267,10 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             mappings.set(deducedMappings);
             function.preview(
                 client,
-                ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders()),
+                ClientHelper.extractBwcPersistableSafeHeaders(
+                    threadPool.getThreadContext(),
+                    clusterService.state().nodes().getMinNodeVersion()
+                ),
                 source,
                 deducedMappings,
                 NUMBER_OF_PREVIEW_BUCKETS,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -94,7 +94,10 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
 
         TransformConfig config = request.getConfig().setHeaders(filteredHeaders).setCreateTime(Instant.now()).setVersion(Version.CURRENT);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -96,7 +96,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         // set headers to run transform as calling user
         Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
 
         TransformConfig config = request.getConfig().setHeaders(filteredHeaders).setCreateTime(Instant.now()).setVersion(Version.CURRENT);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -94,7 +94,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -94,7 +94,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -119,7 +119,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
         }
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
             clusterService.state().nodes().getMinNodeVersion()
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -119,7 +119,10 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
         }
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+        Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            threadPool.getThreadContext(),
+            clusterService.state().nodes().getMinNodeVersion()
+        );
 
         TransformConfigUpdate update = request.getUpdate();
         update.setHeaders(filteredHeaders);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -119,7 +119,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
         }
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+        Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -121,7 +121,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
         // set headers to run transform as calling user
         Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
             threadPool.getThreadContext(),
-            clusterService.state().nodes().getMinNodeVersion()
+            clusterService.state()
         );
 
         TransformConfigUpdate update = request.getUpdate();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -155,9 +155,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
              * as the user who stored the watch, but it needs to run as the user who executes this request.
              */
             watch.status()
-                .setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
-                );
+                .setHeaders(ClientHelper.getPersistableSafeSecurityHeaders(threadPool.getThreadContext(), clusterService.state()));
 
             final String triggerType = watch.trigger().type();
             final TriggerEvent triggerEvent = triggerService.simulateEvent(triggerType, watch.id(), request.getTriggerData());

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.routing.Preference;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -69,6 +70,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
     private final TriggerService triggerService;
     private final WatchParser watchParser;
     private final Client client;
+    private final ClusterService clusterService;
 
     @Inject
     public TransportExecuteWatchAction(
@@ -80,7 +82,8 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
         XPackLicenseState licenseState,
         WatchParser watchParser,
         Client client,
-        TriggerService triggerService
+        TriggerService triggerService,
+        ClusterService clusterService
     ) {
         super(ExecuteWatchAction.NAME, transportService, actionFilters, licenseState, ExecuteWatchRequest::new);
         this.threadPool = threadPool;
@@ -89,6 +92,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
         this.triggerService = triggerService;
         this.watchParser = watchParser;
         this.client = client;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -150,7 +154,13 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
              * Ensure that the headers from the incoming request are used instead those of the stored watch otherwise the watch would run
              * as the user who stored the watch, but it needs to run as the user who executes this request.
              */
-            watch.status().setHeaders(ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));
+            watch.status()
+                .setHeaders(
+                    ClientHelper.extractBwcPersistableSafeHeaders(
+                        threadPool.getThreadContext(),
+                        clusterService.state().nodes().getMinNodeVersion()
+                    )
+                );
 
             final String triggerType = watch.trigger().type();
             final TriggerEvent triggerEvent = triggerService.simulateEvent(triggerType, watch.id(), request.getTriggerData());

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -156,7 +156,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
              */
             watch.status()
                 .setHeaders(
-                    ClientHelper.extractBwcPersistableSafeHeaders(
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                         threadPool.getThreadContext(),
                         clusterService.state().nodes().getMinNodeVersion()
                     )

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -156,10 +156,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
              */
             watch.status()
                 .setHeaders(
-                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(
-                        threadPool.getThreadContext(),
-                        clusterService.state().nodes().getMinNodeVersion()
-                    )
+                    ClientHelper.getPersistableSafeSecurityHeadersForVersion(threadPool.getThreadContext(), clusterService.state())
                 );
 
             final String triggerType = watch.trigger().type();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.license.XPackLicenseState;
@@ -61,6 +62,7 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
     private final Clock clock;
     private final WatchParser parser;
     private final Client client;
+    private final ClusterService clusterService;
     private static final ToXContent.Params DEFAULT_PARAMS = WatcherParams.builder()
         .hideSecrets(false)
         .hideHeaders(false)
@@ -75,13 +77,15 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
         ClockHolder clockHolder,
         XPackLicenseState licenseState,
         WatchParser parser,
-        Client client
+        Client client,
+        ClusterService clusterService
     ) {
         super(PutWatchAction.NAME, transportService, actionFilters, licenseState, PutWatchRequest::new);
         this.threadPool = threadPool;
         this.clock = clockHolder.clock;
         this.parser = parser;
         this.client = client;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -103,7 +107,10 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
             watch.setState(request.isActive(), now);
 
             // ensure we only filter for the allowed headers
-            Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
+            Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+                threadPool.getThreadContext(),
+                clusterService.state().nodes().getMinNodeVersion()
+            );
             watch.status().setHeaders(filteredHeaders);
 
             try (XContentBuilder builder = jsonBuilder()) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
@@ -107,7 +107,7 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
             watch.setState(request.isActive(), now);
 
             // ensure we only filter for the allowed headers
-            Map<String, String> filteredHeaders = ClientHelper.extractBwcPersistableSafeHeaders(
+            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                 threadPool.getThreadContext(),
                 clusterService.state().nodes().getMinNodeVersion()
             );

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
@@ -109,7 +109,7 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
             // ensure we only filter for the allowed headers
             Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
                 threadPool.getThreadContext(),
-                clusterService.state().nodes().getMinNodeVersion()
+                clusterService.state()
             );
             watch.status().setHeaders(filteredHeaders);
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
@@ -107,7 +107,7 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
             watch.setState(request.isActive(), now);
 
             // ensure we only filter for the allowed headers
-            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeadersForVersion(
+            Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
                 threadPool.getThreadContext(),
                 clusterService.state()
             );

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
@@ -6,11 +6,15 @@
  */
 package org.elasticsearch.xpack.watcher.transport.actions;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
@@ -75,6 +79,13 @@ public class TransportPutWatchActionTests extends ESTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
+        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterState clusterState = mock(ClusterState.class);
+        final DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.nodes()).thenReturn(discoveryNodes);
+        when(discoveryNodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
+
         action = new TransportPutWatchAction(
             transportService,
             threadPool,
@@ -82,7 +93,8 @@ public class TransportPutWatchActionTests extends ESTestCase {
             new ClockHolder(new ClockMock()),
             TestUtils.newTestLicenseState(),
             parser,
-            client
+            client,
+            clusterService
         );
     }
 


### PR DESCRIPTION
Authentication headers are persisted as part of a task definition including ML jobs, CCR following etc. The persistence process store them into either an index or the cluster state. In both cases, the headers are retrieved from ThreadContext as a string which is the serialised form of the Authentication object. This string is always serialised with the node's version. 

The problem is: In a mixed cluster, the task can be created in a newer node and persisted into an index but then needs to be loaded by a older node. The older node does not understand the newer format of the serialised Authentication object and hence error out on reading it.

This PR adds additional logic in places where the headers are persisted. It compares the Authentication version with minNodeVersion and rewrites it if the minNodeVersion is older. Since we already filter security headers in places where headers are persisted, the new logic is hooked into the same places and essentially another enhancement on how to handle security headers for persisted tasks.

Resolves: #83567