### PR TITLE
[7.17] [DOCS] Fix typos (#83895)

### DIFF
--- a/docs/painless/painless-contexts/painless-watcher-context-variables.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-context-variables.asciidoc
@@ -9,7 +9,7 @@ The following variables are available in all watcher contexts.
         The id of the watch.
 
 `ctx['id']` (`String`, read-only)::
-        The server generated unique identifer for the run watch.
+        The server generated unique identifier for the run watch.
 
 `ctx['metadata']` (`Map`, read-only)::
         Metadata can be added to the top level of the watch definition. This

--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -366,7 +366,7 @@ The regex above is easier to understand as:
 [discrete]
 === Definition
 
-The `pattern` anlayzer consists of:
+The `pattern` analyzer consists of:
 
 Tokenizer::
 * <<analysis-pattern-tokenizer,Pattern Tokenizer>>

--- a/docs/reference/analysis/tokenfilters/predicate-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/predicate-tokenfilter.asciidoc
@@ -44,7 +44,7 @@ The filter produces the following tokens.
 
 The API response contains the position and offsets of each output token. Note
 the `predicate_token_filter` filter does not change the tokens' original
-positions or offets.
+positions or offsets.
 
 .*Response*
 [%collapsible]

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -72,7 +72,7 @@ The estimated heap size to keep the trained model in memory.
 
 `id`:::
 (Default)
-Idetifier for the trained model.
+Identifier for the trained model.
 
 `ingest.count`, `ic`, `ingestCount`:::
 The total number of documents that are processed by the model.

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1084,7 +1084,7 @@ Total size of all file stores across all selected nodes.
 
 `total_in_bytes`::
 (integer)
-Total size, in bytes, of all file stores across all seleced nodes.
+Total size, in bytes, of all file stores across all selected nodes.
 
 `free`::
 (<<byte-units, byte units>>)

--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -218,7 +218,7 @@ password.
 [[show-keystore-value]]
 ==== Show settings in the keystore
 
-To display the value of a setting in the keystorem use the `show` command:
+To display the value of a setting in the keystore use the `show` command:
 
 [source,sh]
 ----------------------------------------------------------------

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -84,7 +84,7 @@ graph as vertices. For example:
 field::: Identifies a field in the documents of interest.
 include::: Identifies the terms of interest that form the starting points
 from which you want to spider out. You do not have to specify a seed query
-if you specify an include clause. The include clause implicitly querys for
+if you specify an include clause. The include clause implicitly queries for
 documents that contain any of the listed terms listed.
 In addition to specifying a simple array of strings, you can also pass
 objects with `term` and `boost` values to boost matches on particular terms.

--- a/docs/reference/how-to/recipes/scoring.asciidoc
+++ b/docs/reference/how-to/recipes/scoring.asciidoc
@@ -192,7 +192,7 @@ While both options would return similar scores, there are trade-offs:
 <<query-dsl-script-score-query,script_score>> provides a lot of flexibility,
 enabling you to combine the text relevance score with static signals as you
 prefer. On the other hand, the <<rank-feature,`rank_feature` query>> only
-exposes a couple ways to incorporate static signails into the score. However,
+exposes a couple ways to incorporate static signals into the score. However,
 it relies on the <<rank-feature,`rank_feature`>> and
 <<rank-features,`rank_features`>> fields, which index values in a special way
 that allows the <<query-dsl-rank-feature-query,`rank_feature` query>> to skip

--- a/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
@@ -324,7 +324,7 @@ formatting is based on the {kib} settings.
 The peak number of bytes of memory ever used by the model.
 ====
 
-==== _Data delay has occured_
+==== _Data delay has occurred_
 
 `context.message`::
 A preconstructed message for the rule.

--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -75,7 +75,7 @@ configuration. If each node name is a fully-qualified domain name such as
 `master-a.example.com` then you must use fully-qualified domain names in the
 `cluster.initial_master_nodes` list too; conversely if your node names are bare
 hostnames (without the `.example.com` suffix) then you must use bare hostnames
-in the `cluster.initial_master_nodes` list. If you use a mix of fully-qualifed
+in the `cluster.initial_master_nodes` list. If you use a mix of fully-qualified
 and bare hostnames, or there is some other mismatch between `node.name` and
 `cluster.initial_master_nodes`, then the cluster will not form successfully and
 you will see log messages like the following.

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -4,7 +4,7 @@
 
 [discrete]
 [[large-parsing-trees]]
-=== Large queries may throw `ParsingExpection`
+=== Large queries may throw `ParsingException`
 
 Extremely large queries can consume too much memory during the parsing phase, in which case the {es-sql} engine will
 abort parsing and throw an error. In such cases, consider reducing the query to a smaller size by potentially


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [[DOCS] Fix typos (#83895)](https://github.com/elastic/elasticsearch/pull/83895)