### PR TITLE
[ML] Increase timeout for datafeed CCS tests

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -109,11 +109,12 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
         long endTimeMs = indexRemoteDocs(numDocs);
         setupJobAndDatafeed(jobId, datafeedId, endTimeMs);
         // Datafeed should complete and auto-close the job
+        // Use a 60 second timeout because multiple suites run in parallel in CI which slows things down a lot
         assertBusy(() -> {
             JobStats jobStats = getJobStats(jobId);
             assertThat(jobStats.getState(), is(JobState.CLOSED));
             assertThat(jobStats.getDataCounts().getProcessedRecordCount(), is(numDocs));
-        }, 30, TimeUnit.SECONDS);
+        }, 60, TimeUnit.SECONDS);
         clearSkipUnavailable();
     }
 
@@ -143,11 +144,12 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
             });
             networkDisruption.removeAndEnsureHealthy(cluster(REMOTE_CLUSTER));
             // Datafeed should eventually read all the docs
+            // Use a 60 second timeout because multiple suites run in parallel in CI which slows things down a lot
             assertBusy(() -> {
                 JobStats jobStats = getJobStats(jobId);
                 assertThat(jobStats.getState(), is(JobState.OPENED));
                 assertThat(jobStats.getDataCounts().getProcessedRecordCount(), is(numDocs));
-            }, 30, TimeUnit.SECONDS);
+            }, 60, TimeUnit.SECONDS);
         } finally {
             client(LOCAL_CLUSTER).execute(StopDatafeedAction.INSTANCE, new StopDatafeedAction.Request(datafeedId)).actionGet();
             client(LOCAL_CLUSTER).execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId)).actionGet();


### PR DESCRIPTION
When running in CI multiple test suites run in parallel which
causes significant resource contention for heavy tests like the
one that tests datafeeds with CCS.

Increasing the time to wait for the datafeed to complete should
avoid spurious failures.

Fixes #84290