### PR TITLE
Fix ZeroBytesReference#indexOf

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
@@ -25,7 +25,7 @@ public class ZeroBytesReference extends AbstractBytesReference {
 
     @Override
     public int indexOf(byte marker, int from) {
-        if (marker == 0) {
+        if (marker == 0 && from < length) {
             return from;
         } else {
             return -1;

--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
@@ -20,11 +20,13 @@ public class ZeroBytesReference extends AbstractBytesReference {
     private final int length;
 
     public ZeroBytesReference(int length) {
+        assert 0 <= length : length;
         this.length = length;
     }
 
     @Override
     public int indexOf(byte marker, int from) {
+        assert 0 <= from && from <= length : from + " vs " + length;
         if (marker == 0 && from < length) {
             return from;
         } else {
@@ -34,6 +36,7 @@ public class ZeroBytesReference extends AbstractBytesReference {
 
     @Override
     public byte get(int index) {
+        assert 0 <= index && index < length : index + " vs " + length;
         return 0;
     }
 
@@ -44,6 +47,7 @@ public class ZeroBytesReference extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
+        assert from + length <= this.length : from + " and " + length + " vs " + this.length;
         return new ZeroBytesReference(length);
     }
 


### PR DESCRIPTION
This method would claim to find a zero byte even if there are no
remaining bytes in the buffer. This commit fixes that.