### PR TITLE
Test: Ignore .tasks index

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
@@ -205,6 +205,7 @@
       cat.shards:
         h: [index, docs]
         s: [docs]
+        index: "foo,bar"
 
 # don't use the store here it's cached and might be stale
   - match:


### PR DESCRIPTION
The test for sorting in `_cat/shards` fails sometimes because it sees
the `.tasks` index. This limits it to only the indices it expects to be
there.
