### PR TITLE
Fix ImmutableOpenIntMap ketSet to use keys iterator

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -274,16 +274,16 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
     }
 
     private final class KeyIterator implements Iterator<Integer> {
-        private int index = 0;
+        private final Iterator<IntObjectCursor<VType>> cursor = map.iterator();
 
         @Override
         public boolean hasNext() {
-            return index < map.size();
+            return cursor.hasNext();
         }
 
         @Override
         public Integer next() {
-            return map.keys[index++];
+            return cursor.next().key;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/ImmutableOpenMapTests.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ImmutableOpenMapTests extends ESTestCase {
 
@@ -101,6 +102,18 @@ public class ImmutableOpenMapTests extends ESTestCase {
             regionCurrencySymbols.keySet().stream().filter(e -> e.startsWith("U") == false).collect(Collectors.toSet()),
             equalTo(Set.of("Japan", "EU", "Korea"))
         );
+    }
+
+    public void testIntMapKeySet() {
+        ImmutableOpenIntMap<String> map = ImmutableOpenIntMap.<String>builder().fPut(1, "foo").fPut(2, "bar").build();
+        Set<Integer> expectedKeys = Set.of(1, 2);
+        Set<Integer> actualKeys = map.keySet();
+        assertThat(actualKeys.contains(1), is(true));
+        assertThat(actualKeys.contains(2), is(true));
+        assertThat(actualKeys, equalTo(expectedKeys));
+        assertThat(expectedKeys, equalTo(actualKeys));
+        assertThat(expectedKeys.stream().filter(actualKeys::contains).count(), equalTo(2L));
+        assertThat(actualKeys.stream().filter(expectedKeys::contains).count(), equalTo(2L));
     }
 
     public void testSortedKeysSet() {


### PR DESCRIPTION
While reviewing another issue, it was noticed that directly accessing
the `keys` or `values` fields of IntObjectHashMap by index is
problematic. This commit fixes the key set iterator return by
ImmutableOpenIntMap::keySet to use IntObjectHashMap::iterator rather
than accessing the keys directly.

Alternatively, IntObjectHashMap::keys could be used (rather than
IntObjectHashMap::iterator), but it was avoided becaue it materializes a
KeysContainer for each iterator created. But this is probably ok too.

A test has been added that compares key sets and expected values in both
directions, since actual iterator and contains implementations used
varies dependending on which set is used as the expected set - and this
matters. Additionally, what hamcrest actually does to compare these sets
is not obvious, so I added a couple of low-level comparison scenarios
that exercise the Set methods directly.