### PR TITLE
Script DV Test: set shards to 1

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vectors/60_knn_and_binary_dv_fields_api.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vectors/60_knn_and_binary_dv_fields_api.yml
@@ -8,6 +8,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -92,6 +94,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -176,6 +180,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -293,6 +299,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -409,6 +417,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -483,6 +493,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -583,6 +595,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -699,6 +713,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:
@@ -795,6 +811,8 @@
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: "1"
           mappings:
             properties:
               bdv:


### PR DESCRIPTION
Expected script failures in yaml tests succeed if there is an empty shard.

Forcing one shard ensures expected behavior.

Fixes: #84556