### PR TITLE
Remove impacts from health API

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -9,7 +9,6 @@
 
   - is_true: cluster_name
   - match:   { status: "green" }
-  - match:   { impacts: [] }
   - match:   { components.cluster_coordination.status: "green" }
   - match:   { components.cluster_coordination.indicators.instance_has_master.status: "green" }
   - match:   { components.cluster_coordination.indicators.instance_has_master.summary: "Health coordinating instance has a master node." }

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -84,7 +84,6 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
             builder.startObject();
             builder.field("status", status.xContentValue());
             builder.field("cluster_name", clusterName.value());
-            builder.array("impacts");
             builder.startObject("components");
             for (HealthComponentResult component : components) {
                 builder.field(component.name(), component, params);


### PR DESCRIPTION
We added an empty list impacts block on the health API. However, we are
not currently using it, so it makes sense to remove this block for now.