### PR TITLE
adding license requirement to CCR and searchable snapshot

### DIFF
--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -1,6 +1,12 @@
 [role="xpack"]
 [[xpack-ccr]]
 == {ccr-cap}
+
+TIP: To complete these steps, you must obtain a license that includes 
+{ccr}. For more information about Elastic license levels, see 
+https://www.elastic.co/subscriptions and
+{kibana-ref}/managing-licenses.html[License management].
+
 With {ccr}, you can replicate indices across clusters to:
 
 * Continue handling search requests in the event of a datacenter outage

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -1,6 +1,11 @@
 [[searchable-snapshots]]
 == {search-snaps-cap}
 
+TIP: To complete these steps, you must obtain a license that includes 
+{search-snap}. For more information about Elastic license levels, see 
+https://www.elastic.co/subscriptions and
+{kibana-ref}/managing-licenses.html[License management].
+
 {search-snaps-cap} let you use <<snapshot-restore,snapshots>> to search
 infrequently accessed and read-only data in a very cost-effective fashion. The
 <<cold-tier,cold>> and <<frozen-tier,frozen>> data tiers use {search-snaps} to


### PR DESCRIPTION
Using text similar to https://github.com/elastic/elasticsearch/edit/8.0/x-pack/docs/en/watcher/getting-started.asciidoc
