### PR TITLE
Use 'main' when referring to default branch

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
@@ -2,7 +2,7 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+branch-consistency
     display-name: "elastic / elasticsearch # %BRANCH% - branch consistency"
-    description: Testing of the Elasticsearch master branch version consistency.
+    description: Testing of the Elasticsearch %BRANCH% branch version consistency.
     triggers:
       - timed: "H 7 * * *"
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
@@ -21,7 +21,7 @@
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows
           cancel-builds-on-update: true
-          # We've removed the no-jdk distribution on master as well
+          # We've removed the no-jdk distribution on main as well
           white-list-target-branches:
             - 7.17
             - 7.16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
@@ -21,7 +21,7 @@
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows-sample
           cancel-builds-on-update: true
-          # We've removed the no-jdk distribution on master as well
+          # We've removed the no-jdk distribution on main as well
           white-list-target-branches:
             - 7.17
             - 7.16

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -31,7 +31,7 @@ else
   export JAVA15_HOME="${HOME}"/.java/openjdk15
   export JAVA16_HOME="${HOME}"/.java/openjdk16
 
-  ## 6.8 branch is not referenced from any bwc project in master so we need to
+  ## 6.8 branch is not referenced from any bwc project in main so we need to
   ## resolve its dependencies explicitly
   rm -rf checkout/6.8
   git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
@@ -41,6 +41,6 @@ else
 fi
 
 ## Gradle is able to resolve dependencies resolved with earlier gradle versions
-## therefore we run master _AFTER_ we run 6.8 which uses an earlier gradle version
+## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
 export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
 ./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -40,7 +40,7 @@ import static java.util.Collections.unmodifiableList;
  * At any point in time there will be at least three such versions and potentially four in the case of a staged release.
  * <p>
  * <ul>
- * <li>the current version on the `master` branch</li>
+ * <li>the current version on the `main` branch</li>
  * <li>the staged next <b>minor</b> on the `M.N` branch</li>
  * <li>the unreleased <b>bugfix</b>, `M.N-1` branch</li>
  * <li>the unreleased <b>maintenance</b>, M-1.d.e ( d &gt; 0, e &gt; 0) on the `(M-1).d` branch</li>
@@ -54,7 +54,7 @@ import static java.util.Collections.unmodifiableList;
  * We can reliably figure out which the unreleased versions are due to the convention of always adding the next unreleased
  * version number to server in all branches when a version is released.
  * E.x when M.N.c is released M.N.c+1 is added to the Version class mentioned above in all the following branches:
- *  `M.N`, and `master` so we can reliably assume that the leafs of the version tree are unreleased.
+ *  `M.N`, and `main` so we can reliably assume that the leafs of the version tree are unreleased.
  * This convention is enforced by checking the versions we consider to be unreleased against an
  * authoritative source (maven central).
  * We are then able to map the unreleased version to branches in git and Gradle projects that are capable of checking
@@ -133,8 +133,8 @@ public class BwcVersions {
 
     private String getBranchFor(Version version) {
         if (version.equals(currentVersion.elasticsearch)) {
-            // Just assume the current branch is 'master'. It's actually not important, we never check out the current branch.
-            return "master";
+            // Just assume the current branch is 'main'. It's actually not important, we never check out the current branch.
+            return "main";
         } else {
             return version.getMajor() + "." + version.getMinor();
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
@@ -196,7 +196,7 @@ public class DependenciesInfoTask extends ConventionTask {
         if (licenseInfo.spdxLicense() == false) {
             // License has not be identified as SPDX.
             // As we have the license file, we create a Custom entry with the URL to this license file.
-            final String gitBranch = System.getProperty("build.branch", "master");
+            final String gitBranch = System.getProperty("build.branch", "main");
             final String githubBaseURL = "https://raw.githubusercontent.com/elastic/elasticsearch/" + gitBranch + "/";
             licenseType = licenseInfo.identifier()
                 + ";"

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -235,9 +235,10 @@ public class InternalDistributionBwcSetupPlugin implements InternalPlugin {
             } else {
                 c.getOutputs().files(expectedOutputFile);
             }
-            c.getOutputs().cacheIf("BWC distribution caching is disabled on 'master' branch", task -> {
+            c.getOutputs().cacheIf("BWC distribution caching is disabled on 'main' branch", task -> {
                 String gitBranch = System.getenv("GIT_BRANCH");
-                return BuildParams.isCi() && (gitBranch == null || gitBranch.endsWith("master") == false);
+                return BuildParams.isCi()
+                    && (gitBranch == null || gitBranch.endsWith("master") == false || gitBranch.endsWith("main") == false);
             });
             c.args(projectPath.replace('/', ':') + ":" + assembleTaskName);
             if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {

--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/elastic/elasticsearch/tree/master/docs/changelog",
+  "$id": "https://github.com/elastic/elasticsearch/tree/main/docs/changelog",
   "$ref": "#/definitions/Changelog",
   "definitions": {
     "Changelog": {

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/BwcVersionsSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/BwcVersionsSpec.groovy
@@ -41,7 +41,7 @@ class BwcVersionsSpec extends Specification {
             (v('7.16.2')): new UnreleasedVersionInfo(v('7.16.2'), '7.16', ':distribution:bwc:bugfix'),
             (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.17', ':distribution:bwc:staged'),
             (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.0', ':distribution:bwc:minor'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'master', ':distribution')
+            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
         ]
         bwc.wireCompatible == [v('7.17.0'), v('8.0.0'), v('8.1.0')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.16.2'), v('7.17.0'), v('8.0.0'), v('8.1.0')]
@@ -70,7 +70,7 @@ class BwcVersionsSpec extends Specification {
             (v('7.16.1')): new UnreleasedVersionInfo(v('7.16.1'), '7.16', ':distribution:bwc:bugfix'),
             (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.17', ':distribution:bwc:staged'),
             (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.0', ':distribution:bwc:minor'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'master', ':distribution')
+            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
         ]
         bwc.wireCompatible == [v('7.17.0'), v('8.0.0'), v('8.1.0')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('8.0.0'), v('8.1.0')]
@@ -99,7 +99,7 @@ class BwcVersionsSpec extends Specification {
         unreleased == [
             (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:bugfix'),
             (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.0', ':distribution:bwc:staged'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'master', ':distribution')
+            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
         ]
         bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.1.0')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.1.0')]
@@ -126,7 +126,7 @@ class BwcVersionsSpec extends Specification {
         then:
         unreleased == [
             (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:bugfix'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), 'master', ':distribution'),
+            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), 'main', ':distribution'),
         ]
         bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0')]
@@ -154,7 +154,7 @@ class BwcVersionsSpec extends Specification {
         then:
         unreleased == [
             (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:maintenance'),
-            (v('8.0.1')): new UnreleasedVersionInfo(v('8.0.1'), 'master', ':distribution'),
+            (v('8.0.1')): new UnreleasedVersionInfo(v('8.0.1'), 'main', ':distribution'),
         ]
         bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1')]
@@ -184,7 +184,7 @@ class BwcVersionsSpec extends Specification {
         unreleased == [
             (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:maintenance'),
             (v('8.0.1')): new UnreleasedVersionInfo(v('8.0.1'), '8.0', ':distribution:bwc:bugfix'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'master', ':distribution')
+            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
         ]
         bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1'), v('8.1.0')]
         bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1'), v('8.1.0')]

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -19,7 +19,7 @@ BuildParams.getBwcVersions().forPreviousUnreleased { unreleasedVersion ->
             t -> t.args("resolveAllDependencies", "-Dorg.gradle.warning.mode=none")
         }
         if (currentVersion.getMinor() == 0 && currentVersion.getRevision() == 0) {
-            // We only want to resolve dependencies for live versions of master, without cascading this to older versions
+            // We only want to resolve dependencies for live versions of main, without cascading this to older versions
             tasks.named("resolveAllDependencies").configure {
                 dependsOn(resolveAllBwcDepsTaskProvider)
             }


### PR DESCRIPTION
Replace any old references of master with main. These are mostly
cosmetic, as the name of the default branch doesn't actually affect the
build in any meaningful way.

Relates to https://github.com/elastic/elasticsearch/issues/76950