### PR TITLE
Test: skip fetch fields in top_hits pre-7.10

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
@@ -227,8 +227,8 @@ named queries:
 ---
 fetch fields:
   - skip:
-        version: " - 6.99.99"
-        reason:  "total hits moved in 7.0.0"
+        version: " - 7.9.99"
+        reason:  "fetch fields to top_hits in 7.10.0"
 
   - do:
       search:


### PR DESCRIPTION
We added `fields` support to `top_hits` in 7.10. Tests against a cluster
containing 7.9 nodes isn't likely to work....

Closes #84525

