### PR TITLE
[7.17] Use providers for expensive input calculation in testingconvention task (#84508)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
@@ -18,6 +18,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 
+import java.util.stream.Collectors;
+
 public class TestingConventionsPrecommitPlugin extends PrecommitPlugin implements InternalPlugin {
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
@@ -31,8 +33,15 @@ public class TestingConventionsPrecommitPlugin extends PrecommitPlugin implement
                 itRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");
 
                 t.setNaming(namings);
-                t.setTestTasks(project.getTasks().withType(Test.class).matching(test -> test.isEnabled()));
-
+                t.setCandidateClassFilesProvider(
+                    project.provider(
+                        () -> project.getTasks()
+                            .withType(Test.class)
+                            .matching(Task::getEnabled)
+                            .stream()
+                            .collect(Collectors.toMap(Task::getPath, task -> task.getCandidateClassFiles().getFiles()))
+                    )
+                );
                 SourceSetContainer javaSourceSets = GradleUtils.getJavaSourceSets(project);
                 t.setSourceSets(javaSourceSets);
                 // Run only after everything is compiled

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsTasks.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsTasks.java
@@ -11,18 +11,16 @@ import groovy.lang.Closure;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.NamedDomainObjectContainer;
-import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.TaskCollection;
-import org.gradle.api.tasks.testing.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,7 +57,12 @@ public class TestingConventionsTasks extends DefaultTask {
     private ProjectLayout projectLayout;
 
     private SourceSetContainer sourceSets;
-    private TaskCollection<Test> testTasks;
+    private Provider<Map<String, Set<File>>> candidateClassFilesProvider;
+    private Map<String, Set<File>> candidateClassFiles;
+
+    public void setCandidateClassFilesProvider(Provider<Map<String, Set<File>>> candidateClassFilesProvider) {
+        this.candidateClassFilesProvider = candidateClassFilesProvider;
+    }
 
     @Inject
     public TestingConventionsTasks(ProjectLayout projectLayout) {
@@ -69,7 +72,8 @@ public class TestingConventionsTasks extends DefaultTask {
 
     @Input
     public Map<String, Set<File>> getClassFilesPerEnabledTask() {
-        return testTasks.stream().collect(Collectors.toMap(Task::getPath, task -> task.getCandidateClassFiles().getFiles()));
+        candidateClassFiles = candidateClassFilesProvider.get();
+        return candidateClassFiles;
     }
 
     @Input
@@ -147,7 +151,7 @@ public class TestingConventionsTasks extends DefaultTask {
                     .collect(Collectors.toList())
             ).getAsFileTree();
 
-            final Map<String, Set<File>> classFilesPerTask = getClassFilesPerEnabledTask();
+            final Map<String, Set<File>> classFilesPerTask = candidateClassFiles;
 
             final Set<File> testSourceSetFiles = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath().getFiles();
             final Map<String, Set<Class<?>>> testClassesPerTask = classFilesPerTask.entrySet()
@@ -408,10 +412,6 @@ public class TestingConventionsTasks extends DefaultTask {
         } catch (MalformedURLException e) {
             throw new IllegalStateException(e);
         }
-    }
-
-    public void setTestTasks(TaskCollection<Test> testTasks) {
-        this.testTasks = testTasks;
     }
 
     public void setSourceSets(SourceSetContainer sourceSets) {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use providers for expensive input calculation in testingconvention task (#84508)