### PR TITLE
Make rollover cancellable #81763

### DIFF
--- a/docs/changelog/84584.yaml
+++ b/docs/changelog/84584.yaml
@@ -1,0 +1,6 @@
+pr: 84584
+summary: "Make rollover cancellable #81763"
+area: ILM+SLM
+type: enhancement
+issues:
+ - 81763

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RolloverRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RolloverRestCancellationIT.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http;
+
+import org.apache.http.client.methods.HttpPost;
+import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
+import org.elasticsearch.client.Request;
+
+public class RolloverRestCancellationIT extends BlockedSearcherRestCancellationTestCase {
+
+    public void testIndicesStatsRestCancellation() throws Exception {
+        runTest(new Request(HttpPost.METHOD_NAME, "test/_rollover"), RolloverAction.NAME);
+    }
+}

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RolloverRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RolloverRestCancellationIT.java
@@ -14,7 +14,7 @@ import org.elasticsearch.client.Request;
 
 public class RolloverRestCancellationIT extends BlockedSearcherRestCancellationTestCase {
 
-    public void testIndicesStatsRestCancellation() throws Exception {
+    public void testRolloverRestCancellation() throws Exception {
         runTest(new Request(HttpPost.METHOD_NAME, "test/_rollover"), RolloverAction.NAME);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -20,6 +20,9 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
@@ -298,5 +301,10 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
     // param isTypeIncluded decides how mappings should be parsed from XContent
     public void fromXContent(boolean isTypeIncluded, XContentParser parser) throws IOException {
         PARSER.parse(parser, this, isTypeIncluded);
+    }
+
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        return new CancellableTask(id, type, action, "", parentTaskId, headers);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -116,6 +117,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         final ActionListener<RolloverResponse> listener
     ) throws Exception {
 
+        assert task instanceof CancellableTask;
         Metadata metadata = oldState.metadata();
 
         IndicesStatsRequest statsRequest = new IndicesStatsRequest().indices(rolloverRequest.getRolloverTarget())
@@ -164,7 +166,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     .values()
                     .stream()
                     .filter(condition -> trialConditionResults.get(condition.toString()))
-                    .collect(Collectors.toList());
+                    .toList();
 
                 final RolloverResponse trialRolloverResponse = new RolloverResponse(
                     trialSourceIndexName,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
@@ -48,7 +49,9 @@ public class RestRolloverIndexAction extends BaseRestHandler {
         rolloverIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", rolloverIndexRequest.masterNodeTimeout()));
         rolloverIndexRequest.getCreateIndexRequest()
             .waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
-        return channel -> client.admin().indices().rolloverIndex(rolloverIndexRequest, new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
+            .indices()
+            .rolloverIndex(rolloverIndexRequest, new RestToXContentListener<>(channel));
     }
 
     private boolean includeTypeName(RestRequest request) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -55,7 +55,7 @@ import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
-import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -316,7 +316,7 @@ public class TransportRolloverActionTests extends ESTestCase {
         RolloverRequest rolloverRequest = new RolloverRequest("logs-alias", "logs-index-000003");
         rolloverRequest.addMaxIndexDocsCondition(500L);
         rolloverRequest.dryRun(true);
-        transportRolloverAction.masterOperation(mock(Task.class), rolloverRequest, stateBefore, future);
+        transportRolloverAction.masterOperation(mock(CancellableTask.class), rolloverRequest, stateBefore, future);
 
         RolloverResponse response = future.actionGet();
         assertThat(response.getOldIndex(), equalTo("logs-index-000002"));
@@ -332,7 +332,7 @@ public class TransportRolloverActionTests extends ESTestCase {
         rolloverRequest = new RolloverRequest("logs-alias", "logs-index-000003");
         rolloverRequest.addMaxIndexDocsCondition(300L);
         rolloverRequest.dryRun(true);
-        transportRolloverAction.masterOperation(mock(Task.class), rolloverRequest, stateBefore, future);
+        transportRolloverAction.masterOperation(mock(CancellableTask.class), rolloverRequest, stateBefore, future);
 
         response = future.actionGet();
         assertThat(response.getOldIndex(), equalTo("logs-index-000002"));


### PR DESCRIPTION
We use the `RestCancellableNodeClient` in combination with the `CancellableTask` to cancel a rollover if the user closed their connection.

Resolves #81763