### PR TITLE
Remove immutable map specific write method on StreamOutput

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -46,7 +46,7 @@ public class GetAliasesResponse extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeImmutableMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
         out.writeMap(dataStreamAliases, StreamOutput::writeString, StreamOutput::writeList);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -171,10 +171,10 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
         MappingMetadata.writeMappingMetadata(out, mappings);
-        out.writeImmutableMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
-        out.writeImmutableMap(settings, StreamOutput::writeString, (o, v) -> Settings.writeSettingsToStream(v, o));
-        out.writeImmutableMap(defaultSettings, StreamOutput::writeString, (o, v) -> Settings.writeSettingsToStream(v, o));
-        out.writeImmutableMap(dataStreams, StreamOutput::writeString, StreamOutput::writeOptionalString);
+        out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(settings, StreamOutput::writeString, (o, v) -> Settings.writeSettingsToStream(v, o));
+        out.writeMap(defaultSettings, StreamOutput::writeString, (o, v) -> Settings.writeSettingsToStream(v, o));
+        out.writeMap(dataStreams, StreamOutput::writeString, StreamOutput::writeOptionalString);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -94,8 +94,8 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeImmutableMap(indexToSettings, StreamOutput::writeString, (o, s) -> Settings.writeSettingsToStream(s, o));
-        out.writeImmutableMap(indexToDefaultSettings, StreamOutput::writeString, (o, s) -> Settings.writeSettingsToStream(s, o));
+        out.writeMap(indexToSettings, StreamOutput::writeString, (o, s) -> Settings.writeSettingsToStream(s, o));
+        out.writeMap(indexToDefaultSettings, StreamOutput::writeString, (o, s) -> Settings.writeSettingsToStream(s, o));
     }
 
     private static void parseSettingsField(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -278,7 +278,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeImmutableMap(storeStatuses, StreamOutput::writeString, (o, v) -> {
+        out.writeMap(storeStatuses, StreamOutput::writeString, (o, v) -> {
             o.writeVInt(v.size());
             for (Map.Entry<Integer, List<StoreStatus>> shardStatusesEntry : v.entrySet()) {
                 o.writeInt(shardStatusesEntry.getKey());

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -121,14 +121,14 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
             out.writeString(c.getKey());
             c.getValue().writeTo(out);
         }
-        out.writeImmutableMap(this.mostAvailableSpaceUsage, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeImmutableMap(this.shardSizes, StreamOutput::writeString, (o, v) -> out.writeLong(v == null ? -1 : v));
+        out.writeMap(this.mostAvailableSpaceUsage, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(this.shardSizes, StreamOutput::writeString, (o, v) -> out.writeLong(v == null ? -1 : v));
         if (out.getVersion().onOrAfter(DATA_SET_SIZE_SIZE_VERSION)) {
-            out.writeImmutableMap(this.shardDataSetSizes, (o, s) -> s.writeTo(o), (o, v) -> out.writeLong(v));
+            out.writeMap(this.shardDataSetSizes, (o, s) -> s.writeTo(o), (o, v) -> out.writeLong(v));
         }
-        out.writeImmutableMap(this.routingToDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+        out.writeMap(this.routingToDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
         if (out.getVersion().onOrAfter(StoreStats.RESERVED_BYTES_VERSION)) {
-            out.writeImmutableMap(this.reservedSpace);
+            out.writeMap(this.reservedSpace);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -375,7 +375,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
             entry.snapshot().writeTo(out);
             out.writeByte(entry.state().value());
             out.writeStringCollection(entry.indices);
-            out.writeImmutableMap(entry.shards);
+            out.writeMap(entry.shards);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -1294,7 +1294,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeByte(state.value());
             out.writeCollection(indices.values());
             out.writeLong(startTime);
-            out.writeImmutableMap(shards);
+            out.writeMap(shards);
             out.writeLong(repositoryStateId);
             out.writeOptionalString(failure);
             out.writeGenericMap(userMetadata);
@@ -1302,9 +1302,9 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeStringCollection(dataStreams);
             out.writeOptionalWriteable(source);
             if (source == null) {
-                out.writeImmutableMap(ImmutableOpenMap.of());
+                out.writeMap(ImmutableOpenMap.of());
             } else {
-                out.writeImmutableMap(shardStatusByRepoShardId);
+                out.writeMap(shardStatusByRepoShardId);
             }
             out.writeList(featureStates);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -266,7 +266,7 @@ public class ClusterBlocks implements SimpleDiffable<ClusterBlocks> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         writeBlockSet(global, out);
-        out.writeImmutableMap(indicesBlocks, StreamOutput::writeString, (o, s) -> writeBlockSet(s, o));
+        out.writeMap(indicesBlocks, StreamOutput::writeString, (o, s) -> writeBlockSet(s, o));
     }
 
     private static void writeBlockSet(Set<ClusterBlock> blocks, StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -76,7 +76,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
     }
 
     public static void writeMappingMetadata(StreamOutput out, ImmutableOpenMap<String, MappingMetadata> mappings) throws IOException {
-        out.writeImmutableMap(mappings, StreamOutput::writeString, out.getVersion().before(Version.V_8_0_0) ? (o, v) -> {
+        out.writeMap(mappings, StreamOutput::writeString, out.getVersion().before(Version.V_8_0_0) ? (o, v) -> {
             o.writeVInt(v == EMPTY_MAPPINGS ? 0 : 1);
             if (v != EMPTY_MAPPINGS) {
                 o.writeString(MapperService.SINGLE_MAPPING_NAME);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -20,7 +20,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.Writeable.Writer;
 import org.elasticsearch.common.settings.SecureString;
@@ -602,28 +601,6 @@ public abstract class StreamOutput extends OutputStream {
             keyWriter.write(this, entry.getKey());
             valueWriter.write(this, entry.getValue());
         }
-    }
-
-    /**
-     * Write a {@link ImmutableOpenMap} of {@code K}-type keys to {@code V}-type.
-     *
-     * @param keyWriter The key writer
-     * @param valueWriter The value writer
-     */
-    public final <K, V> void writeImmutableMap(final ImmutableOpenMap<K, V> map, final Writer<K> keyWriter, final Writer<V> valueWriter)
-        throws IOException {
-        writeVInt(map.size());
-        for (final Map.Entry<K, V> entry : map.entrySet()) {
-            keyWriter.write(this, entry.getKey());
-            valueWriter.write(this, entry.getValue());
-        }
-    }
-
-    /**
-     * Write a {@link ImmutableOpenMap} of {@code K}-type keys to {@code V}-type.
-     */
-    public final <K extends Writeable, V extends Writeable> void writeImmutableMap(final ImmutableOpenMap<K, V> map) throws IOException {
-        writeImmutableMap(map, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -521,7 +521,7 @@ public class BytesStreamsTests extends ESTestCase {
 
         final ImmutableOpenMap<String, String> expected = expectedBuilder.build();
         final BytesStreamOutput out = new BytesStreamOutput();
-        out.writeImmutableMap(expected, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(expected, StreamOutput::writeString, StreamOutput::writeString);
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
         final ImmutableOpenMap<String, String> loaded = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
 
@@ -537,7 +537,7 @@ public class BytesStreamsTests extends ESTestCase {
 
         final ImmutableOpenMap<TestWriteable, TestWriteable> expected = expectedBuilder.build();
         final BytesStreamOutput out = new BytesStreamOutput();
-        out.writeImmutableMap(expected);
+        out.writeMap(expected);
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
         final ImmutableOpenMap<TestWriteable, TestWriteable> loaded = in.readImmutableMap(TestWriteable::new, TestWriteable::new);
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -526,7 +526,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
 
         final ImmutableOpenMap<String, String> expected = expectedBuilder.build();
         final RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
-        out.writeImmutableMap(expected, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(expected, StreamOutput::writeString, StreamOutput::writeString);
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
         final ImmutableOpenMap<String, String> loaded = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
 
@@ -542,7 +542,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
 
         final ImmutableOpenMap<TestWriteable, TestWriteable> expected = expectedBuilder.build();
         final RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
-        out.writeImmutableMap(expected);
+        out.writeMap(expected);
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
         final ImmutableOpenMap<TestWriteable, TestWriteable> loaded = in.readImmutableMap(TestWriteable::new, TestWriteable::new);
 


### PR DESCRIPTION
Now that ImmutableOpenMap implements Map, there is no need for the
methods to write them on StreamOutput, since the implementation is
exactly the same as writeMap. This commit removes those methods and
changes the existing callers to writeMap.