### PR TITLE
Make ImmutableOpenIntMap implement Map

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -77,7 +77,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         response = client().admin().indices().shardStores(Requests.indicesShardStoresRequest(index).shardStatuses("all")).get();
         assertThat(response.getStoreStatuses().containsKey(index), equalTo(true));
         ImmutableOpenIntMap<List<IndicesShardStoresResponse.StoreStatus>> shardStores = response.getStoreStatuses().get(index);
-        assertThat(shardStores.values().size(), equalTo(2));
+        assertThat(shardStores.size(), equalTo(2));
         for (Map.Entry<Integer, List<IndicesShardStoresResponse.StoreStatus>> shardStoreStatuses : shardStores.entrySet()) {
             for (IndicesShardStoresResponse.StoreStatus storeStatus : shardStoreStatuses.getValue()) {
                 assertThat(storeStatus.getAllocationId(), notNullValue());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1154,7 +1154,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             ).get(MapperService.SINGLE_MAPPING_NAME);
             builder.aliases.putAll(aliases.apply(part.aliases));
             builder.customMetadata.putAll(customData.apply(part.customData));
-            builder.inSyncAllocationIds.putAll(inSyncAllocationIds.apply(part.inSyncAllocationIds));
+            builder.inSyncAllocationIds.putAll((Map<Integer, Set<String>>) inSyncAllocationIds.apply(part.inSyncAllocationIds));
             builder.rolloverInfos.putAll(rolloverInfos.apply(part.rolloverInfos));
             builder.system(isSystem);
             builder.timestampRange(timestampRange);

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -88,8 +88,7 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
 
     @Override
     public boolean containsKey(Object key) {
-        return key instanceof Integer i
-            && map.containsKey(i);
+        return key instanceof Integer i && map.containsKey(i);
     }
 
     @Override
@@ -352,8 +351,7 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
 
         @Override
         public boolean contains(Object o) {
-            return o instanceof Integer i
-                && map.containsKey(i);
+            return o instanceof Integer i && map.containsKey(i);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -21,7 +21,9 @@ import com.carrotsearch.hppc.predicates.IntObjectPredicate;
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import com.carrotsearch.hppc.procedures.IntObjectProcedure;
 
+import java.util.AbstractCollection;
 import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -36,7 +38,7 @@ import java.util.function.Consumer;
  * Can be constructed using a {@link #builder()}, or using {@link #builder(org.elasticsearch.common.collect.ImmutableOpenIntMap)}
  * (which is an optimized option to copy over existing content and modify it).
  */
-public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCursor<VType>> {
+public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, Iterable<IntObjectCursor<VType>> {
 
     private final IntObjectHashMap<VType> map;
 
@@ -44,6 +46,7 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
      * Holds cached entrySet().
      */
     private Set<Map.Entry<Integer, VType>> entrySet;
+    private Set<Integer> keySet;
 
     private ImmutableOpenIntMap(IntObjectHashMap<VType> map) {
         this.map = map;
@@ -81,6 +84,58 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
      */
     public boolean isEmpty() {
         return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return key instanceof Integer i
+            && map.containsKey(i);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        for (int i = 0; i < map.size(); ++i) {
+            if (Objects.equals(map.values[i], value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public VType get(Object key) {
+        if (key instanceof Integer k) {
+            return map.get(k);
+        }
+        return null;
+    }
+
+    @Override
+    public VType put(Integer key, VType value) {
+        throw new UnsupportedOperationException("modification is not supported");
+    }
+
+    @Override
+    public VType remove(Object key) {
+        throw new UnsupportedOperationException("modification is not supported");
+    }
+
+    @Override
+    public void putAll(Map<? extends Integer, ? extends VType> m) {
+        throw new UnsupportedOperationException("modification is not supported");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("modification is not supported");
+    }
+
+    @Override
+    public Set<Integer> keySet() {
+        if (keySet == null) {
+            keySet = new KeySet();
+        }
+        return keySet;
     }
 
     /**
@@ -140,8 +195,18 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
     /**
      * @return Returns a container with all values stored in this map.
      */
-    public ObjectContainer<VType> values() {
-        return map.values();
+    public Collection<VType> values() {
+        return new AbstractCollection<VType>() {
+            @Override
+            public Iterator<VType> iterator() {
+                return valuesIt();
+            }
+
+            @Override
+            public int size() {
+                return map.size();
+            }
+        };
     }
 
     /**
@@ -181,11 +246,11 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
         }
     }
 
-    private final class ConversionIterator implements Iterator<Map.Entry<Integer, VType>> {
+    private final class EntryIterator implements Iterator<Map.Entry<Integer, VType>> {
 
         private final Iterator<IntObjectCursor<VType>> original;
 
-        ConversionIterator() {
+        EntryIterator() {
             this.original = map.iterator();
         }
 
@@ -209,17 +274,52 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
         }
     }
 
-    private final class EntrySet extends AbstractSet<Map.Entry<Integer, VType>> {
+    private final class KeyIterator implements Iterator<Integer> {
+        private int index = 0;
+
+        @Override
+        public boolean hasNext() {
+            return index < map.size();
+        }
+
+        @Override
+        public Integer next() {
+            return map.keys[index++];
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("removal is not supported");
+        }
+    }
+
+    private abstract class UnmodifiableSetView<T> extends AbstractSet<T> {
+
+        @Override
         public int size() {
             return map.size();
         }
 
-        public void clear() {
-            throw new UnsupportedOperationException("removal is unsupported");
+        @Override
+        public Spliterator<T> spliterator() {
+            return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
         }
 
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException("removal is not supported");
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw new UnsupportedOperationException("removal is not supported");
+        }
+    }
+
+    private final class EntrySet extends UnmodifiableSetView<Map.Entry<Integer, VType>> {
+
         public Iterator<Map.Entry<Integer, VType>> iterator() {
-            return new ConversionIterator();
+            return new EntryIterator();
         }
 
         @SuppressWarnings("unchecked")
@@ -236,19 +336,24 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
             return Objects.equals(val, e.getValue());
         }
 
-        public boolean remove(Object o) {
-            throw new UnsupportedOperationException("removal is not supported");
-        }
-
-        public Spliterator<Map.Entry<Integer, VType>> spliterator() {
-            return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
-        }
-
         public void forEach(Consumer<? super Map.Entry<Integer, VType>> action) {
             map.forEach((Consumer<? super IntObjectCursor<VType>>) cursor -> {
                 ImmutableEntry entry = new ImmutableEntry(cursor.key, cursor.value);
                 action.accept(entry);
             });
+        }
+    }
+
+    private final class KeySet extends UnmodifiableSetView<Integer> {
+        @Override
+        public Iterator<Integer> iterator() {
+            return new KeyIterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return o instanceof Integer i
+                && map.containsKey(i);
         }
     }
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -1365,8 +1365,8 @@ public class IndexFollowingIT extends CcrIntegTestCase {
                 new Index("index1", leaderUUID)
             );
 
-            for (final ObjectCursor<IndexShardRoutingTable> shardRoutingTable : leaderRoutingTable.index("index1").shards().values()) {
-                final ShardId shardId = shardRoutingTable.value.shardId();
+            for (final IndexShardRoutingTable shardRoutingTable : leaderRoutingTable.index("index1").shards().values()) {
+                final ShardId shardId = shardRoutingTable.shardId();
                 leaderClient().execute(
                     RetentionLeaseActions.Remove.INSTANCE,
                     new RetentionLeaseActions.RemoveRequest(shardId, retentionLeaseId)

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.ccr;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -95,8 +95,8 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
         int allocationPendingAllShards = 0;
 
         ImmutableOpenIntMap<IndexShardRoutingTable> allShards = clusterState.getRoutingTable().index(index).getShards();
-        for (ObjectCursor<IndexShardRoutingTable> shardRoutingTable : allShards.values()) {
-            for (ShardRouting shardRouting : shardRoutingTable.value.shards()) {
+        for (IndexShardRoutingTable shardRoutingTable : allShards.values()) {
+            for (ShardRouting shardRouting : shardRoutingTable.shards()) {
                 String currentNodeId = shardRouting.currentNodeId();
                 boolean canRemainOnCurrentNode = allocationDeciders.canRemain(
                     shardRouting,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.ActiveShardCount;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.core.ilm;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
@@ -132,8 +132,8 @@ class WaitForIndexColorStep extends ClusterStateWaitStep {
         }
 
         if (indexRoutingTable.allPrimaryShardsActive()) {
-            for (ObjectCursor<IndexShardRoutingTable> shardRouting : indexRoutingTable.getShards().values()) {
-                boolean replicaIndexIsGreen = shardRouting.value.replicaShards().stream().allMatch(ShardRouting::active);
+            for (IndexShardRoutingTable shardRouting : indexRoutingTable.getShards().values()) {
+                boolean replicaIndexIsGreen = shardRouting.replicaShards().stream().allMatch(ShardRouting::active);
                 if (replicaIndexIsGreen == false) {
                     return new Result(false, new Info("index is yellow; not all replica shards are active"));
                 }


### PR DESCRIPTION
This commit makes the ImmutableOpenIntMap wrapper around the hppc int
map implement Java's Map interface. This should ease the interaction
between hppc and non-hppc aware code within Elasticsearch.