### PR TITLE
Adjust timeout for responses from SMB fixture

### DIFF
--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
@@ -107,6 +107,7 @@ public class ActiveDirectorySessionFactoryTests extends AbstractActiveDirectoryT
             .normalizePrefix("xpack.security.authc.realms." + type + "." + name + ".")
             .put(globalSettings)
             .put(getFullSettingKey(identifier, RealmSettings.ORDER_SETTING), 0)
+            .put(getFullSettingKey(identifier, SessionFactorySettings.TIMEOUT_RESPONSE_SETTING), "15s")
             .build();
         final Environment env = TestEnvironment.newEnvironment(mergedSettings);
         this.sslService = new SSLService(env);


### PR DESCRIPTION
We have recently seen a number of failures in ActiveDirectorySessionFactoryTests
where we fail to get a response from the Samba Server we use in
the default time frame of 5 sec. The fixture seems to be up and
running successfully so there is the case that it's just too slow
to respond within the 5 sec. This commit bumps the timeout to 15s

Resolves: https://github.com/elastic/elasticsearch/issues/78624