### PR TITLE
[7.17] Use 'main' when referring to default branch (#84463)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
@@ -2,7 +2,7 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+branch-consistency
     display-name: "elastic / elasticsearch # %BRANCH% - branch consistency"
-    description: Testing of the Elasticsearch master branch version consistency.
+    description: Testing of the Elasticsearch %BRANCH% branch version consistency.
     triggers:
       - timed: "H 7 * * *"
     builders:

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -25,3 +25,16 @@ export JAVA13_HOME="${HOME}"/.java/openjdk13
 export JAVA14_HOME="${HOME}"/.java/openjdk14
 ./gradlew --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies
 
+  ## 6.8 branch is not referenced from any bwc project in main so we need to
+  ## resolve its dependencies explicitly
+  rm -rf checkout/6.8
+  git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
+  export JAVA_HOME="${JAVA11_HOME}"
+  ./checkout/6.8/gradlew --project-dir ./checkout/6.8 --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true --stacktrace resolveAllDependencies
+  rm -rf ./checkout/6.8
+fi
+
+## Gradle is able to resolve dependencies resolved with earlier gradle versions
+## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
+export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
+./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
@@ -196,7 +196,7 @@ public class DependenciesInfoTask extends ConventionTask {
         if (licenseInfo.isSpdxLicense() == false) {
             // License has not be identified as SPDX.
             // As we have the license file, we create a Custom entry with the URL to this license file.
-            final String gitBranch = System.getProperty("build.branch", "master");
+            final String gitBranch = System.getProperty("build.branch", "main");
             final String githubBaseURL = "https://raw.githubusercontent.com/elastic/elasticsearch/" + gitBranch + "/";
             licenseType = licenseInfo.getIdentifier()
                 + ";"

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -237,9 +237,10 @@ public class InternalDistributionBwcSetupPlugin implements InternalPlugin {
             } else {
                 c.getOutputs().files(expectedOutputFile);
             }
-            c.getOutputs().cacheIf("BWC distribution caching is disabled on 'master' branch", task -> {
+            c.getOutputs().cacheIf("BWC distribution caching is disabled on 'main' branch", task -> {
                 String gitBranch = System.getenv("GIT_BRANCH");
-                return BuildParams.isCi() && (gitBranch == null || gitBranch.endsWith("master") == false);
+                return BuildParams.isCi()
+                    && (gitBranch == null || gitBranch.endsWith("master") == false || gitBranch.endsWith("main") == false);
             });
             c.args(projectPath.replace('/', ':') + ":" + assembleTaskName);
             if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {

--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/elastic/elasticsearch/tree/master/docs/changelog",
+  "$id": "https://github.com/elastic/elasticsearch/tree/main/docs/changelog",
   "$ref": "#/definitions/Changelog",
   "definitions": {
     "Changelog": {

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -19,7 +19,7 @@ BuildParams.getBwcVersions().forPreviousUnreleased { unreleasedVersion ->
             t -> t.args("resolveAllDependencies")
         }
         if (currentVersion.getMinor() == 0 && currentVersion.getRevision() == 0) {
-            // We only want to resolve dependencies for live versions of master, without cascading this to older versions
+            // We only want to resolve dependencies for live versions of main, without cascading this to older versions
             tasks.named("resolveAllDependencies").configure {
                 dependsOn(resolveAllBwcDepsTaskProvider)
             }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use 'main' when referring to default branch (#84463)