### PR TITLE
Make RemoteClusterConnectionTests more robust

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -73,6 +73,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
@@ -232,9 +233,9 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                 }
                 closeRemote.countDown();
                 listenerCalled.await();
-                assertNotNull(exceptionReference.get());
-                expectThrows(AlreadyClosedException.class, () -> { throw exceptionReference.get(); });
-
+                Exception e = exceptionReference.get();
+                assertNotNull(e);
+                assertThat(e, either(instanceOf(AlreadyClosedException.class)).or(instanceOf(ConnectTransportException.class)));
             }
         }
     }


### PR DESCRIPTION
Backport a change from `master` to testSlowNodeCanBeCancelled() to also allow a ConnectTransportException.