### PR TITLE
Speed up FieldFCapabilitiesResponse XContent Serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -291,15 +290,15 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             builder.array(NON_AGGREGATABLE_INDICES_FIELD.getPreferredName(), nonAggregatableIndices);
         }
         if (nonDimensionIndices != null) {
-            builder.field(NON_DIMENSION_INDICES_FIELD.getPreferredName(), nonDimensionIndices);
+            builder.array(NON_DIMENSION_INDICES_FIELD.getPreferredName(), nonDimensionIndices);
         }
         if (metricConflictsIndices != null) {
-            builder.field(METRIC_CONFLICTS_INDICES_FIELD.getPreferredName(), metricConflictsIndices);
+            builder.array(METRIC_CONFLICTS_INDICES_FIELD.getPreferredName(), metricConflictsIndices);
         }
         if (meta.isEmpty() == false) {
             builder.startObject("meta");
             List<Map.Entry<String, Set<String>>> entries = new ArrayList<>(meta.entrySet());
-            entries.sort(Comparator.comparing(Map.Entry::getKey)); // provide predictable order
+            entries.sort(Map.Entry.comparingByKey()); // provide predictable order
             for (Map.Entry<String, Set<String>> entry : entries) {
                 List<String> values = new ArrayList<>(entry.getValue());
                 values.sort(String::compareTo); // provide predictable order

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -156,7 +156,11 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
         }
         builder.startObject();
         builder.array(INDICES_FIELD.getPreferredName(), indices);
-        builder.field(FIELDS_FIELD.getPreferredName(), responseMap);
+        builder.startObject(FIELDS_FIELD.getPreferredName());
+        for (var r : responseMap.entrySet()) {
+            builder.xContentValuesMap(r.getKey(), r.getValue());
+        }
+        builder.endObject();
         if (this.failures.size() > 0) {
             builder.field(FAILED_INDICES_FIELD.getPreferredName(), getFailedIndices().length);
             builder.xContentList(FAILURES_FIELD.getPreferredName(), failures);
@@ -178,7 +182,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
                 .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
             List<String> indices = a[1] == null ? Collections.emptyList() : (List<String>) a[1];
             List<FieldCapabilitiesFailure> failures = a[2] == null ? Collections.emptyList() : (List<FieldCapabilitiesFailure>) a[2];
-            return new FieldCapabilitiesResponse(indices.stream().toArray(String[]::new), responseMap, failures);
+            return new FieldCapabilitiesResponse(indices.toArray(String[]::new), responseMap, failures);
         }
     );
 


### PR DESCRIPTION
Explicitly serialize the response map to avoid expensive type lookups
when serializing. Also, avoid some type lookups for index lists
in `FieldCapabilities` downstream and remove an allocation from
sorting the meta entries.

relates https://github.com/elastic/elasticsearch/issues/77466