### PR TITLE
[ML] Limit the number of trained model deployments

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -639,7 +639,7 @@ public class MachineLearning extends Plugin
      * potentially growing uncontrollably we impose a limit on the number of
      * trained model deployments.
      */
-    public static final int MAX_TRAINED_MODEL_DEPLOYMENTS = 200;
+    public static final int MAX_TRAINED_MODEL_DEPLOYMENTS = 100;
 
     private static final Logger logger = LogManager.getLogger(MachineLearning.class);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -633,6 +633,14 @@ public class MachineLearning extends Plugin
         Setting.Property.NodeScope
     );
 
+    /**
+     * Each model deployment results in one or more entries in the cluster state
+     * for the model allocations. In order to prevent the cluster state from
+     * potentially growing uncontrollably we impose a limit on the number of
+     * trained model deployments.
+     */
+    public static final int MAX_TRAINED_MODEL_DEPLOYMENTS = 200;
+
     private static final Logger logger = LogManager.getLogger(MachineLearning.class);
 
     private final Settings settings;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -151,6 +151,17 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             return;
         }
 
+        if (TrainedModelAllocationMetadata.fromState(state).modelAllocations().size() >= MachineLearning.MAX_TRAINED_MODEL_DEPLOYMENTS) {
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Could not start model deployment because existing deployments reached the limit of [{}]",
+                    RestStatus.TOO_MANY_REQUESTS,
+                    MachineLearning.MAX_TRAINED_MODEL_DEPLOYMENTS
+                )
+            );
+            return;
+        }
+
         ActionListener<CreateTrainedModelAllocationAction.Response> waitForDeploymentToStart = ActionListener.wrap(
             modelAllocation -> waitForDeploymentState(request.getModelId(), request.getTimeout(), request.getWaitForState(), listener),
             e -> {


### PR DESCRIPTION
For each model deployment there will be one ore more entries
(depending on number of allocations) into the cluster state.
In order to prevent cluster state from growing uncontrollably
we impose a limit to the number of models that can be deployed
at the same time.
