### PR TITLE
Skip product header check in buggy versions (#84210)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -84,6 +84,9 @@ public class ClientYamlTestClient implements Closeable {
         this.clientBuilderWithSniffedNodes = clientBuilderWithSniffedNodes;
     }
 
+    /**
+     * @return the version of the oldest node in the cluster
+     */
     public Version getEsVersion() {
         return esVersion;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -206,7 +206,7 @@ public class ClientYamlTestExecutionContext {
     }
 
     /**
-     * Returns the current es version as a string
+     * @return the version of the oldest node in the cluster
      */
     public Version esVersion() {
         return clientYamlTestClient.getEsVersion();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -367,7 +367,13 @@ public class DoSection implements ExecutableSection {
             final String testPath = executionContext.getClientYamlTestCandidate() != null
                 ? executionContext.getClientYamlTestCandidate().getTestPath()
                 : null;
-            checkElasticProductHeader(response.getHeaders("X-elastic-product"));
+            if (executionContext.esVersion().after(Version.V_8_1_0)
+                || (executionContext.esVersion().major == Version.V_7_17_0.major && executionContext.esVersion().after(Version.V_7_17_1))) {
+                // #84038 and #84089 mean that this assertion fails when running against a small number of released versions, but at time of
+                // writing it's unclear exactly which released versions will contain the fix.
+                // TODO once a fixed version has been released, adjust the condition above to match.
+                checkElasticProductHeader(response.getHeaders("X-elastic-product"));
+            }
             checkWarningHeaders(response.getWarningHeaders(), testPath);
         } catch (ClientYamlTestResponseException e) {
             ClientYamlTestResponse restTestResponse = e.getRestTestResponse();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
 import org.elasticsearch.xcontent.XContentLocation;
@@ -605,6 +606,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 doSection.getApiCallSection().getNodeSelector()
             )
         ).thenReturn(mockResponse);
+        when(context.esVersion()).thenReturn(VersionUtils.randomVersion(random()));
         when(mockResponse.getHeaders("X-elastic-product")).thenReturn(List.of("Elasticsearch"));
         doSection.execute(context);
         verify(context).callApi(


### PR DESCRIPTION
In #83290 we added an assertion that Elasticsearch returns the product
header in every REST response. Unfortunately this isn't always the case,
we found bugs in a couple of released versions and fixed them in #84038
and #84089. With this commit we skip the new assertion in the
known-buggy versions.

Closes #84036 again.