### PR TITLE
[DOCS] Re-add HTTP proxy settings for GCS repository type

### DIFF
--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -191,6 +191,16 @@ are marked as `Secure`.
     can be specified explicitly. For example, it can be used to switch between projects when the
     same credentials are usable for both the production and the development projects.
 
+`proxy.host`::
+    Host name of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.port`::
+    Port of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.type`::
+    Proxy type for the client. Supported values are `direct` (no proxy),
+    `http`, and `socks`. Defaults to `direct`.
+
 [[repository-gcs-repository]]
 ==== Repository settings
 


### PR DESCRIPTION
Re-adds HTTP proxy settings for the GCS repository type. These settings were added with https://github.com/elastic/elasticsearch/pull/82737.

The docs were accidentally removed as part of https://github.com/elastic/elasticsearch/pull/82996.