### PR TITLE
[ML] Add a unit test for snapshot upgrade params serialization

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParams.java
@@ -38,10 +38,6 @@ public class SnapshotUpgradeTaskParams implements XPackPlugin.XPackPersistentTas
         PARSER.declareString(ConstructingObjectParser.constructorArg(), SNAPSHOT_ID);
     }
 
-    public static SnapshotUpgradeTaskParams fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
-
     public static final String NAME = JOB_SNAPSHOT_UPGRADE_TASK_NAME;
 
     private final String jobId;
@@ -106,5 +102,9 @@ public class SnapshotUpgradeTaskParams implements XPackPlugin.XPackPersistentTas
     @Override
     public String getMlId() {
         return jobId;
+    }
+
+    public static SnapshotUpgradeTaskParams fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/snapshot/upgrade/SnapshotUpgradeTaskParamsTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.job.snapshot.upgrade;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class SnapshotUpgradeTaskParamsTests extends AbstractSerializingTestCase<SnapshotUpgradeTaskParams> {
+
+    @Override
+    protected SnapshotUpgradeTaskParams doParseInstance(XContentParser parser) throws IOException {
+        return SnapshotUpgradeTaskParams.fromXContent(parser);
+    }
+
+    @Override
+    protected SnapshotUpgradeTaskParams createTestInstance() {
+        return new SnapshotUpgradeTaskParams(randomAlphaOfLength(10), randomAlphaOfLength(20));
+    }
+
+    @Override
+    protected Writeable.Reader<SnapshotUpgradeTaskParams> instanceReader() {
+        return SnapshotUpgradeTaskParams::new;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}


### PR DESCRIPTION
Model snapshot upgrade persistent task params may need to be parsed
from X-content if a node is shut down while a model snapshot upgrade
is in progress.

This PR adds a unit test for the serialization.

Backport of #84420