### PR TITLE
Optimize ShardCoreKeyMap a Little

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
@@ -49,64 +49,68 @@ public final class ShardCoreKeyMap {
      * key of this reader can be found later using {@link #getCoreKeysForIndex(String)}.
      */
     public void add(LeafReader reader) {
-        final ShardId shardId = ShardUtils.extractShardId(reader);
-        if (shardId == null) {
-            throw new IllegalArgumentException("Could not extract shard id from " + reader);
-        }
         final IndexReader.CacheHelper cacheHelper = reader.getCoreCacheHelper();
         if (cacheHelper == null) {
-            throw new IllegalArgumentException("Reader " + reader + " does not support caching");
+            throwReaderNotSupportCaching(reader);
         }
         final IndexReader.CacheKey coreKey = cacheHelper.getKey();
 
         if (coreKeyToShard.containsKey(coreKey)) {
-            // Do this check before entering the synchronized block in order to
+            // Do this check before entering the synchronized block in #doAdd in order to
             // avoid taking the mutex if possible (which should happen most of
             // the time).
             return;
         }
 
+        doAdd(reader, cacheHelper, coreKey);
+    }
+
+    private static void throwReaderNotSupportCaching(LeafReader reader) {
+        throw new IllegalArgumentException("Reader " + reader + " does not support caching");
+    }
+
+    private void doAdd(LeafReader reader, IndexReader.CacheHelper cacheHelper, IndexReader.CacheKey coreKey) {
+        final ShardId shardId = ShardUtils.extractShardId(reader);
+        if (shardId == null) {
+            throw new IllegalArgumentException("Could not extract shard id from " + reader);
+        }
         final String index = shardId.getIndexName();
         synchronized (this) {
-            if (coreKeyToShard.containsKey(coreKey) == false) {
-                Set<IndexReader.CacheKey> objects = indexToCoreKey.get(index);
-                if (objects == null) {
-                    objects = new HashSet<>();
-                    indexToCoreKey.put(index, objects);
-                }
-                final boolean added = objects.add(coreKey);
-                assert added;
-                IndexReader.ClosedListener listener = ownerCoreCacheKey -> {
-                    assert coreKey == ownerCoreCacheKey;
-                    synchronized (ShardCoreKeyMap.this) {
-                        coreKeyToShard.remove(ownerCoreCacheKey);
-                        final Set<IndexReader.CacheKey> coreKeys = indexToCoreKey.get(index);
-                        final boolean removed = coreKeys.remove(coreKey);
-                        assert removed;
-                        if (coreKeys.isEmpty()) {
-                            indexToCoreKey.remove(index);
-                        }
+            if (coreKeyToShard.containsKey(coreKey)) {
+                return;
+            }
+            final boolean added = indexToCoreKey.computeIfAbsent(index, k -> new HashSet<>()).add(coreKey);
+            assert added;
+            IndexReader.ClosedListener listener = ownerCoreCacheKey -> {
+                assert coreKey == ownerCoreCacheKey;
+                synchronized (ShardCoreKeyMap.this) {
+                    coreKeyToShard.remove(ownerCoreCacheKey);
+                    final Set<IndexReader.CacheKey> coreKeys = indexToCoreKey.get(index);
+                    final boolean removed = coreKeys.remove(coreKey);
+                    assert removed;
+                    if (coreKeys.isEmpty()) {
+                        indexToCoreKey.remove(index);
                     }
-                };
-                boolean addedListener = false;
-                try {
-                    cacheHelper.addClosedListener(listener);
-                    addedListener = true;
+                }
+            };
+            boolean addedListener = false;
+            try {
+                cacheHelper.addClosedListener(listener);
+                addedListener = true;
 
-                    // Only add the core key to the map as a last operation so that
-                    // if another thread sees that the core key is already in the
-                    // map (like the check just before this synchronized block),
-                    // then it means that the closed listener has already been
-                    // registered.
-                    ShardId previous = coreKeyToShard.put(coreKey, shardId);
-                    assert previous == null;
-                } finally {
-                    if (false == addedListener) {
-                        try {
-                            listener.onClose(coreKey);
-                        } catch (IOException e) {
-                            throw new RuntimeException("Blow up trying to recover from failure to add listener", e);
-                        }
+                // Only add the core key to the map as a last operation so that
+                // if another thread sees that the core key is already in the
+                // map (like the check just before this synchronized block),
+                // then it means that the closed listener has already been
+                // registered.
+                ShardId previous = coreKeyToShard.put(coreKey, shardId);
+                assert previous == null;
+            } finally {
+                if (false == addedListener) {
+                    try {
+                        listener.onClose(coreKey);
+                    } catch (IOException e) {
+                        throw new RuntimeException("Blow up trying to recover from failure to add listener", e);
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.index.cache.query;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.DocIdSet;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,8 +20,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 public class QueryCacheStats implements Writeable, ToXContentFragment {
-
-    private static final Logger logger = LogManager.getLogger(QueryCacheStats.class);
 
     private long ramBytesUsed;
     private long hitCount;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -273,13 +273,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         }
 
         private Stats getOrCreateStats(Object coreKey) {
-            final ShardId shardId = shardKeyMap.getShardId(coreKey);
-            Stats stats = shardStats.get(shardId);
-            if (stats == null) {
-                stats = new Stats(shardId);
-                shardStats.put(shardId, stats);
-            }
-            return stats;
+            return shardStats.computeIfAbsent(shardKeyMap.getShardId(coreKey), Stats::new);
         }
 
         // It's ok to not protect these callbacks by a lock since it is


### PR DESCRIPTION
Just a random find from seeing this method on the hot path in a performance SDH. No benchmarking or so done but an obvious 5 min of coding improvement here IMO (review with ?w=1, it's a very tiny change).

`org.elasticsearch.common.lucene.ShardCoreKeyMap#add` can be optimized a little:
* Extract the cold path from it so we get a chance to inline better (particularly by not having the synchronized section in the hot method any more)
* Only extract shard id from the reader on the cold path where it's needed


