### PR TITLE
Stop checking non-asciidoc files for doc snippets

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -15,8 +15,7 @@ apply plugin: 'elasticsearch.docs-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 ext.docsFileTree = fileTree(projectDir) {
-  // No snippets in here!
-  exclude 'build.gradle'
+  include '**/*.asciidoc'
   // That is where the snippets go, not where they come from!
   exclude 'build/**'
   exclude 'build-idea/**'


### PR DESCRIPTION
When SnippetsTask looks for doc snippets, the list of files it checks includes roughly 350 files that aren't asciidoc files.  Image files (both png and jpg), yaml files, and so on.  It should skip them, rather than trying to read them.
