### PR TITLE
[8.0] Preserve context in snapshotDeletionListeners (#84089)

### DIFF
--- a/docs/changelog/84089.yaml
+++ b/docs/changelog/84089.yaml
@@ -1,0 +1,6 @@
+pr: 84089
+summary: Preserve context in `snapshotDeletionListeners`
+area: Snapshot/Restore
+type: bug
+issues:
+ - 84036

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2286,7 +2286,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private void addDeleteListener(String deleteUUID, ActionListener<Void> listener) {
-        snapshotDeletionListeners.computeIfAbsent(deleteUUID, k -> new CopyOnWriteArrayList<>()).add(listener);
+        snapshotDeletionListeners.computeIfAbsent(deleteUUID, k -> new CopyOnWriteArrayList<>())
+            .add(ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext()));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Preserve context in snapshotDeletionListeners (#84089)