### PR TITLE
Remove redundant mute for bug JDK-8266279

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
@@ -266,10 +266,6 @@ public class CertificateGenerateToolTests extends ESTestCase {
     }
 
     public void testGeneratingSignedCertificates() throws Exception {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72639",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
 
         Path tempDir = initTempDir();
         Path outputFile = tempDir.resolve("out.zip");

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -425,10 +425,6 @@ public class CertificateToolTests extends ESTestCase {
     }
 
     public void testHandleLongPasswords() throws Exception {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
 
         final Path tempDir = initTempDir();
 
@@ -655,10 +651,6 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that all 3 certificates have the right values based on the command line options provided during generation
      */
     public void testCreateCaAndMultipleInstances() throws Exception {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();
@@ -839,10 +831,6 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that the PKCS12 certificate and the PEM certificate trust one another
      */
     public void testTrustBetweenPEMandPKCS12() throws Exception {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
@@ -118,14 +118,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
         assumeFalse("Can't run in a FIPS JVM", inFipsJvm());
     }
 
-    @BeforeClass
-    public static void muteOnBrokenJdk() {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
-    }
-
     public void testGenerateSingleCertificateSigningRequest() throws Exception {
         final Path outFile = testRoot.resolve("csr.zip").toAbsolutePath();
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.support.MockLookupRealm;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.mockito.Mockito;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -118,14 +118,6 @@ public class SamlRealmTests extends SamlTestCase {
         threadContext = new ThreadContext(globalSettings);
     }
 
-    @BeforeClass
-    public static void muteOnBrokenJdk() {
-        assumeFalse(
-            "JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
-            "1.8.0_292".equals(System.getProperty("java.version"))
-        );
-    }
-
     public void testReadIdpMetadataFromFile() throws Exception {
         final Path path = getDataPath("idp1.xml");
         Tuple<RealmConfig, SSLService> config = buildConfig(path.toString());


### PR DESCRIPTION
We had muted specific tests that were hit by JDK-8266279, by not
allowing the tests to run on Java 1.8.0_292. We have since upgraded
our Java 8 version in CI to Java 1.8.0_301 so the muting is
irrelevant and can be removed

Resolves #75571, #75417, #75379, #72639, #72359, #75952, #75718
