### PR TITLE
[7.17] Use providers for expensive input calculation in testingconvention task (#84508)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
@@ -29,6 +29,7 @@ public class TestingConventionsPrecommitPlugin extends PrecommitPlugin implement
                 TestingConventionRule itRule = t.getNaming().maybeCreate("IT");
                 itRule.baseClass("org.elasticsearch.test.ESIntegTestCase");
                 itRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");
+
                 t.setCandidateClassFilesProvider(
                     project.provider(
                         () -> project.getTasks()


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use providers for expensive input calculation in testingconvention task (#84508)