### PR TITLE
Make action names available in NodeClient

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -26,8 +26,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.Transport;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Client that executes actions on the local node.
@@ -65,6 +67,13 @@ public class NodeClient extends AbstractClient {
         this.localConnection = localConnection;
         this.remoteClusterService = remoteClusterService;
         this.namedWriteableRegistry = namedWriteableRegistry;
+    }
+
+    /**
+     * Return the names of all available actions registered with this client.
+     */
+    public List<String> getActionNames() {
+        return actions.keySet().stream().map(ActionType::name).collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -29,7 +29,6 @@ import org.elasticsearch.transport.Transport;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Client that executes actions on the local node.

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -73,7 +73,7 @@ public class NodeClient extends AbstractClient {
      * Return the names of all available actions registered with this client.
      */
     public List<String> getActionNames() {
-        return actions.keySet().stream().map(ActionType::name).collect(Collectors.toList());
+        return actions.keySet().stream().map(ActionType::name).toList();
     }
 
     @Override

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/main/java/org/elasticsearch/xpack/security/operator/actions/RestGetActionsAction.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/main/java/org/elasticsearch/xpack/security/operator/actions/RestGetActionsAction.java
@@ -29,8 +29,6 @@ public class RestGetActionsAction extends BaseRestHandler {
         return "test_get_actions";
     }
 
-    @SuppressForbidden(reason = "Use reflection for testing only")
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final List<String> actionNames = client.getActionNames();

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/main/java/org/elasticsearch/xpack/security/operator/actions/RestGetActionsAction.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/main/java/org/elasticsearch/xpack/security/operator/actions/RestGetActionsAction.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.security.operator.actions;
 
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;


### PR DESCRIPTION
The actions available in NodeClient are registered on node startup and
hidden to callers. However, operator privileges needs to verify that all
actions are classified into operator and non-operator actions. Currently
the test uses reflection hacks to make the internal action objects
available.

This commit makes the action names available as a public method on
NodeClient, so that the reflection hacks are no longer necessary. It
would be nice to have a test specific way to expose this, but the test
code in question actually serves the action names up in a rest api, so
it is not test code, as far as server is concerned, that needs the
action names.