### PR TITLE
Combine date processor patterns into single parser

### DIFF
--- a/docs/changelog/83942.yaml
+++ b/docs/changelog/83942.yaml
@@ -1,0 +1,5 @@
+pr: 83942
+summary: Combine date processor patterns into single parser
+area: Ingest
+type: enhancement
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -72,10 +72,11 @@ public final class DateProcessor extends AbstractProcessor {
         this.targetField = targetField;
         this.formats = formats;
         this.dateParsers = new ArrayList<>(this.formats.size());
-        List<String> javaFormats = new ArrayList<>(this.formats.size());
+        final List<String> javaFormats = new ArrayList<>(this.formats.size());
         for (String format : formats) {
             DateFormat dateFormat = DateFormat.fromString(format);
             if (DateFormat.Java == dateFormat) {
+                // pull out the java formats separately so they can all be processed as a single combined date parser
                 javaFormats.add(format);
             } else {
                 dateParsers.add((params) -> dateFormat.getFunction(format, newDateTimeZone(params), newLocale(params)));

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -72,10 +72,20 @@ public final class DateProcessor extends AbstractProcessor {
         this.targetField = targetField;
         this.formats = formats;
         this.dateParsers = new ArrayList<>(this.formats.size());
+        List<String> javaFormats = new ArrayList<>(this.formats.size());
         for (String format : formats) {
             DateFormat dateFormat = DateFormat.fromString(format);
-            dateParsers.add((params) -> dateFormat.getFunction(format, newDateTimeZone(params), newLocale(params)));
+            if (DateFormat.Java == dateFormat) {
+                javaFormats.add(format);
+            } else {
+                dateParsers.add((params) -> dateFormat.getFunction(format, newDateTimeZone(params), newLocale(params)));
+            }
         }
+
+        if (javaFormats.isEmpty() == false) {
+            dateParsers.add((params) -> DateFormat.Java.getFunction(String.join("||", javaFormats), newDateTimeZone(params), newLocale(params)));
+        }
+
         this.outputFormat = outputFormat;
         formatter = DateFormatter.forPattern(this.outputFormat);
     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -83,7 +83,9 @@ public final class DateProcessor extends AbstractProcessor {
         }
 
         if (javaFormats.isEmpty() == false) {
-            dateParsers.add((params) -> DateFormat.Java.getFunction(String.join("||", javaFormats), newDateTimeZone(params), newLocale(params)));
+            dateParsers.add(
+                (params) -> DateFormat.Java.getFunction(String.join("||", javaFormats), newDateTimeZone(params), newLocale(params))
+            );
         }
 
         this.outputFormat = outputFormat;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -101,8 +101,10 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testShortCircuitAdditionalPatternsAfterFirstMatchingPattern() {
+        final String inputDate = "2010-03-04";
         List<String> matchFormats = new ArrayList<>();
-        matchFormats.add("invalid");
+        matchFormats.add("uuuu");
+        // the following two formats will match the input date but only the first should be applied
         matchFormats.add("uuuu-dd-MM");
         matchFormats.add("uuuu-MM-dd");
         DateProcessor dateProcessor = new DateProcessor(
@@ -116,7 +118,7 @@ public class DateProcessorTests extends ESTestCase {
         );
 
         Map<String, Object> document = new HashMap<>();
-        document.put("date_as_string", "2010-03-04");
+        document.put("date_as_string", inputDate);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
         dateProcessor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("2010-04-03T00:00:00.000+02:00"));


### PR DESCRIPTION
Combines all custom patterns into a single parser so that no more than a single exception is thrown while searching for a matching pattern. This significantly improves performance in scenarios where multiple patterns are attempted and was suggested by @joegallo as a possible alternative to #83801.

Relates to https://github.com/elastic/elasticsearch/issues/73918