### PR TITLE
Restrict run-as to realm and api_key authentication types (#84336)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -74,8 +74,6 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
                 Authentication authentication = securityContext.getAuthentication();
                 if (authentication.isServiceAccount()) {
                     // Service account itself cannot create OAuth2 tokens.
-                    // But it is possible to create an oauth2 token if the service account run-as a different user.
-                    // In this case, the token will be created for the run-as user (not the service account).
                     listener.onFailure(new ElasticsearchException("OAuth2 token creation is not supported for service accounts"));
                     return;
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPriv
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -195,11 +196,8 @@ class AuthenticatorChain {
         };
     }
 
-    private void maybeLookupRunAsUser(
-        Authenticator.Context context,
-        Authentication authentication,
-        ActionListener<Authentication> listener
-    ) {
+    // Package private for test
+    void maybeLookupRunAsUser(Authenticator.Context context, Authentication authentication, ActionListener<Authentication> listener) {
         if (false == runAsEnabled) {
             finishAuthentication(context, authentication, listener);
             return;
@@ -207,6 +205,19 @@ class AuthenticatorChain {
 
         final String runAsUsername = context.getThreadContext().getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
         if (runAsUsername == null) {
+            finishAuthentication(context, authentication, listener);
+            return;
+        }
+
+        // Run-as is supported for authentication with realm or api_key. Run-as for other authentication types is ignored.
+        // Both realm user and api_key can create tokens. They can also run-as another user and create tokens.
+        // In both cases, the created token will have a TOKEN authentication type and hence does not support run-as.
+        if (Authentication.AuthenticationType.REALM != authentication.getAuthenticationType()
+            && Authentication.AuthenticationType.API_KEY != authentication.getAuthenticationType()) {
+            logger.info(
+                "ignore run-as header since it is currently not supported for authentication type [{}]",
+                authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
+            );
             finishAuthentication(context, authentication, listener);
             return;
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -298,7 +298,7 @@ public class AuthenticatorChainTests extends ESTestCase {
     public void testMaybeLookupRunAsUser() {
         final Authentication authentication = randomFrom(
             AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)),
-            AuthenticationTests.randomRealmAuthentication(false)
+            AuthenticationTests.randomRealmAuthentication()
         );
         final String runAsUsername = "your-run-as-username";
         threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, runAsUsername);
@@ -321,8 +321,10 @@ public class AuthenticatorChainTests extends ESTestCase {
 
     public void testRunAsIsIgnoredForUnsupportedAuthenticationTypes() throws IllegalAccessException {
         final Authentication authentication = randomFrom(
-            AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)).token(),
-            AuthenticationTests.randomRealmAuthentication(false).token(),
+            AuthenticationTests.toToken(
+                AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20))
+            ),
+            AuthenticationTests.toToken(AuthenticationTests.randomRealmAuthentication()),
             AuthenticationTests.randomServiceAccountAuthentication(),
             AuthenticationTests.randomAnonymousAuthentication(),
             AuthenticationTests.randomInternalAuthentication()


### PR DESCRIPTION
This PR removes run-as support for authentication types other than realm
and API key. The change essentially makes the behaviour closer to
the existing one (in released versions) except for API keys. This is not
to say that the existing behaviour is the best. But we need more time to
agree on the new behaviour.

Relates: #79809
