### PR TITLE
[DOCS] Mark PR #82409 as a notable release highlight

### DIFF
--- a/docs/changelog/82409.yaml
+++ b/docs/changelog/82409.yaml
@@ -8,7 +8,7 @@ summary: Allow doc-values only search on number types
 # Note: the following release highlight covers a series of PRs that added
 # this support
 highlight:
-  notable: false
+  notable: true
   title: Doc-values-only search on numeric, `date`, `keyword`, `ip`, and `boolean` fields
   body: |-
     You can now run `term` and `range` queries on numeric, `date`, `date_nanos`,


### PR DESCRIPTION
Marks PR #82409 as a notable release highlight in its changelog YAML file. This ensures the highlight displays in the [Elastic Upgrade Guide](https://www.elastic.co/guide/en/elastic-stack/8.1/elasticsearch-highlights.html).

Relates to https://github.com/elastic/elasticsearch/pull/84041