### PR TITLE
Simplify Store$MetadataSnapshot and friends

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1072,10 +1072,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         logger.info(
             "--> start recovery request: starting seq_no {}, commit {}",
             startRecoveryRequest.startingSeqNo(),
-            startRecoveryRequest.metadataSnapshot().getCommitUserData()
+            startRecoveryRequest.metadataSnapshot().commitUserData()
         );
         SequenceNumbers.CommitInfo commitInfoAfterLocalRecovery = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(
-            startRecoveryRequest.metadataSnapshot().getCommitUserData().entrySet()
+            startRecoveryRequest.metadataSnapshot().commitUserData().entrySet()
         );
         assertThat(commitInfoAfterLocalRecovery.localCheckpoint, equalTo(lastSyncedGlobalCheckpoint));
         assertThat(commitInfoAfterLocalRecovery.maxSeqNo, equalTo(lastSyncedGlobalCheckpoint));

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2913,7 +2913,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 throw e;
             }
             final List<String> checkedFiles = new ArrayList<>(metadata.size());
-            for (Map.Entry<String, StoreFileMetadata> entry : metadata.asMap().entrySet()) {
+            for (Map.Entry<String, StoreFileMetadata> entry : metadata.fileMetadataMap().entrySet()) {
                 try {
                     Store.checkIntegrity(entry.getValue(), store.directory());
                     if (corrupt == null) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -299,7 +299,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             metadataSnapshot = recoveryTarget.indexShard().snapshotStoreMetadata();
             // Make sure that the current translog is consistent with the Lucene index; otherwise, we have to throw away the Lucene index.
             try {
-                final String expectedTranslogUUID = metadataSnapshot.getCommitUserData().get(Translog.TRANSLOG_UUID_KEY);
+                final String expectedTranslogUUID = metadataSnapshot.commitUserData().get(Translog.TRANSLOG_UUID_KEY);
                 final long globalCheckpoint = Translog.readGlobalCheckpoint(recoveryTarget.translogLocation(), expectedTranslogUUID);
                 assert globalCheckpoint + 1 >= startingSeqNo : "invalid startingSeqNo " + startingSeqNo + " >= " + globalCheckpoint;
             } catch (IOException | TranslogCorruptedException e) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -547,10 +547,10 @@ public class RecoverySourceHandler {
             for (String name : snapshot.getFileNames()) {
                 final StoreFileMetadata md = recoverySourceMetadata.get(name);
                 if (md == null) {
-                    logger.info("Snapshot differs from actual index for file: {} meta: {}", name, recoverySourceMetadata.asMap());
+                    logger.info("Snapshot differs from actual index for file: {} meta: {}", name, recoverySourceMetadata.fileMetadataMap());
                     throw new CorruptIndexException(
                         "Snapshot differs from actual index - maybe index was removed metadata has "
-                            + recoverySourceMetadata.asMap().size()
+                            + recoverySourceMetadata.fileMetadataMap().size()
                             + " files",
                         name
                     );
@@ -624,11 +624,11 @@ public class RecoverySourceHandler {
             }
 
             for (StoreFileMetadata md : shardRecoveryPlan.getSourceFilesToRecover()) {
-                if (request.metadataSnapshot().asMap().containsKey(md.name())) {
+                if (request.metadataSnapshot().fileMetadataMap().containsKey(md.name())) {
                     logger.trace(
                         "recovery [phase1]: recovering [{}], exists in local store, but is different: remote [{}], local [{}]",
                         md.name(),
-                        request.metadataSnapshot().asMap().get(md.name()),
+                        request.metadataSnapshot().fileMetadataMap().get(md.name()),
                         md
                     );
                 } else {
@@ -638,11 +638,11 @@ public class RecoverySourceHandler {
 
             for (BlobStoreIndexShardSnapshot.FileInfo fileInfo : shardRecoveryPlan.getSnapshotFilesToRecover()) {
                 final StoreFileMetadata md = fileInfo.metadata();
-                if (request.metadataSnapshot().asMap().containsKey(md.name())) {
+                if (request.metadataSnapshot().fileMetadataMap().containsKey(md.name())) {
                     logger.trace(
                         "recovery [phase1]: recovering [{}], exists in local store, but is different: remote [{}], local [{}]",
                         md.name(),
-                        request.metadataSnapshot().asMap().get(md.name()),
+                        request.metadataSnapshot().fileMetadataMap().get(md.name()),
                         md
                     );
                 } else {
@@ -986,32 +986,32 @@ public class RecoverySourceHandler {
         if (source.getSyncId() == null || source.getSyncId().equals(target.getSyncId()) == false) {
             return false;
         }
-        if (source.getNumDocs() != target.getNumDocs()) {
+        if (source.numDocs() != target.numDocs()) {
             throw new IllegalStateException(
                 "try to recover "
                     + request.shardId()
                     + " from primary shard with sync id but number "
                     + "of docs differ: "
-                    + source.getNumDocs()
+                    + source.numDocs()
                     + " ("
                     + request.sourceNode().getName()
                     + ", primary) vs "
-                    + target.getNumDocs()
+                    + target.numDocs()
                     + "("
                     + request.targetNode().getName()
                     + ")"
             );
         }
-        SequenceNumbers.CommitInfo sourceSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(source.getCommitUserData().entrySet());
-        SequenceNumbers.CommitInfo targetSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(target.getCommitUserData().entrySet());
+        SequenceNumbers.CommitInfo sourceSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(source.commitUserData().entrySet());
+        SequenceNumbers.CommitInfo targetSeqNos = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(target.commitUserData().entrySet());
         if (sourceSeqNos.localCheckpoint != targetSeqNos.localCheckpoint || targetSeqNos.maxSeqNo != sourceSeqNos.maxSeqNo) {
             final String message = "try to recover "
                 + request.shardId()
                 + " with sync id but "
                 + "seq_no stats are mismatched: ["
-                + source.getCommitUserData()
+                + source.commitUserData()
                 + "] vs ["
-                + target.getCommitUserData()
+                + target.commitUserData()
                 + "]";
             assert false : message;
             throw new IllegalStateException(message);

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -192,17 +192,13 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
-    public static class StoreFilesMetadata implements Iterable<StoreFileMetadata>, Writeable {
-        private final Store.MetadataSnapshot metadataSnapshot;
-        private final List<RetentionLease> peerRecoveryRetentionLeases;
+    public record StoreFilesMetadata(Store.MetadataSnapshot metadataSnapshot, List<RetentionLease> peerRecoveryRetentionLeases)
+        implements
+            Iterable<StoreFileMetadata>,
+            Writeable {
 
         private static final ShardId FAKE_SHARD_ID = new ShardId("_na_", "_na_", 0);
         public static final StoreFilesMetadata EMPTY = new StoreFilesMetadata(Store.MetadataSnapshot.EMPTY, emptyList());
-
-        public StoreFilesMetadata(Store.MetadataSnapshot metadataSnapshot, List<RetentionLease> peerRecoveryRetentionLeases) {
-            this.metadataSnapshot = metadataSnapshot;
-            this.peerRecoveryRetentionLeases = peerRecoveryRetentionLeases;
-        }
 
         public static StoreFilesMetadata readFrom(StreamInput in) throws IOException {
             if (in.getVersion().before(Version.V_8_2_0)) {
@@ -240,11 +236,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
 
         public boolean fileExists(String name) {
-            return metadataSnapshot.asMap().containsKey(name);
+            return metadataSnapshot.fileMetadataMap().containsKey(name);
         }
 
         public StoreFileMetadata file(String name) {
-            return metadataSnapshot.asMap().get(name);
+            return metadataSnapshot.fileMetadataMap().get(name);
         }
 
         /**
@@ -258,10 +254,6 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
                 .mapToLong(RetentionLease::retainingSequenceNumber)
                 .findFirst()
                 .orElse(-1L);
-        }
-
-        public List<RetentionLease> peerRecoveryRetentionLeases() {
-            return peerRecoveryRetentionLeases;
         }
 
         /**

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3580,7 +3580,7 @@ public class IndexShardTests extends IndexShardTestCase {
             while (stop.get() == false) {
                 try {
                     Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
-                    assertThat(readMeta.getNumDocs(), equalTo(numDocs));
+                    assertThat(readMeta.numDocs(), equalTo(numDocs));
                     assertThat(storeFileMetadatas.recoveryDiff(readMeta).different.size(), equalTo(0));
                     assertThat(storeFileMetadatas.recoveryDiff(readMeta).missing.size(), equalTo(0));
                     assertThat(storeFileMetadatas.recoveryDiff(readMeta).identical.size(), equalTo(storeFileMetadatas.size()));

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -355,7 +355,7 @@ public class StoreTests extends ESTestCase {
         writer.commit();
         writer.close();
         metadata = store.getMetadata(null);
-        assertThat(metadata.asMap().isEmpty(), is(false));
+        assertThat(metadata.fileMetadataMap().isEmpty(), is(false));
         for (StoreFileMetadata meta : metadata) {
             try (IndexInput input = store.directory().openInput(meta.name(), IOContext.DEFAULT)) {
                 String checksum = Store.digestToString(CodecUtil.retrieveChecksum(input));
@@ -486,13 +486,13 @@ public class StoreTests extends ESTestCase {
         for (String file : store.directory().listAll()) {
             if (IndexWriter.WRITE_LOCK_NAME.equals(file) == false && file.startsWith("extra") == false) {
                 assertTrue(
-                    file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length,
-                    metadata.asMap().containsKey(file)
+                    file + " is not in the map: " + metadata.fileMetadataMap().size() + " vs. " + store.directory().listAll().length,
+                    metadata.fileMetadataMap().containsKey(file)
                 );
             } else {
                 assertFalse(
-                    file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length,
-                    metadata.asMap().containsKey(file)
+                    file + " is not in the map: " + metadata.fileMetadataMap().size() + " vs. " + store.directory().listAll().length,
+                    metadata.fileMetadataMap().containsKey(file)
                 );
             }
         }
@@ -678,8 +678,8 @@ public class StoreTests extends ESTestCase {
             }
             dvUpdateSnapshot = store.getMetadata(null);
         }
-        logger.info("--> source: {}", dvUpdateSnapshot.asMap());
-        logger.info("--> target: {}", newCommitMetadata.asMap());
+        logger.info("--> source: {}", dvUpdateSnapshot.fileMetadataMap());
+        logger.info("--> target: {}", newCommitMetadata.fileMetadataMap());
         Store.RecoveryDiff dvUpdateDiff = dvUpdateSnapshot.recoveryDiff(newCommitMetadata);
         final int delFileCount;
         if (delFile == null || dvUpdateDiff.different.isEmpty()) {
@@ -924,12 +924,12 @@ public class StoreTests extends ESTestCase {
         in.setVersion(targetNodeVersion);
         Store.MetadataSnapshot inMetadataSnapshot = Store.MetadataSnapshot.readFrom(in);
         Map<String, StoreFileMetadata> origEntries = new HashMap<>();
-        origEntries.putAll(outMetadataSnapshot.asMap());
-        for (Map.Entry<String, StoreFileMetadata> entry : inMetadataSnapshot.asMap().entrySet()) {
+        origEntries.putAll(outMetadataSnapshot.fileMetadataMap());
+        for (Map.Entry<String, StoreFileMetadata> entry : inMetadataSnapshot.fileMetadataMap().entrySet()) {
             assertThat(entry.getValue().name(), equalTo(origEntries.remove(entry.getKey()).name()));
         }
         assertThat(origEntries.size(), equalTo(0));
-        assertThat(inMetadataSnapshot.getCommitUserData(), equalTo(outMetadataSnapshot.getCommitUserData()));
+        assertThat(inMetadataSnapshot.commitUserData(), equalTo(outMetadataSnapshot.commitUserData()));
     }
 
     public void testEmptyMetadataSnapshotStreaming() throws Exception {
@@ -974,9 +974,9 @@ public class StoreTests extends ESTestCase {
         writer.close();
         Store.MetadataSnapshot metadata;
         metadata = store.getMetadata(randomBoolean() ? null : deletionPolicy.snapshot());
-        assertFalse(metadata.asMap().isEmpty());
+        assertFalse(metadata.fileMetadataMap().isEmpty());
         // do not check for correct files, we have enough tests for that above
-        assertThat(metadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID), equalTo(syncId));
+        assertThat(metadata.commitUserData().get(Engine.SYNC_COMMIT_ID), equalTo(syncId));
         TestUtil.checkIndex(store.directory());
         assertDeleteContent(store, store.directory());
         IOUtils.close(store);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -168,7 +168,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         PlainActionFuture<Void> cleanFilesFuture = new PlainActionFuture<>();
         recoveryTarget.cleanFiles(
             0,
-            Long.parseLong(sourceSnapshot.getCommitUserData().get(SequenceNumbers.MAX_SEQ_NO)),
+            Long.parseLong(sourceSnapshot.commitUserData().get(SequenceNumbers.MAX_SEQ_NO)),
             sourceSnapshot,
             cleanFilesFuture
         );

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -65,7 +65,7 @@ public class StartRecoveryRequestTests extends ESTestCase {
         assertThat(outRequest.targetAllocationId(), equalTo(inRequest.targetAllocationId()));
         assertThat(outRequest.sourceNode(), equalTo(inRequest.sourceNode()));
         assertThat(outRequest.targetNode(), equalTo(inRequest.targetNode()));
-        assertThat(outRequest.metadataSnapshot().asMap(), equalTo(inRequest.metadataSnapshot().asMap()));
+        assertThat(outRequest.metadataSnapshot().fileMetadataMap(), equalTo(inRequest.metadataSnapshot().fileMetadataMap()));
         assertThat(outRequest.isPrimaryRelocation(), equalTo(inRequest.isPrimaryRelocation()));
         assertThat(outRequest.recoveryId(), equalTo(inRequest.recoveryId()));
         assertThat(outRequest.startingSeqNo(), equalTo(inRequest.startingSeqNo()));

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -92,13 +92,13 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
 
             // capture current store files
             final Store.MetadataSnapshot storeFiles = shard.snapshotStoreMetadata();
-            assertFalse(storeFiles.asMap().isEmpty());
+            assertFalse(storeFiles.fileMetadataMap().isEmpty());
 
             // close the shard
             closeShards(shard);
 
             // delete some random files in the store
-            List<String> deletedFiles = randomSubsetOf(randomIntBetween(1, storeFiles.size() - 1), storeFiles.asMap().keySet());
+            List<String> deletedFiles = randomSubsetOf(randomIntBetween(1, storeFiles.size() - 1), storeFiles.fileMetadataMap().keySet());
             for (String deletedFile : deletedFiles) {
                 Files.delete(shard.shardPath().resolveIndex().resolve(deletedFile));
             }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -469,17 +469,29 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     : snapshotMetadata.recoveryDiff(metadata);
 
                 assertThat(
-                    "List of different files should be empty but got [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
+                    "List of different files should be empty but got ["
+                        + metadata.fileMetadataMap()
+                        + "] and ["
+                        + snapshotMetadata.fileMetadataMap()
+                        + ']',
                     diff.different.isEmpty(),
                     is(true)
                 );
                 assertThat(
-                    "List of missing files should be empty but got [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
+                    "List of missing files should be empty but got ["
+                        + metadata.fileMetadataMap()
+                        + "] and ["
+                        + snapshotMetadata.fileMetadataMap()
+                        + ']',
                     diff.missing.isEmpty(),
                     is(true)
                 );
                 assertThat(
-                    "List of files should be identical [" + metadata.asMap() + "] and [" + snapshotMetadata.asMap() + ']',
+                    "List of files should be identical ["
+                        + metadata.fileMetadataMap()
+                        + "] and ["
+                        + snapshotMetadata.fileMetadataMap()
+                        + ']',
                     diff.identical.size(),
                     equalTo(metadata.size())
                 );


### PR DESCRIPTION
`TransportNodesListShardStoreMetadata$StoreFilesMetadata` and
`Store$MetadataSnapshot` are both morally-speaking records, and
`LoadedMetadata` is really the same as `MetadataSnapshot`. This commit
turns them into real records, gets rid of the unnecessary extra class,
and renames some of the accessors.

Spotted while working on #84034
