### PR TITLE
[master] [DOCS] System indices no longer accessible 8.0 (#84377)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -245,7 +245,7 @@ You should not directly access or modify system indices
 as they contain data essential to the operation of the system.
 
 IMPORTANT: Direct access to system indices is deprecated and
-will no longer be allowed in the next major version.
+will no longer be allowed in a future major version.
 
 [discrete]
 [[api-conventions-parameters]]


### PR DESCRIPTION
# Backport

This is an automatic backport to `master` of:
 - #84377

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)