### PR TITLE
[8.0] Unmute BWC rest tests (#84058)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
@@ -23,10 +23,6 @@
                $/
 ---
 "Test cat snapshots output":
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
-
   - do:
       snapshot.create_repository:
         repository: test_cat_snapshots_1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.create/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
 
   - do:
       snapshot.create_repository:
@@ -64,7 +61,6 @@ setup:
 
 ---
 "Get snapshot info when verbose is false":
-
   - do:
       indices.create:
         index: test_index
@@ -202,6 +198,7 @@ setup:
   - skip:
       version: " - 7.12.99"
       reason: "Introduced in 7.13.0"
+
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
@@ -1,9 +1,4 @@
 ---
-setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
----
 "Get repository returns UUID":
   - skip:
       version: " - 7.12.99"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.status/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.status/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -1,9 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 8.1.99"
-      reason: "Pause BWC tests until #83290 is backported"
-
   - do:
       snapshot.create_repository:
         repository: test_repo


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Unmute BWC rest tests (#84058)