### PR TITLE
Clarify docs on field type families

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -7,14 +7,13 @@ intended use. For example, you can index strings to both `text` and `keyword`
 fields. However, `text` field values are <<analysis,analyzed>> for full-text
 search while `keyword` strings are left as-is for filtering and sorting.
 
-Field types are grouped by _family_. Types in the same family support the same
-search functionality but may have different space usage or performance
+Field types are grouped by _family_. Types in the same family have exactly the
+same search behavior but may have different space usage or performance
 characteristics.
 
-Currently, the only type family is `keyword`, which consists of the `keyword`,
-`constant_keyword`, and `wildcard` field types. Other type families have only a
-single field type. For example, the `boolean` type family consists of one field
-type: `boolean`.
+Currently, there are two type families, `keyword` and `text`. Other type
+families have only a single field type. For example, the `boolean` type family
+consists of one field type: `boolean`.
 
 
 [discrete]


### PR DESCRIPTION
There has been some confusion over the definition of a field type family. This
PR clarifies the definition in the docs: the two types should have the exact
same search behavior (including supporting the same queries/ aggs, and
producing the same response). It's not sufficient for them to just allow the
same search operations.

This change also fixes an inaccurate statement that there is only one field
type family so far.