### PR TITLE
Small formatting clean up

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
@@ -140,7 +140,7 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
             && mapperService.documentMapper().sourceMapper().isComplete() == false) {
             context.onFailure(
                 new IllegalStateException(
-                    "Can't snapshot _source only on an index that has incomplete source ie. has _source disabled " + "or filters the source"
+                    "Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source"
                 )
             );
             return;


### PR DESCRIPTION
Replaces some funny code formatting created when we applied spotless to
the code globally. Spotless does a fine job, but this was a little funky
looking.