### PR TITLE
Document partial search results with skip_unavailable

### DIFF
--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -41,7 +41,7 @@ by the configured remote cluster alias.
 
 [[skip-unavailable]]
 `skip_unavailable`::
-Whether a {ccs} skips the cluster if its nodes are unavailable during the
+Whether a {ccs} skips the remote cluster if its nodes are unavailable during the
 search. If `true`, a {ccs} also ignores errors returned by the remote cluster.
 Refer to <<skip-unavailable-clusters>>.
 

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -41,13 +41,8 @@ by the configured remote cluster alias.
 
 [[skip-unavailable]]
 `skip_unavailable`::
-(Boolean, <<dynamic-cluster-setting,Dynamic>>) If `true`, a {ccs} ignores errors
-returned by the remote cluster. If `true`, the {ccs} also skips the remote
-cluster if its nodes are unavailable during the search.
-+
-If `false`, the {ccs} fails if the remote cluster returns an error or is
-unavailable. Defaults to `false`.
-+
+Whether a {ccs} skips the cluster if its nodes are unavailable during the
+search. If `true`, a {ccs} also ignores errors returned by the remote cluster.
 Refer to <<skip-unavailable-clusters>>.
 
 `seeds`::

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -41,8 +41,9 @@ by the configured remote cluster alias.
 
 [[skip-unavailable]]
 `skip_unavailable`::
-    Whether the remote cluster is skipped in case it is searched through
-    a {ccs} request but none of its nodes are available.
+    Whether the remote cluster is skipped in case it is searched through a {ccs}
+    request but none of its nodes are available. Refer to
+    <<skip-unavailable-clusters>>.
 
 `seeds`::
     Initial seed transport addresses of the remote cluster when sniff mode is

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -46,7 +46,9 @@ returned by the remote cluster. If `true`, the {ccs} also skips the remote
 cluster if its nodes are unavailable during the search.
 +
 If `false`, the {ccs} fails if the remote cluster returns an error or is
-unavailable. Defaults to `false`. Refer to <<skip-unavailable-clusters>>.
+unavailable. Defaults to `false`.
++
+Refer to <<skip-unavailable-clusters>>.
 
 `seeds`::
     Initial seed transport addresses of the remote cluster when sniff mode is

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -41,9 +41,12 @@ by the configured remote cluster alias.
 
 [[skip-unavailable]]
 `skip_unavailable`::
-    Whether the remote cluster is skipped in case it is searched through a {ccs}
-    request but none of its nodes are available. Refer to
-    <<skip-unavailable-clusters>>.
+(Boolean, <<dynamic-cluster-setting,Dynamic>>) If `true`, a {ccs} ignores errors
+returned by the remote cluster. If `true`, the {ccs} also skips the remote
+cluster if its nodes are unavailable during the search.
++
+If `false`, the {ccs} fails if the remote cluster returns an error or is
+unavailable. Defaults to `false`. Refer to <<skip-unavailable-clusters>>.
 
 `seeds`::
     Initial seed transport addresses of the remote cluster when sniff mode is

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -299,8 +299,8 @@ If `skip_unavailable` is `true`, a {ccs}:
 * Skips the remote cluster if its nodes are unavailable during the search. The
 response's `_cluster.skipped` value contains a count of any skipped clusters.
 
-* Ignores errors, such as errors related to unavailable shards or indices,
-returned by the remote cluster. This can include errors related to search
+* Ignores errors returned by the remote cluster, such as errors related to
+unavailable shards or indices. This can include errors related to search
 parameters such as <<api-multi-index,`allow_no_indices`>> and
 <<api-multi-index,`ignore_unavailable`>>.
 

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -291,7 +291,7 @@ means the document came from the local cluster.
 === Optional remote clusters
 
 By default, a {ccs} fails if a remote cluster in the request returns an
-error or is unavailable. Use the <<skip-unavailable,`skip_unavailable`>> cluster
+error or is unavailable. Use the `skip_unavailable` cluster
 setting to mark a specific remote cluster as optional for {ccs}.
 
 If `skip_unavailable` is `true`, a {ccs}:

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -288,11 +288,11 @@ means the document came from the local cluster.
 
 [discrete]
 [[skip-unavailable-clusters]]
-=== Skip unavailable clusters
+=== Optional remote clusters
 
-By default, a {ccs} request fails if a remote cluster in the request is
-unavailable. Use the <<skip-unavailable,`skip_unavailable`>> cluster setting to
-mark a specific remote cluster as optional in cross-cluster searches.
+By default, a {ccs} fails if a remote cluster in the request returns an
+error or is unavailable. Use the <<skip-unavailable,`skip_unavailable`>> cluster
+setting to mark a specific remote cluster as optional for {ccs}.
 
 If `skip_unavailable` is `true`, a {ccs}:
 
@@ -300,7 +300,9 @@ If `skip_unavailable` is `true`, a {ccs}:
 response's `_cluster.skipped` value contains a count of any skipped clusters.
 
 * Ignores errors, such as errors related to unavailable shards or indices,
-returned by the remote cluster.
+returned by the remote cluster. This can include errors related to search
+parameters such as <<api-multi-index,`allow_no_indices`>> and
+<<api-multi-index,`ignore_unavailable`>>.
 
 * Ignores the <<search-partial-responses,`allow_partial_search_results`>>
 parameter and the related `search.default_allow_partial_results` cluster setting

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -291,8 +291,8 @@ means the document came from the local cluster.
 === Skip unavailable clusters
 
 By default, a {ccs} request fails if a remote cluster in the request is
-unavailable. You can the `skip_unavailable` cluster setting to mark a specific
-remote cluster as optional in cross-cluster searches.
+unavailable. Use the <<skip-unavailable,`skip_unavailable`>> cluster setting to
+mark a specific remote cluster as optional in cross-cluster searches.
 
 If `skip_unavailable` is `true`, a {ccs}:
 

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -290,14 +290,17 @@ means the document came from the local cluster.
 [[skip-unavailable-clusters]]
 === Skip unavailable clusters
 
-By default, a {ccs} returns an error if a remote cluster in the request is
-unavailable. You can override this default for a specific remote cluster using
-the <<skip-unavailable,`skip_unavailable`>> cluster setting.
+By default, a {ccs} request fails if a remote cluster in the request is
+unavailable. You can the `skip_unavailable` cluster setting to mark a specific
+remote cluster as optional in cross-cluster searches.
 
 If `skip_unavailable` is `true`, a {ccs}:
 
-* Skips the remote cluster if it's unavailable during the search. The response's
-`_cluster.skipped` value contains a count of any skipped clusters.
+* Skips the remote cluster if its nodes are unavailable during the search. The
+response's `_cluster.skipped` value contains a count of any skipped clusters.
+
+* Ignores errors, such as errors related to unavailable shards or indices,
+returned by the remote cluster.
 
 * Ignores the <<search-partial-responses,`allow_partial_search_results`>>
 parameter and the related `search.default_allow_partial_results` cluster setting

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -290,9 +290,9 @@ means the document came from the local cluster.
 [[skip-unavailable-clusters]]
 === Skip unavailable clusters
 
-By default, a {ccs} returns an error if *any* cluster in the request is
-unavailable. You can override this default for a specific remote cluster
-using the <<skip-unavailable,`skip_unavailable`>> cluster setting.
+By default, a {ccs} returns an error if a remote cluster in the request is
+unavailable. You can override this default for a specific remote cluster using
+the <<skip-unavailable,`skip_unavailable`>> cluster setting.
 
 If `skip_unavailable` is `true`, a {ccs}:
 
@@ -300,8 +300,9 @@ If `skip_unavailable` is `true`, a {ccs}:
 `_cluster.skipped` value contains a count of any skipped clusters.
 
 * Ignores the <<search-partial-responses,`allow_partial_search_results`>>
-parameter, if specified, when searching the remote cluster. This means searches
-on the remote cluster may return partial results.
+parameter and the related `search.default_allow_partial_results` cluster setting
+when searching the remote cluster. This means searches on the remote cluster may
+return partial results.
 
 The following <<cluster-update-settings,cluster update settings>>
 API request changes `cluster_two`'s `skip_unavailable` setting to `true`.

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -291,13 +291,20 @@ means the document came from the local cluster.
 === Skip unavailable clusters
 
 By default, a {ccs} returns an error if *any* cluster in the request is
-unavailable.
+unavailable. You can override this default for a specific remote cluster
+using the <<skip-unavailable,`skip_unavailable`>> cluster setting.
 
-To skip an unavailable cluster during a {ccs}, set the
-<<skip-unavailable,`skip_unavailable`>> cluster setting to `true`.
+If `skip_unavailable` is `true`, a {ccs}:
 
-The following <<cluster-update-settings,cluster update settings>> API request
-changes `cluster_two`'s `skip_unavailable` setting to `true`.
+* Skips the remote cluster if it's unavailable during the search. The response's
+`_cluster.skipped` value contains a count of any skipped clusters.
+
+* Ignores the <<search-partial-responses,`allow_partial_search_results`>>
+parameter, if specified, when searching the remote cluster. This means searches
+on the remote cluster may return partial results.
+
+The following <<cluster-update-settings,cluster update settings>>
+API request changes `cluster_two`'s `skip_unavailable` setting to `true`.
 
 [source,console]
 --------------------------------
@@ -311,12 +318,7 @@ PUT _cluster/settings
 // TEST[continued]
 
 If `cluster_two` is disconnected or unavailable during a {ccs}, {es} won't
-include matching documents from that cluster in the final results. If users
-want the <<search-partial-responses,`allow_partial_search_results`>> and
-<<multi-index,`ignore_unavailable`>> parameters of a {ccs} request to take
-effect on remote clusters, the `skip_unavailable` setting of remote clusters
-must not be set to `true`. The other option is to examine the number of skipped
-clusters returned at `_clusters.skipped` in the search response.
+include matching documents from that cluster in the final results.
 
 [discrete]
 [[ccs-network-delays]]

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -311,7 +311,12 @@ PUT _cluster/settings
 // TEST[continued]
 
 If `cluster_two` is disconnected or unavailable during a {ccs}, {es} won't
-include matching documents from that cluster in the final results.
+include matching documents from that cluster in the final results. If users
+want the <<search-partial-responses,`allow_partial_search_results`>> and
+<<multi-index,`ignore_unavailable`>> parameters of a {ccs} request to take
+effect on remote clusters, the `skip_unavailable` setting of remote clusters
+must not be set to `true`. The other option is to examine the number of skipped
+clusters returned at `_clusters.skipped` in the search response.
 
 [discrete]
 [[ccs-network-delays]]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -70,6 +70,12 @@ no partial results. Defaults to `true`.
 To override the default for this field, set the
 `search.default_allow_partial_results` cluster setting to `false`.
 
+A {ccs} request can still return partial search results even
+`default_allow_partial_results` is set to `false` if some remote clusters are
+unavailable and their <<skip-unavailable-clusters,skip_unavailable>> settings
+are set to `true`. In this case, the caller needs to examine the number of
+skipped clusters returned at `_clusters.skipped` in the search response.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -70,12 +70,6 @@ no partial results. Defaults to `true`.
 To override the default for this field, set the
 `search.default_allow_partial_results` cluster setting to `false`.
 
-A {ccs} request can still return partial search results even
-`default_allow_partial_results` is set to `false` if some remote clusters are
-unavailable and their <<skip-unavailable-clusters,skip_unavailable>> settings
-are set to `true`. In this case, the caller needs to examine the number of
-skipped clusters returned at `_clusters.skipped` in the search response.
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]


### PR DESCRIPTION
This commit adds an explanation for the relation between `allow_partial_search_results` and `skip_unavailable` in ccs requests.

Relates to #33915

Closes #82407

### Previews

* Remote info API: https://elasticsearch_84057.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html#cluster-remote-info-api-response-body
* Search across clusters: https://elasticsearch_84057.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-cross-cluster-search.html#skip-unavailable-clusters