### PR TITLE
[7.17] Correct documentation regarding how to restore no `feature_states` (#83814)

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -129,8 +129,9 @@ If `include_global_state` is `true`, the snapshot includes all feature states by
 default. If `include_global_state` is `false`, the snapshot includes no feature
 states by default.
 +
-To exclude all feature states, regardless of the `include_global_state` value,
-specify an empty array (`[]`) or `none`.
+Note that specifying an empty array will result in the default behavior. To
+exclude all feature states, regardless of the `include_global_state` value,
+specify an array with only the value `none` (`["none"]`).
 
 `metadata`::
 (Optional, object)

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -185,8 +185,10 @@ Use the `feature_states` parameter to configure how feature states are restored.
 +
 If `include_global_state` is `true`, the request restores all feature states
 in the snapshot by default. If `include_global_state` is `false`, the request
-restores no feature states by default. To restore no feature states, regardless
-of the `include_global_state` value, specify an empty array (`[]`).
+restores no feature states by default. Note that specifying an empty array
+will result in the default behavior. To restore no feature states, regardless
+of the `include_global_state` value, specify an array containing only the value
+`none` (`["none"]`).
 
 [[restore-snapshot-api-index-settings]]
 `index_settings`::


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Correct documentation regarding how to restore no `feature_states` (#83814)