### PR TITLE
[Transform] Surface script deprecation warnings in deprecation info API

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/OriginSettingClient.java
+++ b/server/src/main/java/org/elasticsearch/client/OriginSettingClient.java
@@ -26,10 +26,16 @@ import java.util.function.Supplier;
 public final class OriginSettingClient extends FilterClient {
 
     private final String origin;
+    private final boolean preserveResponseHeaders;
 
     public OriginSettingClient(Client in, String origin) {
+        this(in, origin, false);
+    }
+
+    public OriginSettingClient(Client in, String origin, boolean preserveResponseHeaders) {
         super(in);
         this.origin = origin;
+        this.preserveResponseHeaders = preserveResponseHeaders;
     }
 
     @Override
@@ -38,7 +44,9 @@ public final class OriginSettingClient extends FilterClient {
         Request request,
         ActionListener<Response> listener
     ) {
-        final Supplier<ThreadContext.StoredContext> supplier = in().threadPool().getThreadContext().newRestorableContext(false);
+        final Supplier<ThreadContext.StoredContext> supplier = in().threadPool()
+            .getThreadContext()
+            .newRestorableContext(preserveResponseHeaders);
         try (ThreadContext.StoredContext ignore = in().threadPool().getThreadContext().stashWithOrigin(origin)) {
             super.doExecute(action, request, new ContextPreservingActionListener<>(supplier, listener));
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformDeprecations.java
@@ -15,6 +15,8 @@ public class TransformDeprecations {
 
     public static final String AGGS_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-aggregation-options";
 
+    public static final String PAINLESS_BREAKING_CHANGES_URL = "https://ela.st/es-deprecation-8-transform-painless-options";
+
     public static final String ACTION_UPGRADE_TRANSFORMS_API =
         "This transform configuration uses obsolete syntax which will be unsupported after the next upgrade. "
             + "Use [/_transform/_upgrade] to upgrade all transforms to the latest format.";

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -92,6 +92,7 @@ public class TransformDeprecationChecker implements DeprecationChecker {
                 };
                 if (numberOfTransforms == 0) {
                     processNextPage.run();
+                    return;
                 }
                 final CountDown numberOfResponsesToProcess = new CountDown(numberOfTransforms);
                 for (TransformConfig config : getTransformResponse.getTransformConfigurations()) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -137,7 +137,7 @@ public class TransformDeprecationChecker implements DeprecationChecker {
     private static DeprecationIssue createDeprecationIssue(String transformId, String warningHeader) {
         return new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
-            HeaderWarning.extractWarningValueFromWarningHeader(warningHeader, true),
+            "Transform [" + transformId + "]: " + HeaderWarning.extractWarningValueFromWarningHeader(warningHeader, true),
             TransformDeprecations.PAINLESS_BREAKING_CHANGES_URL,
             null,
             false,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -122,7 +122,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                 DeprecationChecker.Components components = new DeprecationChecker.Components(
                     xContentRegistry,
                     settings,
-                    new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN),
+                    new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN, true),
                     state
                 );
                 pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(deprecationIssues -> {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransformDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransformDeprecationCheckerTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class TransformDeprecationCheckerTests extends ESTestCase {
+
+    public void testEnabled() {
+        TransformDeprecationChecker transformDeprecationChecker = new TransformDeprecationChecker();
+        assertThat(transformDeprecationChecker.enabled(Settings.EMPTY), is(true));
+    }
+}

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeprecationIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeprecationIT.java
@@ -64,6 +64,7 @@ public class TransformDeprecationIT extends TransformRestTestCase {
         }
         {
             Request deprecationInfoRequest = new Request("GET", "_migration/deprecations");
+            deprecationInfoRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
             Response deprecationInfoResponse = client().performRequest(deprecationInfoRequest);
             assertThat(
                 EntityUtils.toString(deprecationInfoResponse.getEntity()),

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeprecationIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeprecationIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.integration;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.WarningsHandler;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+public class TransformDeprecationIT extends TransformRestTestCase {
+
+    private static final String TEST_USER_NAME = "transform_admin_plus_data";
+    private static final String DATA_ACCESS_ROLE = "test_data_access";
+
+    private static boolean indicesCreated = false;
+
+    // preserve indices in order to reuse source indices in several test cases
+    @Override
+    protected boolean preserveIndicesUponCompletion() {
+        return true;
+    }
+
+    @Before
+    public void createIndexes() throws IOException {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
+
+        // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
+        if (indicesCreated) {
+            return;
+        }
+        createReviewsIndex();
+        indicesCreated = true;
+    }
+
+    public void testDeprecationInfo() throws Exception {
+        {
+            Request deprecationInfoRequest = new Request("GET", "_migration/deprecations");
+            Response deprecationInfoResponse = client().performRequest(deprecationInfoRequest);
+            assertThat(EntityUtils.toString(deprecationInfoResponse.getEntity()), not(containsString("Use of the joda time method")));
+        }
+        {
+            String transformId = "script_deprecated_syntax";
+            Request createTransformRequest = new Request("PUT", getTransformEndpoint() + transformId);
+            // We need this as creation of transform with deprecated script syntax triggers warnings
+            createTransformRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+            String config = createTransformConfig(REVIEWS_INDEX_NAME, transformId);
+            createTransformRequest.setJsonEntity(config);
+            client().performRequest(createTransformRequest);
+        }
+        {
+            Request deprecationInfoRequest = new Request("GET", "_migration/deprecations");
+            Response deprecationInfoResponse = client().performRequest(deprecationInfoRequest);
+            assertThat(
+                EntityUtils.toString(deprecationInfoResponse.getEntity()),
+                allOf(
+                    containsString("Use of the joda time method [getMillis()] is deprecated. Use [toInstant().toEpochMilli()] instead."),
+                    containsString("Use of the joda time method [getEra()] is deprecated. Use [get(ChronoField.ERA)] instead.")
+                )
+            );
+        }
+    }
+
+    private static String createTransformConfig(String sourceIndex, String destinationIndex) {
+        return "{"
+            + "  \"source\": {"
+            + "    \"index\": \""
+            + sourceIndex
+            + "\","
+            + "    \"runtime_mappings\": {"
+            + "      \"timestamp-5m\": {"
+            + "        \"type\": \"date\","
+            + "        \"script\": {"
+            // We don't use "era" for anything in this script. This is solely to generate the deprecation warning.
+            + "          \"source\": \"def era = doc['timestamp'].value.era; emit(doc['timestamp'].value.millis)\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  },"
+            + "  \"dest\": {"
+            + "    \"index\": \""
+            + destinationIndex
+            + "\""
+            + "  },"
+            + "  \"pivot\": {"
+            + "    \"group_by\": {"
+            + "      \"timestamp\": {"
+            + "        \"date_histogram\": {"
+            + "          \"field\": \"timestamp-5m\","
+            + "          \"calendar_interval\": \"1m\""
+            + "        }"
+            + "      }"
+            + "    },"
+            + "    \"aggregations\": {"
+            + "      \"bytes.avg\": {"
+            + "        \"avg\": {"
+            + "          \"field\": \"bytes\""
+            + "        }"
+            + "      },"
+            + "      \"millis\": {"
+            + "        \"scripted_metric\": {"
+            + "          \"init_script\": \"state.m = 0\","
+            + "          \"map_script\": \"state.m = doc['timestamp'].value.millis;\","
+            + "          \"combine_script\": \"return state.m;\","
+            + "          \"reduce_script\": \"def last = 0; for (s in states) {last = s;} return last;\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -180,7 +180,11 @@ public abstract class AbstractCompositeAggFunction implements Function {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(sourceConfig.getQueryConfig().getQuery())
             .runtimeMappings(sourceConfig.getRuntimeMappings());
         buildSearchQuery(sourceBuilder, null, pageSize);
-        return new SearchRequest(sourceConfig.getIndex()).source(sourceBuilder).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        return new SearchRequest(sourceConfig.getIndex()).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .source(sourceBuilder)
+            // This is done so that 2 consecutive queries return the same warnings in response headers.
+            // If the request is cached, the second time it is called the response headers are not preserved.
+            .requestCache(false);
     }
 
     @Override


### PR DESCRIPTION
This PR makes deprecation warnings coming from painless scripts used by transform reported in the deprecation info API.

In order to pass the warning response headers properly to the caller, this PR extends `OriginSettingClient` class' constructor so that it gets `preserveResponseHeaders` boolean flag.

Relates https://github.com/elastic/elasticsearch/issues/82936