### PR TITLE
Fixing the reference time so that age does not change during IndexLifecycleExplainResponseTests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
@@ -133,6 +133,8 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
     private final String snapshotName;
     private final String shrinkIndexName;
 
+    Supplier<Long> nowSupplier = System::currentTimeMillis; // Can be changed for testing
+
     public static IndexLifecycleExplainResponse newManagedIndexResponse(
         String index,
         Long indexCreationDate,
@@ -463,12 +465,12 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
                 );
                 builder.field(
                     TIME_SINCE_INDEX_CREATION_FIELD.getPreferredName(),
-                    getTimeSinceIndexCreation(System::currentTimeMillis).toHumanReadableString(2)
+                    getTimeSinceIndexCreation(nowSupplier).toHumanReadableString(2)
                 );
             }
             if (lifecycleDate != null) {
                 builder.timeField(LIFECYCLE_DATE_MILLIS_FIELD.getPreferredName(), LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
-                builder.field(AGE_FIELD.getPreferredName(), getAge(System::currentTimeMillis).toHumanReadableString(2));
+                builder.field(AGE_FIELD.getPreferredName(), getAge(nowSupplier).toHumanReadableString(2));
             }
             if (phase != null) {
                 builder.field(PHASE_FIELD.getPreferredName(), phase);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
@@ -37,11 +37,16 @@ import static org.hamcrest.Matchers.startsWith;
 public class IndexLifecycleExplainResponseTests extends AbstractSerializingTestCase<IndexLifecycleExplainResponse> {
 
     static IndexLifecycleExplainResponse randomIndexExplainResponse() {
+        final IndexLifecycleExplainResponse indexLifecycleExplainResponse;
         if (frequently()) {
-            return randomManagedIndexExplainResponse();
+            indexLifecycleExplainResponse = randomManagedIndexExplainResponse();
         } else {
-            return randomUnmanagedIndexExplainResponse();
+            indexLifecycleExplainResponse = randomUnmanagedIndexExplainResponse();
         }
+        long now = System.currentTimeMillis();
+        // So that now is the same for the duration of the test. See #84352
+        indexLifecycleExplainResponse.nowSupplier = () -> now;
+        return indexLifecycleExplainResponse;
     }
 
     private static IndexLifecycleExplainResponse randomUnmanagedIndexExplainResponse() {


### PR DESCRIPTION
This change makes it so that the reference time from which the "age" field of the IndexLifecycleExplainResponse
object is derived does not change for the duration of testConcurrentToXContent().
Closes #84352