### PR TITLE
[8.0] Fix SimpleValidateQueryIT#testExplainValidateQueryTwoNodes (#84296)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -183,7 +183,11 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
             .actionGet();
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test").setSource("foo", "text", "bar", i, "baz", "blort").execute().actionGet();
+            client().prepareIndex("test")
+                .setSource("foo", "text", "bar", i, "baz", "blort")
+                .setId(Integer.toString(i))
+                .execute()
+                .actionGet();
         }
         refresh();
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix SimpleValidateQueryIT#testExplainValidateQueryTwoNodes (#84296)