### PR TITLE
Update painless-reindex-context.asciidoc

### DIFF
--- a/docs/painless/painless-contexts/painless-reindex-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-reindex-context.asciidoc
@@ -32,7 +32,7 @@ reindexed into a target index.
 *Side Effects*
 
 `ctx['op']`::
-        Use the default of `index` to update a document. Set to `none` to
+        Use the default of `index` to update a document. Set to `noop` to
         specify no operation or `delete` to delete the current document from
         the index.
 


### PR DESCRIPTION
ctx['op'] should be set to 'noop', not 'none' when specifying no operation.

Elasticsearch error when using 'none':
```json
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Operation type [none] not allowed, only [noop, index, delete] are allowed"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Operation type [none] not allowed, only [noop, index, delete] are allowed"
  },
  "status" : 400
}
```
