### PR TITLE
Not reporting removable settings for deprecated affix settings

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -1461,10 +1461,10 @@ class NodeDeprecationChecks {
         if (canBeFixedByRemovingDynamicSetting) {
             deprecatedClusterSettingKeys.removeAll(deprecatedNodeSettingKeys);
         }
-        final Map<String, Object> meta = createMetaMapForRemovableSettings(
-            canBeFixedByRemovingDynamicSetting,
-            deprecatedClusterSettingKeys
-        );
+        /* Removing affix settings can cause more problems than it's worth, so always make meta null even if the settings are only set
+         * dynamically
+         */
+        final Map<String, Object> meta = null;
         return new DeprecationIssue(warningLevel, message, url, details, false, meta);
     }
 
@@ -1523,7 +1523,10 @@ class NodeDeprecationChecks {
         if (canBeFixedByRemovingDynamicSetting) {
             allClusterSubSettingKeys.removeAll(allNodeSubSettingKeys);
         }
-        final Map<String, Object> meta = createMetaMapForRemovableSettings(canBeFixedByRemovingDynamicSetting, allClusterSubSettingKeys);
+        /* Removing affix settings can cause more problems than it's worth, so always make meta null even if the settings are only set
+         * dynamically
+         */
+        final Map<String, Object> meta = null;
         return new DeprecationIssue(warningLevel, message, url, details, false, meta);
     }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -1893,7 +1893,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             c -> c.apply(nodeSettings, null, clusterState, licenseState)
         );
         final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-settings";
-        Map<String, Object> meta = buildMetaObjectForRemovableSettings(subSetting1Key2, subSetting2Key2);
+        Map<String, Object> meta = null;
         assertThat(
             issues,
             hasItem(


### PR DESCRIPTION
Removing one setting from a group of affix settings can cause Elasticsearch to get into an inconsistent state. This
commit makes it so that we never report removable affix settings in the deprecation info API.