### PR TITLE
[8.1] [DOCS] Update links to avoid redirects (#83944)

### DIFF
--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -20,7 +20,8 @@ required in {kib} to activate the SAML authentication provider.
 NOTE: The SAML support in {kib} is designed on the expectation that it will be
 the primary (or sole) authentication method for users of that {kib} instance.
 Once you enable SAML authentication in {kib} it will affect all users who try
-to login. The <<saml-kibana>> section provides more detail about how this works.
+to login. The <<saml-configure-kibana>> section provides more detail about how
+this works.
 
 [[saml-guide-idp]]
 === The identity provider

--- a/x-pack/docs/en/security/authentication/saml-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-realm.asciidoc
@@ -17,4 +17,4 @@ chain.
 
 In order to simplify the process of configuring SAML authentication within the
 Elastic Stack, there is a step-by-step guide to
-<<saml-guide, Configuring Elasticsearch and Kibana to use SAML single sign-on>>.
+<<saml-guide-stack,Configuring SAML single-sign-on on the {stack}>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.1`:
 - [[DOCS] Update links to avoid redirects (#83944)](https://github.com/elastic/elasticsearch/pull/83944)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)