### PR TITLE
[DOCS] Adds reference of transform reset option to the tutorial

### DIFF
--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -391,7 +391,7 @@ Alternatively, you can use the
 
 If you reset a {transform}, all checkpoints, states, and the destination index 
 (if it was created by the {transform}) are deleted. The {transform} is ready to 
-start again as if it had just been created and is updated to the latest format.
+start again as if it had just been created.
 
 
 .API example

--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -380,14 +380,19 @@ cluster load, a {transform} increases search and indexing load on your
 cluster while it runs. If you're experiencing an excessive load, however, you
 can stop it.
 
-You can start, stop, and manage {transforms} in {kib}:
+You can start, stop, reset, and manage {transforms} in {kib}:
 
 [role="screenshot"]
 image::images/manage-transforms.png["Managing {transforms} in {kib}"]
 
 Alternatively, you can use the
-<<start-transform,start {transforms}>> and
-<<stop-transform,stop {transforms}>> APIs.
+<<start-transform,start {transforms}>>, <<stop-transform,stop {transforms}>> and 
+<<reset-transform, reset {transforms}>> APIs.
+
+If you reset a {transform}, all checkpoints, states, and the destination index 
+(if it was created by the {transform}) are deleted. The {transform} is ready to 
+start again as if it had just been created and is updated to the latest format.
+
 
 .API example
 [%collapsible]


### PR DESCRIPTION
## Overview

The option of resetting a transform via the UI has been added in 8.1.0. This PR amends the transform tutorial to mention the possibility to reset a transform either by using the API or the action from the UI.

### Preview

[eCommerce Tutorial](https://elasticsearch_84194.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ecommerce-transforms.html)