### PR TITLE
[8.1] [DOCS] Re-add HTTP proxy setings from #82737 (#84001)

### DIFF
--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -191,6 +191,16 @@ are marked as `Secure`.
     can be specified explicitly. For example, it can be used to switch between projects when the
     same credentials are usable for both the production and the development projects.
 
+`proxy.host`::
+    Host name of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.port`::
+    Port of a proxy to connect to the Google Cloud Storage through.
+
+`proxy.type`::
+    Proxy type for the client. Supported values are `direct` (no proxy),
+    `http`, and `socks`. Defaults to `direct`.
+
 [[repository-gcs-repository]]
 ==== Repository settings
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.1`:
 - [[DOCS] Re-add HTTP proxy setings from #82737 (#84001)](https://github.com/elastic/elasticsearch/pull/84001)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)