### PR TITLE
[DOCS] Add read_pipeline privilege to transform setup

### DIFF
--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -69,6 +69,7 @@ views already exist for your destination indices),
 * `read` and `view_index_metadata` index privileges on source indices, and
 * `create_index`, `index`, `manage`, and `read` index privileges on destination
 indices 
+* `read_pipeline` cluster privileges, if the {transform} uses an ingest pipeline
 
 Within a {kib} space, for read-only access to {transforms}, you must meet all of
 the following requirements:


### PR DESCRIPTION
This PR updates https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-setup.html since the transform creation wizard requires the read_pipeline cluster privilege in order to add an existing pipeline to the transform. When using the create transform API, no such privilege seems to be required.

Relates to https://github.com/elastic/kibana/pull/123911

### Preview

https://elasticsearch_84151.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-setup.html