### PR TITLE
[8.1] [Test] Fix FollowIndexSecurityIT by granting needed previleges (#84467)

### DIFF
--- a/x-pack/plugin/ccr/qa/security/leader-roles.yml
+++ b/x-pack/plugin/ccr/qa/security/leader-roles.yml
@@ -4,7 +4,5 @@ ccruser:
   indices:
     - names: [ 'allowed-index', 'clean-leader', 'forget-leader', 'logs-eu*' ]
       privileges:
-        - monitor
+        - manage
         - read
-        - manage_leader_index
-        - view_index_metadata


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [Test] Fix FollowIndexSecurityIT by granting needed previleges (#84467)