### PR TITLE
[8.0] Adjust timeout for responses from SMB fixture (#84037)

### DIFF
--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
@@ -107,6 +107,7 @@ public class ActiveDirectorySessionFactoryTests extends AbstractActiveDirectoryT
             .normalizePrefix("xpack.security.authc.realms." + type + "." + name + ".")
             .put(globalSettings)
             .put(getFullSettingKey(identifier, RealmSettings.ORDER_SETTING), 0)
+            .put(getFullSettingKey(identifier, SessionFactorySettings.TIMEOUT_RESPONSE_SETTING), "15s")
             .build();
         final Environment env = TestEnvironment.newEnvironment(mergedSettings);
         this.sslService = new SSLService(env);


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #84037

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)