### PR TITLE
Do not deserialise the document when not needed in the fields fetch phase

### DIFF
--- a/docs/changelog/84184.yaml
+++ b/docs/changelog/84184.yaml
@@ -1,0 +1,5 @@
+pr: 84184
+summary: Do not deserialise the document when not needed in the fields fetch phase
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -174,7 +174,7 @@ public class FieldFetcher {
                 documentFields.put(field, new DocumentField(field, parsedValues, ignoredValues));
             }
         }
-        collectUnmapped(documentFields, sourceLookup.source(), "", 0);
+        collectUnmapped(documentFields, sourceLookup, "", 0);
         return documentFields;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -153,6 +153,13 @@ public class SourceLookup implements Map<String, Object> {
     }
 
     /**
+     * Checks of the source has been deserialized as a {@link Map} of java objects.
+     */
+    public boolean hasSourceAsMap() {
+        return source != null;
+    }
+
+    /**
      * Returns the values associated with the path. Those are "low" level values, and it can
      * handle path expression where an array/list is navigated within.
      */

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -153,7 +153,7 @@ public class SourceLookup implements Map<String, Object> {
     }
 
     /**
-     * Checks of the source has been deserialized as a {@link Map} of java objects.
+     * Checks if the source has been deserialized as a {@link Map} of java objects.
      */
     public boolean hasSourceAsMap() {
         return source != null;


### PR DESCRIPTION
I was looking into allocation profiles on the fetch phase and I realise that if I perform the following query:

```
"body": {
          "_source" : false,
          "size" : 10000,
         "fields": [ "_id"]
        }
```

The allocation profile looks like:

<img width="1750" alt="image" src="https://user-images.githubusercontent.com/29038686/154914308-8d3a329f-355d-43da-acd0-fa6d87f0ec7e.png">


`_id` is a stored value so the deserialisation of _source as a map here is totally unnecessary.  After this PR where we only deserialise it when need it the profile looks like:

<img width="1752" alt="image" src="https://user-images.githubusercontent.com/29038686/154914776-8ebbfd33-feb0-4c92-93ba-da3ea492787f.png">

And performance wise looks much better:

```
**|                                                        Metric |            Task |    Baseline |   Contender |     Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|----------------:|------------:|------------:|---------:|-------:|---------:|
|                                       Total Young Gen GC time |                 |        0.33 |       0.057 |   -0.273 |      s |  -82.73% |
|                                      Total Young Gen GC count |                 |          12 |           6 |       -6 |        |  -50.00% |
|                                                Min Throughput | query-match-all |     1.93177 |     2.00305 |  0.07127 |  ops/s |   +3.69% |
|                                               Mean Throughput | query-match-all |     1.97103 |     2.00615 |  0.03512 |  ops/s |   +1.78% |
|                                             Median Throughput | query-match-all |     1.97594 |     2.00505 |  0.02911 |  ops/s |   +1.47% |
|                                                Max Throughput | query-match-all |     1.98541 |     2.01483 |  0.02941 |  ops/s |   +1.48% |
|                                       50th percentile latency | query-match-all |     929.131 |      329.63 | -599.501 |     ms |  -64.52% |
|                                       90th percentile latency | query-match-all |     1116.77 |     416.851 | -699.921 |     ms |  -62.67% |
|                                       99th percentile latency | query-match-all |     1611.47 |     591.024 | -1020.45 |     ms |  -63.32% |
|                                      100th percentile latency | query-match-all |     1613.02 |     593.793 | -1019.23 |     ms |  -63.19% |
|                                  50th percentile service time | query-match-all |     928.108 |     329.039 | -599.069 |     ms |  -64.55% |
|                                  90th percentile service time | query-match-all |     1115.44 |      415.86 | -699.581 |     ms |  -62.72% |
|                                  99th percentile service time | query-match-all |      1610.9 |     590.157 | -1020.75 |     ms |  -63.36% |
|                                 100th percentile service time | query-match-all |     1612.53 |     592.658 | -1019.87 |     ms |  -63.25% |
|                                                    error rate | query-match-all |           0 |           0 |        0 |      % |    0.00% |

```

I consider this a performance bug, hence the label.