### PR TITLE
Forward-port late deprecation info API changes to 8.x (#83675)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -15,14 +15,25 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Information about deprecated items
  */
 public class DeprecationIssue implements Writeable, ToXContentObject {
+
+    private static final String ACTIONS_META_FIELD = "actions";
+    private static final String OBJECTS_FIELD = "objects";
+    private static final String ACTION_TYPE = "action_type";
+    private static final String REMOVE_SETTINGS_ACTION_TYPE = "remove_settings";
 
     public enum Level implements Writeable {
         /**
@@ -121,6 +132,10 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         return meta;
     }
 
+    private Optional<Meta> getMetaObject() {
+        return Meta.fromMetaMap(meta);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         level.writeTo(out);
@@ -169,5 +184,234 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    public static Map<String, Object> createMetaMapForRemovableSettings(List<String> removableSettings) {
+        return Meta.fromRemovableSettings(removableSettings).toMetaMap();
+    }
+
+    /**
+     * This method returns a DeprecationIssue that has in its meta object the intersection of all auto-removable settings that appear on
+     * all of the DeprecationIssues that are passed in. This method assumes that all DeprecationIssues passed in are equal, except for the
+     * auto-removable settings in the meta object.
+     * @param similarIssues DeprecationIssues that are assumed to be identical except possibly removal actions.
+     * @return A DeprecationIssue containing only the removal actions that are in all similarIssues
+     */
+    public static DeprecationIssue getIntersectionOfRemovableSettings(List<DeprecationIssue> similarIssues) {
+        if (similarIssues == null || similarIssues.isEmpty()) {
+            return null;
+        }
+        if (similarIssues.size() == 1) {
+            return similarIssues.get(0);
+        }
+        DeprecationIssue representativeIssue = similarIssues.get(0);
+        Optional<Meta> metaIntersection = similarIssues.stream()
+            .map(DeprecationIssue::getMetaObject)
+            .reduce(
+                representativeIssue.getMetaObject(),
+                (intersectionSoFar, meta) -> intersectionSoFar.isPresent() && meta.isPresent()
+                    ? Optional.of(intersectionSoFar.get().getIntersection(meta.get()))
+                    : Optional.empty()
+            );
+        return new DeprecationIssue(
+            representativeIssue.level,
+            representativeIssue.message,
+            representativeIssue.url,
+            representativeIssue.details,
+            representativeIssue.resolveDuringRollingUpgrade,
+            metaIntersection.map(Meta::toMetaMap).orElse(null)
+        );
+    }
+
+    /*
+     * This class a represents a DeprecationIssue's meta map. A meta map might look something like:
+     * {
+     *    "_meta":{
+     *       "foo": "bar",
+     *       "actions":[
+     *          {
+     *             "action_type":"remove_settings",
+     *             "objects":[
+     *                "setting1",
+     *                "setting2"
+     *             ]
+     *          }
+     *       ]
+     *    }
+     * }
+     */
+    private static final class Meta {
+        private final List<Action> actions;
+        private final Map<String, Object> nonActionMetadata;
+
+        Meta(List<Action> actions, Map<String, Object> nonActionMetadata) {
+            this.actions = actions;
+            this.nonActionMetadata = nonActionMetadata;
+        }
+
+        private static Meta fromRemovableSettings(List<String> removableSettings) {
+            List<Action> actions;
+            if (removableSettings == null) {
+                actions = null;
+            } else {
+                actions = Collections.singletonList(new RemovalAction(removableSettings));
+            }
+            return new Meta(actions, Collections.emptyMap());
+        }
+
+        private Map<String, Object> toMetaMap() {
+            Map<String, Object> metaMap;
+            if (actions != null) {
+                metaMap = new HashMap<>(nonActionMetadata);
+                List<Map<String, Object>> actionsList = actions.stream().map(Action::toActionMap).collect(Collectors.toList());
+                if (actionsList.isEmpty() == false) {
+                    metaMap.put(ACTIONS_META_FIELD, actionsList);
+                }
+            } else {
+                metaMap = nonActionMetadata;
+            }
+            return metaMap;
+        }
+
+        /*
+         * This method gets the intersection of this Meta with another. It assumes that the Meta objects are identical, except possibly the
+         * contents of the removal actions. So the interection is a new Meta object with only the removal actions that appear in both.
+         */
+        private Meta getIntersection(Meta another) {
+            final List<Action> actionsIntersection;
+            if (actions != null && another.actions != null) {
+                List<Action> combinedActions = this.actions.stream()
+                    .filter(action -> action instanceof RemovalAction == false)
+                    .collect(Collectors.toList());
+                Optional<Action> thisRemovalAction = this.actions.stream().filter(action -> action instanceof RemovalAction).findFirst();
+                Optional<Action> otherRemovalAction = another.actions.stream()
+                    .filter(action -> action instanceof RemovalAction)
+                    .findFirst();
+                if (thisRemovalAction.isPresent() && otherRemovalAction.isPresent()) {
+                    Optional<List<String>> removableSettingsOptional = ((RemovalAction) thisRemovalAction.get()).getRemovableSettings();
+                    List<String> removableSettings = removableSettingsOptional.map(
+                        settings -> settings.stream()
+                            .distinct()
+                            .filter(
+                                setting -> ((RemovalAction) otherRemovalAction.get()).getRemovableSettings()
+                                    .map(list -> list.contains(setting))
+                                    .orElse(false)
+                            )
+                            .collect(Collectors.toList())
+                    ).orElse(Collections.emptyList());
+                    if (removableSettings.isEmpty() == false) {
+                        combinedActions.add(new RemovalAction(removableSettings));
+                    }
+                }
+                actionsIntersection = combinedActions;
+            } else {
+                actionsIntersection = null;
+            }
+            return new Meta(actionsIntersection, nonActionMetadata);
+        }
+
+        /*
+         * Returns an Optional Meta object from a DeprecationIssue's meta Map. If the meta Map is null then the Optional will not be
+         * present.
+         */
+        @SuppressWarnings("unchecked")
+        private static Optional<Meta> fromMetaMap(Map<String, Object> metaMap) {
+            if (metaMap == null) {
+                return Optional.empty();
+            }
+            List<Map<String, Object>> actionMaps = (List<Map<String, Object>>) metaMap.get(ACTIONS_META_FIELD);
+            List<Action> actions;
+            if (actionMaps == null) {
+                actions = null;
+            } else {
+                actions = new ArrayList<>();
+                for (Map<String, Object> actionMap : actionMaps) {
+                    final Action action;
+                    if (REMOVE_SETTINGS_ACTION_TYPE.equals(actionMap.get(ACTION_TYPE))) {
+                        action = RemovalAction.fromActionMap(actionMap);
+                    } else {
+                        action = UnknownAction.fromActionMap(actionMap);
+                    }
+                    actions.add(action);
+                }
+            }
+            Map<String, Object> nonActionMap = metaMap.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equals(ACTIONS_META_FIELD) == false)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            Meta meta = new Meta(actions, nonActionMap);
+            return Optional.of(meta);
+        }
+    }
+
+    /*
+     * A DeprecationIssue's meta Map optionally has an array of actions. This class reprenents one of the items in that array.
+     */
+    private interface Action {
+        /*
+         * This method creates the Map that goes inside the actions list for this Action in a meta Map.
+         */
+        Map<String, Object> toActionMap();
+    }
+
+    /*
+     * This class a represents remove_settings action within the actions list in a meta Map.
+     */
+    private static final class RemovalAction implements Action {
+        private final List<String> removableSettings;
+
+        RemovalAction(List<String> removableSettings) {
+            this.removableSettings = removableSettings;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static RemovalAction fromActionMap(Map<String, Object> actionMap) {
+            final List<String> removableSettings;
+            Object removableSettingsObject = actionMap.get(OBJECTS_FIELD);
+            if (removableSettingsObject == null) {
+                removableSettings = null;
+            } else {
+                removableSettings = (List<String>) removableSettingsObject;
+            }
+            return new RemovalAction(removableSettings);
+        }
+
+        private Optional<List<String>> getRemovableSettings() {
+            return removableSettings == null ? Optional.empty() : Optional.of(removableSettings);
+        }
+
+        @Override
+        public Map<String, Object> toActionMap() {
+            final Map<String, Object> actionMap;
+            if (removableSettings != null) {
+                actionMap = new HashMap<>();
+                actionMap.put(OBJECTS_FIELD, removableSettings);
+                actionMap.put(ACTION_TYPE, REMOVE_SETTINGS_ACTION_TYPE);
+            } else {
+                actionMap = null;
+            }
+            return actionMap;
+        }
+    }
+
+    /*
+     * This represents an action within the actions list in a meta Map that is *not* a removal_action.
+     */
+    private static class UnknownAction implements Action {
+        private final Map<String, Object> actionMap;
+
+        private UnknownAction(Map<String, Object> actionMap) {
+            this.actionMap = actionMap;
+        }
+
+        private static Action fromActionMap(Map<String, Object> actionMap) {
+            return new UnknownAction(actionMap);
+        }
+
+        @Override
+        public Map<String, Object> toActionMap() {
+            return actionMap;
+        }
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -11,12 +11,12 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -38,53 +38,56 @@ public class DeprecationChecks {
 
     static List<Function<ClusterState, DeprecationIssue>> CLUSTER_SETTINGS_CHECKS = Collections.emptyList();
 
-    static List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> NODE_SETTINGS_CHECKS = List.of(
-        NodeDeprecationChecks::checkSharedDataPathSetting,
-        NodeDeprecationChecks::checkReservedPrefixedRealmNames,
-        NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting,
-        NodeDeprecationChecks::checkExporterUseIngestPipelineSettings,
-        NodeDeprecationChecks::checkExporterPipelineMasterTimeoutSetting,
-        NodeDeprecationChecks::checkExporterCreateLegacyTemplateSetting,
-        NodeDeprecationChecks::checkMonitoringSettingHistoryDuration,
-        NodeDeprecationChecks::checkMonitoringSettingCollectIndexRecovery,
-        NodeDeprecationChecks::checkMonitoringSettingCollectIndices,
-        NodeDeprecationChecks::checkMonitoringSettingCollectCcrTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectEnrichStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectIndexRecoveryStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectIndexStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectMlJobStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectNodeStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingCollectClusterStatsTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersHost,
-        NodeDeprecationChecks::checkMonitoringSettingExportersBulkTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersConnectionTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersConnectionReadTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersAuthUsername,
-        NodeDeprecationChecks::checkMonitoringSettingExportersAuthPass,
-        NodeDeprecationChecks::checkMonitoringSettingExportersSSL,
-        NodeDeprecationChecks::checkMonitoringSettingExportersProxyBase,
-        NodeDeprecationChecks::checkMonitoringSettingExportersSniffEnabled,
-        NodeDeprecationChecks::checkMonitoringSettingExportersHeaders,
-        NodeDeprecationChecks::checkMonitoringSettingExportersTemplateTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersMasterTimeout,
-        NodeDeprecationChecks::checkMonitoringSettingExportersEnabled,
-        NodeDeprecationChecks::checkMonitoringSettingExportersType,
-        NodeDeprecationChecks::checkMonitoringSettingExportersAlertsEnabled,
-        NodeDeprecationChecks::checkMonitoringSettingExportersAlertsBlacklist,
-        NodeDeprecationChecks::checkMonitoringSettingExportersIndexNameTimeFormat,
-        NodeDeprecationChecks::checkMonitoringSettingDecommissionAlerts,
-        NodeDeprecationChecks::checkMonitoringSettingEsCollectionEnabled,
-        NodeDeprecationChecks::checkMonitoringSettingCollectionEnabled,
-        NodeDeprecationChecks::checkMonitoringSettingCollectionInterval,
-        NodeDeprecationChecks::checkScriptContextCache,
-        NodeDeprecationChecks::checkScriptContextCompilationsRateLimitSetting,
-        NodeDeprecationChecks::checkScriptContextCacheSizeSetting,
-        NodeDeprecationChecks::checkScriptContextCacheExpirationSetting,
-        NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting,
-        NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
-        NodeDeprecationChecks::checkEqlEnabledSetting,
-        NodeDeprecationChecks::checkNodeAttrData
-    );
+    static final List<
+        NodeDeprecationCheck<Settings, PluginsAndModules, ClusterState, XPackLicenseState, DeprecationIssue>> NODE_SETTINGS_CHECKS = List
+            .of(
+                NodeDeprecationChecks::checkSharedDataPathSetting,
+                NodeDeprecationChecks::checkReservedPrefixedRealmNames,
+                NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting,
+                NodeDeprecationChecks::checkExporterUseIngestPipelineSettings,
+                NodeDeprecationChecks::checkExporterPipelineMasterTimeoutSetting,
+                NodeDeprecationChecks::checkExporterCreateLegacyTemplateSetting,
+                NodeDeprecationChecks::checkMonitoringSettingHistoryDuration,
+                NodeDeprecationChecks::checkMonitoringSettingHistoryDuration,
+                NodeDeprecationChecks::checkMonitoringSettingCollectIndexRecovery,
+                NodeDeprecationChecks::checkMonitoringSettingCollectIndices,
+                NodeDeprecationChecks::checkMonitoringSettingCollectCcrTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectEnrichStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectIndexRecoveryStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectIndexStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectMlJobStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectNodeStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingCollectClusterStatsTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersHost,
+                NodeDeprecationChecks::checkMonitoringSettingExportersBulkTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersConnectionTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersConnectionReadTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersAuthUsername,
+                NodeDeprecationChecks::checkMonitoringSettingExportersAuthPass,
+                NodeDeprecationChecks::checkMonitoringSettingExportersSSL,
+                NodeDeprecationChecks::checkMonitoringSettingExportersProxyBase,
+                NodeDeprecationChecks::checkMonitoringSettingExportersSniffEnabled,
+                NodeDeprecationChecks::checkMonitoringSettingExportersHeaders,
+                NodeDeprecationChecks::checkMonitoringSettingExportersTemplateTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersMasterTimeout,
+                NodeDeprecationChecks::checkMonitoringSettingExportersEnabled,
+                NodeDeprecationChecks::checkMonitoringSettingExportersType,
+                NodeDeprecationChecks::checkMonitoringSettingExportersAlertsEnabled,
+                NodeDeprecationChecks::checkMonitoringSettingExportersAlertsBlacklist,
+                NodeDeprecationChecks::checkMonitoringSettingExportersIndexNameTimeFormat,
+                NodeDeprecationChecks::checkMonitoringSettingDecommissionAlerts,
+                NodeDeprecationChecks::checkMonitoringSettingEsCollectionEnabled,
+                NodeDeprecationChecks::checkMonitoringSettingCollectionEnabled,
+                NodeDeprecationChecks::checkMonitoringSettingCollectionInterval,
+                NodeDeprecationChecks::checkScriptContextCache,
+                NodeDeprecationChecks::checkScriptContextCompilationsRateLimitSetting,
+                NodeDeprecationChecks::checkScriptContextCacheSizeSetting,
+                NodeDeprecationChecks::checkScriptContextCacheExpirationSetting,
+                NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting,
+                NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
+                NodeDeprecationChecks::checkEqlEnabledSetting,
+                NodeDeprecationChecks::checkNodeAttrData
+            );
 
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(
         IndexDeprecationChecks::oldIndicesCheck,
@@ -106,4 +109,8 @@ public class DeprecationChecks {
         return checks.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
+    @FunctionalInterface
+    public interface NodeDeprecationCheck<A, B, C, D, R> {
+        R apply(A first, B second, C third, D fourth);
+    }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -33,6 +34,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,15 +67,21 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         return checks.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
+    /**
+     * This method rolls up DeprecationIssues that are identical but on different nodes. It also roles up DeprecationIssues that are
+     * identical (and on different nodes) except that they differ in the removable settings listed in their meta object. We roll these up
+     * by taking the intersection of all removable settings in otherwise identical DeprecationIssues. That way we don't claim that a
+     * setting can be automatically removed if any node has it in its elasticsearch.yml.
+     * @param response
+     * @return
+     */
     private static List<DeprecationIssue> mergeNodeIssues(NodesDeprecationCheckResponse response) {
-        Map<DeprecationIssue, List<String>> issueListMap = new HashMap<>();
-        for (NodesDeprecationCheckAction.NodeResponse resp : response.getNodes()) {
-            for (DeprecationIssue issue : resp.getDeprecationIssues()) {
-                issueListMap.computeIfAbsent(issue, (key) -> new ArrayList<>()).add(resp.getNode().getName());
-            }
-        }
+        // A collection whose values are lists of DeprecationIssues that differ only by meta values (if that):
+        Collection<List<Tuple<DeprecationIssue, String>>> issuesToMerge = getDeprecationIssuesThatDifferOnlyByMeta(response.getNodes());
+        // A map of DeprecationIssues (containing only the intersection of removable settings) to the nodes they are seen on
+        Map<DeprecationIssue, List<String>> issueToListOfNodesMap = getMergedIssuesToNodesMap(issuesToMerge);
 
-        return issueListMap.entrySet().stream().map(entry -> {
+        return issueToListOfNodesMap.entrySet().stream().map(entry -> {
             DeprecationIssue issue = entry.getKey();
             String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
             return new DeprecationIssue(
@@ -85,6 +93,53 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 issue.getMeta()
             );
         }).collect(Collectors.toList());
+    }
+
+    /*
+     * This method pulls all of the DeprecationIssues from the given nodeResponses, and buckets them into lists of DeprecationIssues that
+     * differ at most by meta values (if that). The returned tuples also contain the node name the deprecation issue was found on. If all
+     * nodes in the cluster were configured identically then all tuples in a list will differ only by the node name.
+     */
+    private static Collection<List<Tuple<DeprecationIssue, String>>> getDeprecationIssuesThatDifferOnlyByMeta(
+        List<NodesDeprecationCheckAction.NodeResponse> nodeResponses
+    ) {
+        Map<DeprecationIssue, List<Tuple<DeprecationIssue, String>>> issuesToMerge = new HashMap<>();
+        for (NodesDeprecationCheckAction.NodeResponse resp : nodeResponses) {
+            for (DeprecationIssue issue : resp.getDeprecationIssues()) {
+                issuesToMerge.computeIfAbsent(
+                    new DeprecationIssue(
+                        issue.getLevel(),
+                        issue.getMessage(),
+                        issue.getUrl(),
+                        issue.getDetails(),
+                        issue.isResolveDuringRollingUpgrade(),
+                        null // Intentionally removing meta from the key so that it's not taken into account for equality
+                    ),
+                    (key) -> new ArrayList<>()
+                ).add(new Tuple<>(issue, resp.getNode().getName()));
+            }
+        }
+        return issuesToMerge.values();
+    }
+
+    /*
+     * At this point we have one DeprecationIssue per node for a given deprecation. This method rolls them up into a single DeprecationIssue
+     * with a list of nodes that they appear on. If two DeprecationIssues on two different nodes differ only by the set of removable
+     * settings (i.e. they have different elasticsearch.yml configurations) then this method takes the intersection of those settings when
+     * it rolls them up.
+     */
+    private static Map<DeprecationIssue, List<String>> getMergedIssuesToNodesMap(
+        Collection<List<Tuple<DeprecationIssue, String>>> issuesToMerge
+    ) {
+        Map<DeprecationIssue, List<String>> issueToListOfNodesMap = new HashMap<>();
+        for (List<Tuple<DeprecationIssue, String>> similarIssues : issuesToMerge) {
+            DeprecationIssue leastCommonDenominator = DeprecationIssue.getIntersectionOfRemovableSettings(
+                similarIssues.stream().map(Tuple::v1).collect(Collectors.toList())
+            );
+            issueToListOfNodesMap.computeIfAbsent(leastCommonDenominator, (key) -> new ArrayList<>())
+                .addAll(similarIssues.stream().map(Tuple::v2).collect(Collectors.toList()));
+        }
+        return issueToListOfNodesMap;
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -13,7 +13,10 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.frozen.FrozenEngine;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Index-specific deprecation checks
@@ -40,6 +43,14 @@ public class IndexDeprecationChecks {
         if (softDeletesEnabled) {
             if (IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexMetadata.getSettings())
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexMetadata.getSettings())) {
+                List<String> settingKeys = new ArrayList<>();
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexMetadata.getSettings())) {
+                    settingKeys.add(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey());
+                }
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexMetadata.getSettings())) {
+                    settingKeys.add(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey());
+                }
+                Map<String, Object> meta = DeprecationIssue.createMetaMapForRemovableSettings(settingKeys);
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "translog retention settings are ignored",
@@ -47,7 +58,7 @@ public class IndexDeprecationChecks {
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored "
                         + "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                     false,
-                    null
+                    meta
                 );
             }
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -11,12 +11,20 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -26,7 +34,9 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.Locale;
+
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
 
 public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     NodesDeprecationCheckRequest,
@@ -35,17 +45,21 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     NodesDeprecationCheckAction.NodeResponse> {
 
     private final Settings settings;
+    private final XPackLicenseState licenseState;
     private final PluginsService pluginsService;
+    private final ClusterInfoService clusterInfoService;
     private volatile List<String> skipTheseDeprecations;
 
     @Inject
     public TransportNodeDeprecationCheckAction(
         Settings settings,
         ThreadPool threadPool,
+        XPackLicenseState licenseState,
         ClusterService clusterService,
         TransportService transportService,
         PluginsService pluginsService,
-        ActionFilters actionFilters
+        ActionFilters actionFilters,
+        ClusterInfoService clusterInfoService
     ) {
         super(
             NodesDeprecationCheckAction.NAME,
@@ -60,6 +74,8 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
         );
         this.settings = settings;
         this.pluginsService = pluginsService;
+        this.licenseState = licenseState;
+        this.clusterInfoService = clusterInfoService;
         skipTheseDeprecations = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
         // Safe to register this here because it happens synchronously before the cluster service is started:
         clusterService.getClusterSettings()
@@ -96,15 +112,84 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
 
     NodesDeprecationCheckAction.NodeResponse nodeOperation(
         NodesDeprecationCheckAction.NodeRequest request,
-        List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> nodeSettingsChecks
+        List<
+            DeprecationChecks.NodeDeprecationCheck<
+                Settings,
+                PluginsAndModules,
+                ClusterState,
+                XPackLicenseState,
+                DeprecationIssue>> nodeSettingsChecks
     ) {
-        Settings filteredSettings = settings.filter(setting -> Regex.simpleMatch(skipTheseDeprecations, setting) == false);
+        Settings filteredNodeSettings = settings.filter(setting -> Regex.simpleMatch(skipTheseDeprecations, setting) == false);
+
+        Metadata metadata = clusterService.state().metadata();
+        Settings transientSettings = metadata.transientSettings()
+            .filter(setting -> Regex.simpleMatch(skipTheseDeprecations, setting) == false);
+        Settings persistentSettings = metadata.persistentSettings()
+            .filter(setting -> Regex.simpleMatch(skipTheseDeprecations, setting) == false);
+        ClusterState filteredClusterState = ClusterState.builder(clusterService.state())
+            .metadata(Metadata.builder(metadata).transientSettings(transientSettings).persistentSettings(persistentSettings).build())
+            .build();
+
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(
             nodeSettingsChecks,
-            (c) -> c.apply(filteredSettings, pluginsService.info())
+            (c) -> c.apply(filteredNodeSettings, pluginsService.info(), filteredClusterState, licenseState)
         );
-
+        DeprecationIssue watermarkIssue = checkDiskLowWatermark(
+            filteredNodeSettings,
+            filteredClusterState.metadata().settings(),
+            clusterInfoService.getClusterInfo(),
+            clusterService.getClusterSettings(),
+            transportService.getLocalNode().getId()
+        );
+        if (watermarkIssue != null) {
+            issues.add(watermarkIssue);
+        }
         return new NodesDeprecationCheckAction.NodeResponse(transportService.getLocalNode(), issues);
     }
 
+    static DeprecationIssue checkDiskLowWatermark(
+        Settings nodeSettings,
+        Settings dynamicSettings,
+        ClusterInfo clusterInfo,
+        ClusterSettings clusterSettings,
+        String nodeId
+    ) {
+        DiskUsage usage = clusterInfo.getNodeMostAvailableDiskUsages().get(nodeId);
+        if (usage != null) {
+            long freeBytes = usage.getFreeBytes();
+            double freeDiskPercentage = usage.getFreeDiskAsPercentage();
+            if (exceedsLowWatermark(nodeSettings, clusterSettings, freeBytes, freeDiskPercentage)
+                || exceedsLowWatermark(dynamicSettings, clusterSettings, freeBytes, freeDiskPercentage)) {
+                return new DeprecationIssue(
+                    DeprecationIssue.Level.CRITICAL,
+                    "Disk usage exceeds low watermark",
+                    "https://ela.st/es-deprecation-7-disk-watermark-exceeded",
+                    String.format(
+                        Locale.ROOT,
+                        "Disk usage exceeds low watermark, which will prevent reindexing indices during upgrade. Get disk usage on "
+                            + "all nodes below the value specified in %s",
+                        CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey()
+                    ),
+                    false,
+                    null
+                );
+            }
+        }
+        return null;
+    }
+
+    private static boolean exceedsLowWatermark(
+        Settings settingsToCheck,
+        ClusterSettings clusterSettings,
+        long freeBytes,
+        double freeDiskPercentage
+    ) {
+        DiskThresholdSettings diskThresholdSettings = new DiskThresholdSettings(settingsToCheck, clusterSettings);
+        if (freeBytes < diskThresholdSettings.getFreeBytesThresholdLow().getBytes()
+            || freeDiskPercentage < diskThresholdSettings.getFreeDiskThresholdLow()) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
@@ -156,6 +156,89 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         }
     }
 
+    public void testFromWithMergeableNodeIssues() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("_all");
+        mapping.field("enabled", false);
+        mapping.endObject().endObject();
+
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test")
+                    .putMapping(Strings.toString(mapping))
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+            )
+            .build();
+
+        DiscoveryNode node1 = new DiscoveryNode(
+            "node1",
+            "nodeId1",
+            "ephemeralId1",
+            "hostName1",
+            "hostAddress1",
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "node2",
+            "nodeId2",
+            "ephemeralId2",
+            "hostName2",
+            "hostAddress2",
+            new TransportAddress(TransportAddress.META_ADDRESS, 9500),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
+        IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
+        Map<String, Object> metaMap1 = DeprecationIssue.createMetaMapForRemovableSettings(
+            Collections.unmodifiableList(Arrays.asList("setting.1", "setting.2", "setting.3"))
+        );
+        Map<String, Object> metaMap2 = DeprecationIssue.createMetaMapForRemovableSettings(
+            Collections.unmodifiableList(Arrays.asList("setting.2", "setting.3"))
+        );
+        DeprecationIssue foundIssue1 = createTestDeprecationIssue(metaMap1);
+        DeprecationIssue foundIssue2 = createTestDeprecationIssue(foundIssue1, metaMap2);
+        List<Function<ClusterState, DeprecationIssue>> clusterSettingsChecks = Collections.emptyList();
+        List<Function<IndexMetadata, DeprecationIssue>> indexSettingsChecks = List.of((idx) -> null);
+
+        NodesDeprecationCheckResponse nodeDeprecationIssues = new NodesDeprecationCheckResponse(
+            new ClusterName(randomAlphaOfLength(5)),
+            Arrays.asList(
+                new NodesDeprecationCheckAction.NodeResponse(node1, Collections.singletonList(foundIssue1)),
+                new NodesDeprecationCheckAction.NodeResponse(node2, Collections.singletonList(foundIssue2))
+            ),
+            emptyList()
+        );
+
+        DeprecationInfoAction.Request request = new DeprecationInfoAction.Request(Strings.EMPTY_ARRAY);
+        DeprecationInfoAction.Response response = DeprecationInfoAction.Response.from(
+            state,
+            resolver,
+            request,
+            nodeDeprecationIssues,
+            indexSettingsChecks,
+            clusterSettingsChecks,
+            Collections.emptyMap(),
+            Collections.emptyList()
+        );
+
+        String details = foundIssue1.getDetails() != null ? foundIssue1.getDetails() + " " : "";
+        DeprecationIssue mergedFoundIssue = new DeprecationIssue(
+            foundIssue1.getLevel(),
+            foundIssue1.getMessage(),
+            foundIssue1.getUrl(),
+            details + "(nodes impacted: [" + node1.getName() + ", " + node2.getName() + "])",
+            foundIssue1.isResolveDuringRollingUpgrade(),
+            foundIssue2.getMeta()
+        );
+        assertThat(response.getNodeSettingsIssues(), equalTo(Collections.singletonList(mergedFoundIssue)));
+    }
+
     public void testRemoveSkippedSettings() throws IOException {
 
         Settings.Builder settingsBuilder = settings(Version.CURRENT);
@@ -231,6 +314,10 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
     }
 
     private static DeprecationIssue createTestDeprecationIssue() {
+        return createTestDeprecationIssue(randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(4), randomAlphaOfLength(4))));
+    }
+
+    private static DeprecationIssue createTestDeprecationIssue(Map<String, Object> metaMap) {
         String details = randomBoolean() ? randomAlphaOfLength(10) : null;
         return new DeprecationIssue(
             randomFrom(Level.values()),
@@ -238,7 +325,18 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
             randomAlphaOfLength(10),
             details,
             randomBoolean(),
-            randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(4), randomAlphaOfLength(4)))
+            metaMap
+        );
+    }
+
+    private static DeprecationIssue createTestDeprecationIssue(DeprecationIssue seedIssue, Map<String, Object> metaMap) {
+        return new DeprecationIssue(
+            seedIssue.getLevel(),
+            seedIssue.getMessage(),
+            seedIssue.getUrl(),
+            seedIssue.getDetails(),
+            seedIssue.isResolveDuringRollingUpgrade(),
+            metaMap
         );
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -59,7 +59,12 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored "
                         + "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                     false,
-                    null
+                    DeprecationIssue.createMetaMapForRemovableSettings(
+                        List.of(
+                            IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(),
+                            IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey()
+                        )
+                    )
                 )
             )
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -9,10 +9,15 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
@@ -27,7 +32,6 @@ import org.mockito.Mockito;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 
 public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
 
@@ -39,49 +43,71 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
         settingsBuilder.putList(
             DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.deprecated.property", "some.other.*.deprecated.property")
+            List.of("some.deprecated.property", "some.other.*.deprecated.property", "some.bad.dynamic.property")
         );
-        Settings inputSettings = settingsBuilder.build();
+        Settings nodeSettings = settingsBuilder.build();
+        settingsBuilder = Settings.builder();
+        settingsBuilder.put("some.bad.dynamic.property", "someValue1");
+        Settings dynamicSettings = settingsBuilder.build();
         ThreadPool threadPool = null;
         final XPackLicenseState licenseState = null;
-        Metadata metadata = Mockito.mock(Metadata.class);
-        ClusterState clusterState = Mockito.mock(ClusterState.class);
-        Mockito.when(clusterState.metadata()).thenReturn(metadata);
+        Metadata metadata = Metadata.builder().transientSettings(dynamicSettings).build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
         ClusterService clusterService = Mockito.mock(ClusterService.class);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
-        ClusterSettings clusterSettings = new ClusterSettings(inputSettings, Set.of(DeprecationChecks.SKIP_DEPRECATIONS_SETTING));
+        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, Set.of(DeprecationChecks.SKIP_DEPRECATIONS_SETTING));
         Mockito.when((clusterService.getClusterSettings())).thenReturn(clusterSettings);
         DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
         TransportService transportService = Mockito.mock(TransportService.class);
         Mockito.when(transportService.getLocalNode()).thenReturn(node);
         PluginsService pluginsService = Mockito.mock(PluginsService.class);
         ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
+        ClusterInfoService clusterInfoService = Mockito.mock(ClusterInfoService.class);
+        ClusterInfo clusterInfo = ClusterInfo.EMPTY;
+        Mockito.when(clusterInfoService.getClusterInfo()).thenReturn(clusterInfo);
         TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
-            inputSettings,
+            nodeSettings,
             threadPool,
+            licenseState,
             clusterService,
             transportService,
             pluginsService,
-            actionFilters
+            actionFilters,
+            clusterInfoService
         );
         NodesDeprecationCheckAction.NodeRequest nodeRequest = null;
-        AtomicReference<Settings> visibleSettings = new AtomicReference<>();
-        BiFunction<Settings, PluginsAndModules, DeprecationIssue> nodeSettingCheck = (settings, p) -> {
-            visibleSettings.set(settings);
-            return null;
-        };
-        java.util.List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> nodeSettingsChecks = List.of(nodeSettingCheck);
+        AtomicReference<Settings> visibleNodeSettings = new AtomicReference<>();
+        AtomicReference<Settings> visibleClusterStateMetadataSettings = new AtomicReference<>();
+        DeprecationChecks.NodeDeprecationCheck<
+            Settings,
+            PluginsAndModules,
+            ClusterState,
+            XPackLicenseState,
+            DeprecationIssue> nodeSettingCheck = (settings, p, clusterState1, l) -> {
+                visibleNodeSettings.set(settings);
+                visibleClusterStateMetadataSettings.set(clusterState1.getMetadata().settings());
+                return null;
+            };
+        java.util.List<
+            DeprecationChecks.NodeDeprecationCheck<
+                Settings,
+                PluginsAndModules,
+                ClusterState,
+                XPackLicenseState,
+                DeprecationIssue>> nodeSettingsChecks = List.of(nodeSettingCheck);
         transportNodeDeprecationCheckAction.nodeOperation(nodeRequest, nodeSettingsChecks);
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.undeprecated.property", "someValue3");
         settingsBuilder.putList("some.undeprecated.list.property", List.of("someValue4", "someValue5"));
         settingsBuilder.putList(
             DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.deprecated.property", "some.other.*.deprecated.property")
+            List.of("some.deprecated.property", "some.other.*.deprecated.property", "some.bad.dynamic.property")
         );
         Settings expectedSettings = settingsBuilder.build();
-        Assert.assertNotNull(visibleSettings.get());
-        Assert.assertEquals(expectedSettings, visibleSettings.get());
+        Assert.assertNotNull(visibleNodeSettings.get());
+        Assert.assertEquals(expectedSettings, visibleNodeSettings.get());
+        Assert.assertNotNull(visibleClusterStateMetadataSettings.get());
+        Assert.assertEquals(Settings.EMPTY, visibleClusterStateMetadataSettings.get());
 
         // Testing that the setting is dynamically updatable:
         Settings newSettings = Settings.builder()
@@ -96,10 +122,69 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         // This is the node setting (since this is the node deprecation check), not the cluster setting:
         settingsBuilder.putList(
             DeprecationChecks.SKIP_DEPRECATIONS_SETTING.getKey(),
-            List.of("some.deprecated.property", "some.other.*.deprecated.property")
+            List.of("some.deprecated.property", "some.other.*.deprecated.property", "some.bad.dynamic.property")
         );
         expectedSettings = settingsBuilder.build();
-        Assert.assertNotNull(visibleSettings.get());
-        Assert.assertEquals(expectedSettings, visibleSettings.get());
+        Assert.assertNotNull(visibleNodeSettings.get());
+        Assert.assertEquals(expectedSettings, visibleNodeSettings.get());
+        Assert.assertNotNull(visibleClusterStateMetadataSettings.get());
+        Assert.assertEquals(
+            Settings.builder().put("some.bad.dynamic.property", "someValue1").build(),
+            visibleClusterStateMetadataSettings.get()
+        );
+    }
+
+    public void testCheckDiskLowWatermark() {
+        Settings nodeSettings = Settings.EMPTY;
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put("cluster.routing.allocation.disk.watermark.low", "10%");
+        Settings settingsWithLowWatermark = settingsBuilder.build();
+        Settings dynamicSettings = settingsWithLowWatermark;
+        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        String nodeId = "123";
+        ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableSpaceUsageBuilder = ImmutableOpenMap.builder();
+        long totalBytesOnMachine = 100;
+        long totalBytesFree = 70;
+        mostAvailableSpaceUsageBuilder.put(nodeId, new DiskUsage(nodeId, "", "", totalBytesOnMachine, totalBytesFree));
+        ClusterInfo clusterInfo = new ClusterInfo(
+            ImmutableOpenMap.of(),
+            mostAvailableSpaceUsageBuilder.build(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of(),
+            ImmutableOpenMap.of()
+        );
+        DeprecationIssue issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
+            nodeSettings,
+            dynamicSettings,
+            clusterInfo,
+            clusterSettings,
+            nodeId
+        );
+        assertNotNull(issue);
+        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
+
+        // Making sure there's no warning when we clear out the cluster settings:
+        dynamicSettings = Settings.EMPTY;
+        issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
+            nodeSettings,
+            dynamicSettings,
+            clusterInfo,
+            clusterSettings,
+            nodeId
+        );
+        assertNull(issue);
+
+        // And make sure there is a warning when the setting is in the node settings but not the cluster settings:
+        nodeSettings = settingsWithLowWatermark;
+        issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
+            nodeSettings,
+            dynamicSettings,
+            clusterInfo,
+            clusterSettings,
+            nodeId
+        );
+        assertNotNull(issue);
+        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
     }
 }


### PR DESCRIPTION
This is a forward-port of #82487, #83544, #83601, #84145, and #84246, but given that the branches had diverged so much they were not a straightforward cherry-picks. It required modifying the interface of the NodeDeprecationChecks to include ClusterState as we do in 7.x.