### PR TITLE
Expect eof when daemonized

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -204,7 +204,6 @@ public class KeystoreManagementTests extends PackagingTestCase {
         stopElasticsearch();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84204")
     public void test44WrongKeystorePasswordOnTty() throws Exception {
         /* Windows issue awaits fix: https://github.com/elastic/elasticsearch/issues/49340 */
         assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -252,7 +252,7 @@ public class Archives {
             : asBlock("expect \"Elasticsearch keystore password:\"",
                 "send \"" + keystorePassword + "\\r\"");
         String checkStartupScript = daemonize
-            ? ""
+            ? "expect eof"
             : asBlock("expect {",
                 "  \"uncaught exception\" { send_user \"\\nStartup failed due to uncaught exception\\n\"; exit 1 }",
                 "  timeout { send_user \"\\nTimed out waiting for startup to succeed\\n\"; exit 1 }",


### PR DESCRIPTION
Closes #84204 again. When running archive packging tests with a keystore
password and the -d option, there does actually need to be an `eof`
expectation or else we don't capture the error when the keystore
password is incorrect.
