### PR TITLE
[8.0] [Stack Monitoring] add kibana_stats version alias to -mb template (#83930)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -492,6 +492,10 @@
                 "uuid": {
                   "type": "alias",
                   "path": "service.id"
+                },
+                "version": {
+                  "type": "alias",
+                  "path": "service.version"
                 }
               }
             },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 1;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #83930

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)