### PR TITLE
Registration of SystemIndexMigrationTask named xcontent objects

### DIFF
--- a/docs/changelog/84136.yaml
+++ b/docs/changelog/84136.yaml
@@ -1,0 +1,6 @@
+pr: 84136
+summary: Registration of `SystemIndexMigrationTask` named xcontent objects
+area: Infra/Core
+type: bug
+issues:
+ - 84115

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -550,7 +550,8 @@ public class Node implements Closeable {
                     IndicesModule.getNamedXContents().stream(),
                     searchModule.getNamedXContents().stream(),
                     pluginsService.filterPlugins(Plugin.class).stream().flatMap(p -> p.getNamedXContent().stream()),
-                    ClusterModule.getNamedXWriteables().stream()
+                    ClusterModule.getNamedXWriteables().stream(),
+                    SystemIndexMigrationExecutor.getNamedXContentParsers().stream()
                 ).flatMap(Function.identity()).collect(toList())
             );
             final Map<String, SystemIndices.Feature> featuresMap = pluginsService.filterPlugins(SystemIndexPlugin.class)

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
@@ -24,6 +24,8 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.ParseField;
 
 import java.util.Collection;
 import java.util.List;
@@ -107,6 +109,21 @@ public class SystemIndexMigrationExecutor extends PersistentTasksExecutor<System
         } else {
             return new PersistentTasksCustomMetadata.Assignment(discoveryNode.getId(), "");
         }
+    }
+
+    public static List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
+        return org.elasticsearch.core.List.of(
+            new NamedXContentRegistry.Entry(
+                PersistentTaskParams.class,
+                new ParseField(SystemIndexMigrationTaskParams.SYSTEM_INDEX_UPGRADE_TASK_NAME),
+                SystemIndexMigrationTaskParams::fromXContent
+            ),
+            new NamedXContentRegistry.Entry(
+                PersistentTaskState.class,
+                new ParseField(SystemIndexMigrationTaskParams.SYSTEM_INDEX_UPGRADE_TASK_NAME),
+                SystemIndexMigrationTaskState::fromXContent
+            )
+        );
     }
 
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParams.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParams.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
@@ -33,6 +34,10 @@ public class SystemIndexMigrationTaskParams implements PersistentTaskParams {
     );
     static {
         // PARSER.declareString etc...
+    }
+
+    public static SystemIndexMigrationTaskParams fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
     }
 
     public SystemIndexMigrationTaskParams() {

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
@@ -36,10 +36,10 @@ public class SystemIndexMigrationTaskState implements PersistentTaskState {
     private static final ParseField FEATURE_METADATA_MAP_FIELD = new ParseField("feature_metadata");
 
     @SuppressWarnings(value = "unchecked")
-    private static final ConstructingObjectParser<SystemIndexMigrationTaskState, Void> PARSER = new ConstructingObjectParser<>(
+    static final ConstructingObjectParser<SystemIndexMigrationTaskState, Void> PARSER = new ConstructingObjectParser<>(
         SYSTEM_INDEX_UPGRADE_TASK_NAME,
         true,
-        args -> new SystemIndexMigrationTaskState((String) args[0], (String) args[1], (Map<String, Object>) args[3])
+        args -> new SystemIndexMigrationTaskState((String) args[0], (String) args[1], (Map<String, Object>) args[2])
     );
 
     static {
@@ -129,5 +129,19 @@ public class SystemIndexMigrationTaskState implements PersistentTaskState {
     @Override
     public int hashCode() {
         return Objects.hash(currentIndex, currentFeature, featureCallbackMetadata);
+    }
+
+    @Override
+    public String toString() {
+        return "SystemIndexMigrationTaskState{"
+            + "currentIndex='"
+            + currentIndex
+            + '\''
+            + ", currentFeature='"
+            + currentFeature
+            + '\''
+            + ", featureCallbackMetadata="
+            + featureCallbackMetadata
+            + '}';
     }
 }

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 
 import java.io.IOException;
-import java.util.Collections;
 
 public class SystemIndexMigrationTaskParamsTests extends AbstractNamedWriteableTestCase<SystemIndexMigrationTaskParams> {
 
@@ -32,15 +31,7 @@ public class SystemIndexMigrationTaskParamsTests extends AbstractNamedWriteableT
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return new NamedWriteableRegistry(
-            Collections.singletonList(
-                new NamedWriteableRegistry.Entry(
-                    SystemIndexMigrationTaskParams.class,
-                    SystemIndexMigrationTaskParams.SYSTEM_INDEX_UPGRADE_TASK_NAME,
-                    SystemIndexMigrationTaskParams::new
-                )
-            )
-        );
+        return new NamedWriteableRegistry(SystemIndexMigrationExecutor.getNamedWriteables());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsXContentTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class SystemIndexMigrationTaskParamsXContentTests extends AbstractXContentTestCase<SystemIndexMigrationTaskParams> {
+
+    @Override
+    protected SystemIndexMigrationTaskParams createTestInstance() {
+        return new SystemIndexMigrationTaskParams();
+    }
+
+    @Override
+    protected SystemIndexMigrationTaskParams doParseInstance(XContentParser parser) throws IOException {
+        return SystemIndexMigrationTaskParams.PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(SystemIndexMigrationExecutor.getNamedXContentParsers());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateTests.java
@@ -14,13 +14,16 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTestCase<SystemIndexMigrationTaskState> {
 
     @Override
     protected SystemIndexMigrationTaskState createTestInstance() {
+        return randomSystemIndexMigrationTask();
+    }
+
+    static SystemIndexMigrationTaskState randomSystemIndexMigrationTask() {
         return new SystemIndexMigrationTaskState(
             randomAlphaOfLengthBetween(5, 20),
             randomAlphaOfLengthBetween(5, 20),
@@ -28,16 +31,16 @@ public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTe
         );
     }
 
-    private Map<String, Object> randomFeatureCallbackMetadata() {
+    private static Map<String, Object> randomFeatureCallbackMetadata() {
         return randomMap(0, 10, () -> new Tuple<>(randomAlphaOfLength(5), randomMetadataValue()));
     }
 
-    private Object randomMetadataValue() {
+    private static Object randomMetadataValue() {
         switch (randomIntBetween(0, 7)) {
             case 0:
                 return randomMap(0, 3, () -> new Tuple<>(randomAlphaOfLength(5), randomMetadataValue()));
             case 1:
-                return randomList(0, 3, this::randomMetadataValue);
+                return randomList(0, 3, SystemIndexMigrationTaskStateTests::randomMetadataValue);
             case 2:
                 return randomLong();
             case 3:
@@ -76,7 +79,10 @@ public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTe
                 feature = randomValueOtherThan(instance.getCurrentFeature(), () -> randomAlphaOfLengthBetween(5, 20));
                 break;
             case 2:
-                featureMetadata = randomValueOtherThan(instance.getFeatureCallbackMetadata(), this::randomFeatureCallbackMetadata);
+                featureMetadata = randomValueOtherThan(
+                    instance.getFeatureCallbackMetadata(),
+                    SystemIndexMigrationTaskStateTests::randomFeatureCallbackMetadata
+                );
                 break;
             default:
                 assert false : "invalid randomization case";
@@ -87,13 +93,8 @@ public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTe
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(
-            Collections.singletonList(
-                new NamedWriteableRegistry.Entry(
-                    SystemIndexMigrationTaskState.class,
-                    SystemIndexMigrationTaskParams.SYSTEM_INDEX_UPGRADE_TASK_NAME,
-                    SystemIndexMigrationTaskState::new
-                )
-            )
+            SystemIndexMigrationExecutor.getNamedWriteables()
+
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateTests.java
@@ -36,7 +36,7 @@ public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTe
     }
 
     private static Object randomMetadataValue() {
-        switch (randomIntBetween(0, 7)) {
+        switch (randomIntBetween(0, 5)) {
             case 0:
                 return randomMap(0, 3, () -> new Tuple<>(randomAlphaOfLength(5), randomMetadataValue()));
             case 1:
@@ -44,14 +44,10 @@ public class SystemIndexMigrationTaskStateTests extends AbstractNamedWriteableTe
             case 2:
                 return randomLong();
             case 3:
-                return randomShort();
-            case 4:
                 return randomBoolean();
-            case 5:
-                return randomFloat();
-            case 6:
+            case 4:
                 return randomDouble();
-            case 7:
+            case 5:
                 return randomAlphaOfLengthBetween(5, 10);
         }
         throw new AssertionError("bad randomization");

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class SystemIndexMigrationTaskStateXContentTests extends AbstractXContentTestCase<SystemIndexMigrationTaskState> {
+
+    // how do we compare float and double?
+    @Override
+    protected SystemIndexMigrationTaskState createTestInstance() {
+        return SystemIndexMigrationTaskStateTests.randomSystemIndexMigrationTask();
+    }
+
+    @Override
+    protected SystemIndexMigrationTaskState doParseInstance(XContentParser parser) throws IOException {
+        return SystemIndexMigrationTaskState.PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(SystemIndexMigrationExecutor.getNamedXContentParsers());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 
 public class SystemIndexMigrationTaskStateXContentTests extends AbstractXContentTestCase<SystemIndexMigrationTaskState> {
 
-    // how do we compare float and double?
     @Override
     protected SystemIndexMigrationTaskState createTestInstance() {
         return SystemIndexMigrationTaskStateTests.randomSystemIndexMigrationTask();


### PR DESCRIPTION
Registering SystemIndexMigrationTaskParams  and SystemIndexMigrationTaskState parsers into named xcontent registry.
closes #84115