### PR TITLE
Add test debug for CCR follow security IT

### DIFF
--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -179,8 +179,12 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
         }, 30, TimeUnit.SECONDS);
         assertThat(indexExists(disallowedIndex), is(false));
         assertBusy(() -> {
-            verifyCcrMonitoring(allowedIndex, allowedIndex);
-            verifyAutoFollowMonitoring();
+            try {
+                verifyCcrMonitoring(allowedIndex, allowedIndex);
+                verifyAutoFollowMonitoring();
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
         }, 30, TimeUnit.SECONDS);
 
         // Cleanup by deleting auto follow pattern and pause following:


### PR DESCRIPTION
Ensure that testAutoFollowPattern includes the original assertion
failures if it's assertBusy ends up failing with an exception.

Relates #84156
