### PR TITLE
[8.0] Fix GeoIpDownloader startup during rolling upgrade (#84000)

### DIFF
--- a/docs/changelog/84000.yaml
+++ b/docs/changelog/84000.yaml
@@ -1,0 +1,5 @@
+pr: 84000
+summary: Fix `GeoIpDownloader` startup during rolling upgrade
+area: Ingest
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -66,9 +66,15 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         Property.Dynamic,
         Property.NodeScope
     );
+
+    // for overriding in tests
+    private static final String DEFAULT_ENDPOINT = System.getProperty(
+        "ingest.geoip.downloader.endpoint.default",
+        "https://geoip.elastic.co/v1/database"
+    );
     public static final Setting<String> ENDPOINT_SETTING = Setting.simpleString(
         "ingest.geoip.downloader.endpoint",
-        "https://geoip.elastic.co/v1/database",
+        DEFAULT_ENDPOINT,
         Property.NodeScope
     );
 
@@ -258,6 +264,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         try {
             updateDatabases();
         } catch (Exception e) {
+            stats = stats.failedDownload();
             logger.error("exception during geoip databases update", e);
         }
         try {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -41,6 +41,13 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     versions = [oldVersion, project.version]
     numberOfNodes = 3
 
+    systemProperty 'ingest.geoip.downloader.enabled.default', 'true'
+    //we don't want to hit real service from each test
+    systemProperty 'ingest.geoip.downloader.endpoint.default', 'http://invalid.endpoint'
+    if (bwcVersion.onOrAfter('7.14.0')) {
+      setting 'ingest.geoip.downloader.endpoint', 'http://invalid.endpoint'
+    }
+
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
     setting 'path.repo', "['${buildDir}/cluster/shared/repo/${baseName}', '${searchableSnapshotRepository}']"
     setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.hamcrest.Matchers;
+
+import java.nio.charset.StandardCharsets;
+
+public class GeoIpUpgradeIT extends AbstractUpgradeTestCase {
+
+    public void testGeoIpDownloader() throws Exception {
+        if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+            assertBusy(() -> {
+                Response response = client().performRequest(new Request("GET", "_cat/tasks"));
+                String tasks = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                assertThat(tasks, Matchers.containsString("geoip-downloader"));
+            });
+            assertBusy(() -> {
+                Response response = client().performRequest(new Request("GET", "_ingest/geoip/stats"));
+                String tasks = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                assertThat(tasks, Matchers.containsString("failed_downloads\":1"));
+            });
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix GeoIpDownloader startup during rolling upgrade (#84000)