### PR TITLE
Revert "Clean up for superuser role name references (#83627)"

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/UsernamesField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/UsernamesField.java
@@ -15,7 +15,7 @@ public final class UsernamesField {
     public static final String SYSTEM_NAME = "_system";
     public static final String SYSTEM_ROLE = "_system";
     public static final String XPACK_SECURITY_NAME = "_xpack_security";
-    public static final String XPACK_SECURITY_ROLE = "_xpack_security";
+    public static final String XPACK_SECURITY_ROLE = "superuser";
     public static final String XPACK_NAME = "_xpack";
     public static final String XPACK_ROLE = "_xpack";
     public static final String LOGSTASH_NAME = "logstash_system";

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
@@ -51,7 +51,7 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
     public InternalEnrollmentTokenGenerator(Environment environment, SSLService sslService, Client client) {
         this.environment = environment;
         this.sslService = sslService;
-        // enrollment tokens API keys will be owned by the "_xpack_security" system user
+        // enrollment tokens API keys will be owned by the "_xpack_security" system user ("superuser" role)
         this.client = new OriginSettingClient(client, SECURITY_ORIGIN);
     }
 


### PR DESCRIPTION
This reverts commit a9cdbf42c6140e7c0e2ac49d8ccd25683741084d.

The role name change does not play well with API key creation. 