### PR TITLE
Shrink join queries in slow log

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
@@ -48,6 +48,8 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
      */
     public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
 
+    private static final boolean DEFAULT_SCORE = false;
+
     private static final ParseField QUERY_FIELD = new ParseField("query");
     private static final ParseField PARENT_TYPE_FIELD = new ParseField("parent_type");
     private static final ParseField SCORE_FIELD = new ParseField("score");
@@ -198,9 +200,13 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
         builder.field(QUERY_FIELD.getPreferredName());
         query.toXContent(builder, params);
         builder.field(PARENT_TYPE_FIELD.getPreferredName(), parentType);
-        builder.field(SCORE_FIELD.getPreferredName(), score);
-        builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
-        printBoostAndQueryName(builder);
+        if (score != DEFAULT_SCORE) {
+            builder.field(SCORE_FIELD.getPreferredName(), score);
+        }
+        if (ignoreUnmapped != DEFAULT_IGNORE_UNMAPPED) {
+            builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
+        }
+        boostAndQueryNameToXContent(builder);
         if (innerHitBuilder != null) {
             builder.field(INNER_HITS_FIELD.getPreferredName(), innerHitBuilder, params);
         }
@@ -210,7 +216,7 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     public static HasParentQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String parentType = null;
-        boolean score = false;
+        boolean score = DEFAULT_SCORE;
         String queryName = null;
         InnerHitBuilder innerHits = null;
         boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -47,7 +47,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     private final String type;
     private final String id;
 
-    private boolean ignoreUnmapped = false;
+    private boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
 
     public ParentIdQueryBuilder(String type, String id) {
         this.type = type;
@@ -103,8 +103,10 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         builder.startObject(NAME);
         builder.field(TYPE_FIELD.getPreferredName(), type);
         builder.field(ID_FIELD.getPreferredName(), id);
-        builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
-        printBoostAndQueryName(builder);
+        if (ignoreUnmapped != DEFAULT_IGNORE_UNMAPPED) {
+            builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
+        }
+        boostAndQueryNameToXContent(builder);
         builder.endObject();
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -200,14 +200,50 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
                 },
                 "parent_type" : "blog",
                 "score" : true,
-                "ignore_unmapped" : false,
-                "boost" : 1.0
+                "ignore_unmapped" : true,
+                "boost" : 2.0
               }
             }""";
         HasParentQueryBuilder parsed = (HasParentQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
         assertEquals(json, "blog", parsed.type());
         assertEquals(json, "something", ((TermQueryBuilder) parsed.query()).value());
+        assertEquals(json, true, parsed.ignoreUnmapped());
+    }
+
+    public void testParseDefaultsRemoved() throws IOException {
+        String json = """
+            {
+              "has_parent" : {
+                "query" : {
+                  "term" : {
+                    "tag" : {
+                      "value" : "something",
+                      "boost" : 1.0
+                    }
+                  }
+                },
+                "parent_type" : "blog",
+                "score" : false,
+                "ignore_unmapped" : false,
+                "boost" : 1.0
+              }
+            }""";
+        checkGeneratedJson("""
+            {
+              "has_parent" : {
+                "query" : {
+                  "term" : {
+                    "tag" : {
+                      "value" : "something",
+                      "boost" : 1.0
+                    }
+                  }
+                },
+                "parent_type" : "blog"
+              }
+            }""", parseQuery(json));
+
     }
 
     public void testIgnoreUnmapped() throws IOException {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -113,7 +113,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
               "parent_id" : {
                 "type" : "child",
                 "id" : "123",
-                "ignore_unmapped" : false,
+                "ignore_unmapped" : true,
                 "boost" : 3.0,
                 "_name" : "name"  }
             }""";
@@ -123,6 +123,25 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
         assertThat(queryBuilder.getId(), Matchers.equalTo("123"));
         assertThat(queryBuilder.boost(), Matchers.equalTo(3f));
         assertThat(queryBuilder.queryName(), Matchers.equalTo("name"));
+    }
+
+    public void testDefaultsRemoved() throws IOException {
+        String query = """
+            {
+              "parent_id" : {
+                "type" : "child",
+                "id" : "123",
+                "ignore_unmapped" : false,
+                "boost" : 1.0
+              }
+            }""";
+        checkGeneratedJson("""
+              {
+              "parent_id" : {
+                "type" : "child",
+                "id" : "123"
+              }
+            }""", parseQuery(query));
     }
 
     public void testIgnoreUnmapped() throws IOException {


### PR DESCRIPTION
This removes the defaults from the slow log for the remaining queries in
the `parent-join` module. So it should be easier to read the slow log
when it contains these queries.

Relates to #76515
