### PR TITLE
User Profile - Use only realmType for file and native realms

### DIFF
--- a/docs/changelog/84205.yaml
+++ b/docs/changelog/84205.yaml
@@ -1,5 +1,0 @@
-pr: 84205
-summary: User Profile - Use only `realmType` for file and native realms
-area: Security
-type: enhancement
-issues: []

--- a/docs/changelog/84205.yaml
+++ b/docs/changelog/84205.yaml
@@ -1,0 +1,5 @@
+pr: 84205
+summary: User Profile - Use only `realmType` for file and native realms
+area: Security
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -54,6 +54,8 @@ import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataReq
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationContext;
 import org.elasticsearch.xpack.core.security.authc.Subject;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
@@ -98,7 +100,6 @@ public class ProfileService {
     }
 
     // TODO: with request when we take request body for profile activation
-
     /**
      * Create a new profile or update an existing profile for the user of the given Authentication.
      * @param authentication This is the object from which the profile will be created or updated.
@@ -261,8 +262,10 @@ public class ProfileService {
             final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
                 .filter(QueryBuilders.termQuery("user_profile.user.username", subject.getUser().principal()));
             if (subject.getRealm().getDomain() == null) {
-                boolQuery.filter(QueryBuilders.termQuery("user_profile.user.realm.name", subject.getRealm().getName()))
-                    .filter(QueryBuilders.termQuery("user_profile.user.realm.type", subject.getRealm().getType()));
+                boolQuery.filter(QueryBuilders.termQuery("user_profile.user.realm.type", subject.getRealm().getType()));
+                if (false == isFileOrNativeRealm(subject.getRealm().getType())) {
+                    boolQuery.filter(QueryBuilders.termQuery("user_profile.user.realm.name", subject.getRealm().getName()));
+                }
             } else {
                 logger.debug(
                     () -> new ParameterizedMessage(
@@ -273,11 +276,12 @@ public class ProfileService {
                     )
                 );
                 subject.getRealm().getDomain().realms().forEach(realmIdentifier -> {
-                    boolQuery.should(
-                        QueryBuilders.boolQuery()
-                            .filter(QueryBuilders.termQuery("user_profile.user.realm.name", realmIdentifier.getName()))
-                            .filter(QueryBuilders.termQuery("user_profile.user.realm.type", realmIdentifier.getType()))
-                    );
+                    final BoolQueryBuilder perRealmQuery = QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termQuery("user_profile.user.realm.type", realmIdentifier.getType()));
+                    if (false == isFileOrNativeRealm(realmIdentifier.getType())) {
+                        perRealmQuery.filter(QueryBuilders.termQuery("user_profile.user.realm.name", realmIdentifier.getName()));
+                    }
+                    boolQuery.should(perRealmQuery);
                 });
                 boolQuery.minimumShouldMatch(1);
             }
@@ -491,6 +495,10 @@ public class ProfileService {
             doc.access(),
             doc.applicationData()
         );
+    }
+
+    private boolean isFileOrNativeRealm(String realmType) {
+        return FileRealmSettings.TYPE.equals(realmType) || NativeRealmSettings.TYPE.equals(realmType);
     }
 
     // Package private for testing


### PR DESCRIPTION
When locating existing profile document for the given authentication,
use only realm type to search for file and native realms. This is
because there can only ever be a single file or native realm and it does
not matter what name it takes.

Relates: #83570

