### PR TITLE
[7.17] Document partial search results with skip_unavailable (#84057)

### DIFF
--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -41,8 +41,9 @@ by the configured remote cluster alias.
 
 [[skip-unavailable]]
 `skip_unavailable`::
-    Whether the remote cluster is skipped in case it is searched through
-    a {ccs} request but none of its nodes are available.
+Whether a {ccs} skips the remote cluster if its nodes are unavailable during the
+search. If `true`, a {ccs} also ignores errors returned by the remote cluster.
+Refer to <<skip-unavailable-clusters>>.
 
 `seeds`::
     Initial seed transport addresses of the remote cluster when sniff mode is

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -292,16 +292,29 @@ means the document came from the local cluster.
 
 [discrete]
 [[skip-unavailable-clusters]]
-=== Skip unavailable clusters
+=== Optional remote clusters
 
-By default, a {ccs} returns an error if *any* cluster in the request is
-unavailable.
+By default, a {ccs} fails if a remote cluster in the request returns an
+error or is unavailable. Use the `skip_unavailable` cluster
+setting to mark a specific remote cluster as optional for {ccs}.
 
-To skip an unavailable cluster during a {ccs}, set the
-<<skip-unavailable,`skip_unavailable`>> cluster setting to `true`.
+If `skip_unavailable` is `true`, a {ccs}:
 
-The following <<cluster-update-settings,cluster update settings>> API request
-changes `cluster_two`'s `skip_unavailable` setting to `true`.
+* Skips the remote cluster if its nodes are unavailable during the search. The
+response's `_cluster.skipped` value contains a count of any skipped clusters.
+
+* Ignores errors returned by the remote cluster, such as errors related to
+unavailable shards or indices. This can include errors related to search
+parameters such as <<multi-index,`allow_no_indices`>> and
+<<multi-index,`ignore_unavailable`>>.
+
+* Ignores the <<search-partial-responses,`allow_partial_search_results`>>
+parameter and the related `search.default_allow_partial_results` cluster setting
+when searching the remote cluster. This means searches on the remote cluster may
+return partial results.
+
+The following <<cluster-update-settings,cluster update settings>>
+API request changes `cluster_two`'s `skip_unavailable` setting to `true`.
 
 [source,console]
 --------------------------------


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #84057

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)