### PR TITLE
Fleet: Add a new mapping for .fleet-actions-results action_input_type field

### DIFF
--- a/docs/changelog/84316.yaml
+++ b/docs/changelog/84316.yaml
@@ -1,0 +1,5 @@
+pr: 84316
+summary: "Fleet: Add a new mapping for .fleet-actions-results `input_type` field"
+area: Security
+type: enhancement
+issues: []

--- a/docs/changelog/84316.yaml
+++ b/docs/changelog/84316.yaml
@@ -1,5 +1,5 @@
 pr: 84316
-summary: "Fleet: Add a new mapping for .fleet-actions-results `input_type` field"
+summary: "Fleet: Add a new mapping for .fleet-actions-results `action_input_type` field"
 area: Security
 type: enhancement
 issues: []

--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
@@ -16,7 +16,7 @@
         "action_id": {
           "type": "keyword"
         },
-        "input_type": {
+        "action_input_type": {
           "type": "keyword"
         },
         "agent_id": {

--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
@@ -16,6 +16,9 @@
         "action_id": {
           "type": "keyword"
         },
+        "input_type": {
+          "type": "keyword"
+        },
         "agent_id": {
           "type": "keyword"
         },


### PR DESCRIPTION
## What does this PR do?
Adds ```input_type``` field mapping for the .fleet-actions-results. 
This allows to use kibana transformations on .fleet-actions-results for specific integration without a need to correlate them to the original .fleet-actions (via the action_id)

This change is a prerequisite to the fleet server feature:
https://github.com/elastic/fleet-server/pull/1164

## Related PRs
- Relates: https://github.com/elastic/fleet-server/pull/1164

## Screenshots

Populated ```action_input_type``` property :
<img width="605" alt="Screen Shot 2022-02-24 at 1 52 00 PM" src="https://user-images.githubusercontent.com/872351/155605479-5d3afd06-124b-48b0-a75b-219606ec4368.png">

