### PR TITLE
Make InternalNumericMetricsAggregation.format field final.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -40,11 +40,10 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
         DocValueFormat format,
         Map<String, Object> metadata
     ) {
-        super(name, metadata);
+        super(name, format, metadata);
         this.keys = keys;
         this.state = state;
         this.keyed = keyed;
-        this.format = format;
     }
 
     /**
@@ -52,7 +51,6 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
      */
     protected AbstractInternalHDRPercentiles(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         keys = in.readDoubleArray();
         long minBarForHighestToLowestValueRatio = in.readLong();
         final int serializedLen = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -37,11 +37,10 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.keys = keys;
         this.state = state;
         this.keyed = keyed;
-        this.format = formatter;
     }
 
     /**
@@ -49,7 +48,6 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
      */
     protected AbstractInternalTDigestPercentiles(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         keys = in.readDoubleArray();
         state = TDigestState.read(in);
         keyed = in.readBoolean();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
@@ -25,10 +25,9 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
     private final long count;
 
     public InternalAvg(String name, double sum, long count, DocValueFormat format, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, format, metadata);
         this.sum = sum;
         this.count = count;
-        this.format = format;
     }
 
     /**
@@ -36,7 +35,6 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
      */
     public InternalAvg(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         sum = in.readDouble();
         count = in.readVLong();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -25,7 +24,7 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
     private final AbstractHyperLogLogPlusPlus counts;
 
     InternalCardinality(String name, AbstractHyperLogLogPlusPlus counts, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, null, metadata);
         this.counts = counts;
     }
 
@@ -34,7 +33,6 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
      */
     public InternalCardinality(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         if (in.readBoolean()) {
             counts = AbstractHyperLogLogPlusPlus.readFrom(in, BigArrays.NON_RECYCLING_INSTANCE);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
@@ -43,8 +43,7 @@ public class InternalMedianAbsoluteDeviation extends InternalNumericMetricsAggre
     private final double medianAbsoluteDeviation;
 
     InternalMedianAbsoluteDeviation(String name, Map<String, Object> metadata, DocValueFormat format, TDigestState valuesSketch) {
-        super(name, metadata);
-        this.format = Objects.requireNonNull(format);
+        super(name, Objects.requireNonNull(format), metadata);
         this.valuesSketch = Objects.requireNonNull(valuesSketch);
 
         this.medianAbsoluteDeviation = computeMedianAbsoluteDeviation(this.valuesSketch);
@@ -52,7 +51,6 @@ public class InternalMedianAbsoluteDeviation extends InternalNumericMetricsAggre
 
     public InternalMedianAbsoluteDeviation(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         valuesSketch = TDigestState.read(in);
         medianAbsoluteDeviation = in.readDouble();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMin.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMin.java
@@ -24,9 +24,8 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
     private final double min;
 
     public InternalMin(String name, double min, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.min = min;
-        this.format = formatter;
     }
 
     /**
@@ -34,7 +33,6 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
      */
     public InternalMin(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         min = in.readDouble();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -36,6 +36,15 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
             super(in);
         }
 
+        /**
+         * Read from a stream.
+         *
+         * @param readFormat whether to read the "format" field
+         */
+        protected SingleValue(StreamInput in, boolean readFormat) throws IOException {
+            super(in, readFormat);
+        }
+
         @Override
         public String getValueAsString() {
             return format.format(value()).toString();
@@ -79,6 +88,15 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
             super(in);
         }
 
+        /**
+         * Read from a stream.
+         *
+         * @param readFormat whether to read the "format" field
+         */
+        protected MultiValue(StreamInput in, boolean readFormat) throws IOException {
+            super(in, readFormat);
+        }
+
         public abstract double value(String name);
 
         public String valueAsString(String name) {
@@ -114,8 +132,17 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
      * Read from a stream.
      */
     protected InternalNumericMetricsAggregation(StreamInput in) throws IOException {
+        this(in, true);
+    }
+
+    /**
+     * Read from a stream.
+     * @param readFormat whether to read the "format" field
+     *                   Should be {@code true} iff the "format" field is being written to the wire by the agg
+     */
+    protected InternalNumericMetricsAggregation(StreamInput in, boolean readFormat) throws IOException {
         super(in);
-        this.format = in.readNamedWriteable(DocValueFormat.class);
+        this.format = readFormat ? in.readNamedWriteable(DocValueFormat.class) : DEFAULT_FORMAT;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -22,11 +22,11 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
 
     private static final DocValueFormat DEFAULT_FORMAT = DocValueFormat.RAW;
 
-    protected DocValueFormat format = DEFAULT_FORMAT;
+    protected final DocValueFormat format;
 
     public abstract static class SingleValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.SingleValue {
-        protected SingleValue(String name, Map<String, Object> metadata) {
-            super(name, metadata);
+        protected SingleValue(String name, DocValueFormat format, Map<String, Object> metadata) {
+            super(name, format, metadata);
         }
 
         /**
@@ -68,8 +68,8 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
     }
 
     public abstract static class MultiValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.MultiValue {
-        protected MultiValue(String name, Map<String, Object> metadata) {
-            super(name, metadata);
+        protected MultiValue(String name, DocValueFormat format, Map<String, Object> metadata) {
+            super(name, format, metadata);
         }
 
         /**
@@ -105,8 +105,9 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
         }
     }
 
-    private InternalNumericMetricsAggregation(String name, Map<String, Object> metadata) {
+    private InternalNumericMetricsAggregation(String name, DocValueFormat format, Map<String, Object> metadata) {
         super(name, metadata);
+        this.format = format != null ? format : DEFAULT_FORMAT;
     }
 
     /**
@@ -114,6 +115,7 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
      */
     protected InternalNumericMetricsAggregation(StreamInput in) throws IOException {
         super(in);
+        this.format = in.readNamedWriteable(DocValueFormat.class);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -56,12 +56,11 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.count = count;
         this.sum = sum;
         this.min = min;
         this.max = max;
-        this.format = formatter;
     }
 
     /**
@@ -69,7 +68,6 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
      */
     public InternalStats(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         count = in.readVLong();
         min = in.readDouble();
         max = in.readDouble();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
@@ -34,7 +34,7 @@ public class InternalValueCount extends InternalNumericMetricsAggregation.Single
      * Read from a stream.
      */
     public InternalValueCount(StreamInput in) throws IOException {
-        super(in);
+        super(in, false);
         value = in.readVLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
@@ -26,7 +26,7 @@ public class InternalValueCount extends InternalNumericMetricsAggregation.Single
     private final long value;
 
     public InternalValueCount(String name, long value, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, null, metadata);
         this.value = value;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvg.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvg.java
@@ -25,10 +25,9 @@ public class InternalWeightedAvg extends InternalNumericMetricsAggregation.Singl
     private final double weight;
 
     InternalWeightedAvg(String name, double sum, double weight, DocValueFormat format, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, format, metadata);
         this.sum = sum;
         this.weight = weight;
-        this.format = format;
     }
 
     /**
@@ -36,7 +35,6 @@ public class InternalWeightedAvg extends InternalNumericMetricsAggregation.Singl
      */
     public InternalWeightedAvg(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         sum = in.readDouble();
         weight = in.readDouble();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Max.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Max.java
@@ -24,8 +24,7 @@ public class Max extends InternalNumericMetricsAggregation.SingleValue {
     private final double max;
 
     public Max(String name, double max, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
-        this.format = formatter;
+        super(name, formatter, metadata);
         this.max = max;
     }
 
@@ -34,7 +33,6 @@ public class Max extends InternalNumericMetricsAggregation.SingleValue {
      */
     public Max(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         max = in.readDouble();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Sum.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Sum.java
@@ -24,9 +24,8 @@ public class Sum extends InternalNumericMetricsAggregation.SingleValue {
     private final double sum;
 
     public Sum(String name, double sum, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.sum = sum;
-        this.format = formatter;
     }
 
     /**
@@ -34,7 +33,6 @@ public class Sum extends InternalNumericMetricsAggregation.SingleValue {
      */
     public Sum(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         sum = in.readDouble();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValue.java
@@ -31,10 +31,9 @@ public class InternalBucketMetricValue extends InternalNumericMetricsAggregation
     private String[] keys;
 
     public InternalBucketMetricValue(String name, String[] keys, double value, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.keys = keys;
         this.value = value;
-        this.format = formatter;
     }
 
     /**
@@ -42,7 +41,6 @@ public class InternalBucketMetricValue extends InternalNumericMetricsAggregation
      */
     public InternalBucketMetricValue(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         value = in.readDouble();
         keys = in.readStringArray();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -42,7 +42,7 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         if ((percentiles.length == percents.length) == false) {
             throw new IllegalArgumentException(
                 "The number of provided percents and percentiles didn't match. percents: "
@@ -51,7 +51,6 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
                     + Arrays.toString(percentiles)
             );
         }
-        this.format = formatter;
         this.percentiles = percentiles;
         this.percents = percents;
         this.keyed = keyed;
@@ -69,7 +68,6 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
      */
     public InternalPercentilesBucket(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         percentiles = in.readDoubleArray();
         percents = in.readDoubleArray();
         keyed = in.readBoolean();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
@@ -26,8 +26,7 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
     protected final double value;
 
     public InternalSimpleValue(String name, double value, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
-        this.format = formatter;
+        super(name, formatter, metadata);
         this.value = value;
     }
 
@@ -36,7 +35,6 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
      */
     public InternalSimpleValue(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         value = in.readDouble();
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -175,9 +175,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
     private final TDigestState state;
 
     InternalBoxplot(String name, TDigestState state, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.state = state;
-        this.format = formatter;
     }
 
     /**
@@ -185,7 +184,6 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
      */
     public InternalBoxplot(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         state = TDigestState.read(in);
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/cumulativecardinality/InternalSimpleLongValue.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/cumulativecardinality/InternalSimpleLongValue.java
@@ -25,8 +25,7 @@ public class InternalSimpleLongValue extends InternalNumericMetricsAggregation.S
     protected final long value;
 
     public InternalSimpleLongValue(String name, long value, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
-        this.format = formatter;
+        super(name, formatter, metadata);
         this.value = value;
     }
 
@@ -35,7 +34,6 @@ public class InternalSimpleLongValue extends InternalNumericMetricsAggregation.S
      */
     public InternalSimpleLongValue(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         value = in.readZLong();
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/InternalRate.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/InternalRate.java
@@ -26,10 +26,9 @@ public class InternalRate extends InternalNumericMetricsAggregation.SingleValue 
     final double divisor;
 
     public InternalRate(String name, double sum, double divisor, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.sum = sum;
         this.divisor = divisor;
-        this.format = formatter;
     }
 
     /**
@@ -37,7 +36,6 @@ public class InternalRate extends InternalNumericMetricsAggregation.SingleValue 
      */
     public InternalRate(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         sum = in.readDouble();
         divisor = in.readDouble();
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/InternalTTest.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/InternalTTest.java
@@ -26,9 +26,8 @@ public class InternalTTest extends InternalNumericMetricsAggregation.SingleValue
     protected final TTestState state;
 
     InternalTTest(String name, TTestState state, DocValueFormat formatter, Map<String, Object> metadata) {
-        super(name, metadata);
+        super(name, formatter, metadata);
         this.state = state;
-        this.format = formatter;
     }
 
     /**
@@ -36,7 +35,6 @@ public class InternalTTest extends InternalNumericMetricsAggregation.SingleValue
      */
     public InternalTTest(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         state = in.readNamedWriteable(TTestState.class);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
@@ -23,7 +23,7 @@ class TestMultiValueAggregation extends InternalNumericMetricsAggregation.MultiV
     private final Map<String, Double> values;
 
     TestMultiValueAggregation(String name, Map<String, Double> values) {
-        super(name, emptyMap());
+        super(name, null, emptyMap());
         this.values = values;
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -178,7 +178,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         private final Map<String, Double> values;
 
         TestNumericMultiValueAggregation(String name, Map<String, Double> values) {
-            super(name, emptyMap());
+            super(name, null, emptyMap());
             this.values = values;
         }
 


### PR DESCRIPTION
This PR makes `InternalNumericMetricsAggregation.format` field `final`.
This makes it a bit easier to reason about `InternalNumericMetricsAggregation` class if it is obvious that `format` field won't be overwritten.
From the functional PoV it is a no-op.

The idea for this PR emerged while debugging https://github.com/elastic/elasticsearch/issues/84622