### PR TITLE
Fix ImmutableOpenIntMap.containsValue to use object iterator

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -17,6 +17,7 @@ import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.ObjectContainer;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.predicates.IntObjectPredicate;
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import com.carrotsearch.hppc.procedures.IntObjectProcedure;
@@ -93,8 +94,8 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
 
     @Override
     public boolean containsValue(Object value) {
-        for (int i = 0; i < map.size(); ++i) {
-            if (Objects.equals(map.values[i], value)) {
+        for (ObjectCursor<VType> cursor : map.values()) {
+            if (Objects.equals(cursor.value, value)) {
                 return true;
             }
         }

--- a/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
@@ -241,10 +241,7 @@ public class ImmutableOpenMapTests extends ESTestCase {
     }
 
     public void testIntMapContainsValue() {
-        ImmutableOpenIntMap<String> map = ImmutableOpenIntMap.<String>builder()
-            .fPut(1, "foo")
-            .fPut(2, "bar")
-            .build();
+        ImmutableOpenIntMap<String> map = ImmutableOpenIntMap.<String>builder().fPut(1, "foo").fPut(2, "bar").build();
         assertTrue(map.containsValue("bar"));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
@@ -240,6 +240,14 @@ public class ImmutableOpenMapTests extends ESTestCase {
         assertFalse(map.entrySet().contains(entry(2, null)));
     }
 
+    public void testIntMapContainsValue() {
+        ImmutableOpenIntMap<String> map = ImmutableOpenIntMap.<String>builder()
+            .fPut(1, "foo")
+            .fPut(2, "bar")
+            .build();
+        assertTrue(map.containsValue("bar"));
+    }
+
     private static <KType, VType> Map.Entry<KType, VType> entry(KType key, VType value) {
         Map<KType, VType> map = Maps.newMapWithExpectedSize(1);
         map.put(key, value);


### PR DESCRIPTION
This commit fixes a bug in the implementation of containsValue so that
it does not incorrectly iterate over the underlying values array, which
may have more elements than the map size. A test is also added to ensure
the method now works as expected.