### PR TITLE
[ML] Fix race condition when stopping a recently relocated datafeed

### DIFF
--- a/docs/changelog/84636.yaml
+++ b/docs/changelog/84636.yaml
@@ -1,0 +1,5 @@
+pr: 84636
+summary: Fix race condition when stopping a recently relocated datafeed
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
@@ -177,10 +177,7 @@ public class TransportStartDatafeedActionTests extends ESTestCase {
             params,
             Collections.emptyMap()
         );
-        assertThat(
-            task.setDatafeedRunner(datafeedRunner),
-            is(TransportStartDatafeedAction.DatafeedTask.StoppedOrIsolatedBeforeRunning.NEITHER)
-        );
+        assertThat(task.setDatafeedRunner(datafeedRunner), is(TransportStartDatafeedAction.DatafeedTask.StoppedOrIsolated.NEITHER));
         return task;
     }
 }


### PR DESCRIPTION
It was possible that a request to stop a datafeed that had very recently
relocated from one node to another could get ignored and leave the
datafeed running.

The changes in this PR fix this by closing a loophole where a stop request
would not get recorded if the DatafeedRunner for the datafeed was set but
its DatafeedRunner.Holder was not. Now we always record that a datafeed
task has been told to stop, and abort the startup process when we see this
has happened.

Relates #81649