### PR TITLE
[ML] Record node shutdown start time for each node

### DIFF
--- a/docs/changelog/84355.yaml
+++ b/docs/changelog/84355.yaml
@@ -1,0 +1,5 @@
+pr: 84355
+summary: Node shutdown start time recorded for each node
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/84355.yaml
+++ b/docs/changelog/84355.yaml
@@ -1,5 +1,5 @@
 pr: 84355
-summary: Node shutdown start time recorded for each node
+summary: Record node shutdown start time for each node
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
@@ -25,7 +25,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MlLifeCycleService {
 
@@ -45,7 +47,7 @@ public class MlLifeCycleService {
     private final AutodetectProcessManager autodetectProcessManager;
     private final DataFrameAnalyticsManager analyticsManager;
     private final MlMemoryTracker memoryTracker;
-    private volatile Instant shutdownStartTime;
+    private final Map<String, Instant> shutdownStartTimes = new ConcurrentHashMap<>();
 
     MlLifeCycleService(
         ClusterService clusterService,
@@ -91,7 +93,7 @@ public class MlLifeCycleService {
      * @return Has all active ML work vacated the specified node?
      */
     public boolean isNodeSafeToShutdown(String nodeId) {
-        return isNodeSafeToShutdown(nodeId, clusterService.state(), shutdownStartTime, Clock.systemUTC());
+        return isNodeSafeToShutdown(nodeId, clusterService.state(), shutdownStartTimes.get(nodeId), Clock.systemUTC());
     }
 
     static boolean isNodeSafeToShutdown(String nodeId, ClusterState state, Instant shutdownStartTime, Clock clock) {
@@ -122,11 +124,9 @@ public class MlLifeCycleService {
     }
 
     void signalGracefulShutdown(ClusterState state, Collection<String> shutdownNodeIds, Clock clock) {
-        if (shutdownNodeIds.contains(state.nodes().getLocalNodeId())) {
-            if (shutdownStartTime == null) {
-                shutdownStartTime = Instant.now(clock);
-                logger.info("Starting node shutdown sequence for ML");
-            }
+        String localNodeId = state.nodes().getLocalNodeId();
+        updateShutdownStartTimes(shutdownNodeIds, localNodeId, clock);
+        if (shutdownNodeIds.contains(localNodeId)) {
             datafeedRunner.vacateAllDatafeedsOnThisNode(
                 "previously assigned node [" + state.nodes().getLocalNode().getName() + "] is shutting down"
             );
@@ -134,7 +134,19 @@ public class MlLifeCycleService {
         }
     }
 
-    Instant getShutdownStartTime() {
-        return shutdownStartTime;
+    Instant getShutdownStartTime(String nodeId) {
+        return shutdownStartTimes.get(nodeId);
+    }
+
+    private void updateShutdownStartTimes(Collection<String> shutdownNodeIds, String localNodeId, Clock clock) {
+        for (String shutdownNodeId : shutdownNodeIds) {
+            shutdownStartTimes.computeIfAbsent(shutdownNodeId, key -> {
+                if (key.equals(localNodeId)) {
+                    logger.info("Starting node shutdown sequence for ML");
+                }
+                return Instant.now(clock);
+            });
+        }
+        shutdownStartTimes.keySet().retainAll(shutdownNodeIds);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
@@ -186,6 +186,7 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             memoryTracker
         );
 
+        // Local node is node-2 here
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder()
             .add(
                 new DiscoveryNode(
@@ -227,7 +228,7 @@ public class MlLifeCycleServiceTests extends ESTestCase {
 
         final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
         mlLifeCycleService.signalGracefulShutdown(clusterState, shutdownNodeIds, clock);
-        assertThat(mlLifeCycleService.getShutdownStartTime(), is(clock.instant()));
+        assertThat(mlLifeCycleService.getShutdownStartTime("node-2"), is(clock.instant()));
 
         verify(datafeedRunner).vacateAllDatafeedsOnThisNode("previously assigned node [node-2-name] is shutting down");
         verify(autodetectProcessManager).vacateOpenJobsOnThisNode();
@@ -236,7 +237,7 @@ public class MlLifeCycleServiceTests extends ESTestCase {
         // Calling the method again should not advance the start time
         Clock advancedClock = Clock.fixed(clock.instant().plus(Duration.ofMinutes(1)), ZoneId.systemDefault());
         mlLifeCycleService.signalGracefulShutdown(clusterState, shutdownNodeIds, advancedClock);
-        assertThat(mlLifeCycleService.getShutdownStartTime(), is(clock.instant()));
+        assertThat(mlLifeCycleService.getShutdownStartTime("node-2"), is(clock.instant()));
     }
 
     public void testSignalGracefulShutdownExcludingLocalNode() {
@@ -249,6 +250,8 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             analyticsManager,
             memoryTracker
         );
+
+        // Local node is node-2 here
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder()
             .add(
                 new DiscoveryNode(
@@ -286,8 +289,12 @@ public class MlLifeCycleServiceTests extends ESTestCase {
 
         Collection<String> shutdownNodeIds = randomBoolean() ? Collections.singleton("node-1") : Arrays.asList("node-1", "node-3");
 
-        mlLifeCycleService.signalGracefulShutdown(clusterState, shutdownNodeIds, Clock.systemUTC());
-        assertThat(mlLifeCycleService.getShutdownStartTime(), nullValue());
+        final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        mlLifeCycleService.signalGracefulShutdown(clusterState, shutdownNodeIds, clock);
+        // The local node, node-2, is definitely not shutting down, but we should have still recorded
+        // what time node-1 started shutting down, as we may get asked about it later
+        assertThat(mlLifeCycleService.getShutdownStartTime("node-2"), nullValue());
+        assertThat(mlLifeCycleService.getShutdownStartTime("node-1"), is(clock.instant()));
 
         verifyNoMoreInteractions(datafeedRunner, mlController, autodetectProcessManager, analyticsManager, memoryTracker);
     }


### PR DESCRIPTION
The ML integration into the node shutdown API was supposed to
have functionality that allowed nodes to shut down 10 minutes
after the initial request if jobs did not vacate the node
gracefully in that time.

Unfortunately this functionality did not always work, as the
node that gets asked whether a particular node is ready to
shut down might not be the node that is shutting down.

This change makes every node remember the time that ML nodes
were asked to shut down, so that every node is in a position
to respond accurately to whether an ML node is ready to shut
down, including taking the timeout into account.