### PR TITLE
Assert written metadata is readable (#84142)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateIT.java
@@ -268,15 +268,11 @@ public class ClusterStateIT extends ESIntegTestCase {
 
         @Override
         protected void registerBuiltinWritables() {
-            registerMetadataCustom(
-                NodeCustom.TYPE,
-                NodeCustom::new,
-                parser -> {
-                    // dummy parser just so reloading the CS doesn't throw
-                    parser.skipChildren();
-                    return getInstance();
-                }
-            );
+            registerMetadataCustom(NodeCustom.TYPE, NodeCustom::new, parser -> {
+                // dummy parser just so reloading the CS doesn't throw
+                parser.skipChildren();
+                return getInstance();
+            });
         }
 
         @Override
@@ -302,15 +298,11 @@ public class ClusterStateIT extends ESIntegTestCase {
 
         @Override
         protected void registerBuiltinWritables() {
-            registerMetadataCustom(
-                NodeAndTransportClientCustom.TYPE,
-                NodeAndTransportClientCustom::new,
-                parser -> {
-                    // dummy parser just so reloading the CS doesn't throw
-                    parser.skipChildren();
-                    return getInstance();
-                }
-            );
+            registerMetadataCustom(NodeAndTransportClientCustom.TYPE, NodeAndTransportClientCustom::new, parser -> {
+                // dummy parser just so reloading the CS doesn't throw
+                parser.skipChildren();
+                return getInstance();
+            });
         }
 
         @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateIT.java
@@ -271,7 +271,11 @@ public class ClusterStateIT extends ESIntegTestCase {
             registerMetadataCustom(
                 NodeCustom.TYPE,
                 NodeCustom::new,
-                parser -> { throw new IOException(new UnsupportedOperationException()); }
+                parser -> {
+                    // dummy parser just so reloading the CS doesn't throw
+                    parser.skipChildren();
+                    return getInstance();
+                }
             );
         }
 
@@ -301,7 +305,11 @@ public class ClusterStateIT extends ESIntegTestCase {
             registerMetadataCustom(
                 NodeAndTransportClientCustom.TYPE,
                 NodeAndTransportClientCustom::new,
-                parser -> { throw new IOException(new UnsupportedOperationException()); }
+                parser -> {
+                    // dummy parser just so reloading the CS doesn't throw
+                    parser.skipChildren();
+                    return getInstance();
+                }
             );
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskInitializationFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskInitializationFailureIT.java
@@ -26,6 +26,8 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -89,6 +91,20 @@ public class PersistentTaskInitializationFailureIT extends ESIntegTestCase {
                     PersistentTaskParams.class,
                     FailingInitializationPersistentTaskExecutor.TASK_NAME,
                     FailingInitializationTaskParams::new
+                )
+            );
+        }
+
+        @Override
+        public List<NamedXContentRegistry.Entry> getNamedXContent() {
+            return Collections.singletonList(
+                new NamedXContentRegistry.Entry(
+                    PersistentTaskParams.class,
+                    new ParseField(FailingInitializationPersistentTaskExecutor.TASK_NAME),
+                    p -> {
+                        p.skipChildren();
+                        return new FailingInitializationTaskParams();
+                    }
                 )
             );
         }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -40,10 +40,12 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.RecyclingBytesStreamOutput;
 import org.elasticsearch.common.io.Streams;
@@ -206,7 +208,7 @@ public class PersistedClusterStateService {
 
                 final IndexWriter indexWriter = createIndexWriter(directory, false);
                 closeables.add(indexWriter);
-                metadataIndexWriters.add(new MetadataIndexWriter(directory, indexWriter));
+                metadataIndexWriters.add(new MetadataIndexWriter(path, directory, indexWriter));
             }
             success = true;
         } finally {
@@ -214,7 +216,18 @@ public class PersistedClusterStateService {
                 IOUtils.closeWhileHandlingException(closeables);
             }
         }
-        return new Writer(metadataIndexWriters, nodeId, bigArrays, relativeTimeMillisSupplier, () -> slowWriteLoggingThreshold);
+        return new Writer(
+            metadataIndexWriters,
+            nodeId,
+            bigArrays,
+            relativeTimeMillisSupplier,
+            () -> slowWriteLoggingThreshold,
+            getAssertOnCommit()
+        );
+    }
+
+    CheckedBiConsumer<Path, DirectoryReader, IOException> getAssertOnCommit() {
+        return Assertions.ENABLED ? this::loadOnDiskState : null;
     }
 
     private static IndexWriter createIndexWriter(Directory directory, boolean openExisting) throws IOException {
@@ -585,10 +598,12 @@ public class PersistedClusterStateService {
     private static class MetadataIndexWriter implements Closeable {
 
         private final Logger logger;
+        private final Path path;
         private final Directory directory;
         private final IndexWriter indexWriter;
 
-        MetadataIndexWriter(Directory directory, IndexWriter indexWriter) {
+        MetadataIndexWriter(Path path, Directory directory, IndexWriter indexWriter) {
+            this.path = path;
             this.directory = directory;
             this.indexWriter = indexWriter;
             this.logger = Loggers.getLogger(MetadataIndexWriter.class, directory.toString());
@@ -663,18 +678,24 @@ public class PersistedClusterStateService {
         // next one.
         private int documentBufferUsed;
 
+        @Nullable // if assertions disabled or we explicitly don't want to assert on commit in a test
+        private final CheckedBiConsumer<Path, DirectoryReader, IOException> assertOnCommit;
+
         private Writer(
             List<MetadataIndexWriter> metadataIndexWriters,
             String nodeId,
             BigArrays bigArrays,
             LongSupplier relativeTimeMillisSupplier,
-            Supplier<TimeValue> slowWriteLoggingThresholdSupplier
+            Supplier<TimeValue> slowWriteLoggingThresholdSupplier,
+            @Nullable // if assertions disabled or we explicitly don't want to assert on commit in a test
+            CheckedBiConsumer<Path, DirectoryReader, IOException> assertOnCommit
         ) {
             this.metadataIndexWriters = metadataIndexWriters;
             this.nodeId = nodeId;
             this.bigArrays = bigArrays;
             this.relativeTimeMillisSupplier = relativeTimeMillisSupplier;
             this.slowWriteLoggingThresholdSupplier = slowWriteLoggingThresholdSupplier;
+            this.assertOnCommit = assertOnCommit;
         }
 
         private void ensureOpen() {
@@ -946,6 +967,22 @@ public class PersistedClusterStateService {
             } finally {
                 closeIfAnyIndexWriterHasTragedyOrIsClosed();
             }
+            assert assertOnCommit();
+        }
+
+        private boolean assertOnCommit() {
+            if (assertOnCommit != null /* TODO && Randomness.get().nextInt(100) == 0 */) {
+                // only rarely run this assertion since reloading the whole state can be quite expensive
+                for (final MetadataIndexWriter metadataIndexWriter : metadataIndexWriters) {
+                    try (DirectoryReader directoryReader = DirectoryReader.open(metadataIndexWriter.indexWriter)) {
+                        assertOnCommit.accept(metadataIndexWriter.path, directoryReader);
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            }
+
+            return true;
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -61,6 +61,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
@@ -83,6 +84,7 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -1557,7 +1559,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     private static final NamedXContentRegistry DEFAULT_NAMED_X_CONTENT_REGISTRY = new NamedXContentRegistry(
-        ClusterModule.getNamedXWriteables()
+        CollectionUtils.concatLists(ClusterModule.getNamedXWriteables(), IndicesModule.getNamedXContents())
     );
 
     protected static final NamedWriteableRegistry DEFAULT_NAMED_WRITABLE_REGISTRY = new NamedWriteableRegistry(


### PR DESCRIPTION
We write the cluster state to disk on every update, but we only read it
back when a node restarts. Few tests actually restart nodes at all, and
almost all of the ones that do will wait for the cluster to be in a
specific state before stopping any nodes. This means we are lacking
coverage of reading cluster states from disk.

This commit introduces an assertion which occasionally attempts to
reload the cluster state it just wrote and ensures that this attempt
succeeds and throws no exceptions.

Co-authored-by: Tanguy Leroux <tlrx.dev@gmail.com>