### PR TITLE
[7.17] Await listener in ReplicationOperationTests#testNoLongerPrimary (#84616)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -59,7 +60,9 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithActivePrimary;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
@@ -266,7 +269,6 @@ public class ReplicationOperationTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84610")
     public void testNoLongerPrimary() throws Exception {
         final String index = "test";
         final ShardId shardId = new ShardId(index, "_na_", 0);
@@ -360,13 +362,19 @@ public class ReplicationOperationTests extends ESTestCase {
         op.execute();
 
         assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
-        assertTrue("listener is not marked as done", listener.isDone());
+        assertThat(
+            expectThrows(
+                ExecutionException.class,
+                ReplicationOperation.RetryOnPrimaryException.class,
+                () -> listener.get(10, TimeUnit.SECONDS)
+            ).getMessage(),
+            anyOf(containsString("demoted while failing replica shard"), containsString("shutting down while failing replica shard"))
+        );
         if (shardActionFailure instanceof ShardStateAction.NoLongerPrimaryShardException) {
             assertTrue(primaryFailed.get());
         } else {
             assertFalse(primaryFailed.get());
         }
-        assertListenerThrows("should throw exception to trigger retry", listener, ReplicationOperation.RetryOnPrimaryException.class);
     }
 
     public void testAddedReplicaAfterPrimaryOperation() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Await listener in ReplicationOperationTests#testNoLongerPrimary (#84616)