### PR TITLE
[8.1] SQL: Deprecate index_include_frozen request parameter and `FROZEN` keyword (#83943)

### DIFF
--- a/docs/changelog/83943.yaml
+++ b/docs/changelog/83943.yaml
@@ -1,0 +1,19 @@
+pr: 83943
+summary: Deprecate `index_include_frozen` request parameter
+area: SQL
+type: deprecation
+issues:
+  - 81939
+deprecation:
+  title: Deprecate `index_include_frozen` request parameter in `_sql` API
+  area: REST API
+  details: |-
+    Following the deprecation of frozen indices, the `index_include_frozen`
+    parameter and `FROZEN` syntax is now also deprecated.
+  impact: |-
+    You should unfreeze frozen indices using the
+    {ref}/unfreeze-index-api.html[unfreeze index API] and stop using the
+    `index_include_frozen` parameter or the `FROZEN` keyword in SQL
+    queries. For some use cases, the frozen tier may be a suitable
+    replacement for frozen indices. See {ref}/data-tiers.html[data tiers]
+    for more information.

--- a/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcWarningsIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcWarningsIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.qa.jdbc.security;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.sql.qa.jdbc.JdbcWarningsTestCase;
+
+import java.util.Properties;
+
+public class JdbcWarningsIT extends JdbcWarningsTestCase {
+
+    @Override
+    protected Settings restClientSettings() {
+        return JdbcConnectionIT.securitySettings();
+    }
+
+    @Override
+    protected String getProtocol() {
+        return JdbcConnectionIT.SSL_ENABLED ? "https" : "http";
+    }
+
+    @Override
+    protected Properties connectionProperties() {
+        Properties properties = super.connectionProperties();
+        properties.putAll(JdbcSecurityUtils.adminProperties());
+        return properties;
+    }
+
+}

--- a/x-pack/plugin/sql/qa/jdbc/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcWarningsIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcWarningsIT.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.qa.jdbc.single_node;
+
+import org.elasticsearch.xpack.sql.qa.jdbc.JdbcWarningsTestCase;
+
+public class JdbcWarningsIT extends JdbcWarningsTestCase {}

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcWarningsTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcWarningsTestCase.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.qa.jdbc;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public abstract class JdbcWarningsTestCase extends JdbcIntegrationTestCase {
+
+    public void testDeprecationWarningsDoNotReachJdbcDriver() throws Exception {
+        index("test_data", b -> b.field("foo", 1));
+
+        try (Connection connection = esJdbc(); Statement statement = connection.createStatement()) {
+            ResultSet rs = statement.executeQuery("SELECT * FROM FROZEN \"test_*\"");
+            assertNull(rs.getWarnings());
+        }
+    }
+
+}

--- a/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlDeprecationIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlDeprecationIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.qa.single_node;
+
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.xpack.sql.qa.rest.BaseRestSqlTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.xpack.sql.qa.rest.RestSqlTestCase.SQL_QUERY_REST_ENDPOINT;
+
+public class RestSqlDeprecationIT extends BaseRestSqlTestCase {
+
+    public void testIndexIncludeParameterIsDeprecated() throws IOException {
+        testDeprecationWarning(
+            query("SELECT * FROM test").mode(randomMode()).indexIncludeFrozen(randomBoolean()),
+            "[index_include_frozen] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers "
+                + "in place of frozen indices."
+        );
+    }
+
+    public void testIncludeFrozenSyntaxIsDeprecatedInShowTables() throws IOException {
+        testFrozenSyntaxIsDeprecated("SHOW TABLES INCLUDE FROZEN", "INCLUDE FROZEN");
+    }
+
+    public void testIncludeFrozenSyntaxIsDeprecatedInShowColumns() throws IOException {
+        testFrozenSyntaxIsDeprecated("SHOW COLUMNS INCLUDE FROZEN IN test", "INCLUDE FROZEN");
+    }
+
+    public void testIncludeFrozenSyntaxIsDeprecatedInDescribeTable() throws IOException {
+        testFrozenSyntaxIsDeprecated("DESCRIBE INCLUDE FROZEN test", "INCLUDE FROZEN");
+    }
+
+    public void testFrozenSyntaxIsDeprecatedInFromClause() throws IOException {
+        testFrozenSyntaxIsDeprecated("SELECT * FROM FROZEN test", "FROZEN");
+    }
+
+    private void testFrozenSyntaxIsDeprecated(String query, String syntax) throws IOException {
+        testDeprecationWarning(
+            query(query).mode(randomMode()),
+            "["
+                + syntax
+                + "] syntax is deprecated because frozen indices have been deprecated. "
+                + "Consider cold or frozen tiers in place of frozen indices."
+        );
+    }
+
+    private void testDeprecationWarning(RequestObjectBuilder query, String warning) throws IOException {
+        index("{\"foo\": 1}");
+
+        Request request = new Request("POST", SQL_QUERY_REST_ENDPOINT);
+        request.setEntity(new StringEntity(query.toString(), ContentType.APPLICATION_JSON));
+        request.setOptions(expectWarnings(warning));
+    }
+
+}

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/BaseRestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/BaseRestSqlTestCase.java
@@ -29,6 +29,7 @@ import static org.elasticsearch.xpack.sql.proto.CoreProtocol.CURSOR_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.FETCH_SIZE_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.FIELD_MULTI_VALUE_LENIENCY_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.FILTER_NAME;
+import static org.elasticsearch.xpack.sql.proto.CoreProtocol.INDEX_INCLUDE_FROZEN_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.KEEP_ALIVE_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.KEEP_ON_COMPLETION_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.MODE_NAME;
@@ -139,6 +140,11 @@ public abstract class BaseRestSqlTestCase extends RemoteClusterAwareSqlRestTestC
 
         public RequestObjectBuilder runtimeMappings(String runtimeMappings) {
             request.append(field(RUNTIME_MAPPINGS_NAME, runtimeMappings));
+            return this;
+        }
+
+        public RequestObjectBuilder indexIncludeFrozen(boolean includeFrozen) {
+            request.append(field(INDEX_INCLUDE_FROZEN_NAME, includeFrozen));
             return this;
         }
 

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
@@ -76,7 +76,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<TestSqlQue
             randomAlphaOfLength(10),
             requestInfo,
             randomBoolean(),
-            randomBoolean(),
+            false, // deprecated
             randomTV(),
             randomBoolean(),
             randomTVGreaterThan(MIN_KEEP_ALIVE)

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
@@ -120,13 +120,17 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
     public Object visitShowTables(ShowTablesContext ctx) {
         TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
         String index = ti != null ? ti.qualifiedIndex() : null;
+
+        boolean includeFrozen = ctx.FROZEN() != null;
+        maybeWarnDeprecatedFrozenSyntax(includeFrozen, "INCLUDE FROZEN");
+
         return new ShowTables(
             source(ctx),
             visitLikePattern(ctx.clusterLike),
             visitString(ctx.cluster),
             index,
             visitLikePattern(ctx.tableLike),
-            ctx.FROZEN() != null
+            includeFrozen
         );
     }
 
@@ -139,7 +143,11 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
     public Object visitShowColumns(ShowColumnsContext ctx) {
         TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
         String index = ti != null ? ti.qualifiedIndex() : null;
-        return new ShowColumns(source(ctx), string(ctx.cluster), index, visitLikePattern(ctx.tableLike), ctx.FROZEN() != null);
+
+        boolean includeFrozen = ctx.FROZEN() != null;
+        maybeWarnDeprecatedFrozenSyntax(includeFrozen, "INCLUDE FROZEN");
+
+        return new ShowColumns(source(ctx), string(ctx.cluster), index, visitLikePattern(ctx.tableLike), includeFrozen);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.sql.parser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
@@ -63,10 +65,22 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
 import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
 
 abstract class LogicalPlanBuilder extends ExpressionBuilder {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(CommandBuilder.class);
+
+    private static final String FROZEN_DEPRECATION_WARNING = "[{}] syntax is deprecated because frozen indices have been deprecated. "
+        + "Consider cold or frozen tiers in place of frozen indices.";
+
+    protected void maybeWarnDeprecatedFrozenSyntax(boolean includeFrozen, String syntax) {
+        if (includeFrozen) {
+            DEPRECATION_LOGGER.warn(DeprecationCategory.PARSING, "include_frozen_syntax", format(null, FROZEN_DEPRECATION_WARNING, syntax));
+        }
+    }
 
     protected LogicalPlanBuilder(Map<Token, SqlTypedParamValue> params, ZoneId zoneId) {
         super(params, zoneId);
@@ -267,7 +281,9 @@ abstract class LogicalPlanBuilder extends ExpressionBuilder {
     public LogicalPlan visitTableName(TableNameContext ctx) {
         String alias = visitQualifiedName(ctx.qualifiedName());
         TableIdentifier tableIdentifier = visitTableIdentifier(ctx.tableIdentifier());
-        return new UnresolvedRelation(source(ctx), tableIdentifier, alias, ctx.FROZEN() != null);
+        boolean includeFrozen = ctx.FROZEN() != null;
+        maybeWarnDeprecatedFrozenSyntax(includeFrozen, "FROZEN");
+        return new UnresolvedRelation(source(ctx), tableIdentifier, alias, includeFrozen);
     }
 
     private Limit limit(LogicalPlan plan, Source source, Token limit) {


### PR DESCRIPTION
Backports the following commits to 8.1:
 - SQL: Deprecate index_include_frozen request parameter and `FROZEN` keyword (#83943)