### PR TITLE
keyword field supports truncation, default truncation length is 32766

### DIFF
--- a/docs/changelog/84333.yaml
+++ b/docs/changelog/84333.yaml
@@ -1,0 +1,5 @@
+pr: 84333
+summary: keyword field supports truncation, default truncation length is 32766
+area: Mapping
+type: enhancement
+issues: [60329]

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -78,6 +78,13 @@ The following parameters are accepted by `keyword` fields:
     dynamic mapping rules create a sub `keyword` field that overrides this
     default by setting `ignore_above: 256`.
 
+`truncate_above`::
+
+    Truncate any string longer than this value. Default to `32766` so that
+    all values can be written into lucene. This defualt value is useful for
+    protecting against Lucene's term byte-length limit of `32766`.
+    Any string will be truncated first, then apply `ignore_above` setting.
+
 <<mapping-index,`index`>>::
 
     Should the field be quickly searchable? Accepts `true` (default) and


### PR DESCRIPTION
solve https://github.com/elastic/elasticsearch/issues/60329
--
Currently it seems difficult for users that are not completely in control of the data they ingest into a keyword field to truncate those values (see https://github.com/elastic/elasticsearch/issues/57984).
Lucene enforces a maximum term length of 32766 which, when exceeded, causes a rejection of the indexed document, so a user reading e.g. from a database with values out of control needs to somehow prevent this.

With the `truncate_above` field option, we can truncate the input values. 

With the following mapping, any string longer than 5 bytes will be truncated to 5 bytes.
```json
{
   "properties":{
      "keyField":{
         "type":"keyword",
         "truncate_above":5	// reserve 5 bytes at most
      },
      "rawField":{
         "type":"text",
         "fields":{
            "raw":{
               "type":"keyword",
               "truncate_above":5	// reserve 5 bytes at most
            }
         }
      }
   }
}
```