### PR TITLE
[DOCS] Add tag for 8.1 release highlights

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -23,7 +23,7 @@ Other versions:
 // Description.
 // end::notable-highlights[]
 
-
+// tag::notable-highlights[]
 [discrete]
 [[doc_values_only_search_on_numeric_date_keyword_ip_boolean_fields]]
 === Doc-values-only search on numeric, `date`, `keyword`, `ip`, and `boolean` fields
@@ -38,4 +38,4 @@ In exchange for slower queries, doc-value-only fields offer:
 
 For more information about doc values, refer to the
 {ref}/doc-values.html[`doc_values` mapping parameter documentation].
-
+// end::notable-highlights[]


### PR DESCRIPTION
This tag ensures the highlight displays in the [Elastic Upgrade Guide](https://www.elastic.co/guide/en/elastic-stack/8.1/elasticsearch-highlights.html).