### PR TITLE
[ML] fix NER token grouping when special tokens are used

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
@@ -229,7 +229,7 @@ public class NerProcessor extends NlpTask.Processor {
             int startTokenIndex = 0;
             int numSpecialTokens = 0;
             while (startTokenIndex < tokenization.tokenIds().length) {
-                int inputMapping = tokenization.tokenIds()[startTokenIndex];
+                int inputMapping = tokenization.tokenMap()[startTokenIndex];
                 if (inputMapping < 0) {
                     // This token does not map to a token in the input (special tokens)
                     startTokenIndex++;


### PR DESCRIPTION
Introduced by https://github.com/elastic/elasticsearch/pull/83835

This switches back our token tagging to take into account the tokens position when reconstituting and tagging tokens for NER.