### PR TITLE
Fix test and unmute #84617

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskIT.java
@@ -55,7 +55,6 @@ public class GeoIpDownloaderTaskIT extends AbstractGeoIpIT {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84617")
     public void testTaskRemovedAfterCancellation() throws Exception {
         assertAcked(
             client().admin()
@@ -69,11 +68,13 @@ public class GeoIpDownloaderTaskIT extends AbstractGeoIpIT {
             assertNotNull(task);
             assertTrue(task.isAssigned());
         });
-        ListTasksResponse tasks = client().admin()
-            .cluster()
-            .listTasks(new ListTasksRequest().setActions("geoip-downloader[c]"))
-            .actionGet();
-        assertEquals(1, tasks.getTasks().size());
+        assertBusy(() -> {
+            ListTasksResponse tasks = client().admin()
+                .cluster()
+                .listTasks(new ListTasksRequest().setActions("geoip-downloader[c]"))
+                .actionGet();
+            assertEquals(1, tasks.getTasks().size());
+        });
         assertAcked(
             client().admin()
                 .cluster()


### PR DESCRIPTION
I believe that it is a timing issue, sometimes the task is not ready yet. I added a `assertBusy` and run it with `-Dtests.iters=10000` and it didn't fail, so I thought this was good enough. Any thoughts?

I also added all the versions from the initial PR where the test was introduced #84028.