### PR TITLE
[8.1] [ML] Text structure finder caps exclude lines pattern at 1000 characters

### DIFF
--- a/docs/changelog/84236.yaml
+++ b/docs/changelog/84236.yaml
@@ -1,0 +1,6 @@
+pr: 84236
+summary: Text structure finder caps exclude lines pattern at 1000 characters
+area: Machine Learning
+type: bug
+issues:
+ - 83434


### PR DESCRIPTION
Because of the way Filebeat parses CSV files the text structure finder
needs to generate a regular expression that will ignore the header row
of the CSV file.

It does this by concatenating the column names separated by the delimiter
with optional quoting. However, if there are hundreds of columns this can
lead to a very long regular expression, potentially one that cannot be
evaluated by some programming languages.

This change limits the length of the regular expression to 1000 characters
by only including elements for the first few columns when there are many.
Matching 1000 characters of header should be sufficient to reliably
identify the header row even when it is much longer. It is extremely
unlikely that there would be a data row where the first 1000 characters
exactly matched the header but then subsequent fields diverged.

Backport of #84236