### PR TITLE
[8.1] [DOCS] Remove 8.0.1 coming tag (#84297)

### DIFF
--- a/docs/reference/release-notes/8.0.asciidoc
+++ b/docs/reference/release-notes/8.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.0.1]]
 == {es} version 8.0.1
 
-coming::[8.0.1]
-
 Also see <<breaking-changes-8.0,Breaking changes in 8.0>>.
 
 [[bug-8.0.1]]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #84297

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)