### PR TITLE
[8.1] Adding removable settings to the meta block for more deprecated dynamic settings (#84378)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -109,7 +109,9 @@ public class NodeDeprecationChecks {
         final String details = additionalDetailMessage == null
             ? String.format(Locale.ROOT, "Remove the [%s] setting.", removedSettingKey)
             : String.format(Locale.ROOT, "Remove the [%s] setting. %s", removedSettingKey, additionalDetailMessage);
-        return new DeprecationIssue(deprecationLevel, message, url, details, false, null);
+        boolean canAutoRemoveSetting = removedSetting.exists(clusterSettings) && removedSetting.exists(nodeSettings) == false;
+        Map<String, Object> meta = createMetaMapForRemovableSettings(canAutoRemoveSetting, removedSettingKey);
+        return new DeprecationIssue(deprecationLevel, message, url, details, false, meta);
     }
 
     static DeprecationIssue checkSharedDataPathSetting(


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Adding removable settings to the meta block for more deprecated dynamic settings (#84378)