### PR TITLE
Move InferenceConfigUpdate under VersionedNamedWriteable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -121,6 +122,7 @@ public class ClassificationConfigUpdate implements InferenceConfigUpdate, NamedX
         return topClassesResultsField;
     }
 
+    @Override
     public String getResultsField() {
         return resultsField;
     }
@@ -244,6 +246,11 @@ public class ClassificationConfigUpdate implements InferenceConfigUpdate, NamedX
             && (topClassesResultsField == null || topClassesResultsField.equals(originalConfig.getTopClassesResultsField()))
             && (numTopClasses == null || originalConfig.getNumTopClasses() == numTopClasses)
             && (predictionFieldType == null || predictionFieldType.equals(originalConfig.getPredictionFieldType()));
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_7_8_0;
     }
 
     public static class Builder implements InferenceConfigUpdate.Builder<Builder, ClassificationConfigUpdate> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -65,6 +65,11 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
         return EmptyConfigUpdate.class.hashCode();
     }
 
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_7_9_0;
+    }
+
     public static class Builder implements InferenceConfigUpdate.Builder<Builder, EmptyConfigUpdate> {
 
         @Override
@@ -72,6 +77,7 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
             return this;
         }
 
+        @Override
         public EmptyConfigUpdate build() {
             return new EmptyConfigUpdate();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -102,6 +103,11 @@ public class FillMaskConfigUpdate extends NlpConfigUpdate implements NamedXConte
     }
 
     @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
+    }
+
+    @Override
     public InferenceConfig apply(InferenceConfig originalConfig) {
         if (originalConfig instanceof FillMaskConfig == false) {
             throw ExceptionsHelper.badRequestException(
@@ -191,6 +197,7 @@ public class FillMaskConfigUpdate extends NlpConfigUpdate implements NamedXConte
             return this;
         }
 
+        @Override
         public FillMaskConfigUpdate build() {
             return new FillMaskConfigUpdate(this.numTopClasses, this.resultsField, this.tokenizationUpdate);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
@@ -6,7 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public interface InferenceConfigUpdate extends NamedWriteable {
+public interface InferenceConfigUpdate extends VersionedNamedWriteable {
     Set<String> RESERVED_ML_FIELD_NAMES = new HashSet<>(
         Arrays.asList(WarningInferenceResults.WARNING.getPreferredName(), TrainedModelConfig.MODEL_ID.getPreferredName())
     );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -144,6 +145,11 @@ public class NerConfigUpdate extends NlpConfigUpdate {
         return Objects.hash(resultsField, tokenizationUpdate);
     }
 
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
+    }
+
     public static class Builder implements InferenceConfigUpdate.Builder<NerConfigUpdate.Builder, NerConfigUpdate> {
         private String resultsField;
         private TokenizationUpdate tokenizationUpdate;
@@ -159,6 +165,7 @@ public class NerConfigUpdate extends NlpConfigUpdate {
             return this;
         }
 
+        @Override
         public NerConfigUpdate build() {
             return new NerConfigUpdate(resultsField, tokenizationUpdate);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -146,6 +147,11 @@ public class PassThroughConfigUpdate extends NlpConfigUpdate implements NamedXCo
         return Objects.hash(resultsField, tokenizationUpdate);
     }
 
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
+    }
+
     public static class Builder implements InferenceConfigUpdate.Builder<PassThroughConfigUpdate.Builder, PassThroughConfigUpdate> {
         private String resultsField;
         private TokenizationUpdate tokenizationUpdate;
@@ -161,6 +167,7 @@ public class PassThroughConfigUpdate extends NlpConfigUpdate implements NamedXCo
             return this;
         }
 
+        @Override
         public PassThroughConfigUpdate build() {
             return new PassThroughConfigUpdate(this.resultsField, tokenizationUpdate);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -84,6 +85,7 @@ public class RegressionConfigUpdate implements InferenceConfigUpdate, NamedXCont
         return numTopFeatureImportanceValues;
     }
 
+    @Override
     public String getResultsField() {
         return resultsField;
     }
@@ -107,6 +109,11 @@ public class RegressionConfigUpdate implements InferenceConfigUpdate, NamedXCont
     @Override
     public String getName() {
         return NAME.getPreferredName();
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_7_8_0;
     }
 
     @Override
@@ -186,6 +193,7 @@ public class RegressionConfigUpdate implements InferenceConfigUpdate, NamedXCont
             return this;
         }
 
+        @Override
         public RegressionConfigUpdate build() {
             return new RegressionConfigUpdate(resultsField, numTopFeatureImportanceValues);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -66,6 +67,11 @@ public class ResultsFieldUpdate implements InferenceConfigUpdate {
     @Override
     public String getWriteableName() {
         return NAME;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_7_9_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -21,10 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.CLASSIFICATION_LABELS;
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.NUM_TOP_CLASSES;
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.RESULTS_FIELD;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.TOKENIZATION;
-import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig.CLASSIFICATION_LABELS;
-import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig.NUM_TOP_CLASSES;
-import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig.RESULTS_FIELD;
 
 public class TextClassificationConfigUpdate extends NlpConfigUpdate implements NamedXContentObject {
 
@@ -94,6 +95,11 @@ public class TextClassificationConfigUpdate extends NlpConfigUpdate implements N
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
     }
 
     @Override
@@ -237,6 +243,7 @@ public class TextClassificationConfigUpdate extends NlpConfigUpdate implements N
             return this;
         }
 
+        @Override
         public TextClassificationConfigUpdate build() {
             return new TextClassificationConfigUpdate(
                 this.classificationLabels,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -96,6 +97,11 @@ public class TextEmbeddingConfigUpdate extends NlpConfigUpdate implements NamedX
     }
 
     @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
+    }
+
+    @Override
     public InferenceConfig apply(InferenceConfig originalConfig) {
         if ((resultsField == null || resultsField.equals(originalConfig.getResultsField())) && super.isNoop()) {
             return originalConfig;
@@ -160,6 +166,7 @@ public class TextEmbeddingConfigUpdate extends NlpConfigUpdate implements NamedX
             return this;
         }
 
+        @Override
         public TextEmbeddingConfigUpdate build() {
             return new TextEmbeddingConfigUpdate(resultsField, tokenizationUpdate);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -235,8 +236,14 @@ public class ZeroShotClassificationConfigUpdate extends NlpConfigUpdate implemen
             return this;
         }
 
+        @Override
         public ZeroShotClassificationConfigUpdate build() {
             return new ZeroShotClassificationConfigUpdate(labels, isMultiLabel, resultsField, tokenizationUpdate);
         }
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
     }
 }


### PR DESCRIPTION
In #81809 we introduced a mechanism to check searializability of search request
to earlier version nodes already on the coordinating node. This requires
knowledge about the version that NamedWritable classes have been introduced,
which is why we started moving classes that are used inside the search request
under the VersionedNamedWriteable interface to make sure future additions
implement the mthod that provides the version information.

This change moves the InferenceConfigUpdate and implementing classes under that
sub-interface. I have used the versions they were first released in
looking at the pull requests that introduced the classes.