### PR TITLE
[8.0] [DOCS] Update CCS forward compatibility docs (#84055)

### DIFF
--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -182,19 +182,24 @@ parameters are ignored, and responses, where warranted, include `_type` :
 [%collapsible]
 ====
 *Details* +
-Elastic only supports searches from a local cluster to a remote cluster running:
+In 8.0+, Elastic supports searches from a local cluster to a remote cluster
+running:
 
 * The previous minor version.
 * The same version.
-* A newer version. This version must also be compatible with the local cluster
-as outlined in the
-{ref}/modules-cross-cluster-search.html#ccs-version-compatibility[compatibility
-matrix].
+* A newer minor version in the same major version.
+
+Elastic also supports searches from a local cluster running the last minor
+version of a major version to a remote cluster running any minor version in the
+following major version. For example, a local 7.17 cluster can search any
+remote 8.x cluster.
+
+include::{es-repo-dir}/search/search-your-data/ccs-version-compat-matrix.asciidoc[]
 
 IMPORTANT: For the {ref}/eql-search-api.html[EQL search API], the local and
 remote clusters must use the same {es} version.
 
-For example, a local 8.0 cluster can search a remote {prev-major-last} or 8.0
+For example, a local 8.0 cluster can search a remote 7.17 or any remote 8.x
 cluster. However, a search from a local 8.0 cluster to a remote 7.16 or 6.8
 cluster is not supported.
 
@@ -203,8 +208,7 @@ Previously, we also supported searches on remote clusters running:
 * Any minor version of the local cluster's major version.
 * The last minor release of the previous major version.
 
-However, such searches can result in undefined behavior, particularly if the
-search uses a recent feature that's unsupported in the remote cluster.
+However, such searches can result in undefined behavior.
 
 *Impact* +
 If you only run cross-cluster searches on remote clusters using the same or a

--- a/docs/reference/search/search-your-data/ccs-version-compat-matrix.asciidoc
+++ b/docs/reference/search/search-your-data/ccs-version-compat-matrix.asciidoc
@@ -1,0 +1,10 @@
+[cols="^,^,^,^,^"]
+|====
+| 4+^h| Remote cluster version
+h| Local cluster version
+                  |  6.8        | 7.1–7.16   | 7.17       | 8.0
+| 6.8             |  {yes-icon} | {yes-icon} | {yes-icon} | {no-icon}
+| 7.1–7.16        |  {yes-icon} | {yes-icon} | {yes-icon} | {no-icon}
+| 7.17            |  {yes-icon} | {yes-icon} | {yes-icon} | {yes-icon}
+| 8.0             |  {no-icon}  | {no-icon}  | {yes-icon} | {yes-icon}
+|====

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -430,26 +430,31 @@ image:images/ccs/ccs-min-roundtrip-client-response.svg[]
 [[ccs-supported-configurations]]
 === Supported {ccs} configurations
 
-Elastic only supports searches from a local cluster to a remote cluster running:
+In 8.0+, Elastic supports searches from a local cluster to a remote cluster
+running:
 
 * The previous minor version.
 * The same version.
-* A newer version. This version must also be compatible with the local cluster
-as outlined in the following matrix.
-+
-[%collapsible]
+* A newer minor version in the same major version.
+
+Elastic also supports searches from a local cluster running the last minor
+version of a major version to a remote cluster running any minor version in the
+following major version. For example, a local 7.17 cluster can search any
+remote 8.x cluster.
+
 [[ccs-version-compatibility]]
-.Version compatibility matrix
-====
-include::{es-repo-dir}/modules/remote-clusters-shared.asciidoc[tag=remote-cluster-compatibility-matrix]
-====
+include::{es-repo-dir}/search/search-your-data/ccs-version-compat-matrix.asciidoc[]
 
 IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
 clusters must use the same {es} version.
 
-For example, a local 8.0 cluster can search a remote {prev-major-last} or 8.0
+For example, a local 8.0 cluster can search a remote 7.17 or any remote 8.x
 cluster. However, a search from a local 8.0 cluster to a remote 7.16 or 6.8
 cluster is not supported.
+
+Only features that exist across all searched clusters are supported. Using a
+feature with a remote cluster where the feature is not supported will result in
+undefined behavior.
 
 A {ccs} using an unsupported configuration may still work. However, such
 searches aren't tested by Elastic, and their behavior isn't guaranteed.
@@ -463,8 +468,7 @@ on the same version of {es}. If you need to maintain clusters with different
 versions, you can:
 
 * Maintain a dedicated cluster for {ccs}. Keep this cluster on the earliest
-version needed to search the other clusters. For example, if you have 6.8, 7.14,
-and {prev-major-last} clusters, you can maintain a dedicated 6.8 cluster to use
+version needed to search the other clusters. For example, if you have 7.17 and 8.x clusters, you can maintain a dedicated 7.17 cluster to use
 as the local cluster for {ccs}.
 
 * Keep each cluster no more than one minor version apart. This lets you use any


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #84055

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)