### PR TITLE
Only check for metadata input on the root object

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -66,4 +66,8 @@ public final class ContentPath {
     public int length() {
         return index;
     }
+
+    public boolean atRoot() {
+        return index == 0;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -603,11 +603,12 @@ public final class DocumentParser {
     // we do not check for shadowing runtime fields because they only apply to leaf
     // fields
     private static Mapper getMapper(final DocumentParserContext context, ObjectMapper objectMapper, String fieldName) {
-        String fieldPath = context.path().pathAsText(fieldName);
-        // Check if mapper is a metadata mapper first
-        Mapper mapper = context.getMetadataMapper(fieldPath);
-        if (mapper != null) {
-            return mapper;
+        if (context.path().atRoot()) {
+            // Check if mapper is a metadata mapper first
+            Mapper mapper = context.getMetadataMapper(fieldName);
+            if (mapper != null) {
+                return mapper;
+            }
         }
         return objectMapper.getMapper(fieldName);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1452,7 +1452,9 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testDocumentContainsAllowedMetadataField() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        DocumentMapper mapper = createDocumentMapper("""
+            { "_doc": { "dynamic" : "strict", "properties" : { "object" : { "type" : "object" } } } }
+            """);
         {
             // A metadata field that parses a value fails to parse a null value
             MapperParsingException e = expectThrows(
@@ -1482,6 +1484,14 @@ public class DocumentParserTests extends MapperServiceTestCase {
             );
             IndexableField field = doc.rootDoc().getField(DocumentParserTestsPlugin.MockMetadataMapper.CONTENT_TYPE);
             assertEquals("mock-metadata-field-value", field.stringValue());
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+                b.startObject("object");
+                b.field(DocumentParserTestsPlugin.MockMetadataMapper.CONTENT_TYPE, "mock-metadata-field-value");
+                b.endObject();
+            })));
+            assertTrue(e.getMessage(), e.getMessage().contains("dynamic introduction of [_mock_metadata] within [object]"));
         }
     }
 


### PR DESCRIPTION
We have found that `ContentPath.pathAsText()` ends up being a very hot path
in indexing, and that it is specifically called a lot when checking that the current
path does not lead to a metadata mapper.  The metadata mappers that accept
input only exist at the root, however, so instead of building the full path we can
instead check that we are on the root mapper and then just pass the current
field to the lookup.