### PR TITLE
Remove dependency on reindex

### DIFF
--- a/modules/kibana/build.gradle
+++ b/modules/kibana/build.gradle
@@ -12,10 +12,6 @@ esplugin {
   classname 'org.elasticsearch.kibana.KibanaPlugin'
 }
 
-dependencies {
-  api project(path: ':modules:reindex')
-}
-
 testClusters.configureEach {
   module ':modules:reindex'
 }


### PR DESCRIPTION
The kibana module only defines a system index, it has no need to include
the reindex module.
