### PR TITLE
Restart ES after keystore upgrade in postinst

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -75,7 +75,26 @@ if [ "x$IS_UPGRADE" != "xtrue" ]; then
         echo "### You can start elasticsearch service by executing"
         echo " sudo /etc/init.d/elasticsearch start"
     fi
-elif [ "$RESTART_ON_UPGRADE" = "true" ]; then
+fi
+
+# the equivalent code for rpm is in posttrans
+if [ "$PACKAGE" = "deb" ]; then
+    if [ ! -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
+        /usr/share/elasticsearch/bin/elasticsearch-keystore create
+        chown root:elasticsearch "${ES_PATH_CONF}"/elasticsearch.keystore
+        chmod 660 "${ES_PATH_CONF}"/elasticsearch.keystore
+        md5sum "${ES_PATH_CONF}"/elasticsearch.keystore > "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
+    else
+        if /usr/share/elasticsearch/bin/elasticsearch-keystore has-passwd --silent ; then
+          echo "### Warning: unable to upgrade encrypted keystore" 1>&2
+          echo " Please run elasticsearch-keystore upgrade and enter password" 1>&2
+        else
+          /usr/share/elasticsearch/bin/elasticsearch-keystore upgrade
+        fi
+    fi
+fi
+
+if [ "$RESTART_ON_UPGRADE" = "true" ]; then
 
     echo -n "Restarting elasticsearch service..."
     if command -v systemctl >/dev/null; then
@@ -98,23 +117,6 @@ elif [ "$RESTART_ON_UPGRADE" = "true" ]; then
         /etc/rc.d/init.d/elasticsearch restart || true
     fi
     echo " OK"
-fi
-
-# the equivalent code for rpm is in posttrans
-if [ "$PACKAGE" = "deb" ]; then
-    if [ ! -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
-        /usr/share/elasticsearch/bin/elasticsearch-keystore create
-        chown root:elasticsearch "${ES_PATH_CONF}"/elasticsearch.keystore
-        chmod 660 "${ES_PATH_CONF}"/elasticsearch.keystore
-        md5sum "${ES_PATH_CONF}"/elasticsearch.keystore > "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
-    else
-        if /usr/share/elasticsearch/bin/elasticsearch-keystore has-passwd --silent ; then
-          echo "### Warning: unable to upgrade encrypted keystore" 1>&2
-          echo " Please run elasticsearch-keystore upgrade and enter password" 1>&2
-        else
-          /usr/share/elasticsearch/bin/elasticsearch-keystore upgrade
-        fi
-    fi
 fi
 
 @scripts.footer@

--- a/docs/changelog/84224.yaml
+++ b/docs/changelog/84224.yaml
@@ -1,0 +1,6 @@
+pr: 84224
+summary: Restart ES after keystore upgrade in postinst
+area: Packaging
+type: bug
+issues:
+ - 82433

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -92,6 +92,8 @@ public class DebPreservationTests extends PackagingTestCase {
         assertPathsDoNotExist(installation.config, installation.envFile, SYSVINIT_SCRIPT);
 
         assertThat(packageStatus(distribution()).exitCode, is(1));
+
+        installation = null;
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.packaging.test;
 
 import org.elasticsearch.packaging.util.Distribution;
+import org.elasticsearch.packaging.util.Packages.JournaldWrapper;
 import org.junit.BeforeClass;
 
 import java.nio.file.Paths;
@@ -24,6 +25,8 @@ import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.packageStatus;
 import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeTrue;
 
@@ -89,5 +92,32 @@ public class DebPreservationTests extends PackagingTestCase {
         assertPathsDoNotExist(installation.config, installation.envFile, SYSVINIT_SCRIPT);
 
         assertThat(packageStatus(distribution()).exitCode, is(1));
+    }
+
+    /**
+     * Check that restarting on upgrade doesn't run into a problem where the keystore
+     * upgrade is attempted as the wrong user i.e. the restart happens at the correct
+     * point. See #82433.
+     */
+    public void test40RestartOnUpgrade() throws Exception {
+        assertRemoved(distribution());
+        installation = installPackage(sh, distribution());
+        assertInstalled(distribution());
+
+        // Ensure ES is started
+        sh.run("systemctl daemon-reload");
+        sh.run("systemctl enable elasticsearch.service");
+        sh.run("systemctl start elasticsearch.service");
+
+        final JournaldWrapper journaldWrapper = new JournaldWrapper(sh);
+        sh.getEnv().put("RESTART_ON_UPGRADE", "true");
+        installation = installPackage(sh, distribution());
+        final String logs = journaldWrapper.getLogs().stdout;
+
+        assertThat(
+            "Upgrade failed because the keystore couldn't be written",
+            logs,
+            not(containsString("java.nio.file.AccessDeniedException: /etc/elasticsearch/elasticsearch.keystore.tmp"))
+        );
     }
 }


### PR DESCRIPTION
Closes #82433. If the environment variable `RESTART_ON_UPGRADE` is
true, then ensure that we delay restarting Elasticseach until after
the keystore is upgraded, or else we can run into permissions
problems.

Note that this issue only appears to manifest pre-8.0. I was unable
to replicate it in an 8.2 snapshot debian package, which I attributed
to the security-by-default work. I will still forward-port the
changes in case of regressions.
