### PR TITLE
WIP: Add "Has master-eligible nodes" Indicator for Health API

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/indicators/HasEligibleMasterNodeIndicator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/indicators/HasEligibleMasterNodeIndicator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination.indicators;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.health.HealthIndicatorResult;
+import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthStatus;
+
+import static org.elasticsearch.health.ServerHealthComponents.CLUSTER_COORDINATION;
+
+public class HasEligibleMasterNodeIndicator implements HealthIndicatorService {
+
+    public static final String HAS_ELIGIBLE_MASTER = "has_eligible_master";
+
+    private final ClusterService clusterService;
+
+    public HasEligibleMasterNodeIndicator(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public String name() {
+        return HAS_ELIGIBLE_MASTER;
+    }
+
+    @Override
+    public String component() {
+        return CLUSTER_COORDINATION;
+    }
+
+    @Override
+    public HealthIndicatorResult calculate() {
+        for (DiscoveryNode node : clusterService.state().nodes()) {
+            if (node.getRoles().contains(DiscoveryNodeRole.MASTER_ROLE)) {
+                return HealthIndicatorResult.of(
+                    HAS_ELIGIBLE_MASTER,
+                    CLUSTER_COORDINATION,
+                    HealthStatus.GREEN,
+                    "There is a master-eligible node."
+                );
+            }
+        }
+        return HealthIndicatorResult.of(HAS_ELIGIBLE_MASTER, CLUSTER_COORDINATION, HealthStatus.RED, "No master-eligible nodes.");
+    }
+}

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
@@ -17,6 +17,10 @@ public record HealthIndicatorResult(String name, String component, HealthStatus 
     implements
         ToXContentObject {
 
+    public static HealthIndicatorResult of(String name, String component, HealthStatus status, String summary) {
+        return new HealthIndicatorResult(name, component, status, summary, HealthIndicatorDetails.EMPTY);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -41,6 +41,7 @@ import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.InstanceHasMasterHealthIndicatorService;
+import org.elasticsearch.cluster.coordination.indicators.HasEligibleMasterNodeIndicator;
 import org.elasticsearch.cluster.desirednodes.DesiredNodesSettingsValidator;
 import org.elasticsearch.cluster.metadata.IndexMetadataVerifier;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
@@ -1035,7 +1036,8 @@ public class Node implements Closeable {
     private HealthService createHealthService(ClusterService clusterService) {
         var serverHealthIndicatorServices = List.of(
             new InstanceHasMasterHealthIndicatorService(clusterService),
-            new RepositoryIntegrityHealthIndicatorService(clusterService)
+            new RepositoryIntegrityHealthIndicatorService(clusterService),
+            new HasEligibleMasterNodeIndicator(clusterService)
         );
         var pluginHealthIndicatorServices = pluginsService.filterPlugins(HealthPlugin.class)
             .stream()

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/indicators/HasEligibleMasterNodeIndicatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/indicators/HasEligibleMasterNodeIndicatorTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination.indicators;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.health.HealthIndicatorResult;
+import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INGEST_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.MASTER_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.TRANSFORM_ROLE;
+
+public class HasEligibleMasterNodeIndicatorTests extends ESTestCase {
+
+    public void testIsGreenIfThereIsMasterNode() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster"))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(new DiscoveryNode("node1", transportAddress(), emptyMap(), Set.of(DATA_ROLE), Version.CURRENT))
+                    .add(new DiscoveryNode("node2", transportAddress(), emptyMap(), Set.of(DATA_ROLE), Version.CURRENT))
+                    .add(new DiscoveryNode("node3", transportAddress(), emptyMap(), Set.of(MASTER_ROLE), Version.CURRENT))
+                    .build()
+            )
+            .build();
+
+        ClusterService clusterService = clusterService(clusterState);
+        HealthIndicatorResult noEligibleMasterNodes = new HasEligibleMasterNodeIndicator(clusterService).calculate();
+
+        assertEquals("has_eligible_master", noEligibleMasterNodes.name());
+        assertEquals(HealthStatus.GREEN, noEligibleMasterNodes.status());
+        assertEquals("There is a master-eligible node.", noEligibleMasterNodes.summary());
+    }
+
+    public void testIsRedIfThereNoMasterNodes() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster"))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(new DiscoveryNode("node_1", transportAddress(), emptyMap(), Set.of(DATA_ROLE), Version.CURRENT))
+                    .add(new DiscoveryNode("node_2", transportAddress(), emptyMap(), Set.of(TRANSFORM_ROLE), Version.CURRENT))
+                    .add(new DiscoveryNode("node_3", transportAddress(), emptyMap(), Set.of(INGEST_ROLE), Version.CURRENT))
+                    .build()
+            )
+            .build();
+
+        HealthIndicatorResult noEligibleMasterNodes = new HasEligibleMasterNodeIndicator(clusterService(clusterState)).calculate();
+
+        assertEquals("has_eligible_master", noEligibleMasterNodes.name());
+        assertEquals(HealthStatus.RED, noEligibleMasterNodes.status());
+        assertEquals("No master-eligible nodes.", noEligibleMasterNodes.summary());
+    }
+
+    public void testRedIfThereNoNodes() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster")).nodes(DiscoveryNodes.builder().build()).build();
+
+        HealthIndicatorResult noEligibleMasterNodes = new HasEligibleMasterNodeIndicator(clusterService(clusterState)).calculate();
+
+        assertEquals("has_eligible_master", noEligibleMasterNodes.name());
+        assertEquals(HealthStatus.RED, noEligibleMasterNodes.status());
+        assertEquals("No master-eligible nodes.", noEligibleMasterNodes.summary());
+    }
+
+    private static TransportAddress transportAddress() {
+        return buildNewFakeTransportAddress();
+    }
+
+    private static ClusterService clusterService(ClusterState clusterState) {
+        ClusterService clusterService = Mockito.mock(ClusterService.class);
+        Mockito.when(clusterService.state()).thenReturn(clusterState);
+        return clusterService;
+    }
+}


### PR DESCRIPTION
The PR is WIP. It uses the local cluster state for the indicator which can return erroneous results for the cluster.