### PR TITLE
Drop unnecessary persisted metadata on data nodes

### DIFF
--- a/docs/changelog/84148.yaml
+++ b/docs/changelog/84148.yaml
@@ -1,0 +1,5 @@
+pr: 84148
+summary: Drop unnecessary global metadata on data nodes
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -468,7 +468,6 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         assertThat(seqNoStats.getLocalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
-    @AwaitsFix(bugUrl = "TODO")
     public void testCorruptTranslogTruncationOfReplica() throws Exception {
         internalCluster().startMasterOnlyNode();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -468,6 +468,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         assertThat(seqNoStats.getLocalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
+    @AwaitsFix(bugUrl = "TODO")
     public void testCorruptTranslogTruncationOfReplica() throws Exception {
         internalCluster().startMasterOnlyNode();
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
@@ -230,7 +229,7 @@ public class ClusterFormationFailureHelper {
             assert requiredNodes <= realNodeIds.size() : nodeIds;
 
             if (nodeIds.size() == 1) {
-                if (nodeIds.contains(GatewayMetaState.STALE_STATE_CONFIG_NODE_ID)) {
+                if (nodeIds.contains(VotingConfiguration.STALE_STATE_CONFIG_NODE_ID)) {
                     return "one or more nodes that have already participated as master-eligible nodes in the cluster but this node was "
                         + "not master-eligible the last time it joined the cluster";
                 } else {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -325,9 +325,22 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
      */
     public static class VotingConfiguration implements Writeable, ToXContentFragment {
 
+        /**
+         * Fake node ID for a voting configuration written by a master-ineligible data node to indicate that its on-disk state is
+         * potentially stale (since it is written asynchronously after application, rather than before acceptance). This node ID means that
+         * if the node is restarted as a master-eligible node then it does not win any elections until it has received a fresh cluster
+         * state.
+         */
+        public static final String STALE_STATE_CONFIG_NODE_ID = "STALE_STATE_CONFIG";
+
         public static final VotingConfiguration EMPTY_CONFIG = new VotingConfiguration(Collections.emptySet());
+
         public static final VotingConfiguration MUST_JOIN_ELECTED_MASTER = new VotingConfiguration(
             Collections.singleton("_must_join_elected_master_")
+        );
+
+        public static final VotingConfiguration STALE_STATE_CONFIG = new VotingConfiguration(
+            Collections.singleton(STALE_STATE_CONFIG_NODE_ID)
         );
 
         private final Set<String> nodeIds;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -645,6 +645,17 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
+    public IndexMetadata forDataNodePersistence() {
+        final var builder = builder(this);
+        builder.putMapping(MappingMetadata.EMPTY_MAPPINGS);
+        builder.removeAllAliases();
+        for (String customKey : customData.keySet()) {
+            builder.removeCustom(customKey);
+        }
+        // TODO clear out unnecessary settings too? NB need SETTING_DATA_PATH for RemoveCorruptedShardDataCommand
+        return builder.build();
+    }
+
     IndexMetadata withMappingMetadata(MappingMetadata mapping) {
         if (mapping() == mapping) {
             return this;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -323,7 +323,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                 ImmutableOpenMap.of(),
                 ImmutableOpenMap.of(),
                 ImmutableOpenMap.of(),
-                ImmutableOpenMap.of(),
+                EMPTY_METADATA.customs,
                 Strings.EMPTY_ARRAY,
                 Strings.EMPTY_ARRAY,
                 Strings.EMPTY_ARRAY,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -301,6 +301,42 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
         );
     }
 
+    /**
+     * @return a copy of this {@link Metadata} with most of the global components removed since these need not be persisted on data nodes.
+     */
+    public Metadata forDataNodePersistence() {
+        return Metadata.builder(
+            new Metadata(
+                clusterUUID,
+                clusterUUIDCommitted,
+                version,
+                CoordinationMetadata.builder(coordinationMetadata)
+                    .lastAcceptedConfiguration(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
+                    .lastCommittedConfiguration(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
+                    .build(),
+                Settings.EMPTY,
+                Settings.EMPTY,
+                Settings.EMPTY,
+                DiffableStringMap.EMPTY,
+                0,
+                0,
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                Strings.EMPTY_ARRAY,
+                Strings.EMPTY_ARRAY,
+                Strings.EMPTY_ARRAY,
+                Strings.EMPTY_ARRAY,
+                Strings.EMPTY_ARRAY,
+                Strings.EMPTY_ARRAY,
+                Collections.emptySortedMap(),
+                Collections.emptyMap(),
+                Version.CURRENT
+            )
+        ).build();
+    }
+
     public long version() {
         return this.version;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -305,7 +305,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
      * @return a copy of this {@link Metadata} with most of the global components removed since these need not be persisted on data nodes.
      */
     public Metadata forDataNodePersistence() {
-        return Metadata.builder(
+        final var builder = Metadata.builder(
             new Metadata(
                 clusterUUID,
                 clusterUUIDCommitted,
@@ -334,7 +334,11 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                 Collections.emptyMap(),
                 Version.CURRENT
             )
-        ).build();
+        );
+        for (final var indexMetadata : indices.values()) {
+            builder.put(indexMetadata.forDataNodePersistence(), false);
+        }
+        return builder.build();
     }
 
     public long version() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
-import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.test.ESTestCase;
 
@@ -827,7 +826,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         assertThat(
             new ClusterFormationState(
                 Settings.EMPTY,
-                state(localNode, GatewayMetaState.STALE_STATE_CONFIG_NODE_ID),
+                state(localNode, VotingConfiguration.STALE_STATE_CONFIG_NODE_ID),
                 emptyList(),
                 emptyList(),
                 0L,

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -515,7 +515,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                     GatewayMetaState.AsyncPersistedState.resetVotingConfiguration(state),
                     reloadedPersistedState.getLastAcceptedState()
                 );
-                assertNotNull(reloadedPersistedState.getLastAcceptedState().metadata().index(indexName));
+                assertNull(reloadedPersistedState.getLastAcceptedState().metadata().index(indexName));
             }
         } finally {
             IOUtils.close(cleanup);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -515,7 +515,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                     GatewayMetaState.AsyncPersistedState.resetVotingConfiguration(state),
                     reloadedPersistedState.getLastAcceptedState()
                 );
-                assertNull(reloadedPersistedState.getLastAcceptedState().metadata().index(indexName));
+                assertNotNull(reloadedPersistedState.getLastAcceptedState().metadata().index(indexName));
             }
         } finally {
             IOUtils.close(cleanup);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -442,11 +442,11 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 .coordinationMetadata();
             assertThat(
                 persistedCoordinationMetadata.getLastAcceptedConfiguration(),
-                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration)
+                equalTo(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
             );
             assertThat(
                 persistedCoordinationMetadata.getLastCommittedConfiguration(),
-                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration)
+                equalTo(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
             );
 
             persistedState.markLastAcceptedStateAsCommitted();
@@ -469,11 +469,11 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             persistedCoordinationMetadata = persistedClusterStateService.loadBestOnDiskState(false).metadata.coordinationMetadata();
             assertThat(
                 persistedCoordinationMetadata.getLastAcceptedConfiguration(),
-                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration)
+                equalTo(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
             );
             assertThat(
                 persistedCoordinationMetadata.getLastCommittedConfiguration(),
-                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration)
+                equalTo(CoordinationMetadata.VotingConfiguration.STALE_STATE_CONFIG)
             );
             assertTrue(persistedClusterStateService.loadBestOnDiskState(false).metadata.clusterUUIDCommitted());
 


### PR DESCRIPTION
Data nodes and master nodes both persist the cluster metadata in much
the same way, except that persistence on master-ineligible data nodes is
async to cluster state updates and the state that these nodes write is
modified slightly to mark it as unreliable.

We largely persist the state on data nodes in order to lock them into
their cluster, which really only needs a very small portion of the
metadata. Moreover the unnecessary bits can prevent a node from starting
if, for instance, there is a de/serialization bug or some problem with
settings validation. Recovery from such a situation typically requires
work on every affected node, and that can be tedious in a large cluster.

With this commit we drop all the unnecessary bits of cluster state
before writing it to disk on master-ineligible data nodes, saving a
bunch of pointless effort and reducing the work needed to recover a
cluster from a bad on-disk state.