### PR TITLE
Instructions to retrieve keystore pwd

### DIFF
--- a/docs/reference/setup/install/security-files-reference.asciidoc
+++ b/docs/reference/setup/install/security-files-reference.asciidoc
@@ -16,3 +16,20 @@ Keystore that contains the key and certificate for the HTTP layer for this node.
 `transport.p12`::
 Keystore that contains the key and certificate for the transport layer for all
 the nodes in your cluster.
+
+The PKCS#12 keystores `http.p12` and `transport.p12` are password protected and
+the passwords are stored as <<secure-settings,secure settings>>. You can retrieve
+the passwords so that you can inspect or change the keystore contents using
+`bin/elasticsearch-keystore`.
+
+Use the following command to retrieve the password for `transport.p12`:
+[source,sh]
+-------------------------
+bin/elasticsearch-keystore show xpack.security.transport.ssl.keystore.secure_password
+-------------------------
+
+Use the following command to retrieve the password for `http.p12`:
+[source,sh]
+-------------------------
+bin/elasticsearch-keystore show xpack.security.http.ssl.keystore.secure_password
+-------------------------

--- a/docs/reference/setup/install/security-files-reference.asciidoc
+++ b/docs/reference/setup/install/security-files-reference.asciidoc
@@ -17,10 +17,11 @@ Keystore that contains the key and certificate for the HTTP layer for this node.
 Keystore that contains the key and certificate for the transport layer for all
 the nodes in your cluster.
 
-The PKCS#12 keystores `http.p12` and `transport.p12` are password protected and
-the passwords are stored as <<secure-settings,secure settings>>. You can retrieve
-the passwords so that you can inspect or change the keystore contents using
-`bin/elasticsearch-keystore`.
+`http.p12` and `transport.p12` are password-protected PKCS#12 keystores. {es}
+stores the passwords for these keystores as  <<secure-settings,secure
+settings>>. To retrieve the passwords so that you can inspect or change the
+keystore contents, use the
+<<elasticsearch-keystore,`bin/elasticsearch-keystore`>> tool.
 
 Use the following command to retrieve the password for `transport.p12`:
 [source,sh]

--- a/docs/reference/setup/install/security-files-reference.asciidoc
+++ b/docs/reference/setup/install/security-files-reference.asciidoc
@@ -23,14 +23,14 @@ settings>>. To retrieve the passwords so that you can inspect or change the
 keystore contents, use the
 <<elasticsearch-keystore,`bin/elasticsearch-keystore`>> tool.
 
-Use the following command to retrieve the password for `transport.p12`:
-[source,sh]
--------------------------
-bin/elasticsearch-keystore show xpack.security.transport.ssl.keystore.secure_password
--------------------------
-
 Use the following command to retrieve the password for `http.p12`:
 [source,sh]
 -------------------------
 bin/elasticsearch-keystore show xpack.security.http.ssl.keystore.secure_password
+-------------------------
+
+Use the following command to retrieve the password for `transport.p12`:
+[source,sh]
+-------------------------
+bin/elasticsearch-keystore show xpack.security.transport.ssl.keystore.secure_password
 -------------------------


### PR DESCRIPTION
In 8.0.0. we introduce TLS autoconfiguration. We store the key and
certificate materials in password protected PKCS#12 keystores and
we store these passwords in the elasticsearch keystore.
This commit adds instructions on how to get hold of the passwords
for users to inspect or alter the PKCS#12 keystores.