### PR TITLE
[8.1] Getting deprecation.skip_deprecated_settings to work with dynamic settings (#81836) (#84523)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -11,9 +11,13 @@ package org.elasticsearch.common.logging;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A logger that logs deprecation notices. Logger should be initialized with a class or name which will be used
@@ -35,7 +39,7 @@ public class DeprecationLogger {
      * More serious that WARN by 1, but less serious than ERROR
      */
     public static Level CRITICAL = Level.forName("CRITICAL", Level.WARN.intLevel() - 1);
-
+    private static volatile List<String> skipTheseDeprecations = Collections.emptyList();
     private final Logger logger;
 
     /**
@@ -54,6 +58,19 @@ public class DeprecationLogger {
      */
     public static DeprecationLogger getLogger(String name) {
         return new DeprecationLogger(name);
+    }
+
+    /**
+     * The DeprecationLogger uses the "deprecation.skip_deprecated_settings" setting to decide whether to log a deprecation for a setting.
+     * This is a node setting. This method initializes the DeprecationLogger class with the node settings for the node in order to read the
+     * "deprecation.skip_deprecated_settings" setting. This only needs to be called once per JVM. If it is not called, the default behavior
+     * is to assume that the "deprecation.skip_deprecated_settings" setting is not set.
+     * @param nodeSettings The settings for this node
+     */
+    public static void initialize(Settings nodeSettings) {
+        skipTheseDeprecations = nodeSettings == null
+            ? Collections.emptyList()
+            : nodeSettings.getAsList("deprecation.skip_deprecated_settings");
     }
 
     private DeprecationLogger(String parentLoggerName) {
@@ -95,12 +112,14 @@ public class DeprecationLogger {
     }
 
     private DeprecationLogger logDeprecation(Level level, DeprecationCategory category, String key, String msg, Object[] params) {
-        assert category != DeprecationCategory.COMPATIBLE_API
-            : "DeprecationCategory.COMPATIBLE_API should be logged with compatibleApiWarning method";
-        String opaqueId = HeaderWarning.getXOpaqueId();
-        String productOrigin = HeaderWarning.getProductOrigin();
-        ESLogMessage deprecationMessage = DeprecatedMessage.of(category, key, opaqueId, productOrigin, msg, params);
-        doPrivilegedLog(level, deprecationMessage);
+        if (Regex.simpleMatch(skipTheseDeprecations, key) == false) {
+            assert category != DeprecationCategory.COMPATIBLE_API
+                : "DeprecationCategory.COMPATIBLE_API should be logged with compatibleApiWarning method";
+            String opaqueId = HeaderWarning.getXOpaqueId();
+            String productOrigin = HeaderWarning.getProductOrigin();
+            ESLogMessage deprecationMessage = DeprecatedMessage.of(category, key, opaqueId, productOrigin, msg, params);
+            doPrivilegedLog(level, deprecationMessage);
+        }
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -579,14 +579,11 @@ public class Setting<T> implements ToXContentObject {
         if (this.isDeprecated() && this.exists(settings)) {
             // It would be convenient to show its replacement key, but replacement is often not so simple
             final String key = getKey();
-            List<String> skipTheseDeprecations = settings.getAsList("deprecation.skip_deprecated_settings");
-            if (Regex.simpleMatch(skipTheseDeprecations, key) == false) {
-                String message = "[{}] setting was deprecated in Elasticsearch and will be removed in a future release.";
-                if (this.isDeprecatedWarningOnly()) {
-                    Settings.DeprecationLoggerHolder.deprecationLogger.warn(DeprecationCategory.SETTINGS, key, message, key);
-                } else {
-                    Settings.DeprecationLoggerHolder.deprecationLogger.critical(DeprecationCategory.SETTINGS, key, message, key);
-                }
+            String message = "[{}] setting was deprecated in Elasticsearch and will be removed in a future release.";
+            if (this.isDeprecatedWarningOnly()) {
+                Settings.DeprecationLoggerHolder.deprecationLogger.warn(DeprecationCategory.SETTINGS, key, message, key);
+            } else {
+                Settings.DeprecationLoggerHolder.deprecationLogger.critical(DeprecationCategory.SETTINGS, key, message, key);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -300,6 +300,8 @@ public class Node implements Closeable {
         final List<Closeable> resourcesToClose = new ArrayList<>(); // register everything we need to release in the case of an error
         boolean success = false;
         try {
+            // Pass the node settings to the DeprecationLogger class so that it can have the deprecation.skip_deprecated_settings setting:
+            DeprecationLogger.initialize(initialEnvironment.settings());
             Settings tmpSettings = Settings.builder()
                 .put(initialEnvironment.settings())
                 .put(Client.CLIENT_TYPE_SETTING_S.getKey(), CLIENT_TYPE)

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.AbstractScopedSettings.SettingUpdater;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -1396,7 +1397,7 @@ public class SettingTests extends ESTestCase {
     }
 
     public void testCheckForDeprecationWithSkipSetting() {
-        final String settingName = "foo.bar";
+        final String settingName = "foo.bar.hide.this";
         final String settingValue = "blat";
         final Setting<String> setting = Setting.simpleString(settingName, settingValue);
         final Settings settings = Settings.builder().put(settingName, settingValue).build();
@@ -1409,6 +1410,7 @@ public class SettingTests extends ESTestCase {
             .put(settingName, settingValue)
             .putList("deprecation.skip_deprecated_settings", settingName)
             .build();
+        DeprecationLogger.initialize(settingsWithSkipDeprecationSetting);
         deprecatedSetting.checkDeprecation(settingsWithSkipDeprecationSetting);
         ensureNoWarnings();
     }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Getting deprecation.skip_deprecated_settings to work with dynamic settings (#81836) (#84523)