### PR TITLE
Add @timestamp as a metadata field on TSDB indexes

### DIFF
--- a/docs/changelog/84294.yaml
+++ b/docs/changelog/84294.yaml
@@ -1,0 +1,5 @@
+pr: 84294
+summary: Add @timestamp as a metadata field on TSDB indexes
+area: TSDB
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -277,7 +277,6 @@ public class SearchCancellationIT extends ESIntegTestCase {
             ).setMapping("""
                 {
                   "properties": {
-                    "@timestamp": {"type": "date", "format": "epoch_millis"},
                     "dim": {"type": "keyword", "time_series_dimension": true}
                   }
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1215,10 +1215,6 @@ public class MetadataCreateIndexService {
     ) throws IOException {
         MapperService mapperService = indexService.mapperService();
         IndexMode indexMode = indexService.getIndexSettings() != null ? indexService.getIndexSettings().getMode() : IndexMode.STANDARD;
-        final CompressedXContent defaultMapping = indexMode.getDefaultMapping();
-        if (defaultMapping != null) {
-            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, defaultMapping, MergeReason.INDEX_TEMPLATE);
-        }
         for (CompressedXContent mapping : mappings) {
             mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -10,15 +10,11 @@ package org.elasticsearch.index;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
-import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentDimensions;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedLookup;
@@ -68,11 +64,6 @@ public enum IndexMode {
             if (isDataStream) {
                 MetadataCreateDataStreamService.validateTimestampFieldMapping(mappingLookup);
             }
-        }
-
-        @Override
-        public CompressedXContent getDefaultMapping() {
-            return null;
         }
 
         @Override
@@ -134,12 +125,7 @@ public enum IndexMode {
 
         @Override
         public void validateTimestampFieldMapping(boolean isDataStream, MappingLookup mappingLookup) throws IOException {
-            MetadataCreateDataStreamService.validateTimestampFieldMapping(mappingLookup);
-        }
 
-        @Override
-        public CompressedXContent getDefaultMapping() {
-            return DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
         }
 
         @Override
@@ -164,27 +150,6 @@ public enum IndexMode {
 
     protected String tsdbMode() {
         return "[" + IndexSettings.MODE.getKey() + "=time_series]";
-    }
-
-    public static final CompressedXContent DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
-
-    static {
-        try {
-            DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING = new CompressedXContent(
-                ((builder, params) -> builder.startObject(MapperService.SINGLE_MAPPING_NAME)
-                    .startObject(DataStreamTimestampFieldMapper.NAME)
-                    .field("enabled", true)
-                    .endObject()
-                    .startObject("properties")
-                    .startObject(DataStreamTimestampFieldMapper.DEFAULT_PATH)
-                    .field("type", DateFieldMapper.CONTENT_TYPE)
-                    .endObject()
-                    .endObject()
-                    .endObject())
-            );
-        } catch (IOException e) {
-            throw new AssertionError(e);
-        }
     }
 
     private static final List<Setting<?>> TIME_SERIES_UNSUPPORTED = List.of(
@@ -232,12 +197,6 @@ public enum IndexMode {
      * validate timestamp mapping for this index.
      */
     public abstract void validateTimestampFieldMapping(boolean isDataStream, MappingLookup mappingLookup) throws IOException;
-
-    /**
-     * Get default mapping for this index or {@code null} if there is none.
-     */
-    @Nullable
-    public abstract CompressedXContent getDefaultMapping();
 
     /**
      * Get timebounds

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -92,6 +92,7 @@ public abstract class DocumentParserContext {
     private final DocumentDimensions dimensions;
     private Field version;
     private SeqNoFieldMapper.SequenceIDFields seqID;
+    private Long timestamp;
 
     private DocumentParserContext(DocumentParserContext in) {
         this.mappingLookup = in.mappingLookup;
@@ -107,6 +108,7 @@ public abstract class DocumentParserContext {
         this.version = in.version;
         this.seqID = in.seqID;
         this.dimensions = in.dimensions;
+        this.timestamp = in.timestamp;
     }
 
     protected DocumentParserContext(
@@ -198,6 +200,14 @@ public abstract class DocumentParserContext {
 
     public final void seqID(SeqNoFieldMapper.SequenceIDFields seqID) {
         this.seqID = seqID;
+    }
+
+    public final Long getTimestampValue() {
+        return this.timestamp;
+    }
+
+    public final void setTimestampValue(long timestamp) {
+        this.timestamp = timestamp;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -163,9 +163,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             indexSettings,
             indexAnalyzers
         );
-        Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(
-            indexSettings.getIndexVersionCreated()
-        );
+        Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(indexSettings);
         this.parserContextSupplier = () -> parserContextFunction.apply(null);
         this.mappingParser = new MappingParser(
             parserContextSupplier,
@@ -197,9 +195,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> getMetadataMappers() {
         final DocumentMapper existingMapper = mapper;
-        final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(
-            indexSettings.getIndexVersionCreated()
-        );
+        final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(indexSettings);
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = new LinkedHashMap<>();
         if (existingMapper == null) {
             for (MetadataFieldMapper.TypeParser parser : metadataMapperParsers.values()) {
@@ -507,7 +503,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      * this method considers all mapper plugins
      */
     public boolean isMetadataField(String field) {
-        return mapperRegistry.getMetadataMapperParsers(indexVersionCreated).containsKey(field);
+        return mapperRegistry.getMetadataMapperParsers(indexSettings).containsKey(field);
     }
 
     public boolean isMultiField(String field) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimestampMetadataMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimestampMetadataMapper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.elasticsearch.common.time.DateFormatter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class TimestampMetadataMapper extends MetadataFieldMapper {
+
+    public static final String CONTENT_TYPE = "@timestamp";
+    public static final String NAME = "@timestamp";
+    public static final DateFormatter DEFAULT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+
+    private TimestampMetadataMapper() {
+        super(
+            new DateFieldMapper.DateFieldType(
+                NAME,
+                true,
+                false,
+                true,
+                DEFAULT_DATE_TIME_FORMATTER,
+                DateFieldMapper.Resolution.MILLISECONDS,
+                null,
+                null,
+                Collections.emptyMap()
+            )
+        );
+    }
+
+    private static final TimestampMetadataMapper INSTANCE = new TimestampMetadataMapper();
+
+    public static TypeParser PARSER = new FixedTypeParser(c -> INSTANCE);
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public void parse(DocumentParserContext context) throws IOException {
+        if (context.getTimestampValue() != null) {
+            throw new MapperParsingException("@timestamp field can only have a single value");
+        }
+        long value = DEFAULT_DATE_TIME_FORMATTER.parseMillis(context.parser().text());
+        context.setTimestampValue(value);
+    }
+
+    @Override
+    public void postParse(DocumentParserContext context) throws IOException {
+        if (context.getTimestampValue() == null) {
+            throw new MapperParsingException("Document did not contain a @timestamp field");
+        }
+        context.rootDoc().add(new LongPoint(NAME, context.getTimestampValue()));
+        context.rootDoc().add(new SortedNumericDocValuesField(NAME, context.getTimestampValue()));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -18,7 +18,6 @@ import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
@@ -1707,13 +1706,6 @@ public class IndicesService extends AbstractLifecycleComponent
      */
     public Function<String, Predicate<String>> getFieldFilter() {
         return mapperRegistry.getFieldFilter();
-    }
-
-    /**
-     * Returns the registered metadata field names for the provided compatible {@link Version}.
-     */
-    public Set<String> getMetadataFields(Version version) {
-        return mapperRegistry.getMetadataMapperParsers(version).keySet();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -46,9 +46,7 @@ public class MappingParserTests extends MapperServiceTestCase {
             indexSettings,
             IdFieldMapper.NO_FIELD_DATA
         );
-        Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(
-            indexSettings.getIndexVersionCreated()
-        );
+        Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers = mapperRegistry.getMetadataMapperParsers(indexSettings);
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = new LinkedHashMap<>();
         metadataMapperParsers.values().stream().map(parser -> parser.getDefault(parserContextSupplier.get())).forEach(m -> {
             if (m != null) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimestampMetadataFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimestampMetadataFieldMapperTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+
+public class TimestampMetadataFieldMapperTests extends MapperServiceTestCase {
+
+    @Override
+    protected Settings getIndexSettings() {
+        return Settings.builder().put("index.mode", "time_series").put("index.routing_path", "field").build();
+    }
+
+    public void testTimestampIndexing() throws IOException {
+        DocumentMapper mapper = createDocumentMapper("""
+            { "_doc" : { "properties" : { "field" : { "type" : "keyword", "time_series_dimension" : true } } } }
+            """);
+
+        ParsedDocument doc = mapper.parse(source("""
+            { "field" : "value", "@timestamp" : "2022-02-22T22:22:22Z" }
+            """));
+
+        IndexableField[] fields = doc.rootDoc().getFields("@timestamp");
+        assertEquals(2, fields.length);
+    }
+
+    public void testTimestampMustBePresent() throws IOException {
+        DocumentMapper mapper = createDocumentMapper("""
+            { "_doc" : { "properties" : { "field" : { "type" : "keyword", "time_series_dimension" : true } } } }
+            """);
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source("""
+            { "field" : "value" }
+            """)));
+        assertEquals("Document did not contain a @timestamp field", e.getMessage());
+    }
+
+    public void testTimestampMustBeSingleValued() throws IOException {
+        DocumentMapper mapper = createDocumentMapper("""
+            { "_doc" : { "properties" : { "field" : { "type" : "keyword", "time_series_dimension" : true } } } }
+            """);
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source("""
+            { "field" : "value", "@timestamp" : [ "2022-02-22T22:22:22Z", "2022-02-22T22:22:23Z" ] }
+            """)));
+        assertEquals("@timestamp field can only have a single value", e.getMessage());
+    }
+
+    public void testMalformedTimestamp() throws IOException {
+        DocumentMapper mapper = createDocumentMapper("""
+            { "_doc" : { "properties" : { "field" : { "type" : "keyword", "time_series_dimension" : true } } } }
+            """);
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source("""
+            { "field" : "value", "@timestamp" : "foo" }
+            """)));
+        assertEquals("failed to parse date field [foo] with format [strict_date_optional_time||epoch_millis]", e.getCause().getMessage());
+    }
+}


### PR DESCRIPTION
This automatically adds the mapping for a `@timestamp` field to all indexes
in `time_series` mode, and makes it impossible to misconfigure it.  We can now
also ensure that each incoming document has a single value in this field.