### PR TITLE
Fixing deprecation info API bugs that came up in testing

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
@@ -47,10 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING;
 import static org.elasticsearch.search.SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING;
-import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.LIFECYCLE_POLL_INTERVAL_SETTING;
-import static org.elasticsearch.xpack.deprecation.NodeDeprecationChecks.checkRemovedSetting;
 
 public class ClusterDeprecationChecks {
     private static final Logger logger = LogManager.getLogger(ClusterDeprecationChecks.class);
@@ -568,38 +564,6 @@ public class ClusterDeprecationChecks {
         return false;
     }
 
-    static DeprecationIssue checkPollIntervalTooLow(ClusterState state) {
-        String pollIntervalString = state.metadata().settings().get(LIFECYCLE_POLL_INTERVAL_SETTING.getKey());
-        if (Strings.isNullOrEmpty(pollIntervalString)) {
-            return null;
-        }
-
-        TimeValue pollInterval;
-        try {
-            pollInterval = TimeValue.parseTimeValue(pollIntervalString, LIFECYCLE_POLL_INTERVAL_SETTING.getKey());
-        } catch (IllegalArgumentException e) {
-            logger.error("Failed to parse [{}] value: [{}]", LIFECYCLE_POLL_INTERVAL_SETTING.getKey(), pollIntervalString);
-            return null;
-        }
-
-        if (pollInterval.compareTo(TimeValue.timeValueSeconds(1)) < 0) {
-            return new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
-                "Index Lifecycle Management poll interval is set too low",
-                "https://ela.st/es-deprecation-7-indices-lifecycle-poll-interval-setting",
-                String.format(
-                    Locale.ROOT,
-                    "The ILM [%s] setting is set to [%s]. Set the interval to at least 1s.",
-                    LIFECYCLE_POLL_INTERVAL_SETTING.getKey(),
-                    pollIntervalString
-                ),
-                false,
-                null
-            );
-        }
-        return null;
-    }
-
     static DeprecationIssue checkTemplatesWithCustomAndMultipleTypes(ClusterState state) {
         Set<String> templatesWithMultipleTypes = new TreeSet<>();
         Set<String> templatesWithCustomTypes = new TreeSet<>();
@@ -654,17 +618,6 @@ public class ClusterDeprecationChecks {
             );
         }
         return deprecationIssue;
-    }
-
-    static DeprecationIssue checkClusterRoutingAllocationIncludeRelocationsSetting(final ClusterState clusterState) {
-        return checkRemovedSetting(
-            clusterState.metadata().settings(),
-            null,
-            CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
-            "https://ela.st/es-deprecation-7-cluster-routing-allocation-disk-include-relocations-setting",
-            "Relocating shards are always taken into account in 8.0.",
-            DeprecationIssue.Level.WARNING
-        );
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -47,7 +47,6 @@ public class DeprecationChecks {
         Arrays.asList(
             ClusterDeprecationChecks::checkUserAgentPipelines,
             ClusterDeprecationChecks::checkTemplatesWithTooManyFields,
-            ClusterDeprecationChecks::checkPollIntervalTooLow,
             ClusterDeprecationChecks::checkTemplatesWithFieldNamesDisabled,
             ClusterDeprecationChecks::checkTemplatesWithCustomAndMultipleTypes,
             ClusterDeprecationChecks::checkTemplatesWithChainedMultiFields,
@@ -58,7 +57,6 @@ public class DeprecationChecks {
             ClusterDeprecationChecks::checkComponentTemplatesWithBoostedFields,
             ClusterDeprecationChecks::checkTemplatesWithBoostFieldsInDynamicTemplates,
             ClusterDeprecationChecks::checkComponentTemplatesWithBoostedFieldsInDynamicTemplates,
-            ClusterDeprecationChecks::checkClusterRoutingAllocationIncludeRelocationsSetting,
             ClusterDeprecationChecks::checkGeoShapeTemplates,
             ClusterDeprecationChecks::checkSparseVectorTemplates,
             ClusterDeprecationChecks::checkILMFreezeActions,
@@ -242,7 +240,8 @@ public class DeprecationChecks {
                 NodeDeprecationChecks::checkWatcherHistoryCleanerServiceSetting,
                 NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
                 NodeDeprecationChecks::checkEqlEnabledSetting,
-                NodeDeprecationChecks::checkNodeAttrData
+                NodeDeprecationChecks::checkNodeAttrData,
+                NodeDeprecationChecks::checkPollIntervalTooLow
             )
         ).collect(Collectors.toList());
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -540,6 +540,14 @@ public class IndexDeprecationChecks {
         if (softDeletesEnabled) {
             if (IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexMetadata.getSettings())
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexMetadata.getSettings())) {
+                List<String> removableSettings = new ArrayList<>();
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexMetadata.getSettings())) {
+                    removableSettings.add(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey());
+                }
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexMetadata.getSettings())) {
+                    removableSettings.add(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey());
+                }
+                Map<String, Object> meta = DeprecationIssue.createMetaMapForRemovableSettings(removableSettings);
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "Translog retention settings are deprecated",
@@ -548,7 +556,7 @@ public class IndexDeprecationChecks {
                         + "translog has not been used in peer recoveries with soft-deletes enabled since 7.0 and these settings have no "
                         + "effect.",
                     false,
-                    null
+                    meta
                 );
             }
         }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -657,7 +658,9 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                         + "The translog has not been used in peer recoveries with soft-deletes enabled since 7.0 and these settings "
                         + "have no effect.",
                     false,
-                    null
+                    DeprecationIssue.createMetaMapForRemovableSettings(
+                        Arrays.asList("index.translog.retention.size", "index.translog.retention.age")
+                    )
                 )
             )
         );


### PR DESCRIPTION
This fixes the following bugs that were found while testing the upgrade assistant:
* The check for the "indices.lifecycle.poll_interval" setting only checked dynamically-set values
* The check for the "cluster.routing.allocation.disk.include_relocations" setting was done in both the cluster check and the node check (and the level was inconsistent between the two).
* The dynamic "index.translog.retention.*" were not being listed as removable in the meta block.
* Several dynamic node/cluster settings were not being listed as removable in the meta block.