### PR TITLE
Fix DirectBlobContainerIndexInput cloning method

### DIFF
--- a/docs/changelog/84341.yaml
+++ b/docs/changelog/84341.yaml
@@ -1,0 +1,6 @@
+pr: 84341
+summary: Fix `DirectBlobContainerIndexInput` cloning method
+area: Snapshot/Restore
+type: bug
+issues:
+ - 84238

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInput.java
@@ -258,19 +258,10 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     @Override
     public DirectBlobContainerIndexInput clone() {
-        final DirectBlobContainerIndexInput clone = new DirectBlobContainerIndexInput(
-            "clone(" + this + ")",
-            directory,
-            fileInfo,
-            context,
-            stats,
-            position,
-            offset,
-            length,
-            // Clones might not be closed when they are no longer needed, but we must always close streamForSequentialReads. The simple
-            // solution: do not optimize sequential reads on clones.
-            NO_SEQUENTIAL_READ_OPTIMIZATION
-        );
+        final DirectBlobContainerIndexInput clone = (DirectBlobContainerIndexInput) super.clone();
+        // Clones might not be closed when they are no longer needed, but we must always close streamForSequentialReads. The simple
+        // solution: do not optimize sequential reads on clones.
+        clone.sequentialReadSize = NO_SEQUENTIAL_READ_OPTIMIZATION;
         clone.isClone = true;
         return clone;
     }


### PR DESCRIPTION
The method doesn't use the parent classes `clone()` method and
therefore the BufferedIndexInput's `bufferStart` member is not cloned 
either and has the value `0`. 

The recent Lucene update which includes LUCENE-10377 introduced
more usages of the Lucene*SkipReader which internally uses an
`IndexInput` cloned twice (and the second clone will have a wrong 
buffer start value).

Test failures in recent history (see #84238) have been reproduced
and now pass with this fix.

Closes #84238