### PR TITLE
Adding a warning if node.attr.data is set

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -82,7 +82,8 @@ public class DeprecationChecks {
         NodeDeprecationChecks::checkScriptContextCacheExpirationSetting,
         NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting,
         NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
-        NodeDeprecationChecks::checkEqlEnabledSetting
+        NodeDeprecationChecks::checkEqlEnabledSetting,
+        NodeDeprecationChecks::checkNodeAttrData
     );
 
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -616,4 +616,23 @@ public class NodeDeprecationChecks {
         );
     }
 
+    static DeprecationIssue checkNodeAttrData(
+        final Settings settings,
+        final PluginsAndModules pluginsAndModules
+    ) {
+        String nodeAttrDataValue = settings.get("node.attr.data");
+        if (nodeAttrDataValue == null) {
+            return null;
+        }
+        return new DeprecationIssue(
+            DeprecationIssue.Level.WARNING,
+            "Setting node.attributes.data is not recommended",
+            "https://ela.st/es-deprecation-7-node-attr-data-setting",
+            "One or more of your nodes is configured with node.attributes.data settings. This is typically used to create a "
+                + "hot/warm or tiered architecture, based on legacy guidelines. Data tiers are a recommended replacement for tiered "
+                + "architecture clusters.",
+            false,
+            null
+        );
+    }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -616,10 +616,7 @@ public class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkNodeAttrData(
-        final Settings settings,
-        final PluginsAndModules pluginsAndModules
-    ) {
+    static DeprecationIssue checkNodeAttrData(final Settings settings, final PluginsAndModules pluginsAndModules) {
         String nodeAttrDataValue = settings.get("node.attr.data");
         if (nodeAttrDataValue == null) {
             return null;

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -675,4 +675,21 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             )
         );
     }
+
+    public void testCheckNodeAttrData() {
+        Settings settings = Settings.builder().put("node.attr.data", randomAlphaOfLength(randomIntBetween(4, 20))).build();
+        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+        final List<DeprecationIssue> issues = getDeprecationIssues(settings, pluginsAndModules);
+        final DeprecationIssue expected = new DeprecationIssue(
+            DeprecationIssue.Level.WARNING,
+            "Setting node.attributes.data is not recommended",
+            "https://ela.st/es-deprecation-7-node-attr-data-setting",
+            "One or more of your nodes is configured with node.attributes.data settings. This is typically used to create a "
+                + "hot/warm or tiered architecture, based on legacy guidelines. Data tiers are a recommended replacement for tiered "
+                + "architecture clusters.",
+            false,
+            null
+        );
+        assertThat(issues, hasItem(expected));
+    }
 }


### PR DESCRIPTION
This adds a warning-level deprecation if a user has set the `node.attr.data` setting, since it is a sign that they are
trying to create a hot/warm setup in the way that is no longer supported.
Closes #83800