### PR TITLE
Fix PolicyStepsRegistry's cachedSteps null handling

### DIFF
--- a/docs/changelog/84588.yaml
+++ b/docs/changelog/84588.yaml
@@ -1,0 +1,5 @@
+pr: 84588
+summary: Fix `PolicyStepsRegistry's` `cachedSteps` null handling
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -357,6 +357,9 @@ public class PolicyStepsRegistry {
         final Step s = phaseSteps.stream().filter(step -> step.getKey().equals(stepKey)).findFirst().orElse(null);
         if (s != null) {
             cachedSteps.put(indexMetadata.getIndex(), Tuple.tuple(indexMetadata, s));
+            // assert that the cache works as expected -- that is, if we put something into the cache,
+            // we should get back the same thing if we were to invoke getStep again with the same arguments
+            assert s == getStep(indexMetadata, stepKey);
         }
         return s;
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -309,8 +309,11 @@ public class PolicyStepsRegistry {
         // n.b. we're using instance equality here for the IndexMetadata rather than object equality because it's fast,
         // this means that we're erring on the side of cache misses (if the IndexMetadata changed in any way, it'll be
         // a new instance, so we'll miss-and-repopulate the cache for the index in question)
-        if (cachedStep != null && cachedStep.v1() == indexMetadata && cachedStep.v2().getKey().equals(stepKey)) {
-            return cachedStep.v2();
+        if (cachedStep != null && cachedStep.v1() == indexMetadata) {
+            assert cachedStep.v2() != null;
+            if (cachedStep.v2() != null && cachedStep.v2().getKey().equals(stepKey)) {
+                return cachedStep.v2();
+            }
         }
 
         if (ErrorStep.NAME.equals(stepKey.getName())) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -352,7 +352,9 @@ public class PolicyStepsRegistry {
 
         // Return the step that matches the given stepKey or else null if we couldn't find it
         final Step s = phaseSteps.stream().filter(step -> step.getKey().equals(stepKey)).findFirst().orElse(null);
-        cachedSteps.put(indexMetadata.getIndex(), Tuple.tuple(indexMetadata, s));
+        if (s != null) {
+            cachedSteps.put(indexMetadata.getIndex(), Tuple.tuple(indexMetadata, s));
+        }
         return s;
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -310,7 +310,7 @@ public class PolicyStepsRegistry {
         // this means that we're erring on the side of cache misses (if the IndexMetadata changed in any way, it'll be
         // a new instance, so we'll miss-and-repopulate the cache for the index in question)
         if (cachedStep != null && cachedStep.v1() == indexMetadata) {
-            assert cachedStep.v2() != null;
+            assert cachedStep.v2() != null : "null steps should never be cached in the policy step registry";
             if (cachedStep.v2() != null && cachedStep.v2().getKey().equals(stepKey)) {
                 return cachedStep.v2();
             }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -191,11 +191,10 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         SortedMap<String, LifecyclePolicyMetadata> metas = new TreeMap<>();
         metas.put("policy", policyMetadata);
         PolicyStepsRegistry registry = new PolicyStepsRegistry(metas, null, null, REGISTRY, client, null);
-        Step actualStep = registry.getStep(
-            indexMetadata,
-            new Step.StepKey(step.getKey().getPhase(), step.getKey().getAction(), step.getKey().getName() + "-bad")
-        );
-        assertNull(actualStep);
+        Step.StepKey badStepKey = new Step.StepKey(step.getKey().getPhase(), step.getKey().getAction(), step.getKey().getName() + "-bad");
+        assertNull(registry.getStep(indexMetadata, badStepKey));
+        // repeat the test to make sure that nulls don't poison the registry's cache
+        assertNull(registry.getStep(indexMetadata, badStepKey));
     }
 
     public void testUpdateFromNothingToSomethingToNothing() throws Exception {


### PR DESCRIPTION
Fix for a bug introduced in #82316

In the event that we cache a null (~= "not found") for a given IndexMetadata and StepKey, then subsequent lookups via that same IndexMetadata and StepKey will NPE instead of merely returning null.

As a fix, I've gone with no longer caching nulls paired with asserts that make sure we never find a null in the cache, and that if we put something into the cache we can always pull that exact same thing back out on a subsequent call to ~getStep~ getCachedStep with the same arguments.