### PR TITLE
Clean ctors for IncludeExclude

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -336,7 +336,7 @@ public class MinDocCountIT extends AbstractTermsTestCase {
                         .executionHint(randomExecutionHint())
                         .order(order)
                         .size(size)
-                        .includeExclude(include == null ? null : new IncludeExclude(include, null))
+                        .includeExclude(include == null ? null : new IncludeExclude(include, null, null, null))
                         .shardSize(cardinality + randomInt(10))
                         .minDocCount(minDocCount)
                 )

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
@@ -349,7 +349,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(
                 terms(termsName).field("tag")
-                    .includeExclude(new IncludeExclude(null, "tag.*"))
+                    .includeExclude(new IncludeExclude(null, "tag.*", null, null))
                     .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
             )
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum"))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -104,7 +104,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(
                 terms(termsName).field("tag")
-                    .includeExclude(new IncludeExclude(null, "tag.*"))
+                    .includeExclude(new IncludeExclude(null, "tag.*", null, null))
                     .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
             )
             .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum").setPercents(PERCENTS))

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -69,15 +69,20 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
             throw new IllegalArgumentException("Cannot specify any excludes when using a partition-based include");
         }
 
-        return new IncludeExclude(include.include, exclude.exclude, include.includeValues, exclude.excludeValues);
+        return new IncludeExclude(
+            include.include == null ? null : include.include.getOriginalString(),
+            exclude.exclude == null ? null : exclude.exclude.getOriginalString(),
+            include.includeValues,
+            exclude.excludeValues
+        );
     }
 
     public static IncludeExclude parseInclude(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.VALUE_STRING) {
-            return new IncludeExclude(parser.text(), null);
+            return new IncludeExclude(parser.text(), null, null, null);
         } else if (token == XContentParser.Token.START_ARRAY) {
-            return new IncludeExclude(new TreeSet<>(parseArrayToSet(parser)), null);
+            return new IncludeExclude(null, null, new TreeSet<>(parseArrayToSet(parser)), null);
         } else if (token == XContentParser.Token.START_OBJECT) {
             String currentFieldName = null;
             Integer partition = null, numPartitions = null;
@@ -111,9 +116,9 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
     public static IncludeExclude parseExclude(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.VALUE_STRING) {
-            return new IncludeExclude(null, parser.text());
+            return new IncludeExclude(null, parser.text(), null, null);
         } else if (token == XContentParser.Token.START_ARRAY) {
-            return new IncludeExclude(null, new TreeSet<>(parseArrayToSet(parser)));
+            return new IncludeExclude(null, null, null, new TreeSet<>(parseArrayToSet(parser)));
         } else {
             throw new IllegalArgumentException("Unrecognized token for an exclude [" + token + "]");
         }
@@ -311,11 +316,7 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
      * @param include   The regular expression pattern for the terms to be included
      * @param exclude   The regular expression pattern for the terms to be excluded
      */
-    public IncludeExclude(RegExp include, RegExp exclude) {
-        this(include, exclude, null, null);
-    }
-
-    public IncludeExclude(RegExp include, RegExp exclude, SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
+    public IncludeExclude(String include, String exclude, SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
         if (include == null && exclude == null && includeValues == null && excludeValues == null) {
             throw new IllegalArgumentException();
         }
@@ -325,45 +326,12 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         if (exclude != null && excludeValues != null) {
             throw new IllegalArgumentException();
         }
-        this.include = include;
-        this.exclude = exclude;
+        this.include = include == null ? null : new RegExp(include);
+        this.exclude = exclude == null ? null : new RegExp(exclude);
         this.includeValues = includeValues;
         this.excludeValues = excludeValues;
         this.incZeroBasedPartition = 0;
         this.incNumPartitions = 0;
-    }
-
-    public IncludeExclude(String include, String exclude, String[] includeValues, String[] excludeValues) {
-        this(
-            include == null ? null : new RegExp(include),
-            exclude == null ? null : new RegExp(exclude),
-            convertToBytesRefSet(includeValues),
-            convertToBytesRefSet(excludeValues)
-        );
-    }
-
-    public IncludeExclude(String include, String exclude) {
-        this(include == null ? null : new RegExp(include), exclude == null ? null : new RegExp(exclude));
-    }
-
-    /**
-     * @param includeValues   The terms to be included
-     * @param excludeValues   The terms to be excluded
-     */
-    public IncludeExclude(SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
-        this(null, null, includeValues, excludeValues);
-    }
-
-    public IncludeExclude(String[] includeValues, String[] excludeValues) {
-        this(convertToBytesRefSet(includeValues), convertToBytesRefSet(excludeValues));
-    }
-
-    public IncludeExclude(double[] includeValues, double[] excludeValues) {
-        this(convertToBytesRefSet(includeValues), convertToBytesRefSet(excludeValues));
-    }
-
-    public IncludeExclude(long[] includeValues, long[] excludeValues) {
-        this(convertToBytesRefSet(includeValues), convertToBytesRefSet(excludeValues));
     }
 
     public IncludeExclude(int partition, int numPartitions) {
@@ -450,39 +418,6 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
         out.writeVInt(incNumPartitions);
         out.writeVInt(incZeroBasedPartition);
-    }
-
-    private static SortedSet<BytesRef> convertToBytesRefSet(String[] values) {
-        SortedSet<BytesRef> returnSet = null;
-        if (values != null) {
-            returnSet = new TreeSet<>();
-            for (String value : values) {
-                returnSet.add(new BytesRef(value));
-            }
-        }
-        return returnSet;
-    }
-
-    private static SortedSet<BytesRef> convertToBytesRefSet(double[] values) {
-        SortedSet<BytesRef> returnSet = null;
-        if (values != null) {
-            returnSet = new TreeSet<>();
-            for (double value : values) {
-                returnSet.add(new BytesRef(String.valueOf(value)));
-            }
-        }
-        return returnSet;
-    }
-
-    private static SortedSet<BytesRef> convertToBytesRefSet(long[] values) {
-        SortedSet<BytesRef> returnSet = null;
-        if (values != null) {
-            returnSet = new TreeSet<>();
-            for (long value : values) {
-                returnSet.add(new BytesRef(String.valueOf(value)));
-            }
-        }
-        return returnSet;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -29,6 +29,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
@@ -316,7 +317,12 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
      * @param include   The regular expression pattern for the terms to be included
      * @param exclude   The regular expression pattern for the terms to be excluded
      */
-    public IncludeExclude(String include, String exclude, SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
+    public IncludeExclude(
+        @Nullable String include,
+        @Nullable String exclude,
+        @Nullable SortedSet<BytesRef> includeValues,
+        @Nullable SortedSet<BytesRef> excludeValues
+    ) {
         if (include == null && exclude == null && includeValues == null && excludeValues == null) {
             throw new IllegalArgumentException();
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RareTermsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.RareTermsAggregationBuilder;
@@ -34,9 +33,9 @@ public class RareTermsTests extends BaseAggregationTestCase<RareTermsAggregation
         if (randomBoolean()) {
             IncludeExclude incExc = null;
             switch (randomInt(6)) {
-                case 0 -> incExc = new IncludeExclude(new RegExp("foobar"), null);
-                case 1 -> incExc = new IncludeExclude(null, new RegExp("foobaz"));
-                case 2 -> incExc = new IncludeExclude(new RegExp("foobar"), new RegExp("foobaz"));
+                case 0 -> incExc = new IncludeExclude("foobar", null, null, null);
+                case 1 -> incExc = new IncludeExclude(null, "foobaz", null, null);
+                case 2 -> incExc = new IncludeExclude("foobar", "foobaz", null, null);
                 case 3 -> {
                     SortedSet<BytesRef> includeValues = new TreeSet<>();
                     int numIncs = randomIntBetween(1, 20);
@@ -44,7 +43,7 @@ public class RareTermsTests extends BaseAggregationTestCase<RareTermsAggregation
                         includeValues.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                     }
                     SortedSet<BytesRef> excludeValues = null;
-                    incExc = new IncludeExclude(includeValues, excludeValues);
+                    incExc = new IncludeExclude(null, null, includeValues, excludeValues);
                 }
                 case 4 -> {
                     SortedSet<BytesRef> includeValues2 = null;
@@ -53,7 +52,7 @@ public class RareTermsTests extends BaseAggregationTestCase<RareTermsAggregation
                     for (int i = 0; i < numExcs2; i++) {
                         excludeValues2.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                     }
-                    incExc = new IncludeExclude(includeValues2, excludeValues2);
+                    incExc = new IncludeExclude(null, null, includeValues2, excludeValues2);
                 }
                 case 5 -> {
                     SortedSet<BytesRef> includeValues3 = new TreeSet<>();
@@ -66,7 +65,7 @@ public class RareTermsTests extends BaseAggregationTestCase<RareTermsAggregation
                     for (int i = 0; i < numExcs3; i++) {
                         excludeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                     }
-                    incExc = new IncludeExclude(includeValues3, excludeValues3);
+                    incExc = new IncludeExclude(null, null, includeValues3, excludeValues3);
                 }
                 case 6 -> {
                     final int numPartitions = randomIntBetween(1, 100);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
@@ -122,9 +121,9 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
     static IncludeExclude getIncludeExclude() {
         IncludeExclude incExc = null;
         switch (randomInt(5)) {
-            case 0 -> incExc = new IncludeExclude(new RegExp("foobar"), null);
-            case 1 -> incExc = new IncludeExclude(null, new RegExp("foobaz"));
-            case 2 -> incExc = new IncludeExclude(new RegExp("foobar"), new RegExp("foobaz"));
+            case 0 -> incExc = new IncludeExclude("foobar", null, null, null);
+            case 1 -> incExc = new IncludeExclude(null, "foobaz", null, null);
+            case 2 -> incExc = new IncludeExclude("foobar", "foobaz", null, null);
             case 3 -> {
                 SortedSet<BytesRef> includeValues = new TreeSet<>();
                 int numIncs = randomIntBetween(1, 20);
@@ -132,7 +131,7 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                     includeValues.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 SortedSet<BytesRef> excludeValues = null;
-                incExc = new IncludeExclude(includeValues, excludeValues);
+                incExc = new IncludeExclude(null, null, includeValues, excludeValues);
             }
             case 4 -> {
                 SortedSet<BytesRef> includeValues2 = null;
@@ -141,7 +140,7 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                 for (int i = 0; i < numExcs2; i++) {
                     excludeValues2.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
-                incExc = new IncludeExclude(includeValues2, excludeValues2);
+                incExc = new IncludeExclude(null, null, includeValues2, excludeValues2);
             }
             case 5 -> {
                 SortedSet<BytesRef> includeValues3 = new TreeSet<>();
@@ -154,7 +153,7 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                 for (int i = 0; i < numExcs3; i++) {
                     excludeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
-                incExc = new IncludeExclude(includeValues3, excludeValues3);
+                incExc = new IncludeExclude(null, null, includeValues3, excludeValues3);
             }
             default -> fail();
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -91,14 +90,14 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
             factory.format("###.##");
         }
         if (randomBoolean()) {
-            RegExp includeRegexp = null, excludeRegexp = null;
+            String includeRegexp = null, excludeRegexp = null;
             SortedSet<BytesRef> includeValues = null, excludeValues = null;
             boolean hasIncludeOrExclude = false;
 
             if (randomBoolean()) {
                 hasIncludeOrExclude = true;
                 if (randomBoolean()) {
-                    includeRegexp = new RegExp(randomAlphaOfLengthBetween(5, 10));
+                    includeRegexp = randomAlphaOfLengthBetween(5, 10);
                 } else {
                     includeValues = new TreeSet<>();
                     int numIncs = randomIntBetween(1, 20);
@@ -111,7 +110,7 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
             if (randomBoolean()) {
                 hasIncludeOrExclude = true;
                 if (randomBoolean()) {
-                    excludeRegexp = new RegExp(randomAlphaOfLengthBetween(5, 10));
+                    excludeRegexp = randomAlphaOfLengthBetween(5, 10);
                 } else {
                     excludeValues = new TreeSet<>();
                     int numIncs = randomIntBetween(1, 20);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/BinaryTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/BinaryTermsAggregatorTests.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -73,7 +72,7 @@ public class BinaryTermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testBadIncludeExclude() throws IOException {
-        IncludeExclude includeExclude = new IncludeExclude(new RegExp("foo"), null);
+        IncludeExclude includeExclude = new IncludeExclude("foo", null, null, null);
 
         // Make sure the include/exclude fails regardless of how the user tries to type hint the agg
         AggregationExecutionException e = expectThrows(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregatorTests.java
@@ -18,7 +18,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -92,7 +91,7 @@ public class NumericTermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testBadIncludeExclude() throws IOException {
-        IncludeExclude includeExclude = new IncludeExclude(new RegExp("foo"), null);
+        IncludeExclude includeExclude = new IncludeExclude("foo", null, null, null);
 
         // Numerics don't support any regex include/exclude, so should fail no matter what we do
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -66,6 +66,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toList;
@@ -155,24 +157,11 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
             dataset,
             aggregation -> aggregation.field(LONG_FIELD)
                 .maxDocCount(2) // bump to 2 since we're only including "2"
-                .includeExclude(new IncludeExclude(new long[] { 2 }, new long[] {})),
+                .includeExclude(new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("2"))), new TreeSet<>())),
             agg -> {
                 assertEquals(1, agg.getBuckets().size());
                 LongRareTerms.Bucket bucket = (LongRareTerms.Bucket) agg.getBuckets().get(0);
                 assertThat(bucket.getKey(), equalTo(2L));
-                assertThat(bucket.getDocCount(), equalTo(2L));
-            }
-        );
-        testSearchCase(
-            query,
-            dataset,
-            aggregation -> aggregation.field(KEYWORD_FIELD)
-                .maxDocCount(2) // bump to 2 since we're only including "2"
-                .includeExclude(new IncludeExclude(new String[] { "2" }, new String[] {})),
-            agg -> {
-                assertEquals(1, agg.getBuckets().size());
-                StringRareTerms.Bucket bucket = (StringRareTerms.Bucket) agg.getBuckets().get(0);
-                assertThat(bucket.getKeyAsString(), equalTo("2"));
                 assertThat(bucket.getDocCount(), equalTo(2L));
             }
         );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -56,6 +56,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
 import static org.hamcrest.Matchers.equalTo;
@@ -142,7 +145,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNotNull(terms.getBucketByKey("even"));
 
                 // Search odd with regex includeexcludes
-                sigAgg.includeExclude(new IncludeExclude("o.d", null));
+                sigAgg.includeExclude(new IncludeExclude("o.d", null, null, null));
                 terms = searchAndReduce(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType);
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
@@ -151,10 +154,10 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNull(terms.getBucketByKey("even"));
 
                 // Search with string-based includeexcludes
-                String oddStrings[] = new String[] { "odd", "weird" };
-                String evenStrings[] = new String[] { "even", "regular" };
+                SortedSet<BytesRef> oddStrings = new TreeSet<>(Set.of(new BytesRef("odd"), new BytesRef("weird")));
+                SortedSet<BytesRef> evenStrings = new TreeSet<>(Set.of(new BytesRef("even"), new BytesRef("regular")));
 
-                sigAgg.includeExclude(new IncludeExclude(oddStrings, evenStrings));
+                sigAgg.includeExclude(new IncludeExclude(null, null, oddStrings, evenStrings));
                 sigAgg.significanceHeuristic(heuristic);
                 terms = searchAndReduce(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType);
                 assertThat(terms.getSubsetSize(), equalTo(5L));
@@ -165,7 +168,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNull(terms.getBucketByKey("even"));
                 assertNull(terms.getBucketByKey("regular"));
 
-                sigAgg.includeExclude(new IncludeExclude(evenStrings, oddStrings));
+                sigAgg.includeExclude(new IncludeExclude(null, null, evenStrings, oddStrings));
                 terms = searchAndReduce(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType);
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(0, terms.getBuckets().size());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -42,6 +42,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantText;
@@ -125,7 +128,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             indexDocuments(w);
 
-            String[] incExcValues = { "duplicate" };
+            SortedSet<BytesRef> incExcValues = new TreeSet<>(Set.of(new BytesRef("duplicate")));
 
             try (IndexReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
@@ -134,7 +137,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 // Inclusive of values
                 {
                     SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "text").includeExclude(
-                        new IncludeExclude(incExcValues, null)
+                        new IncludeExclude(null, null, incExcValues, null)
                     );
                     SamplerAggregationBuilder aggBuilder = new SamplerAggregationBuilder("sampler").subAggregation(sigAgg);
                     if (randomBoolean()) {
@@ -152,7 +155,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 // Exclusive of values
                 {
                     SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "text").includeExclude(
-                        new IncludeExclude(null, incExcValues)
+                        new IncludeExclude(null, null, null, incExcValues)
                     );
                     SamplerAggregationBuilder aggBuilder = new SamplerAggregationBuilder("sampler").subAggregation(sigAgg);
                     if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -125,6 +125,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -428,7 +430,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         String executionHint = randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString();
 
         AggregationBuilder builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude("val00.+", null))
+            .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("mv_field")
             .size(12)
             .order(BucketOrder.key(true));
@@ -458,7 +460,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude("val00.+", null))
+            .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -477,7 +479,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude("val00.+", null))
+            .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -496,7 +498,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude("val00.+", "(val000|val001)"))
+            .includeExclude(new IncludeExclude("val00.+", "(val000|val001)", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -521,7 +523,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude(null, "val00.+"))
+            .includeExclude(new IncludeExclude(null, "val00.+", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -534,7 +536,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude(new String[] { "val000", "val010" }, null))
+            .includeExclude(new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("val000"), new BytesRef("val010"))), null))
             .field("mv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -550,7 +552,22 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .includeExclude(
                 new IncludeExclude(
                     null,
-                    new String[] { "val001", "val002", "val003", "val004", "val005", "val006", "val007", "val008", "val009", "val011" }
+                    null,
+                    null,
+                    new TreeSet<>(
+                        Set.of(
+                            new BytesRef("val001"),
+                            new BytesRef("val002"),
+                            new BytesRef("val003"),
+                            new BytesRef("val004"),
+                            new BytesRef("val005"),
+                            new BytesRef("val006"),
+                            new BytesRef("val007"),
+                            new BytesRef("val008"),
+                            new BytesRef("val009"),
+                            new BytesRef("val011")
+                        )
+                    )
                 )
             )
             .field("mv_field")
@@ -570,7 +587,18 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     "val00.+",
                     null,
                     null,
-                    new String[] { "val001", "val002", "val003", "val004", "val005", "val006", "val007", "val008" }
+                    new TreeSet<>(
+                        Set.of(
+                            new BytesRef("val001"),
+                            new BytesRef("val002"),
+                            new BytesRef("val003"),
+                            new BytesRef("val004"),
+                            new BytesRef("val005"),
+                            new BytesRef("val006"),
+                            new BytesRef("val007"),
+                            new BytesRef("val008")
+                        )
+                    )
                 )
             )
             .field("mv_field")
@@ -585,7 +613,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, ft1, ft2);
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
-            .includeExclude(new IncludeExclude(null, "val01.+", new String[] { "val001", "val002", "val010" }, null))
+            .includeExclude(
+                new IncludeExclude(
+                    null,
+                    "val01.+",
+                    new TreeSet<>(Set.of(new BytesRef("val001"), new BytesRef("val002"), new BytesRef("val010"))),
+                    null
+                )
+            )
             .field("mv_field")
             .order(BucketOrder.key(true));
         testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
@@ -648,7 +683,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     String executionHint = randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString();
                     TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.LONG)
                         .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(new long[] { 0, 5 }, null))
+                        .includeExclude(new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("0"), new BytesRef("5"))), null))
                         .field("long_field")
                         .order(BucketOrder.key(true));
                     AggregationContext context = createAggregationContext(indexSearcher, null, fieldType);
@@ -666,7 +701,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                     aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.LONG)
                         .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(null, new long[] { 0, 5 }))
+                        .includeExclude(new IncludeExclude(null, null, null, new TreeSet<>(Set.of(new BytesRef("0"), new BytesRef("5")))))
                         .field("long_field")
                         .order(BucketOrder.key(true));
                     context = createAggregationContext(indexSearcher, null, fieldType);
@@ -689,7 +724,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     fieldType = new NumberFieldMapper.NumberFieldType("double_field", NumberFieldMapper.NumberType.DOUBLE);
                     aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.DOUBLE)
                         .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(new double[] { 0.0, 5.0 }, null))
+                        .includeExclude(
+                            new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("0.0"), new BytesRef("5.0"))), null)
+                        )
                         .field("double_field")
                         .order(BucketOrder.key(true));
                     context = createAggregationContext(indexSearcher, null, fieldType);
@@ -707,7 +744,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                     aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.DOUBLE)
                         .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(null, new double[] { 0.0, 5.0 }))
+                        .includeExclude(
+                            new IncludeExclude(null, null, null, new TreeSet<>(Set.of(new BytesRef("0.0"), new BytesRef("5.0"))))
+                        )
                         .field("double_field")
                         .order(BucketOrder.key(true));
                     context = createAggregationContext(indexSearcher, null, fieldType);
@@ -1584,7 +1623,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         topLevelProfileTestCase(
             between(3000, 4000),
             0,
-            new IncludeExclude(null, "missing"),
+            new IncludeExclude(null, "missing", null, null),
             GlobalOrdinalsStringTermsAggregator.class,
             m -> m.entry("has_filter", true).entry("collection_strategy", "remap using single bucket ords")
         );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
@@ -26,17 +26,18 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class IncludeExcludeTests extends ESTestCase {
     public void testEmptyTermsWithOrds() throws IOException {
-        IncludeExclude inexcl = new IncludeExclude(new TreeSet<>(Collections.singleton(new BytesRef("foo"))), null);
+        IncludeExclude inexcl = new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("foo"))), null);
         OrdinalsFilter filter = inexcl.convertToOrdinalsFilter(DocValueFormat.RAW);
         LongBitSet acceptedOrds = filter.acceptedGlobalOrdinals(DocValues.emptySortedSet());
         assertEquals(0, acceptedOrds.length());
 
-        inexcl = new IncludeExclude(null, new TreeSet<>(Collections.singleton(new BytesRef("foo"))));
+        inexcl = new IncludeExclude(null, null, null, new TreeSet<>(Set.of(new BytesRef("foo"))));
         filter = inexcl.convertToOrdinalsFilter(DocValueFormat.RAW);
         acceptedOrds = filter.acceptedGlobalOrdinals(DocValues.emptySortedSet());
         assertEquals(0, acceptedOrds.length());
@@ -87,8 +88,8 @@ public class IncludeExcludeTests extends ESTestCase {
     }
 
     public void testTermAccept() throws IOException {
-        String[] fooSet = { "foo" };
-        String[] barSet = { "bar" };
+        SortedSet<BytesRef> fooSet = new TreeSet<>(Set.of(new BytesRef("foo")));
+        SortedSet<BytesRef> barSet = new TreeSet<>(Set.of(new BytesRef("bar")));
         String fooRgx = "f.*";
         String barRgx = "b.*";
 
@@ -152,33 +153,33 @@ public class IncludeExcludeTests extends ESTestCase {
     }
 
     public void testExactIncludeValuesEquals() throws IOException {
-        String[] incValues = { "a", "b" };
-        String[] differentIncValues = { "a", "c" };
-        IncludeExclude serialized = serialize(new IncludeExclude(incValues, null), IncludeExclude.INCLUDE_FIELD);
+        SortedSet<BytesRef> incValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("b")));
+        SortedSet<BytesRef> differentIncValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("c")));
+        IncludeExclude serialized = serialize(new IncludeExclude(null, null, incValues, null), IncludeExclude.INCLUDE_FIELD);
         assertFalse(serialized.isPartitionBased());
         assertFalse(serialized.isRegexBased());
 
-        IncludeExclude same = new IncludeExclude(incValues, null);
+        IncludeExclude same = new IncludeExclude(null, null, incValues, null);
         assertEquals(serialized, same);
         assertEquals(serialized.hashCode(), same.hashCode());
 
-        IncludeExclude different = new IncludeExclude(differentIncValues, null);
+        IncludeExclude different = new IncludeExclude(null, null, differentIncValues, null);
         assertFalse(serialized.equals(different));
         assertTrue(serialized.hashCode() != different.hashCode());
     }
 
     public void testExactExcludeValuesEquals() throws IOException {
-        String[] excValues = { "a", "b" };
-        String[] differentExcValues = { "a", "c" };
-        IncludeExclude serialized = serialize(new IncludeExclude(null, excValues), IncludeExclude.EXCLUDE_FIELD);
+        SortedSet<BytesRef> excValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("b")));
+        SortedSet<BytesRef> differentExcValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("c")));
+        IncludeExclude serialized = serialize(new IncludeExclude(null, null, null, excValues), IncludeExclude.EXCLUDE_FIELD);
         assertFalse(serialized.isPartitionBased());
         assertFalse(serialized.isRegexBased());
 
-        IncludeExclude same = new IncludeExclude(null, excValues);
+        IncludeExclude same = new IncludeExclude(null, null, null, excValues);
         assertEquals(serialized, same);
         assertEquals(serialized.hashCode(), same.hashCode());
 
-        IncludeExclude different = new IncludeExclude(null, differentExcValues);
+        IncludeExclude different = new IncludeExclude(null, null, null, differentExcValues);
         assertFalse(serialized.equals(different));
         assertTrue(serialized.hashCode() != different.hashCode());
     }
@@ -186,15 +187,15 @@ public class IncludeExcludeTests extends ESTestCase {
     public void testRegexInclude() throws IOException {
         String incRegex = "foo.*";
         String differentRegex = "bar.*";
-        IncludeExclude serialized = serialize(new IncludeExclude(incRegex, null), IncludeExclude.INCLUDE_FIELD);
+        IncludeExclude serialized = serialize(new IncludeExclude(incRegex, null, null, null), IncludeExclude.INCLUDE_FIELD);
         assertFalse(serialized.isPartitionBased());
         assertTrue(serialized.isRegexBased());
 
-        IncludeExclude same = new IncludeExclude(incRegex, null);
+        IncludeExclude same = new IncludeExclude(incRegex, null, null, null);
         assertEquals(serialized, same);
         assertEquals(serialized.hashCode(), same.hashCode());
 
-        IncludeExclude different = new IncludeExclude(differentRegex, null);
+        IncludeExclude different = new IncludeExclude(differentRegex, null, null, null);
         assertFalse(serialized.equals(different));
         assertTrue(serialized.hashCode() != different.hashCode());
     }
@@ -202,15 +203,15 @@ public class IncludeExcludeTests extends ESTestCase {
     public void testRegexExclude() throws IOException {
         String excRegex = "foo.*";
         String differentRegex = "bar.*";
-        IncludeExclude serialized = serialize(new IncludeExclude(null, excRegex), IncludeExclude.EXCLUDE_FIELD);
+        IncludeExclude serialized = serialize(new IncludeExclude(null, excRegex, null, null), IncludeExclude.EXCLUDE_FIELD);
         assertFalse(serialized.isPartitionBased());
         assertTrue(serialized.isRegexBased());
 
-        IncludeExclude same = new IncludeExclude(null, excRegex);
+        IncludeExclude same = new IncludeExclude(null, excRegex, null, null);
         assertEquals(serialized, same);
         assertEquals(serialized.hashCode(), same.hashCode());
 
-        IncludeExclude different = new IncludeExclude(null, differentRegex);
+        IncludeExclude different = new IncludeExclude(null, differentRegex, null, null);
         assertFalse(serialized.equals(different));
         assertTrue(serialized.hashCode() != different.hashCode());
     }
@@ -247,24 +248,24 @@ public class IncludeExcludeTests extends ESTestCase {
         String incRegex = "foo.*";
         String excRegex = "football";
         String differentExcRegex = "foosball";
-        IncludeExclude serialized = serializeMixedRegex(new IncludeExclude(incRegex, excRegex));
+        IncludeExclude serialized = serializeMixedRegex(new IncludeExclude(incRegex, excRegex, null, null));
         assertFalse(serialized.isPartitionBased());
         assertTrue(serialized.isRegexBased());
 
-        IncludeExclude same = new IncludeExclude(incRegex, excRegex);
+        IncludeExclude same = new IncludeExclude(incRegex, excRegex, null, null);
         assertEquals(serialized, same);
         assertEquals(serialized.hashCode(), same.hashCode());
 
-        IncludeExclude different = new IncludeExclude(incRegex, differentExcRegex);
+        IncludeExclude different = new IncludeExclude(incRegex, differentExcRegex, null, null);
         assertFalse(serialized.equals(different));
         assertTrue(serialized.hashCode() != different.hashCode());
     }
 
     public void testRegexIncludeAndSetExclude() throws IOException {
         String incRegex = "foo.*";
-        String[] excValues = { "a", "b" };
+        SortedSet<BytesRef> excValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("b")));
         String differentIncRegex = "foosball";
-        String[] differentExcValues = { "a", "c" };
+        SortedSet<BytesRef> differentExcValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("c")));
 
         IncludeExclude serialized = serializeMixedRegex(new IncludeExclude(incRegex, null, null, excValues));
         assertFalse(serialized.isPartitionBased());
@@ -284,9 +285,9 @@ public class IncludeExcludeTests extends ESTestCase {
     }
 
     public void testSetIncludeAndRegexExclude() throws IOException {
-        String[] incValues = { "a", "b" };
+        SortedSet<BytesRef> incValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("b")));
         String excRegex = "foo.*";
-        String[] differentIncValues = { "a", "c" };
+        SortedSet<BytesRef> differentIncValues = new TreeSet<>(Set.of(new BytesRef("a"), new BytesRef("c")));
         String differentExcRegex = "foosball";
 
         IncludeExclude serialized = serializeMixedRegex(new IncludeExclude(null, excRegex, incValues, null));
@@ -343,7 +344,7 @@ public class IncludeExcludeTests extends ESTestCase {
     }
 
     public void testInvalidIncludeExcludeCombination() {
-        String[] values = { "foo" };
+        SortedSet<BytesRef> values = new TreeSet<>(Set.of(new BytesRef("foo")));
         String regex = "foo";
 
         expectThrows(IllegalArgumentException.class, () -> new IncludeExclude((String) null, null, null, null));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/VertexRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/VertexRequest.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.protocol.xpack.graph;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest.TermBoost;
@@ -17,6 +18,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * A request to identify terms from a choice of field as part of a {@link Hop}.
@@ -25,14 +28,15 @@ import java.util.Set;
  *
  */
 public class VertexRequest implements ToXContentObject {
+    public static final int DEFAULT_SIZE = 5;
+    public static final int DEFAULT_MIN_DOC_COUNT = 3;
+    public static final int DEFAULT_SHARD_MIN_DOC_COUNT = 2;
+
     private String fieldName;
     private int size = DEFAULT_SIZE;
-    public static final int DEFAULT_SIZE = 5;
     private Map<String, TermBoost> includes;
     private Set<String> excludes;
-    public static final int DEFAULT_MIN_DOC_COUNT = 3;
     private int minDocCount = DEFAULT_MIN_DOC_COUNT;
-    public static final int DEFAULT_SHARD_MIN_DOC_COUNT = 2;
     private int shardMinDocCount = DEFAULT_SHARD_MIN_DOC_COUNT;
 
     public VertexRequest() {
@@ -154,17 +158,20 @@ public class VertexRequest implements ToXContentObject {
         return includes.values().toArray(new TermBoost[includes.size()]);
     }
 
-    public String[] includeValuesAsStringArray() {
-        String[] result = new String[includes.size()];
-        int i = 0;
-        for (TermBoost tb : includes.values()) {
-            result[i++] = tb.term;
+    public SortedSet<BytesRef> includeValuesAsSortedSet() {
+        SortedSet<BytesRef> set = new TreeSet<>();
+        for (String include : includes.keySet()) {
+            set.add(new BytesRef(include));
         }
-        return result;
+        return set;
     }
 
-    public String[] excludesAsArray() {
-        return excludes.toArray(new String[excludes.size()]);
+    public SortedSet<BytesRef> excludesAsSortedSet() {
+        SortedSet<BytesRef> set = new TreeSet<>();
+        for (String include : excludes) {
+            set.add(new BytesRef(include));
+        }
+        return set;
     }
 
     public int minDocCount() {


### PR DESCRIPTION
In order to fix an error where large regexes in `include` or
`exclude` fields of the `terms` agg crash the node (#82923) I'd like to
centralize construction of the `RegExp` so we can test it for
large-ness in one spot. The trouble is, there are half a dozen ctors for
`IncludeExclude` and some take `String` and some take `RegExp` and some
take a sets of `String` and some take sets of `BytesRef`. It's all very
convenient for client code, but confusing to deal with. This removes all
but two of the ctors for `IncludeExclude` and mostly standardizes on one
that has:
```
String includeRe, String excludeRe, Set<BytesRef> includePrecise, Set<BytesRef> excludePecise
```

Now I can fix #82923 in a fairly simple follow up.
