### PR TITLE
Update create-api-keys.asciidoc

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -69,7 +69,7 @@ authentication; it will not have authority to call {es} APIs.
 --
 
 `expiration`::
-(Optional, string) Expiration time for the API key. By default, API keys never
+(Optional, <<time-units, time units>>) Expiration time for the API key. By default, API keys never
 expire.
 
 `metadata`::


### PR DESCRIPTION
it seems expiration is defined as org.elasticsearch.core.TimeValue.
https://github.com/elastic/elasticsearch/blob/358484bd1ed1bab532c2acee929f1d8afd67c49d/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java#L338

I think it should be documented as time unit.  but please review if this PR would be really appropreate or accurate.
https://www.elastic.co/guide/en/elasticsearch/reference/8.0/api-conventions.html#time-units

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
