### PR TITLE
[ML] Register the named X-content parser for snapshot upgrade params

### DIFF
--- a/docs/changelog/84420.yaml
+++ b/docs/changelog/84420.yaml
@@ -1,0 +1,6 @@
+pr: 84420
+summary: Register the named X-content parser for snapshot upgrade params
+area: Machine Learning
+type: bug
+issues:
+ - 84419

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -141,6 +141,7 @@ import org.elasticsearch.xpack.core.ml.action.ValidateJobConfigAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
+import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskParams;
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskState;
 import org.elasticsearch.xpack.core.monitoring.MonitoringFeatureSetUsage;
 import org.elasticsearch.xpack.core.rollup.RollupFeatureSetUsage;
@@ -595,6 +596,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 PersistentTaskParams.class,
                 new ParseField(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME),
                 StartDataFrameAnalyticsAction.TaskParams::fromXContent
+            ),
+            new NamedXContentRegistry.Entry(
+                PersistentTaskParams.class,
+                new ParseField(MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME),
+                SnapshotUpgradeTaskParams::fromXContent
             ),
             // ML - Task states
             new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(DatafeedState.NAME), DatafeedState::fromXContent),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParams.java
@@ -14,6 +14,7 @@ import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.MlTaskParams;
 
@@ -101,5 +102,9 @@ public class SnapshotUpgradeTaskParams implements PersistentTaskParams, MlTaskPa
     @Override
     public String getMlId() {
         return jobId;
+    }
+
+    public static SnapshotUpgradeTaskParams fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParamsTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.job.snapshot.upgrade;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class SnapshotUpgradeTaskParamsTests extends AbstractSerializingTestCase<SnapshotUpgradeTaskParams> {
+
+    @Override
+    protected SnapshotUpgradeTaskParams doParseInstance(XContentParser parser) throws IOException {
+        return SnapshotUpgradeTaskParams.fromXContent(parser);
+    }
+
+    @Override
+    protected SnapshotUpgradeTaskParams createTestInstance() {
+        return new SnapshotUpgradeTaskParams(randomAlphaOfLength(10), randomAlphaOfLength(20));
+    }
+
+    @Override
+    protected Writeable.Reader<SnapshotUpgradeTaskParams> instanceReader() {
+        return SnapshotUpgradeTaskParams::new;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}


### PR DESCRIPTION
Model snapshot upgrade persistent task params may need to be parsed
from X-content if a node is shut down while a model snapshot upgrade
is in progress.

Previously the X-content parser for model snapshot upgrade persistent
task params existed but was not registered. This PR corrects that
omission.

Fixes #84419