### PR TITLE
Do not allow negative age in ILM explain

### DIFF
--- a/docs/changelog/84043.yaml
+++ b/docs/changelog/84043.yaml
@@ -1,0 +1,5 @@
+pr: 84043
+summary: Do not allow negative age in ILM explain
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
@@ -395,7 +395,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         if (lifecycleDate == null) {
             return TimeValue.MINUS_ONE;
         } else {
-            return TimeValue.timeValueMillis(System.currentTimeMillis() - lifecycleDate);
+            return TimeValue.timeValueMillis(Math.max(0L, System.currentTimeMillis() - lifecycleDate));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -27,6 +28,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
 public class IndexLifecycleExplainResponseTests extends AbstractSerializingTestCase<IndexLifecycleExplainResponse> {
@@ -92,6 +94,29 @@ public class IndexLifecycleExplainResponseTests extends AbstractSerializingTestC
         );
         assertThat(exception.getMessage(), startsWith("managed index response must have complete step details"));
         assertThat(exception.getMessage(), containsString("=null"));
+    }
+
+    public void testNegativeAge() {
+        IndexLifecycleExplainResponse response = IndexLifecycleExplainResponse.newManagedIndexResponse(
+            "index",
+            "policy",
+            System.currentTimeMillis() + 25000000, // date in the future
+            "phase",
+            "action",
+            "step",
+            null,
+            false,
+            null,
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            "repo",
+            "snapshot",
+            "shrink",
+            null,
+            null
+        );
+        assertThat(response.getAge(), equalTo(TimeValue.ZERO));
     }
 
     @Override


### PR DESCRIPTION
If the clocks are not synchronized between nodes, it's possible for the creation date of an index to
be far in the future compared to the current time of a node in the cluster. This can lead the age to
be calculated as a negative value when explaining the ILM status of an index and return an error
like:

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "duration cannot be negative, was given [-8402614]"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "duration cannot be negative, was given [-8402614]",
    "suppressed" : [
      {
        "type" : "illegal_state_exception",
        "reason" : "Failed to close the XContentBuilder",
        "caused_by" : {
          "type" : "i_o_exception",
          "reason" : "Unclosed object or array found"
        }
      }
    ]
  },
  "status" : 400
}
```

With this commit, the ILM age is now '0' if it is negative, preventing throwing the exception.
