### PR TITLE
Remove redundant response of empty result in AsyncShardFetch to avoid OOM issue

### DIFF
--- a/docs/changelog/84010.yaml
+++ b/docs/changelog/84010.yaml
@@ -1,0 +1,5 @@
+pr: 84010
+summary: Remove redundant response of empty result in AsyncShardFetch
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -189,7 +189,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                 String customDataPath,
                 Lister<? extends BaseNodesResponse<NodeGatewayStartedShards>, NodeGatewayStartedShards> action
             ) {
-                super(logger, type, shardId, customDataPath, action);
+                super(logger, type, shardId, customDataPath, action, x -> true);
             }
 
             @Override


### PR DESCRIPTION
In the process of full restart, OOM problems are often encountered. After dump analysis and we found the following problems.

![image](https://user-images.githubusercontent.com/1617828/154204952-5021fcea-6ff4-4163-a702-873e38e6599d.png)

In the process of fetching data, the master will ask each data whether it owns the shard, and all the returned results of the node will be saved in the map<nodeId, nodeResponse> in AsyncShardFetch. In most cases, a shard only has data on several nodes, but the intermediate result map will still save the return results of all nodes.

In this MR, we only save valid intermediate result of node responses and ignore the node responses that does not hold the shard at all.

It is proved to be successfully in our company and the OOM issue is gone after the optimization.
