### PR TITLE
[7.13] [DOCS] Fix `ignore_unavailable` parameter definition (#84071)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -97,8 +97,8 @@ Comma-separated list of filters for the API response. See
 <<common-options-response-filtering>>.
 
 `ignore_unavailable`::
-(Optional, Boolean) If `true`, missing or closed indices are not included in the
-response. Defaults to `true`.
+(Optional, Boolean) If `false`, the request returns an error if it targets a
+missing or closed index. Defaults to `true`.
 
 `keep_alive`::
 +

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -418,8 +418,8 @@ end::ignore_throttled[]
 
 tag::index-ignore-unavailable[]
 `ignore_unavailable`::
-(Optional, Boolean) If `true`, missing or closed indices are not included in the
-response. Defaults to `false`.
+(Optional, Boolean) If `false`, the request returns an error if it targets a
+missing or closed index. Defaults to `false`.
 end::index-ignore-unavailable[]
 
 tag::include-defaults[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.13`:
 - [[DOCS] Fix `ignore_unavailable` parameter definition (#84071)](https://github.com/elastic/elasticsearch/pull/84071)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)