### PR TITLE
GeoIP update logging

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -249,7 +249,7 @@ public final class DatabaseNodeService implements Closeable {
 
         // 2 types of threads:
         // 1) The thread that checks whether database should be retrieved / updated and creates (^) tmp file (cluster state applied thread)
-        // 2) the thread that downloads the db file, updates the databases map and then removes the tmp file
+        // 2) the thread that downloads the db file from the .geoip_databases index, updates the databases map and then removes the tmp file
         // Thread 2 may have updated the databases map after thread 1 detects that there is no entry (or md5 mismatch) for a database.
         // If thread 2 then also removes the tmp file before thread 1 attempts to create it then we're about to retrieve the same database
         // twice. This check is here to avoid this:
@@ -261,7 +261,7 @@ public final class DatabaseNodeService implements Closeable {
         }
 
         final Path databaseTmpFile = Files.createFile(geoipTmpDirectory.resolve(databaseName + ".tmp"));
-        LOGGER.info("downloading geoip database [{}] to [{}]", databaseName, databaseTmpGzFile);
+        LOGGER.info("retrieve geoip database [{}] from [{}] to [{}]", databaseName, GeoIpDownloader.DATABASES_INDEX, databaseTmpGzFile);
         retrieveDatabase(
             databaseName,
             recordedMd5,
@@ -300,7 +300,7 @@ public final class DatabaseNodeService implements Closeable {
                 Files.delete(databaseTmpGzFile);
             },
             failure -> {
-                LOGGER.error((Supplier<?>) () -> new ParameterizedMessage("failed to download database [{}]", databaseName), failure);
+                LOGGER.error((Supplier<?>) () -> new ParameterizedMessage("failed to retrieve database [{}]", databaseName), failure);
                 try {
                     Files.deleteIfExists(databaseTmpFile);
                     Files.deleteIfExists(databaseTmpGzFile);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -155,7 +155,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
             updateTimestamp(name, state.get(name));
             return;
         }
-        logger.info("updating geoip database [" + name + "]");
+        logger.debug("downloading geoip database [{}]", name);
         String url = databaseInfo.get("url").toString();
         if (url.startsWith("http") == false) {
             // relative url, add it after last slash (i.e resolve sibling) or at the end if there's no slash after http[s]://
@@ -170,7 +170,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
                 state = state.put(name, new Metadata(start, firstChunk, lastChunk - 1, md5, start));
                 updateTaskState();
                 stats = stats.successfulDownload(System.currentTimeMillis() - start).count(state.getDatabases().size());
-                logger.info("updated geoip database [" + name + "]");
+                logger.info("successfully downloaded geoip database [{}]", name);
                 deleteOldChunks(name, firstChunk);
             }
         } catch (Exception e) {


### PR DESCRIPTION
The only place we download the database (in the traditional pull from
the configured endpoint sense) is in the `GeoIpDownloader`. The
`DatabaseNodeService` is looking up the chunks of data we save in the
`.geoip_databases` index.

This updates the logging to be clear about who does what.