### PR TITLE
[DOCS] Add note for HTTP proxy connections to GCS repos

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -130,6 +130,19 @@ it was built when the operation started.
 [[repository-gcs-client]]
 ==== Client Settings
 
+[NOTE]
+====
+You can't use an HTTP proxy to connect a `gcs` repository to Google Cloud
+Storage in {version}. Client settings to support HTTP proxies are only available
+in 8.0 and later versions.
+
+For more information on these client settings, check the
+{ref-80}/repository-gcs.html#repository-gcs-client[8.0 documentation]. For
+upgrade instructions, check
+https://www.elastic.co/guide/en/elastic-stack/8.0/upgrading-elastic-stack.html[Upgrading
+Elastic].
+====
+
 The client used to connect to Google Cloud Storage has a number of settings available.
 Client setting names are of the form `gcs.client.CLIENT_NAME.SETTING_NAME` and are specified
 inside `elasticsearch.yml`. The default client name looked up by a `gcs` repository is

--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -139,7 +139,7 @@ in 8.0 and later versions.
 For more information on these client settings, check the
 {ref-80}/repository-gcs.html#repository-gcs-client[8.0 documentation]. For
 upgrade instructions, check
-https://www.elastic.co/guide/en/elastic-stack/8.0/upgrading-elastic-stack.html[Upgrading
+https://www.elastic.co/guide/en/elastic-stack/8.0/upgrading-elastic-stack.html[Upgrade
 Elastic].
 ====
 


### PR DESCRIPTION
We've had a few users ask about support for HTTP proxy connections to GCS snapshot repositories in 7.x and 6.x.
However, client settings for those connections are only supported in 8.0+

This adds a note to the 7.17 and 6.8 docs to nudge users to upgrade.

Relates to https://github.com/elastic/elasticsearch/pull/82737

Closes https://github.com/elastic/elasticsearch/issues/83959

### Preview

https://elasticsearch_84004.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/7.17/repository-gcs-client.html