### PR TITLE
[8.1] Short circuit date patterns after first match (#83764)

### DIFF
--- a/docs/changelog/83764.yaml
+++ b/docs/changelog/83764.yaml
@@ -1,0 +1,5 @@
+pr: 83764
+summary: Short circuit date patterns after first match
+area: Ingest
+type: bug
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -102,6 +102,7 @@ public final class DateProcessor extends AbstractProcessor {
         for (Function<Map<String, Object>, Function<String, ZonedDateTime>> dateParser : dateParsers) {
             try {
                 dateTime = dateParser.apply(ingestDocument.getSourceAndMetadata()).apply(value);
+                break;
             } catch (Exception e) {
                 // try the next parser and keep track of the exceptions
                 lastException = ExceptionsHelper.useOrSuppress(lastException, e);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -100,6 +100,28 @@ public class DateProcessorTests extends ESTestCase {
         }
     }
 
+    public void testShortCircuitAdditionalPatternsAfterFirstMatchingPattern() {
+        List<String> matchFormats = new ArrayList<>();
+        matchFormats.add("invalid");
+        matchFormats.add("uuuu-dd-MM");
+        matchFormats.add("uuuu-MM-dd");
+        DateProcessor dateProcessor = new DateProcessor(
+            randomAlphaOfLength(10),
+            null,
+            templatize(ZoneId.of("Europe/Amsterdam")),
+            templatize(Locale.ENGLISH),
+            "date_as_string",
+            matchFormats,
+            "date_as_date"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("date_as_string", "2010-03-04");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("2010-04-03T00:00:00.000+02:00"));
+    }
+
     public void testJavaPatternNoTimezone() {
         DateProcessor dateProcessor = new DateProcessor(
             randomAlphaOfLength(10),


### PR DESCRIPTION
In other words, don't attempt to parse the date with the rest of the patterns after one matches.

Relates to https://github.com/elastic/elasticsearch/issues/73918

Backport of #83764
