### PR TITLE
Remove `eof` from expect script

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -167,7 +167,6 @@ public class KeystoreManagementTests extends PackagingTestCase {
     /**
      * This test simulates a user starting Elasticsearch on the command line without daemonizing
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84204")
     public void test42KeystorePasswordOnTtyRunningInForeground() throws Exception {
         /* Windows issue awaits fix: https://github.com/elastic/elasticsearch/issues/49340 */
         assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -250,8 +250,7 @@ public class Archives {
         String keystoreScript = keystorePassword == null
             ? ""
             : asBlock("expect \"Elasticsearch keystore password:\"",
-                "send \"" + keystorePassword + "\\r\"",
-                "expect eof");
+                "send \"" + keystorePassword + "\\r\"");
         String checkStartupScript = daemonize
             ? ""
             : asBlock("expect {",


### PR DESCRIPTION
Hopefully fixes #84204. When we build an expect script in the packaging
tests, we insert `expect eof` after supplying the password. This makes
expect wait until the output of ES is closed, which isn't actaully what
we want, as we then go on to expect on a number of other outputs. So,
remove this `eof`, and let the other expectations do their work.