### PR TITLE
Mute DatafeedCcsIT.testDatafeedWithCcsRemoteUnavailable

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -117,6 +117,7 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
         clearSkipUnavailable();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84268")
     public void testDatafeedWithCcsRemoteUnavailable() throws Exception {
         setSkipUnavailable(randomBoolean());
         String jobId = "ccs-unavailable-job";


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/84268