### PR TITLE
Adding a check that a test attribute name is not also a role name

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -263,7 +264,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         Map<String, String> validAttributes = new HashMap<>();
         for (int i = 0; i < numAttrs; i++) {
             validAttributes.put(
-                randomValueOtherThanMany(validAttributes::containsKey, () -> randomAlphaOfLengthBetween(1, 20)),
+                randomValueOtherThanMany(
+                    attr -> validAttributes.containsKey(attr) || DiscoveryNodeRole.roleNames().contains(attr),
+                    () -> randomAlphaOfLengthBetween(1, 20)
+                ),
                 randomAlphaOfLengthBetween(1, 20)
             );
         }


### PR DESCRIPTION
SetSingleNodeAllocateStepTests.testPerformActionAttrsRequestFails() randomly generates attribute names. In rare
cases the attribute name happens to be a role name. When that happens we get a stack trace like:
```
java.lang.AssertionError: Node roles must not be provided as attributes but saw attributes {ml=hBMqqQPjpdFWLMvGFle}

	at __randomizedtesting.SeedInfo.seed([6B438F3C3DADE5D2:662CBD8302D65AFD]:0)
	at org.elasticsearch.cluster.node.DiscoveryNode.<init>(DiscoveryNode.java:238)
	at org.elasticsearch.cluster.node.DiscoveryNode.<init>(DiscoveryNode.java:179)
	at org.elasticsearch.cluster.node.DiscoveryNode.createLocal(DiscoveryNode.java:247)
	at org.elasticsearch.xpack.core.ilm.SetSingleNodeAllocateStepTests.testPerformActionAttrsRequestFails(SetSingleNodeAllocateStepTests.java:298)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```
This change makes sure that test attribute names are not also role names.
Closes #84159