### PR TITLE
Add extra section on doc-value-only fields to documentation

### DIFF
--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -27,7 +27,11 @@ have doc values enabled.
 Query performance on doc values is much slower than on index structures, but
 offers an interesting tradeoff between disk usage and query performance for
 fields that are only rarely queried and where query performance is not as
-important. Doc-value-only fields can be configured as follows:
+important. This makes doc-value-only fields a good fit for fields that are
+not expected to be normally used for filtering, for example gauges or
+counters on metric data.
+
+Doc-value-only fields can be configured as follows:
 
 [source,console]
 --------------------------------------------------
@@ -36,10 +40,10 @@ PUT my-index-000001
   "mappings": {
     "properties": {
       "status_code": { <1>
-        "type":  "keyword"
+        "type":  "long"
       },
       "session_id": { <2>
-        "type":  "keyword",
+        "type":  "long",
         "index": false
       }
     }
@@ -47,9 +51,9 @@ PUT my-index-000001
 }
 --------------------------------------------------
 
-<1> The `status_code` field is a regular keyword field.
+<1> The `status_code` field is a regular long field.
 <2> The `session_id` field has `index` disabled, and is therefore a
-    doc-value-only keyword field.
+    doc-value-only long field.
 
 ==== Disabling doc values
 

--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -17,14 +17,41 @@ makes this data access pattern possible. They store the same values as the
 sorting and aggregations. Doc values are supported on almost all field types,
 with the __notable exception of `text` and `annotated_text` fields__.
 
+[[doc-value-only-fields]]
+==== Doc-value-only fields
+
 <<number,Numeric types>>, <<date,date types>>, the <<boolean,boolean type>>,
 <<ip,ip type>>, <<geo-point,geo_point type>> and the <<keyword,keyword type>>
-can also be queried
-when they are not <<mapping-index,indexed>> but only have doc values enabled.
+can also be queried when they are not <<mapping-index,indexed>> but only
+have doc values enabled.
 Query performance on doc values is much slower than on index structures, but
 offers an interesting tradeoff between disk usage and query performance for
 fields that are only rarely queried and where query performance is not as
-important.
+important. Doc-value-only fields can be configured as follows:
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "status_code": { <1>
+        "type":  "keyword"
+      },
+      "session_id": { <2>
+        "type":  "keyword",
+        "index": false
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+<1> The `status_code` field is a regular keyword field.
+<2> The `session_id` field has `index` disabled, and is therefore a
+    doc-value-only keyword field.
+
+==== Disabling doc values
 
 All fields which support doc values have them enabled by default. If you are
 sure that you don't need to sort or aggregate on a field, or access the field

--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -53,7 +53,7 @@ PUT my-index-000001
 
 <1> The `status_code` field is a regular long field.
 <2> The `session_id` field has `index` disabled, and is therefore a
-    doc-value-only long field.
+    doc-value-only long field as doc values are enabled by default.
 
 ==== Disabling doc values
 


### PR DESCRIPTION
Adds a dedicated section for doc-value-only fields to the docs that can be linked to.