### PR TITLE
Mark the `id` path parameter as optional for logstash.get_pipeline

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/logstash.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/logstash.get_pipeline.json
@@ -12,6 +12,10 @@
     "url":{
       "paths":[
         {
+          "path":"/_logstash/pipeline",
+          "methods":[ "GET" ]
+        },
+        {
           "path":"/_logstash/pipeline/{id}",
           "methods":[ "GET" ],
           "parts":{


### PR DESCRIPTION
Per [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html) the `id` parameter for the `logstash.get_pipeline` API should be optional. Currently the spec has `id` as required.

Reported originally in: https://github.com/elastic/elasticsearch-py/issues/1925