### PR TITLE
Use static empty store files metadata

### DIFF
--- a/docs/changelog/84034.yaml
+++ b/docs/changelog/84034.yaml
@@ -1,0 +1,5 @@
+pr: 84034
+summary: Use static empty store files metadata
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -759,23 +759,15 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      */
     public static final class MetadataSnapshot implements Iterable<StoreFileMetadata>, Writeable {
         private final Map<String, StoreFileMetadata> metadata;
-
-        public static final MetadataSnapshot EMPTY = new MetadataSnapshot();
-
         private final Map<String, String> commitUserData;
-
         private final long numDocs;
+
+        public static final MetadataSnapshot EMPTY = new MetadataSnapshot(emptyMap(), emptyMap(), 0L);
 
         public MetadataSnapshot(Map<String, StoreFileMetadata> metadata, Map<String, String> commitUserData, long numDocs) {
             this.metadata = metadata;
             this.commitUserData = commitUserData;
             this.numDocs = numDocs;
-        }
-
-        MetadataSnapshot() {
-            metadata = emptyMap();
-            commitUserData = emptyMap();
-            numDocs = 0;
         }
 
         MetadataSnapshot(IndexCommit commit, Directory directory, Logger logger) throws IOException {
@@ -786,26 +778,21 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
         }
 
-        /**
-         * Read from a stream.
-         */
-        public MetadataSnapshot(StreamInput in) throws IOException {
-            final int size = in.readVInt();
-            Map<String, StoreFileMetadata> metadata = new HashMap<>();
-            for (int i = 0; i < size; i++) {
-                StoreFileMetadata meta = new StoreFileMetadata(in);
-                metadata.put(meta.name(), meta);
+        public static MetadataSnapshot readFrom(StreamInput in) throws IOException {
+            final int metadataSize = in.readVInt();
+            final Map<String, StoreFileMetadata> metadata = metadataSize == 0 ? emptyMap() : new HashMap<>();
+            for (int i = 0; i < metadataSize; i++) {
+                final var storeFileMetadata = new StoreFileMetadata(in);
+                metadata.put(storeFileMetadata.name(), storeFileMetadata);
             }
-            Map<String, String> commitUserData = new HashMap<>();
-            int num = in.readVInt();
-            for (int i = num; i > 0; i--) {
-                commitUserData.put(in.readString(), in.readString());
-            }
+            final var commitUserData = in.readMap(StreamInput::readString, StreamInput::readString);
+            final var numDocs = in.readLong();
 
-            this.metadata = unmodifiableMap(metadata);
-            this.commitUserData = unmodifiableMap(commitUserData);
-            this.numDocs = in.readLong();
-            assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
+            if (metadataSize == 0 && commitUserData.size() == 0 && numDocs == 0) {
+                return MetadataSnapshot.EMPTY;
+            } else {
+                return new MetadataSnapshot(metadata, commitUserData, numDocs);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -52,6 +52,7 @@ import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
@@ -780,7 +781,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         public static MetadataSnapshot readFrom(StreamInput in) throws IOException {
             final int metadataSize = in.readVInt();
-            final Map<String, StoreFileMetadata> metadata = metadataSize == 0 ? emptyMap() : new HashMap<>();
+            final Map<String, StoreFileMetadata> metadata = metadataSize == 0 ? emptyMap() : Maps.newMapWithExpectedSize(metadataSize);
             for (int i = 0; i < metadataSize; i++) {
                 final var storeFileMetadata = new StoreFileMetadata(in);
                 metadata.put(storeFileMetadata.name(), storeFileMetadata);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
@@ -43,7 +43,7 @@ public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
         super(in);
         recoveryId = in.readLong();
         shardId = new ShardId(in);
-        snapshotFiles = new Store.MetadataSnapshot(in);
+        snapshotFiles = Store.MetadataSnapshot.readFrom(in);
         totalTranslogOps = in.readVInt();
         globalCheckpoint = in.readZLong();
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -40,7 +40,7 @@ public class StartRecoveryRequest extends TransportRequest {
         targetAllocationId = in.readString();
         sourceNode = new DiscoveryNode(in);
         targetNode = new DiscoveryNode(in);
-        metadataSnapshot = new Store.MetadataSnapshot(in);
+        metadataSnapshot = Store.MetadataSnapshot.readFrom(in);
         primaryRelocation = in.readBoolean();
         startingSeqNo = in.readLong();
         if (in.getVersion().onOrAfter(RecoverySettings.SNAPSHOT_FILE_DOWNLOAD_THROTTLING_SUPPORTED_VERSION)) {

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -684,7 +684,6 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             data.put(
                 node,
                 new TransportNodesListShardStoreMetadata.StoreFilesMetadata(
-                    shardId,
                     new Store.MetadataSnapshot(unmodifiableMap(filesAsMap), unmodifiableMap(commitData), randomInt()),
                     peerRecoveryRetentionLeases
                 )

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionAction.java
@@ -114,7 +114,7 @@ public class PutCcrRestoreSessionAction extends ActionType<PutCcrRestoreSessionA
         PutCcrRestoreSessionResponse(StreamInput in) throws IOException {
             super(in);
             node = new DiscoveryNode(in);
-            storeFileMetadata = new Store.MetadataSnapshot(in);
+            storeFileMetadata = Store.MetadataSnapshot.readFrom(in);
             mappingVersion = in.readVLong();
         }
 


### PR DESCRIPTION
In a large cluster we expect most nodes not to have a copy of most
shards, but today during replica shard allocation we create a new (and
nontrivial) object for each node that has no copy of a shard. With this
commit we check at deserialization time whether the response is empty
and, if so, avoid the unnecessary instantiation.

Relates #77466