### PR TITLE
[DOCS] Expands description of the reset transform API

### DIFF
--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -27,7 +27,11 @@ in the `transform_admin` built-in role.
 Before you can reset the {transform}, you must stop it; alternatively, use the
 `force` query parameter.
 
-If the destination index was created by the transform, it is deleted.
+If you reset a {transform}, all checkpoints, states, and the destination index 
+(if it was created by the {transform}) are deleted. The {transform} is updated 
+to the latest format as if the <<update-transform>> was used. The {transform} is 
+ready to start again as if it had just been created.
+
 
 [[reset-transform-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -29,8 +29,8 @@ Before you can reset the {transform}, you must stop it; alternatively, use the
 
 If you reset a {transform}, all checkpoints, states, and the destination index 
 (if it was created by the {transform}) are deleted. The {transform} is updated 
-to the latest format as if the <<update-transform>> was used. The {transform} is 
-ready to start again as if it had just been created.
+to the latest format as if the <<update-transform>> API was used. The 
+{transform} is ready to start again as if it had just been created.
 
 
 [[reset-transform-path-parms]]


### PR DESCRIPTION
## Overview

This PR adds details about what the reset transform API does based on https://github.com/elastic/elasticsearch/issues/75768.

### Preview

[Reset transform API description](https://elasticsearch_84270.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/reset-transform.html#_description_21)