### PR TITLE
[DOCS] Fix shrink index API prereqs

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -31,7 +31,7 @@ POST /my-index-000001/_shrink/shrunk-my-index-000001
 * Before you can shrink an index:
 
 ** The index must be read-only.
-** All primary shards for the index must reside on the same node.
+** All shards for the index must have a copy (either primary or replica) on the same node.
 ** The index must have a `green` <<cluster-health,health status>>.
 
 To make shard allocation easier, we recommend you also remove the index's

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -31,7 +31,7 @@ POST /my-index-000001/_shrink/shrunk-my-index-000001
 * Before you can shrink an index:
 
 ** The index must be read-only.
-** All shards for the index must have a copy (either primary or replica) on the same node.
+** A copy of every shard in the index must reside on the same node.
 ** The index must have a `green` <<cluster-health,health status>>.
 
 To make shard allocation easier, we recommend you also remove the index's


### PR DESCRIPTION
It's not actually the case that all the primaries need to be on the same node, replicas are sufficient. I think this got switched to the incorrect wording in #59985 -- so the docs should be fixed back to 7.8 branch if we're doing a completion run.