### PR TITLE
Restrict run-as to realm and api_key authentication types

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -178,6 +178,7 @@ public class Authentication implements ToXContentObject {
         Objects.requireNonNull(runAs);
         assert false == runAs.isRunAs();
         assert false == getUser().isRunAs();
+        assert AuthenticationType.REALM == getAuthenticationType() || AuthenticationType.API_KEY == getAuthenticationType();
         return new Authentication(
             new User(runAs, getUser()),
             getAuthenticatedBy(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -207,9 +207,6 @@ public class AuthenticationTests extends ESTestCase {
         RealmRef lookupRealmRef = randomRealmRef(true);
         // realm/token run-as
         Authentication test = Authentication.newRealmAuthentication(randomUser(), authnRealmRef);
-        if (randomBoolean()) {
-            test = test.token();
-        }
         test = test.runAs(randomUser(), lookupRealmRef);
         if (randomBoolean()) {
             test = test.token();
@@ -217,9 +214,6 @@ public class AuthenticationTests extends ESTestCase {
         assertThat(test.isAssignedToDomain(), is(true));
         assertThat(test.getDomain(), is(lookupRealmRef.getDomain()));
         test = Authentication.newRealmAuthentication(randomUser(), randomRealmRef(false));
-        if (randomBoolean()) {
-            test = test.token();
-        }
         test = test.runAs(randomUser(), lookupRealmRef);
         if (randomBoolean()) {
             test = test.token();
@@ -227,9 +221,6 @@ public class AuthenticationTests extends ESTestCase {
         assertThat(test.isAssignedToDomain(), is(true));
         assertThat(test.getDomain(), is(lookupRealmRef.getDomain()));
         test = Authentication.newRealmAuthentication(randomUser(), authnRealmRef);
-        if (randomBoolean()) {
-            test = test.token();
-        }
         test = test.runAs(randomUser(), randomRealmRef(false));
         if (randomBoolean()) {
             test = test.token();
@@ -237,9 +228,6 @@ public class AuthenticationTests extends ESTestCase {
         assertThat(test.isAssignedToDomain(), is(false));
         assertThat(test.getDomain(), nullValue());
         test = Authentication.newRealmAuthentication(randomUser(), randomRealmRef(false));
-        if (randomBoolean()) {
-            test = test.token();
-        }
         test = test.runAs(randomUser(), lookupRealmRef);
         if (randomBoolean()) {
             test = test.token();
@@ -248,9 +236,6 @@ public class AuthenticationTests extends ESTestCase {
         assertThat(test.getDomain(), is(lookupRealmRef.getDomain()));
         // api key run-as
         test = randomApiKeyAuthentication(randomUser(), randomAlphaOfLengthBetween(10, 20), Version.CURRENT);
-        if (randomBoolean()) {
-            test = test.token();
-        }
         assertThat(test.isAssignedToDomain(), is(false));
         assertThat(test.getDomain(), nullValue());
         if (randomBoolean()) {
@@ -268,25 +253,10 @@ public class AuthenticationTests extends ESTestCase {
             assertThat(test.isAssignedToDomain(), is(false));
             assertThat(test.getDomain(), nullValue());
         }
-        // service account run-as
+        // service account cannot run-as
         test = randomServiceAccountAuthentication();
         assertThat(test.isAssignedToDomain(), is(false));
         assertThat(test.getDomain(), nullValue());
-        if (randomBoolean()) {
-            test = test.runAs(randomUser(), lookupRealmRef);
-            if (randomBoolean()) {
-                test = test.token();
-            }
-            assertThat(test.isAssignedToDomain(), is(true));
-            assertThat(test.getDomain(), is(lookupRealmRef.getDomain()));
-        } else {
-            test = test.runAs(randomUser(), randomRealmRef(false));
-            if (randomBoolean()) {
-                test = test.token();
-            }
-            assertThat(test.isAssignedToDomain(), is(false));
-            assertThat(test.getDomain(), nullValue());
-        }
     }
 
     public void testDomainSerialize() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -74,8 +74,6 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
                 Authentication authentication = securityContext.getAuthentication();
                 if (authentication.isServiceAccount()) {
                     // Service account itself cannot create OAuth2 tokens.
-                    // But it is possible to create an oauth2 token if the service account run-as a different user.
-                    // In this case, the token will be created for the run-as user (not the service account).
                     listener.onFailure(new ElasticsearchException("OAuth2 token creation is not supported for service accounts"));
                     return;
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -189,11 +190,8 @@ class AuthenticatorChain {
         };
     }
 
-    private void maybeLookupRunAsUser(
-        Authenticator.Context context,
-        Authentication authentication,
-        ActionListener<Authentication> listener
-    ) {
+    // Package private for test
+    void maybeLookupRunAsUser(Authenticator.Context context, Authentication authentication, ActionListener<Authentication> listener) {
         if (false == runAsEnabled) {
             finishAuthentication(context, authentication, listener);
             return;
@@ -201,6 +199,19 @@ class AuthenticatorChain {
 
         final String runAsUsername = context.getThreadContext().getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
         if (runAsUsername == null) {
+            finishAuthentication(context, authentication, listener);
+            return;
+        }
+
+        // Run-as is supported for authentication with realm or api_key. Run-as for other authentication types is ignored.
+        // Both realm user and api_key can create tokens. They can also run-as another user and create tokens.
+        // In both cases, the created token will have a TOKEN authentication type and hence does not support run-as.
+        if (Authentication.AuthenticationType.REALM != authentication.getAuthenticationType()
+            && Authentication.AuthenticationType.API_KEY != authentication.getAuthenticationType()) {
+            logger.info(
+                "ignore run-as header since it is not supported for authentication type [{}]",
+                authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
+            );
             finishAuthentication(context, authentication, listener);
             return;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -209,7 +209,7 @@ class AuthenticatorChain {
         if (Authentication.AuthenticationType.REALM != authentication.getAuthenticationType()
             && Authentication.AuthenticationType.API_KEY != authentication.getAuthenticationType()) {
             logger.info(
-                "ignore run-as header since it is not supported for authentication type [{}]",
+                "ignore run-as header since it is currently not supported for authentication type [{}]",
                 authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
             );
             finishAuthentication(context, authentication, listener);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -7,17 +7,24 @@
 
 package org.elasticsearch.xpack.security.authc;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
@@ -31,10 +38,13 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -283,6 +293,80 @@ public class AuthenticatorChainTests extends ESTestCase {
             e.getMetadata("es.additional_unsuccessful_credentials"),
             hasItem(containsString(unsuccessfulApiKey ? "unsuccessful api key" : "unsuccessful bearer token"))
         );
+    }
+
+    public void testMaybeLookupRunAsUser() {
+        final Authentication authentication = randomFrom(
+            AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)),
+            AuthenticationTests.randomRealmAuthentication(false)
+        );
+        final String runAsUsername = "your-run-as-username";
+        threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, runAsUsername);
+        assertThat(authentication.getUser().principal(), not(equalTo(runAsUsername)));
+
+        final AuthenticationService.AuditableRequest auditableRequest = mock(AuthenticationService.AuditableRequest.class);
+        final Authenticator.Context context = new Authenticator.Context(threadContext, auditableRequest, null, true, realms);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Tuple<User, Realm>> listener = (ActionListener<Tuple<User, Realm>>) invocation.getArguments()[2];
+            listener.onResponse(null);
+            return null;
+        }).when(realmsAuthenticator).lookupRunAsUser(any(), any(), any());
+        final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+        authenticatorChain.maybeLookupRunAsUser(context, authentication, future);
+        future.actionGet();
+        verify(realmsAuthenticator).lookupRunAsUser(eq(context), eq(authentication), any());
+    }
+
+    public void testRunAsIsIgnoredForUnsupportedAuthenticationTypes() throws IllegalAccessException {
+        final Authentication authentication = randomFrom(
+            AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)).token(),
+            AuthenticationTests.randomRealmAuthentication(false).token(),
+            AuthenticationTests.randomServiceAccountAuthentication(),
+            AuthenticationTests.randomAnonymousAuthentication(),
+            AuthenticationTests.randomInternalAuthentication()
+        );
+        threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, "you-shall-not-pass");
+        assertThat(
+            authentication.getUser().principal(),
+            not(equalTo(threadContext.getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER)))
+        );
+
+        final AuthenticationService.AuditableRequest auditableRequest = mock(AuthenticationService.AuditableRequest.class);
+        final Authenticator.Context context = new Authenticator.Context(threadContext, auditableRequest, null, true, realms);
+
+        doAnswer(invocation -> {
+            fail("should not reach here");
+            return null;
+        }).when(realmsAuthenticator).lookupRunAsUser(any(), any(), any());
+
+        final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
+        Loggers.setLevel(logger, Level.INFO);
+        final MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(logger, appender);
+        appender.start();
+
+        try {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "run-as",
+                    AuthenticatorChain.class.getName(),
+                    Level.INFO,
+                    "ignore run-as header since it is not supported for authentication type ["
+                        + authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
+                        + "]"
+                )
+            );
+            final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
+            authenticatorChain.maybeLookupRunAsUser(context, authentication, future);
+            assertThat(future.actionGet(), equalTo(authentication));
+            appender.assertAllExpectationsMatched();
+        } finally {
+            appender.stop();
+            Loggers.setLevel(logger, Level.INFO);
+            Loggers.removeAppender(logger, appender);
+        }
     }
 
     private Authenticator.Context createAuthenticatorContext() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -353,7 +353,7 @@ public class AuthenticatorChainTests extends ESTestCase {
                     "run-as",
                     AuthenticatorChain.class.getName(),
                     Level.INFO,
-                    "ignore run-as header since it is not supported for authentication type ["
+                    "ignore run-as header since it is currently not supported for authentication type ["
                         + authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
                         + "]"
                 )


### PR DESCRIPTION
This PR removes run-as support for authentication types other than realm
and API key. The change essentially makes the behaviour closer to
the existing one (in released versions) except for API keys. This is not
to say that the existing behaviour is the best. But we need more time to
agree on the new behaviour.

Relates: #79809
