### PR TITLE
Weaken assertion on top_hits explain test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
@@ -109,12 +109,12 @@ explain:
   - length:   { aggregations.page.buckets: 2 }
   - match:    { aggregations.page.buckets.0.key: 1 }
   - close_to: { aggregations.page.buckets.0.top_hits.hits.hits.0._explanation.value: { value: 0.14543022, error: 0.001 }}
-  - match:    { aggregations.page.buckets.0.top_hits.hits.hits.0._explanation.description: "weight(text:the in 0) [PerFieldSimilarity], result of:" }
+  - match:    { aggregations.page.buckets.0.top_hits.hits.hits.0._explanation.description: "/weight\\(text:the\\ in\\ \\d\\)\\ \\[PerFieldSimilarity\\],\\ result\\ of:/" }
   - close_to: { aggregations.page.buckets.0.top_hits.hits.hits.1._explanation.value: { value: 0.13353139, error: 0.001 }}
-  - match:    { aggregations.page.buckets.0.top_hits.hits.hits.1._explanation.description: "weight(text:the in 1) [PerFieldSimilarity], result of:" }
+  - match:    { aggregations.page.buckets.0.top_hits.hits.hits.1._explanation.description: "/weight\\(text:the\\ in\\ \\d\\)\\ \\[PerFieldSimilarity\\],\\ result\\ of:/" }
   - match:    { aggregations.page.buckets.1.key: 2 }
   - close_to: { aggregations.page.buckets.1.top_hits.hits.hits.0._explanation.value: { value: 0.12343238, error: 0.001 }}
-  - match:    { aggregations.page.buckets.1.top_hits.hits.hits.0._explanation.description: "weight(text:the in 2) [PerFieldSimilarity], result of:" }
+  - match:    { aggregations.page.buckets.1.top_hits.hits.hits.0._explanation.description: "/weight\\(text:the\\ in\\ \\d\\)\\ \\[PerFieldSimilarity\\],\\ result\\ of:/" }
 
 ---
 from:


### PR DESCRIPTION
The tests for the explanation of top_hits asserted that the explanation
matches precise strings. Which it mostly does. But there seem to be edge
cases where a number in the string varies. We really don't care about
the number. This replaces the string assertion with a regex that doesn't
care about the number.

Closes #84590