### PR TITLE
Test `fetch` in top hits in 7.11+

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/200_top_hits.yml
@@ -227,8 +227,8 @@ named queries:
 ---
 fetch fields:
   - skip:
-        version: " - 7.9.99"
-        reason:  "fetch fields to top_hits in 7.10.0"
+        version: " - 7.10.99"
+        reason:  "fetch fields fixed for top_hits in 7.11.0"
 
   - do:
       search:


### PR DESCRIPTION
Something is wrong with `fetch` in `top_hits` in 7.10 and I'm not sure
what. But at this point it's not worth figuring it out. So we'll skip
testing `fetch` in `top_hits` until 7.11.

Closes #84590
