### PR TITLE
[8.1] Do not deserialise the document when not needed in the fields fetch phase (#84184)

### DIFF
--- a/docs/changelog/84184.yaml
+++ b/docs/changelog/84184.yaml
@@ -1,0 +1,5 @@
+pr: 84184
+summary: Do not deserialise the document when not needed in the fields fetch phase
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -174,7 +174,7 @@ public class FieldFetcher {
                 documentFields.put(field, new DocumentField(field, parsedValues, ignoredValues));
             }
         }
-        collectUnmapped(documentFields, sourceLookup.source(), "", 0);
+        collectUnmapped(documentFields, sourceLookup, "", 0);
         return documentFields;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -153,6 +153,13 @@ public class SourceLookup implements Map<String, Object> {
     }
 
     /**
+     * Checks if the source has been deserialized as a {@link Map} of java objects.
+     */
+    public boolean hasSourceAsMap() {
+        return source != null;
+    }
+
+    /**
      * Returns the values associated with the path. Those are "low" level values, and it can
      * handle path expression where an array/list is navigated within.
      */


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Do not deserialise the document when not needed in the fields fetch phase (#84184)