### PR TITLE
[8.0] Fix DirectBlobContainerIndexInput cloning method (#84341)

### DIFF
--- a/docs/changelog/84341.yaml
+++ b/docs/changelog/84341.yaml
@@ -1,0 +1,6 @@
+pr: 84341
+summary: Fix `DirectBlobContainerIndexInput` cloning method
+area: Snapshot/Restore
+type: bug
+issues:
+ - 84238

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInput.java
@@ -258,19 +258,10 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     @Override
     public DirectBlobContainerIndexInput clone() {
-        final DirectBlobContainerIndexInput clone = new DirectBlobContainerIndexInput(
-            "clone(" + this + ")",
-            directory,
-            fileInfo,
-            context,
-            stats,
-            position,
-            offset,
-            length,
-            // Clones might not be closed when they are no longer needed, but we must always close streamForSequentialReads. The simple
-            // solution: do not optimize sequential reads on clones.
-            NO_SEQUENTIAL_READ_OPTIMIZATION
-        );
+        final DirectBlobContainerIndexInput clone = (DirectBlobContainerIndexInput) super.clone();
+        // Clones might not be closed when they are no longer needed, but we must always close streamForSequentialReads. The simple
+        // solution: do not optimize sequential reads on clones.
+        clone.sequentialReadSize = NO_SEQUENTIAL_READ_OPTIMIZATION;
         clone.isClone = true;
         return clone;
     }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix DirectBlobContainerIndexInput cloning method (#84341)