### PR TITLE
[7.17] [DOCS] System indices no longer accessible 8.0 (#84377)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -180,7 +180,7 @@ You should not directly access or modify system indices
 as they contain data essential to the operation of the system.
 
 IMPORTANT: Direct access to system indices is deprecated and
-will no longer be allowed in the next major version.
+will no longer be allowed in a future major version.
 
 [[date-math-index-names]]
 === Date math support in index and index alias names


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #84377

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)