### PR TITLE
DOCS Security audit ignore for the `action` event field  (#83583)

### DIFF
--- a/x-pack/docs/en/security/auditing/ignore-policy.asciidoc
+++ b/x-pack/docs/en/security/auditing/ignore-policy.asciidoc
@@ -23,7 +23,7 @@ accountability gaps that could render illegitimate actions undetectable.
 Please take time to review these policies whenever your system architecture changes.
 
 A policy is a named set of filter rules. Each filter rule applies to a single event attribute,
-one of the `users`, `realms`, `roles` or `indices` attributes. The filter rule defines
+one of the `users`, `realms`, `actions`, `roles` or `indices` attributes. The filter rule defines
 a list of <<regexp-syntax,Lucene regexp>>, *any* of which has to match the value of the audit
 event attribute for the rule to match.
 A policy matches an event if *all* the rules comprising it match the event.


### PR DESCRIPTION
Security audit ignore filter policies work on the audit event's action field.

Co-Authored-By: Johannes Mahne <johannes.mahne@elastic.co>

Forward port of https://github.com/elastic/elasticsearch/pull/83583