### PR TITLE
Issue 83363 - Support to explain as query string

### DIFF
--- a/docs/changelog/83955.yaml
+++ b/docs/changelog/83955.yaml
@@ -1,0 +1,5 @@
+pr: 83955
+summary: Fix to read `explain` as query string
+area: Search
+type: bug
+issues: []

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
@@ -74,6 +74,7 @@ public class RestSearchTemplateAction extends BaseRestHandler {
         SearchTemplateRequest searchTemplateRequest;
         try (XContentParser parser = request.contentOrSourceParamParser()) {
             searchTemplateRequest = SearchTemplateRequest.fromXContent(parser);
+            searchTemplateRequest.setExplain(request.paramAsBoolean("explain", searchTemplateRequest.isExplain()));
         }
         searchTemplateRequest.setRequest(searchRequest);
 

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
@@ -140,6 +140,60 @@
   - length: { profile: 1 }
 
 ---
+"Explain as query string":
+
+  - do:
+      index:
+        index:  test
+        id:     "1"
+        body:   { "theField": "foo" }
+
+  - do:
+      index:
+        index:  test
+        id:     "2"
+        body:   { "theField": "foo 2" }
+
+  - do:
+      index:
+        index:  test
+        id:     "3"
+        body:   { "theField": "foo 3" }
+
+  - do:
+      index:
+        index:  test
+        id:     "4"
+        body:   { "theField": "foo 4" }
+
+  # we use a different index here since we compare the explain description which contains a doc ID and we can only be sure that it's 0
+  # if we are the only doc in the shard.
+  - do:
+      index:
+        index:  otherindex
+        id:     "5"
+        body:   { "otherField": "foo" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      put_script:
+        id: "template_1"
+        body: { "script": { "lang": "mustache", "source": { "query": { "match": { "{{field}}": { "query" : "{{value}}", "operator" : "{{operator}}{{^operator}}or{{/operator}}" } } }, "size": "{{size}}" } } }
+  - match: { acknowledged: true }
+
+  - do:
+      search_template:
+        rest_total_hits_as_int: true
+        explain: true
+        body: { "id" : "template_1", "params": { "size": "2", "field": "otherField", "value": "foo" } }
+
+  - match: { hits.total: 1 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._explanation.description: "weight(otherField:foo in 0) [PerFieldSimilarity], result of:" }
+
+---
+
 "Test with new response format":
   - do:
       index:


### PR DESCRIPTION
Bugfix related to issue [83363](https://github.com/elastic/elasticsearch/issues/83363).