### PR TITLE
[7.17] [ML] Record node shutdown start time for each node

### DIFF
--- a/docs/changelog/84355.yaml
+++ b/docs/changelog/84355.yaml
@@ -1,0 +1,5 @@
+pr: 84355
+summary: Record node shutdown start time for each node
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
The ML integration into the node shutdown API was supposed to
have functionality that allowed nodes to shut down 10 minutes
after the initial request if jobs did not vacate the node
gracefully in that time.

Unfortunately this functionality did not always work, as the
node that gets asked whether a particular node is ready to
shut down might not be the node that is shutting down.

This change makes every node remember the time that ML nodes
were asked to shut down, so that every node is in a position
to respond accurately to whether an ML node is ready to shut
down, including taking the timeout into account.

Backport of #84355