### PR TITLE
[DOCS] Remove note about partial response from bulk API docs

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -351,14 +351,6 @@ The bulk API's response contains the individual results of each operation in the
 request, returned in the order submitted. The success or failure of an
 individual operation does not affect other operations in the request.
 
-[[bulk-partial-responses]]
-.Partial responses
-****
-To ensure fast responses, the bulk API will respond with partial results if one
-or more shards fail. See <<shard-failures, Shard failures>> for more
-information.
-****
-
 `took`::
 (integer)
 How long, in milliseconds, it took to process the bulk request.

--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -126,7 +126,6 @@ respond with partial results if one or more shards fail:
 
 * <<search-search, Search>>
 * <<search-multi-search, Multi Search>>
-* <<docs-bulk, Bulk>>
 * <<docs-multi-get, Multi Get>>
 
 Responses containing partial results still provide a `200 OK` HTTP status code.


### PR DESCRIPTION
The bulk API response with a `200 OK` HTTP status always returns an entry for each action in the request. Partial responses aren't applicable.