### PR TITLE
DOCS: more visibility over how min_age works when rollover is present

### DIFF
--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -52,7 +52,11 @@ For example, you might define a `timeseries_policy` that has two phases:
 * A `hot` phase that defines a rollover action to specify that an index rolls over when it
 reaches either a `max_primary_shard_size` of 50 gigabytes or a `max_age` of 30 days.
 * A `delete` phase that sets `min_age` to remove the index 90 days after rollover.
-Note that this value is relative to the rollover time, not the index creation time.
+
+[NOTE]
+====
+The `min_age` value is relative to the rollover time, not the index creation time.
+====
 
 You can create the policy through {kib} or with the
 <<ilm-put-lifecycle,create or update policy>> API.


### PR DESCRIPTION
This makes it more visible that the `min_age` phase transition times
are based on index rollover date rather than index creation date.