### PR TITLE
Use same system index pattern in restricted names

### DIFF
--- a/docs/changelog/84180.yaml
+++ b/docs/changelog/84180.yaml
@@ -1,0 +1,5 @@
+pr: 84180
+summary: Use same system index pattern in restricted names
+area: Authorization
+type: enhancement
+issues: []

--- a/docs/changelog/84180.yaml
+++ b/docs/changelog/84180.yaml
@@ -1,5 +1,5 @@
 pr: 84180
-summary: Use same system index pattern in restricted names
+summary: Unify index name pattern between security system-index and RBAC restricted names
 area: Authorization
 type: enhancement
 issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNames.java
@@ -17,20 +17,26 @@ import org.elasticsearch.xpack.core.security.support.Automatons;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public final class RestrictedIndicesNames {
     public static final String INTERNAL_SECURITY_MAIN_INDEX_6 = ".security-6";
     public static final String INTERNAL_SECURITY_MAIN_INDEX_7 = ".security-7";
     public static final String SECURITY_MAIN_ALIAS = ".security";
 
-    // See o.e.x.security.Security#getSecurityMainIndexDescriptor
-    private static final String SECURITY_INDEX_PREFIX = SECURITY_MAIN_ALIAS + "-";
-    private static final Automaton SECURITY_INDEX_AUTOMATON = Operations.concatenate(
-        List.of(Automata.makeString(SECURITY_INDEX_PREFIX), Automata.makeCharRange('0', '9'), Automata.makeAnyString())
-    );
-
     public static final String INTERNAL_SECURITY_TOKENS_INDEX_7 = ".security-tokens-7";
     public static final String SECURITY_TOKENS_ALIAS = ".security-tokens";
+
+    // See o.e.x.security.Security#getSecurityMainIndexDescriptor, o.e.x.security.Security#getSecurityTokensIndexDescriptor
+    private static final Automaton SECURITY_INDEX_AUTOMATON = Operations.concatenate(
+        List.of(
+            Operations.union(Automata.makeString(SECURITY_MAIN_ALIAS), Automata.makeString(SECURITY_TOKENS_ALIAS)),
+            Automata.makeChar('-'),
+            Automata.makeCharRange('0', '9'),
+            Automata.makeAnyString()
+        )
+    );
+    private static final Predicate<String> SECURITY_INDEX_PREDICATE = Automatons.predicate(SECURITY_INDEX_AUTOMATON);
 
     // public for tests
     public static final String ASYNC_SEARCH_PREFIX = ".async-search";
@@ -48,27 +54,9 @@ public final class RestrictedIndicesNames {
     );
 
     public static boolean isRestricted(String concreteIndexName) {
-        return isStaticRestrictedIndex(concreteIndexName)
-            || isAsyncSearchIndex(concreteIndexName)
-            || isAlternativeSecurityIndex(concreteIndexName);
-    }
-
-    private static boolean isStaticRestrictedIndex(String concreteIndexName) {
-        return RESTRICTED_NAMES.contains(concreteIndexName);
-    }
-
-    private static boolean isAsyncSearchIndex(String concreteIndexName) {
-        return concreteIndexName.startsWith(ASYNC_SEARCH_PREFIX);
-    }
-
-    private static boolean isAlternativeSecurityIndex(String concreteIndexName) {
-        if (concreteIndexName.startsWith(SECURITY_INDEX_PREFIX) && concreteIndexName.length() > SECURITY_INDEX_PREFIX.length()) {
-            final char ch = concreteIndexName.charAt(SECURITY_INDEX_PREFIX.length());
-            // Intentionally use ASCII (not unicode) digits because that's what the automaton uses
-            return ch >= '0' && ch <= '9';
-        } else {
-            return false;
-        }
+        return RESTRICTED_NAMES.contains(concreteIndexName)
+            || concreteIndexName.startsWith(ASYNC_SEARCH_PREFIX)
+            || SECURITY_INDEX_PREDICATE.test(concreteIndexName);
     }
 
     public static final Automaton NAMES_AUTOMATON = Automatons.unionAndMinimize(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
@@ -36,9 +36,14 @@ public class RestrictedIndicesNamesTests extends ESTestCase {
         testIndex(".security-tokens-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 20), true);
 
         testIndex("security", false);
+        testIndex(randomAlphaOfLength(1) + "security", false);
         testIndex("security-6", false);
+        testIndex("@security-6", false);
         testIndex(".not-security-7", false);
         testIndex(".security-", false);
+        testIndex("security-tokens", false);
+        testIndex("security-tokens-7", false);
+        testIndex("_security-tokens", false);
         testIndex(".security-" + randomAlphaOfLengthBetween(1, 3), false);
         testIndex(".security-tokens-" + randomAlphaOfLengthBetween(1, 3), false);
         testIndex(".security" + randomAlphaOfLengthBetween(1, 10), false);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
@@ -32,12 +32,17 @@ public class RestrictedIndicesNamesTests extends ESTestCase {
         testIndex(".security-" + randomIntBetween(0, 999_999), true);
         testIndex(".security-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 20), true);
 
+        testIndex(".security-tokens-7", true);
+        testIndex(".security-tokens-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 20), true);
+
         testIndex("security", false);
         testIndex("security-6", false);
         testIndex(".not-security-7", false);
         testIndex(".security-", false);
-        testIndex(".security-" + randomAlphaOfLengthBetween(1, 10), false);
+        testIndex(".security-" + randomAlphaOfLengthBetween(1, 3), false);
+        testIndex(".security-tokens-" + randomAlphaOfLengthBetween(1, 3), false);
         testIndex(".security" + randomAlphaOfLengthBetween(1, 10), false);
+        testIndex(".security-tokens" + randomAlphaOfLengthBetween(1, 10), false);
         testIndex(".security" + randomIntBetween(1, 9), false);
         testIndex(".security-" + randomAlphaOfLength(1) + randomIntBetween(1, 9), false);
         testIndex(".security" + randomAlphaOfLength(1) + randomIntBetween(1, 9), false);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.index;
+
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class RestrictedIndicesNamesTests extends ESTestCase {
+
+    private final CharacterRunAutomaton RUN_AUTOMATON = new CharacterRunAutomaton(RestrictedIndicesNames.NAMES_AUTOMATON);
+
+    public void testAsyncSearchNames() {
+        testIndex(".async-search", true);
+        testIndex(".async-search-" + randomAlphaOfLengthBetween(1, 8), true);
+        testIndex(".async-search" + randomInt(), true);
+        testIndex("async-search" + randomInt(), false);
+        testIndex(".asynchronous-search" + randomInt(), false);
+        testIndex(".not-async-search" + randomAlphaOfLengthBetween(1, 8), false);
+    }
+
+    public void testSecurityNames() {
+        testIndex(".security", true);
+        testIndex(".security-6", true);
+        testIndex(".security-7", true);
+        testIndex(".security-" + randomIntBetween(0, 999_999), true);
+        testIndex(".security-" + randomIntBetween(0, 99) + "-" + randomAlphaOfLengthBetween(1, 20), true);
+
+        testIndex("security", false);
+        testIndex("security-6", false);
+        testIndex(".not-security-7", false);
+        testIndex(".security-", false);
+        testIndex(".security-" + randomAlphaOfLengthBetween(1, 10), false);
+        testIndex(".security" + randomIntBetween(1, 9), false);
+        testIndex(".security-" + randomAlphaOfLength(1) + randomIntBetween(1, 9), false);
+    }
+
+    private void testIndex(String name, boolean expected) {
+        assertThat("For index [" + name + "]", RestrictedIndicesNames.isRestricted(name), is(expected));
+        assertThat("For index [" + name + "]", RUN_AUTOMATON.run(name), is(expected));
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/index/RestrictedIndicesNamesTests.java
@@ -18,11 +18,11 @@ public class RestrictedIndicesNamesTests extends ESTestCase {
 
     public void testAsyncSearchNames() {
         testIndex(".async-search", true);
-        testIndex(".async-search-" + randomAlphaOfLengthBetween(1, 8), true);
-        testIndex(".async-search" + randomInt(), true);
-        testIndex("async-search" + randomInt(), false);
-        testIndex(".asynchronous-search" + randomInt(), false);
-        testIndex(".not-async-search" + randomAlphaOfLengthBetween(1, 8), false);
+        testIndex(".async-search" + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 8), true);
+        testIndex(".async-search" + (randomBoolean() ? "-" : "") + randomInt(), true);
+        testIndex("async-search" + (randomBoolean() ? "-" : "") + randomInt(), false);
+        testIndex(".asynchronous-search" + (randomBoolean() ? "-" : "") + randomInt(), false);
+        testIndex(".not-async-search" + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 8), false);
     }
 
     public void testSecurityNames() {
@@ -30,15 +30,17 @@ public class RestrictedIndicesNamesTests extends ESTestCase {
         testIndex(".security-6", true);
         testIndex(".security-7", true);
         testIndex(".security-" + randomIntBetween(0, 999_999), true);
-        testIndex(".security-" + randomIntBetween(0, 99) + "-" + randomAlphaOfLengthBetween(1, 20), true);
+        testIndex(".security-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 20), true);
 
         testIndex("security", false);
         testIndex("security-6", false);
         testIndex(".not-security-7", false);
         testIndex(".security-", false);
         testIndex(".security-" + randomAlphaOfLengthBetween(1, 10), false);
+        testIndex(".security" + randomAlphaOfLengthBetween(1, 10), false);
         testIndex(".security" + randomIntBetween(1, 9), false);
         testIndex(".security-" + randomAlphaOfLength(1) + randomIntBetween(1, 9), false);
+        testIndex(".security" + randomAlphaOfLength(1) + randomIntBetween(1, 9), false);
     }
 
     private void testIndex(String name, boolean expected) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1686,7 +1686,7 @@ public class Security extends Plugin
         }
     }
 
-    private static SystemIndexDescriptor getSecurityMainIndexDescriptor() {
+    static SystemIndexDescriptor getSecurityMainIndexDescriptor() {
         return SystemIndexDescriptor.builder()
             .setMinimumNodeVersion(FLATTENED_FIELD_TYPE_INTRODUCED)
             // This can't just be `.security-*` because that would overlap with the tokens index pattern

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1686,7 +1686,7 @@ public class Security extends Plugin
         }
     }
 
-    static SystemIndexDescriptor getSecurityMainIndexDescriptor() {
+    private static SystemIndexDescriptor getSecurityMainIndexDescriptor() {
         return SystemIndexDescriptor.builder()
             .setMinimumNodeVersion(FLATTENED_FIELD_TYPE_INTRODUCED)
             // This can't just be `.security-*` because that would overlap with the tokens index pattern

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
 
@@ -18,10 +17,9 @@ import static org.hamcrest.Matchers.is;
 public class SecuritySystemIndexTests extends ESTestCase {
 
     public void testSystemIndexNameIsRestricted() {
-        final SystemIndexDescriptor descriptor = Security.getSecurityMainIndexDescriptor();
         Consumer<String> check = idx -> assertThat(
             "For index [" + idx + "]",
-            descriptor.matchesIndexPattern(idx),
+            Security.SECURITY_MAIN_INDEX_DESCRIPTOR.matchesIndexPattern(idx),
             is(RestrictedIndicesNames.isRestricted(idx))
         );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
@@ -19,7 +19,8 @@ public class SecuritySystemIndexTests extends ESTestCase {
     public void testSystemIndexNameIsRestricted() {
         Consumer<String> check = idx -> assertThat(
             "For index [" + idx + "]",
-            Security.SECURITY_MAIN_INDEX_DESCRIPTOR.matchesIndexPattern(idx),
+            Security.SECURITY_MAIN_INDEX_DESCRIPTOR.matchesIndexPattern(idx)
+                || Security.SECURITY_TOKEN_INDEX_DESCRIPTOR.matchesIndexPattern(idx),
             is(RestrictedIndicesNames.isRestricted(idx))
         );
 
@@ -31,6 +32,10 @@ public class SecuritySystemIndexTests extends ESTestCase {
 
         check.accept(".security-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 12));
         check.accept(".security-" + randomAlphaOfLengthBetween(1, 12) + (randomBoolean() ? "-" : "") + randomIntBetween(0, 99));
+
+        check.accept(".security-tokens-" + randomAlphaOfLengthBetween(1, 12));
+        check.accept(".security-tokens-" + randomIntBetween(1, 99));
+        check.accept(".security-tokens-" + randomIntBetween(1, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 12));
 
         check.accept("." + randomAlphaOfLengthBetween(1, 12) + "-security");
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
@@ -38,5 +38,10 @@ public class SecuritySystemIndexTests extends ESTestCase {
         check.accept(".security-tokens-" + randomIntBetween(1, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 12));
 
         check.accept("." + randomAlphaOfLengthBetween(1, 12) + "-security");
+
+        check.accept(randomAlphaOfLengthBetween(1, 3) + "security");
+        check.accept(randomAlphaOfLengthBetween(1, 3) + ".security");
+        check.accept(randomAlphaOfLengthBetween(1, 3) + ".security-6");
+        check.accept(randomAlphaOfLengthBetween(1, 3) + "security-tokens-7");
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecuritySystemIndexTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.is;
+
+public class SecuritySystemIndexTests extends ESTestCase {
+
+    public void testSystemIndexNameIsRestricted() {
+        final SystemIndexDescriptor descriptor = Security.getSecurityMainIndexDescriptor();
+        Consumer<String> check = idx -> assertThat(
+            "For index [" + idx + "]",
+            descriptor.matchesIndexPattern(idx),
+            is(RestrictedIndicesNames.isRestricted(idx))
+        );
+
+        check.accept(".security-" + randomIntBetween(0, 99));
+        check.accept(".security" + randomIntBetween(0, 99));
+
+        check.accept(".security-" + randomAlphaOfLengthBetween(1, 12));
+        check.accept(".security" + randomAlphaOfLengthBetween(1, 12));
+
+        check.accept(".security-" + randomIntBetween(0, 99) + (randomBoolean() ? "-" : "") + randomAlphaOfLengthBetween(1, 12));
+        check.accept(".security-" + randomAlphaOfLengthBetween(1, 12) + (randomBoolean() ? "-" : "") + randomIntBetween(0, 99));
+
+        check.accept("." + randomAlphaOfLengthBetween(1, 12) + "-security");
+    }
+}


### PR DESCRIPTION
The index pattern that was used for the ".security" system index was
not identical to the pattern used in RestrictedIndices. The
consequence was that it would be possible for a user without
restricted indices access to create an index that would get caught by
the system indices pattern, which could lead to confusion.

In 8.0 all system indices are automatically restricted, using the
index name pattern from the system index descriptor, so in 7.17 we are
changing the restricted index name to cover the same set of names as
the system index descriptor
