### PR TITLE
[8.0] Mute `top_hits aggregation with sequence numbers` YAML test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits_metric.yml
@@ -130,7 +130,9 @@ setup:
 
 ---
 "top_hits aggregation with sequence numbers":
-
+ - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/84500"
   - do:
       search:
         index: my-index


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/84500