### PR TITLE
User Profile: Adjustments to mappings and search

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
@@ -38,7 +38,6 @@ public record Profile(
         @Nullable String domainName,
         String email,
         String fullName,
-        String displayName,
         boolean active
     ) implements Writeable, ToXContent {
 
@@ -47,7 +46,6 @@ public record Profile(
                 in.readString(),
                 in.readStringList(),
                 in.readString(),
-                in.readOptionalString(),
                 in.readOptionalString(),
                 in.readOptionalString(),
                 in.readOptionalString(),
@@ -74,9 +72,6 @@ public record Profile(
             if (fullName != null) {
                 builder.field("full_name", fullName);
             }
-            if (displayName != null) {
-                builder.field("display_name", displayName);
-            }
             builder.field("active", active);
             builder.endObject();
             return builder;
@@ -90,7 +85,6 @@ public record Profile(
             out.writeOptionalString(domainName);
             out.writeOptionalString(email);
             out.writeOptionalString(fullName);
-            out.writeOptionalString(displayName);
             out.writeBoolean(active);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SearchProfilesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SearchProfilesResponse.java
@@ -67,7 +67,7 @@ public class SearchProfilesResponse extends ActionResponse implements ToXContent
                 builder.field("relation", totalHits.relation == TotalHits.Relation.EQUAL_TO ? "eq" : "gte");
             }
             builder.endObject();
-            builder.startArray("users");
+            builder.startArray("profiles");
             {
                 for (ProfileHit profileHit : profileHits) {
                     profileHit.toXContent(builder, params);
@@ -95,12 +95,10 @@ public class SearchProfilesResponse extends ActionResponse implements ToXContent
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             {
-                builder.field("_score", score);
                 builder.field("uid", profile.uid());
                 profile.user().toXContent(builder, params);
                 builder.field("access", profile.access());
                 builder.field("data", profile.applicationData());
-                // TODO: output a field of sort which is just score plus uid?
             }
             builder.endObject();
             return builder;

--- a/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
+++ b/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
@@ -54,7 +54,6 @@ public class ProfileIT extends ESRestTestCase {
               },
               "email": "foo@example.com",
               "full_name": "User Foo",
-              "display_name": "Curious Foo",
               "active": true
             },
             "last_synchronized": %s,
@@ -154,9 +153,8 @@ public class ProfileIT extends ESRestTestCase {
         assertThat(searchProfileResponseMap1, hasKey("took"));
         assertThat(searchProfileResponseMap1.get("total"), equalTo(Map.of("value", 1, "relation", "eq")));
         @SuppressWarnings("unchecked")
-        final List<Map<String, Object>> users = (List<Map<String, Object>>) searchProfileResponseMap1.get("users");
+        final List<Map<String, Object>> users = (List<Map<String, Object>>) searchProfileResponseMap1.get("profiles");
         assertThat(users, hasSize(1));
-        assertThat(users.get(0), hasKey("_score"));
         assertThat(users.get(0).get("uid"), equalTo(uid));
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileSingleNodeTests.java
@@ -249,6 +249,7 @@ public class ProfileSingleNodeTests extends AbstractProfileSingleNodeTestCase {
             final PutUserRequest putUserRequest1 = new PutUserRequest();
             putUserRequest1.username(key);
             putUserRequest1.fullName(value);
+            putUserRequest1.email(key.substring(5) + "email@example.org");
             putUserRequest1.roles("rac_role");
             putUserRequest1.passwordHash(nativeRacUserPasswordHash.toCharArray());
             assertThat(client().execute(PutUserAction.INSTANCE, putUserRequest1).actionGet().created(), is(true));
@@ -274,6 +275,13 @@ public class ProfileSingleNodeTests extends AbstractProfileSingleNodeTestCase {
         // Match of different terms on different fields
         final SearchProfilesResponse.ProfileHit[] profiles5 = doSearch(randomFrom("admin very", "very admin"));
         assertThat(extractUsernames(profiles5), equalTo(users.keySet()));
+
+        // Match email
+        final SearchProfilesResponse.ProfileHit[] profiles6 = doSearch(randomFrom("fooem", "fooemail"));
+        assertThat(extractUsernames(profiles6), equalTo(Set.of("user_foo")));
+
+        final SearchProfilesResponse.ProfileHit[] profiles7 = doSearch("example.org");
+        assertThat(extractUsernames(profiles7), equalTo(users.keySet()));
     }
 
     public void testProfileAPIsWhenIndexNotCreated() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
@@ -46,7 +46,6 @@ public record ProfileDocument(
         Authentication.RealmRef realm,
         String email,
         String fullName,
-        String displayName,
         boolean active
     ) implements ToXContent {
 
@@ -58,9 +57,6 @@ public record ProfileDocument(
             builder.field("realm", realm);
             builder.field("email", email);
             builder.field("full_name", fullName);
-            if (displayName != null) {
-                builder.field("display_name", displayName);
-            }
             builder.field("active", active);
             builder.endObject();
             return builder;
@@ -68,7 +64,7 @@ public record ProfileDocument(
 
         public Profile.ProfileUser toProfileUser() {
             final String domainName = realm.getDomain() != null ? realm.getDomain().name() : null;
-            return new Profile.ProfileUser(username, roles, realm.getName(), domainName, email, fullName, displayName, active);
+            return new Profile.ProfileUser(username, roles, realm.getName(), domainName, email, fullName, active);
         }
     }
 
@@ -107,7 +103,6 @@ public record ProfileDocument(
                 subject.getRealm(),
                 subjectUser.email(),
                 subjectUser.fullName(),
-                null,
                 subjectUser.enabled()
             ),
             Map.of(),
@@ -129,8 +124,7 @@ public record ProfileDocument(
             (Authentication.RealmRef) args[2],
             (String) args[3],
             (String) args[4],
-            (String) args[5],
-            (Boolean) args[6]
+            (Boolean) args[5]
         )
     );
 
@@ -160,7 +154,6 @@ public record ProfileDocument(
         PROFILE_DOC_USER_PARSER.declareObject(constructorArg(), (p, c) -> REALM_REF_PARSER.parse(p, c), new ParseField("realm"));
         PROFILE_DOC_USER_PARSER.declareStringOrNull(optionalConstructorArg(), new ParseField("email"));
         PROFILE_DOC_USER_PARSER.declareStringOrNull(optionalConstructorArg(), new ParseField("full_name"));
-        PROFILE_DOC_USER_PARSER.declareStringOrNull(optionalConstructorArg(), new ParseField("display_name"));
         PROFILE_DOC_USER_PARSER.declareBoolean(constructorArg(), new ParseField("active"));
 
         PROFILE_DOC_PARSER.declareString(constructorArg(), new ParseField("uid"));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -182,9 +182,7 @@ public class ProfileService {
                         "user_profile.user.full_name",
                         "user_profile.user.full_name._2gram",
                         "user_profile.user.full_name._3gram",
-                        "user_profile.user.display_name",
-                        "user_profile.user.display_name._2gram",
-                        "user_profile.user.display_name._3gram"
+                        "user_profile.user.email"
                     ).type(MultiMatchQueryBuilder.Type.BOOL_PREFIX)
                 );
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -482,8 +482,6 @@ public class ProfileService {
                 // Replace with incoming information even when they are null
                 subjectUser.email(),
                 subjectUser.fullName(),
-                // TODO: displayName is not available in Authentication object
-                doc.user().displayName(),
                 subjectUser.enabled()
             ),
             doc.access(),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -851,10 +851,6 @@ public class SecuritySystemIndices {
                                     builder.field("type", "search_as_you_type");
                                     builder.endObject();
 
-                                    builder.startObject("display_name");
-                                    builder.field("type", "search_as_you_type");
-                                    builder.endObject();
-
                                     builder.startObject("active");
                                     builder.field("type", "boolean");
                                     builder.endObject();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -78,7 +78,6 @@ public class ProfileServiceTests extends ESTestCase {
               },
               "email": "foo@example.com",
               "full_name": "User Foo",
-              "display_name": "Curious Foo",
               "active": true
             },
             "last_synchronized": %s,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -165,7 +165,6 @@ public class ProfileServiceTests extends ESTestCase {
                         "domainA",
                         "foo@example.com",
                         "User Foo",
-                        "Curious Foo",
                         true
                     ),
                     Map.of(),


### PR DESCRIPTION
This PR makes the following few adjustments based discussions:

1. Remove display_name from mappings
2. Include email in Name search
3. Rename top level field from "users" to "profiles" in the search
   response
4. Remove `_score` from search response
