### PR TITLE
Fork to WRITE thread when failing shard

### DIFF
--- a/docs/changelog/84606.yaml
+++ b/docs/changelog/84606.yaml
@@ -1,0 +1,6 @@
+pr: 84606
+summary: Fork to WRITE thread when failing shard
+area: Engine
+type: bug
+issues:
+ - 84602

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -61,6 +61,7 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
+import org.elasticsearch.transport.Transports;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -1099,6 +1100,7 @@ public abstract class Engine implements Closeable {
      * The underlying store is marked corrupted iff failure is caused by index corruption
      */
     public void failEngine(String reason, @Nullable Exception failure) {
+        assert Transports.assertNotTransportThread("failEngine can block on IO");
         if (failure != null) {
             maybeDie(reason, failure);
         }


### PR DESCRIPTION
If a replication operation fails then the primary will try and fail the
replica. If this operation also fails (i.e. another shard copy has been
promoted to primary) then the primary must fail itself. Today it does
this on a transport thread. This is a problem because failing the shard
needs to acquire a lock which may be held by another operation that is
performing some potentially-long-running IO.

With this commit we add an assertion that the engine is never failed on
a transport thread, and adjust `ReplicationOperation` to fork the call
to `failShard` to the `WRITE` threadpool. Without the change to
`ReplicationOperation` the assertion is tripped by `testAckedIndexing`.

Closes #84602