### PR TITLE
[8.1] Fix GeoHexAggregationBuilderTests (#84049)

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexAggregationBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexAggregationBuilderTests.java
@@ -46,10 +46,10 @@ public class GeoHexAggregationBuilderTests extends AbstractSerializingTestCase<G
             geoHexGridAggregationBuilder.precision(randomIntBetween(0, H3.MAX_H3_RES));
         }
         if (randomBoolean()) {
-            geoHexGridAggregationBuilder.size(randomIntBetween(0, 256 * 256));
+            geoHexGridAggregationBuilder.size(randomIntBetween(1, 256 * 256));
         }
         if (randomBoolean()) {
-            geoHexGridAggregationBuilder.shardSize(randomIntBetween(0, 256 * 256));
+            geoHexGridAggregationBuilder.shardSize(randomIntBetween(1, 256 * 256));
         }
         if (randomBoolean()) {
             geoHexGridAggregationBuilder.setGeoBoundingBox(GeoTestUtils.randomBBox());


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Fix GeoHexAggregationBuilderTests (#84049)