### PR TITLE
[Test] Fix FollowIndexSecurityIT by granting needed previleges

### DIFF
--- a/x-pack/plugin/ccr/qa/security/leader-roles.yml
+++ b/x-pack/plugin/ccr/qa/security/leader-roles.yml
@@ -4,7 +4,5 @@ ccruser:
   indices:
     - names: [ 'allowed-index', 'clean-leader', 'forget-leader', 'logs-eu*' ]
       privileges:
-        - monitor
+        - manage
         - read
-        - manage_leader_index
-        - view_index_metadata

--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ccr;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -32,7 +31,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84156")
 public class FollowIndexSecurityIT extends ESCCRRestTestCase {
 
     @Override


### PR DESCRIPTION
CCR user on the leader cluster needs more privileges than what are
documented (#61308). Specifically it needs to renew the retention lease
at a fixed time interval. This PR fixes it by granting the "manage"
index privilege to the CCR user on the leader cluster.

Note we still want to revisit privileges required CCR or at least fix
our documentation. This will be tracked with #61308.

Resolves: #84156
