### PR TITLE
Avoid overhead of zip / unzip modules when packaging distribution

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -35,6 +35,10 @@ gradlePlugin {
       id = 'elasticsearch.build'
       implementationClass = 'org.elasticsearch.gradle.internal.BuildPlugin'
     }
+    distro {
+      id = 'elasticsearch.distro'
+      implementationClass = 'org.elasticsearch.gradle.internal.distribution.ElasticsearchDistributionPlugin'
+    }
     distroTest {
       id = 'elasticsearch.distro-test'
       implementationClass = 'org.elasticsearch.gradle.internal.test.DistroTestPlugin'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -1,4 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
 package org.elasticsearch.gradle.internal.distibution
 
-class ElasticsearchDistributionPluginFuncTest {
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class ElasticsearchDistributionPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "copied modules are resolved from explodedBundleZip"() {
+        given:
+        moduleSubProject()
+
+        buildFile << """plugins {
+                id 'base'
+                id 'elasticsearch.distro'
+            }
+            
+            def someCopy = tasks.register('someCopy', Sync) {
+                into 'build/targetDir'
+            }
+            
+            distro.copyModule(someCopy, project(":module"))
+            """
+        when:
+        def result = gradleRunner("someCopy").build()
+
+        then:
+        result.task(":someCopy").outcome == TaskOutcome.SUCCESS
+        file('build/targetDir/modules/some-test-module/some-test-module.jar').exists()
+        file('build/targetDir/modules/some-test-module/plugin-descriptor.properties').exists()
+    }
+
+    private File moduleSubProject() {
+        settingsFile << "include 'module'"
+        file('module/build.gradle') << """
+            plugins {
+                id 'elasticsearch.esplugin'
+            }
+            
+            esplugin {
+                name = 'some-test-module'
+                classname = 'org.acme.never.used.TestPluginClass'
+                description = 'some plugin description'
+            }
+            
+            // for testing purposes only
+            configurations.compileOnly.dependencies.clear()
+        """
+    }
 }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -1,0 +1,4 @@
+package org.elasticsearch.gradle.internal.distibution
+
+class ElasticsearchDistributionPluginFuncTest {
+}

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -18,7 +18,6 @@ class ElasticsearchDistributionPluginFuncTest extends AbstractGradleFuncTest {
         moduleSubProject()
 
         buildFile << """plugins {
-                id 'base'
                 id 'elasticsearch.distro'
             }
             

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -20,9 +20,6 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.CopySpec;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.bundling.Zip;
 
 import java.util.Optional;
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -108,12 +108,12 @@ public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
     protected static void addNoticeGeneration(final Project project, PluginPropertiesExtension extension) {
         final var licenseFile = extension.getLicenseFile();
         var tasks = project.getTasks();
-        Provider<CopySpec> bundleSpec = extension.getBundleSpec();
+        var bundleSpec = extension.getBundleSpec();
         if (licenseFile != null) {
-            bundleSpec = bundleSpec.map(spec -> spec.from(licenseFile.getParentFile(), s -> {
+            bundleSpec.from(licenseFile.getParentFile(), s -> {
                 s.include(licenseFile.getName());
                 s.rename(f -> "LICENSE.txt");
-            }));
+            });
         }
 
         final var noticeFile = extension.getNoticeFile();
@@ -122,8 +122,7 @@ public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
                 noticeTask.setInputFile(noticeFile);
                 noticeTask.source(Util.getJavaMainSourceSet(project).get().getAllJava());
             });
-            bundleSpec = bundleSpec.map(spec -> spec.from(generateNotice));
+            bundleSpec.from(generateNotice);
         }
-        extension.setBundleSpec(bundleSpec);
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -20,7 +20,7 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
         project.getTasks().withType(TestingConventionsTasks.class).named("testingConventions").configure(t -> {
             t.getNaming().clear();
             t.getNaming()
-                .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.tests.util.LuceneTestCase"));
+                    .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.tests.util.LuceneTestCase"));
             t.getNaming().create("IT", testingConventionRule -> {
                 testingConventionRule.baseClass("org.elasticsearch.test.ESIntegTestCase");
                 testingConventionRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -20,7 +20,7 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
         project.getTasks().withType(TestingConventionsTasks.class).named("testingConventions").configure(t -> {
             t.getNaming().clear();
             t.getNaming()
-                    .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.tests.util.LuceneTestCase"));
+                .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.tests.util.LuceneTestCase"));
             t.getNaming().create("IT", testingConventionRule -> {
                 testingConventionRule.baseClass("org.elasticsearch.test.ESIntegTestCase");
                 testingConventionRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
@@ -1,0 +1,2 @@
+package org.elasticsearch.gradle.internal.distribution;public class ElasticsearchDistributionExtension {
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
@@ -11,7 +11,6 @@ package org.elasticsearch.gradle.internal.distribution;
 import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -32,14 +31,14 @@ public class ElasticsearchDistributionExtension {
     }
 
     private Configuration moduleZip(Project module) {
-        Map<String, String> moduleConfigurationCoords = Map.of("path", module.getPath(), "configuration", EXPLODED_BUNDLE_CONFIG);
-        Dependency dep = project.getDependencies().project(moduleConfigurationCoords);
+        var moduleConfigurationCoords = Map.of("path", module.getPath(), "configuration", EXPLODED_BUNDLE_CONFIG);
+        var dep = project.getDependencies().project(moduleConfigurationCoords);
         return project.getConfigurations().detachedConfiguration(dep);
     }
 
     public void copyModule(TaskProvider<AbstractCopyTask> copyTask, Project module) {
         copyTask.configure(sync -> {
-            Configuration moduleConfig = moduleZip(module);
+            var moduleConfig = moduleZip(module);
             sync.dependsOn(moduleConfig);
             Callable<File> callableSingleFile = () -> moduleConfig.getSingleFile();
             sync.from(callableSingleFile, spec -> {
@@ -50,7 +49,7 @@ public class ElasticsearchDistributionExtension {
 
                 // This adds a implicit dependency for 'module' to PluginBuildPlugin which is fine as we just fail
                 // in case an invalid 'module' not applying this plugin is passed here
-                String moduleName = module.getExtensions().getByType(PluginPropertiesExtension.class).getName();
+                var moduleName = module.getExtensions().getByType(PluginPropertiesExtension.class).getName();
 
                 spec.eachFile(d -> {
                     if (CONFIG_BIN_REGEX_PATTERN.matcher(d.getRelativePath().getPathString()).matches() == false) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
@@ -1,2 +1,61 @@
-package org.elasticsearch.gradle.internal.distribution;public class ElasticsearchDistributionExtension {
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.distribution;
+
+import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.tasks.AbstractCopyTask;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.elasticsearch.gradle.plugin.PluginBuildPlugin.EXPLODED_BUNDLE_CONFIG;
+
+public class ElasticsearchDistributionExtension {
+
+    private final Project project;
+
+    public ElasticsearchDistributionExtension(Project project) {
+        this.project = project;
+    }
+
+    private Configuration moduleZip(Project module) {
+        Dependency dep = project.getDependencies().project(Map.of("path", module.getPath(), "configuration", EXPLODED_BUNDLE_CONFIG));
+        Configuration config = project.getConfigurations().detachedConfiguration(dep);
+        return config;
+    }
+
+    public void copyModule(TaskProvider<AbstractCopyTask> copyTask, Project module) {
+        copyTask.configure(sync -> {
+            Configuration moduleConfig = moduleZip(module);
+            sync.dependsOn(moduleConfig);
+            Callable<Object> callableSingleFile = () -> moduleConfig.getSingleFile();
+            sync.from(callableSingleFile, spec -> {
+                spec.setIncludeEmptyDirs(false);
+
+                // these are handled separately in the log4j config tasks in the :distribution plugin
+                spec.exclude("*/config/log4j2.properties");
+                spec.exclude("config/log4j2.properties");
+                String moduleName = resolveModuleName(module);
+                spec.eachFile(d -> d.setRelativePath(d.getRelativePath().prepend("modules", moduleName)));
+            });
+        });
+    }
+
+    private static String resolveModuleName(Project module) {
+        if (module.getPlugins().hasPlugin("elasticsearch.esplugin")) {
+            return module.getExtensions().getByType(PluginPropertiesExtension.class).getName();
+        }
+        throw new GradleException("Cannot copy from project not applying the 'elasticsearch.esplugin' plugin");
+    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
@@ -18,11 +18,13 @@ import org.gradle.api.tasks.TaskProvider;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
 
 import static org.elasticsearch.gradle.plugin.PluginBuildPlugin.EXPLODED_BUNDLE_CONFIG;
 
 public class ElasticsearchDistributionExtension {
-    public static final String CONFIG_BIN_REGEX = "([^\\/]+\\/)?(config|bin)\\/.*";
+    private static final Pattern CONFIG_BIN_REGEX_PATTERN = Pattern.compile("([^\\/]+\\/)?(config|bin)\\/.*");
+
     private final Project project;
 
     public ElasticsearchDistributionExtension(Project project) {
@@ -45,12 +47,13 @@ public class ElasticsearchDistributionExtension {
                 // these are handled separately in the log4j config tasks in the :distribution plugin
                 spec.exclude("*/config/log4j2.properties");
                 spec.exclude("config/log4j2.properties");
+
                 // This adds a implicit dependency for 'module' to PluginBuildPlugin which is fine as we just fail
                 // in case an invalid 'module' not applying this plugin is passed here
                 String moduleName = module.getExtensions().getByType(PluginPropertiesExtension.class).getName();
 
                 spec.eachFile(d -> {
-                    if (d.getRelativePath().getPathString().matches(CONFIG_BIN_REGEX) == false) {
+                    if (CONFIG_BIN_REGEX_PATTERN.matcher(d.getRelativePath().getPathString()).matches() == false) {
                         d.setRelativePath(d.getRelativePath().prepend("modules", moduleName));
                     }
                 });

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
@@ -1,0 +1,2 @@
+package org.elasticsearch.gradle.internal.distribution;public class ElasticsearchDistributionPlugin {
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
@@ -1,2 +1,25 @@
-package org.elasticsearch.gradle.internal.distribution;public class ElasticsearchDistributionPlugin {
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.distribution;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Provides an extension named 'distro' to provide common operations used when setting up and bundling
+ * elasticsearch distributions. Having those here instead of in the build scripts makes testing and maintaining
+ * this common functionality easier
+ * */
+public class ElasticsearchDistributionPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().create("distro", ElasticsearchDistributionExtension.class, project);
+    }
 }

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.plugin
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "can assemble plugin via #taskName"() {
+        given:
+        buildFile << """plugins {
+                id 'elasticsearch.esplugin'
+            }
+            
+            esplugin { 
+                description = 'test plugin'
+                classname = 'com.acme.plugin.TestPlugin'
+            }
+            
+            tasks.named('explodedBundlePlugin').configure {
+                doLast {
+                    println outputs.files.files[0].listFiles()
+                }
+            }
+            // for testing purposes only
+            configurations.compileOnly.dependencies.clear()
+            """
+
+        when:
+        def result = gradleRunner(taskName).build()
+
+        then:
+        result.task(taskName).outcome == TaskOutcome.SUCCESS
+        file(expectedOutputPath).exists()
+
+        where:
+        expectedOutputPath                    | taskName
+        "build/distributions/hello-world.zip" | ":bundlePlugin"
+        "build/explodedBundle/"               | ":explodedBundlePlugin"
+
+    }
+
+}

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.gradle.plugin;
 
-import groovy.lang.Closure;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.gradle.Version;
@@ -31,6 +29,7 @@ import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -50,6 +49,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 /**
@@ -72,37 +72,36 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
         final var bundleTask = createBundleTasks(project, extension);
         project.afterEvaluate(project1 -> {
-            final var extension1 = project1.getExtensions().getByType(PluginPropertiesExtension.class);
-            configurePublishing(project1, extension1);
-            var name = extension1.getName();
+            configurePublishing(project1, extension);
+            String name = extension.getName();
             project1.setProperty("archivesBaseName", name);
-            project1.setDescription(extension1.getDescription());
+            project1.setDescription(extension.getDescription());
 
-            if (extension1.getName() == null) {
+            if (extension.getName() == null) {
                 throw new InvalidUserDataException("name is a required setting for esplugin");
             }
 
-            if (extension1.getDescription() == null) {
+            if (extension.getDescription() == null) {
                 throw new InvalidUserDataException("description is a required setting for esplugin");
             }
 
-            if (extension1.getType().equals(PluginType.BOOTSTRAP) == false && extension1.getClassname() == null) {
+            if (extension.getType().equals(PluginType.BOOTSTRAP) == false && extension.getClassname() == null) {
                 throw new InvalidUserDataException("classname is a required setting for esplugin");
             }
 
             Map<String, Object> map = new LinkedHashMap<>(12);
-            map.put("name", extension1.getName());
-            map.put("description", extension1.getDescription());
-            map.put("version", extension1.getVersion());
+            map.put("name", extension.getName());
+            map.put("description", extension.getDescription());
+            map.put("version", extension.getVersion());
             map.put("elasticsearchVersion", Version.fromString(VersionProperties.getElasticsearch()).toString());
             map.put("javaVersion", project1.getExtensions().getByType(JavaPluginExtension.class).getTargetCompatibility().toString());
-            map.put("classname", extension1.getType().equals(PluginType.BOOTSTRAP) ? "" : extension1.getClassname());
-            map.put("extendedPlugins", extension1.getExtendedPlugins().stream().collect(Collectors.joining(",")));
-            map.put("hasNativeController", extension1.isHasNativeController());
-            map.put("requiresKeystore", extension1.isRequiresKeystore());
-            map.put("type", extension1.getType().toString());
-            map.put("javaOpts", extension1.getJavaOpts());
-            map.put("licensed", extension1.isLicensed());
+            map.put("classname", extension.getType().equals(PluginType.BOOTSTRAP) ? "" : extension.getClassname());
+            map.put("extendedPlugins", extension.getExtendedPlugins().stream().collect(Collectors.joining(",")));
+            map.put("hasNativeController", extension.isHasNativeController());
+            map.put("requiresKeystore", extension.isRequiresKeystore());
+            map.put("type", extension.getType().toString());
+            map.put("javaOpts", extension.getJavaOpts());
+            map.put("licensed", extension.isLicensed());
             project1.getTasks().withType(Copy.class).named("pluginProperties").configure(copy -> {
                 copy.expand(map);
                 copy.getInputs().properties(map);
@@ -113,6 +112,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
         // allow running ES with this plugin in the foreground of a build
         var testClusters = testClusters(project, TestClustersPlugin.EXTENSION_NAME);
         var runCluster = testClusters.register("runTask", c -> {
+            // TODO: use explodedPlugin here for modules
             if (GradleUtils.isModuleProject(project.getPath())) {
                 c.module(bundleTask.flatMap((Transformer<Provider<RegularFile>, Zip>) zip -> zip.getArchiveFile()));
             } else {
@@ -194,43 +194,10 @@ public class PluginBuildPlugin implements Plugin<Project> {
         testSourceSet.getOutput().dir(map, new File(project.getBuildDir(), "generated-resources"));
         testSourceSet.getResources().srcDir(pluginMetadata);
 
+        Provider<CopySpec> bundleSpec = createBundleSpec(project, pluginMetadata, buildProperties);
+        extension.setBundleSpec(bundleSpec);
         // create the actual bundle task, which zips up all the files for the plugin
-        final var bundle = project.getTasks().register("bundlePlugin", Zip.class, zip -> {
-            zip.from(buildProperties);
-            zip.from(pluginMetadata, copySpec -> {
-                // metadata (eg custom security policy)
-                // the codebases properties file is only for tests and not needed in production
-                copySpec.exclude("plugin-security.codebases");
-            });
-
-            /*
-             * If the plugin is using the shadow plugin then we need to bundle
-             * that shadow jar.
-             */
-            zip.from(new Closure<Object>(null, null) {
-                public Object doCall(Object it) {
-                    return project.getPluginManager().hasPlugin("com.github.johnrengelman.shadow")
-                        ? project.getTasks().named("shadowJar")
-                        : project.getTasks().named("jar");
-                }
-
-                public Object doCall() {
-                    return doCall(null);
-                }
-
-            });
-            zip.from(
-                project.getConfigurations()
-                    .getByName("runtimeClasspath")
-                    .minus(project.getConfigurations().getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME))
-            );
-            // extra files for the plugin to go into the zip
-            zip.from("src/main/packaging");// TODO: move all config/bin/_size/etc into packaging
-            zip.from("src/main", copySpec -> {
-                copySpec.include("config/**");
-                copySpec.include("bin/**");
-            });
-        });
+        final var bundle = project.getTasks().register("bundlePlugin", Zip.class, zip -> zip.with(bundleSpec.get()));
         project.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME).configure(task -> task.dependsOn(bundle));
 
         // also make the zip available as a configuration (used when depending on this project)
@@ -238,7 +205,48 @@ public class PluginBuildPlugin implements Plugin<Project> {
         configuration.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE);
         project.getArtifacts().add("zip", bundle);
 
+        TaskProvider<Copy> explodedBundle = project.getTasks().register("explodedBundlePlugin", Copy.class, copy -> {
+            copy.with(bundleSpec.get());
+            copy.into(new File(project.getBuildDir(), "explodedBundle"));
+        });
+
+        // also make the exploded bundle available as a configuration (used when depending on this project)
+        Configuration explodedZip = project.getConfigurations().create("explodedZip");
+        explodedZip.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
+        project.getArtifacts().add("explodedZip", explodedBundle);
         return bundle;
+    }
+
+    private static Provider<CopySpec> createBundleSpec(Project project, File pluginMetadata, TaskProvider<Copy> buildProperties) {
+
+        return project.provider(() -> {
+            CopySpec bundleSpec = project.copySpec();
+            bundleSpec.from(buildProperties);
+            bundleSpec.from(pluginMetadata, copySpec -> {
+                // metadata (eg custom security policy)
+                // the codebases properties file is only for tests and not needed in production
+                copySpec.exclude("plugin-security.codebases");
+            });
+            bundleSpec.from(
+                (Callable<TaskProvider<Task>>) () -> project.getPluginManager().hasPlugin("com.github.johnrengelman.shadow")
+                    ? project.getTasks().named("shadowJar")
+                    : project.getTasks().named("jar")
+            );
+            bundleSpec.from(
+                project.getConfigurations()
+                    .getByName("runtimeClasspath")
+                    .minus(project.getConfigurations().getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME))
+            );
+
+            // extra files for the plugin to go into the zip
+            bundleSpec.from("src/main/packaging");// TODO: move all config/bin/_size/etc into packaging
+            bundleSpec.from("src/main", copySpec -> {
+                copySpec.include("config/**");
+                copySpec.include("bin/**");
+            });
+            return bundleSpec;
+        });
+
     }
 
     public static final String PLUGIN_EXTENSION_NAME = "esplugin";

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -59,6 +59,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
     public static final String PLUGIN_EXTENSION_NAME = "esplugin";
     public static final String BUNDLE_PLUGIN_TASK_NAME = "bundlePlugin";
+    public static final String EXPLODED_BUNDLE_CONFIG = "explodedBundleZip";
 
     @Override
     public void apply(final Project project) {
@@ -212,9 +213,11 @@ public class PluginBuildPlugin implements Plugin<Project> {
         });
 
         // also make the exploded bundle available as a configuration (used when depending on this project)
-        Configuration explodedZip = project.getConfigurations().create("explodedZip");
-        explodedZip.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
-        project.getArtifacts().add("explodedZip", explodedBundle);
+        Configuration explodedBundleZip = project.getConfigurations().create(EXPLODED_BUNDLE_CONFIG);
+        explodedBundleZip.setCanBeResolved(false);
+        explodedBundleZip.setCanBeConsumed(true);
+        explodedBundleZip.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
+        project.getArtifacts().add(EXPLODED_BUNDLE_CONFIG, explodedBundle);
         return bundle;
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -219,31 +219,31 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
     private static CopySpec createBundleSpec(Project project, File pluginMetadata, TaskProvider<Copy> buildProperties) {
 
-            CopySpec bundleSpec = project.copySpec();
-            bundleSpec.from(buildProperties);
-            bundleSpec.from(pluginMetadata, copySpec -> {
-                // metadata (eg custom security policy)
-                // the codebases properties file is only for tests and not needed in production
-                copySpec.exclude("plugin-security.codebases");
-            });
-            bundleSpec.from(
-                (Callable<TaskProvider<Task>>) () -> project.getPluginManager().hasPlugin("com.github.johnrengelman.shadow")
-                    ? project.getTasks().named("shadowJar")
-                    : project.getTasks().named("jar")
-            );
-            bundleSpec.from(
-                project.getConfigurations()
-                    .getByName("runtimeClasspath")
-                    .minus(project.getConfigurations().getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME))
-            );
+        CopySpec bundleSpec = project.copySpec();
+        bundleSpec.from(buildProperties);
+        bundleSpec.from(pluginMetadata, copySpec -> {
+            // metadata (eg custom security policy)
+            // the codebases properties file is only for tests and not needed in production
+            copySpec.exclude("plugin-security.codebases");
+        });
+        bundleSpec.from(
+            (Callable<TaskProvider<Task>>) () -> project.getPluginManager().hasPlugin("com.github.johnrengelman.shadow")
+                ? project.getTasks().named("shadowJar")
+                : project.getTasks().named("jar")
+        );
+        bundleSpec.from(
+            project.getConfigurations()
+                .getByName("runtimeClasspath")
+                .minus(project.getConfigurations().getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME))
+        );
 
-            // extra files for the plugin to go into the zip
-            bundleSpec.from("src/main/packaging");// TODO: move all config/bin/_size/etc into packaging
-            bundleSpec.from("src/main", copySpec -> {
-                copySpec.include("config/**");
-                copySpec.include("bin/**");
-            });
-            return bundleSpec;
+        // extra files for the plugin to go into the zip
+        bundleSpec.from("src/main/packaging");// TODO: move all config/bin/_size/etc into packaging
+        bundleSpec.from("src/main", copySpec -> {
+            copySpec.include("config/**");
+            copySpec.include("bin/**");
+        });
+        return bundleSpec;
 
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.RegularFile;
@@ -157,7 +156,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
     }
 
     /**
-     * Adds bundlePlugin tasks which builds the dir and zip containing the plugin jars,
+     * Adds bundle tasks which builds the dir and zip containing the plugin jars,
      * metadata, properties, and packaging files
      */
     private static TaskProvider<Zip> createBundleTasks(final Project project, PluginPropertiesExtension extension) {
@@ -196,14 +195,14 @@ public class PluginBuildPlugin implements Plugin<Project> {
         testSourceSet.getOutput().dir(map, new File(project.getBuildDir(), "generated-resources"));
         testSourceSet.getResources().srcDir(pluginMetadata);
 
-        CopySpec bundleSpec = createBundleSpec(project, pluginMetadata, buildProperties);
+        var bundleSpec = createBundleSpec(project, pluginMetadata, buildProperties);
         extension.setBundleSpec(bundleSpec);
         // create the actual bundle task, which zips up all the files for the plugin
         final var bundle = project.getTasks().register("bundlePlugin", Zip.class, zip -> zip.with(bundleSpec));
         project.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME).configure(task -> task.dependsOn(bundle));
 
         // also make the zip available as a configuration (used when depending on this project)
-        Configuration configuration = project.getConfigurations().create("zip");
+        var configuration = project.getConfigurations().create("zip");
         configuration.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE);
         project.getArtifacts().add("zip", bundle);
 
@@ -213,7 +212,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
         });
 
         // also make the exploded bundle available as a configuration (used when depending on this project)
-        Configuration explodedBundleZip = project.getConfigurations().create(EXPLODED_BUNDLE_CONFIG);
+        var explodedBundleZip = project.getConfigurations().create(EXPLODED_BUNDLE_CONFIG);
         explodedBundleZip.setCanBeResolved(false);
         explodedBundleZip.setCanBeConsumed(true);
         explodedBundleZip.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
@@ -222,8 +221,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
     }
 
     private static CopySpec createBundleSpec(Project project, File pluginMetadata, TaskProvider<Copy> buildProperties) {
-
-        CopySpec bundleSpec = project.copySpec();
+        var bundleSpec = project.copySpec();
         bundleSpec.from(buildProperties);
         bundleSpec.from(pluginMetadata, copySpec -> {
             // metadata (eg custom security policy)
@@ -248,7 +246,5 @@ public class PluginBuildPlugin implements Plugin<Project> {
             copySpec.include("bin/**");
         });
         return bundleSpec;
-
     }
-
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -39,6 +39,7 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Zip;
 
@@ -206,9 +207,9 @@ public class PluginBuildPlugin implements Plugin<Project> {
         configuration.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE);
         project.getArtifacts().add("zip", bundle);
 
-        TaskProvider<Copy> explodedBundle = project.getTasks().register("explodedBundlePlugin", Copy.class, copy -> {
-            copy.with(bundleSpec);
-            copy.into(new File(project.getBuildDir(), "explodedBundle"));
+        var explodedBundle = project.getTasks().register("explodedBundlePlugin", Sync.class, sync -> {
+            sync.with(bundleSpec);
+            sync.into(new File(project.getBuildDir(), "explodedBundle"));
         });
 
         // also make the exploded bundle available as a configuration (used when depending on this project)

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
  */
 public class PluginBuildPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_EXTENSION_NAME = "esplugin";
     public static final String BUNDLE_PLUGIN_TASK_NAME = "bundlePlugin";
 
     @Override
@@ -155,7 +156,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
     }
 
     /**
-     * Adds a bundlePlugin task which builds the zip containing the plugin jars,
+     * Adds bundlePlugin tasks which builds the dir and zip containing the plugin jars,
      * metadata, properties, and packaging files
      */
     private static TaskProvider<Zip> createBundleTasks(final Project project, PluginPropertiesExtension extension) {
@@ -247,5 +248,4 @@ public class PluginBuildPlugin implements Plugin<Project> {
 
     }
 
-    public static final String PLUGIN_EXTENSION_NAME = "esplugin";
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
@@ -56,7 +56,7 @@ public class PluginPropertiesExtension {
     private File noticeFile;
 
     private final Project project;
-    private Provider<CopySpec> bundleSpec;
+    private CopySpec bundleSpec;
 
     public PluginPropertiesExtension(Project project) {
         this.project = project;
@@ -172,11 +172,11 @@ public class PluginPropertiesExtension {
         this.extendedPlugins = extendedPlugins;
     }
 
-    public void setBundleSpec(Provider<CopySpec> bundleSpec) {
+    public void setBundleSpec(CopySpec bundleSpec) {
         this.bundleSpec = bundleSpec;
     }
 
-    public Provider<CopySpec> getBundleSpec() {
+    public CopySpec getBundleSpec() {
         return bundleSpec;
     }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
@@ -12,7 +12,6 @@ import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
-import org.gradle.api.provider.Provider;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
@@ -9,8 +9,10 @@
 package org.elasticsearch.gradle.plugin;
 
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.provider.Provider;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -54,6 +56,7 @@ public class PluginPropertiesExtension {
     private File noticeFile;
 
     private final Project project;
+    private Provider<CopySpec> bundleSpec;
 
     public PluginPropertiesExtension(Project project) {
         this.project = project;
@@ -167,5 +170,13 @@ public class PluginPropertiesExtension {
 
     public void setExtendedPlugins(List<String> extendedPlugins) {
         this.extendedPlugins = extendedPlugins;
+    }
+
+    public void setBundleSpec(Provider<CopySpec> bundleSpec) {
+        this.bundleSpec = bundleSpec;
+    }
+
+    public Provider<CopySpec> getBundleSpec() {
+        return bundleSpec;
     }
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -20,6 +20,7 @@ import java.nio.file.Path
 
 plugins {
   id 'base'
+  id 'elasticsearch.distro'
 }
 
 configurations {
@@ -129,40 +130,6 @@ def buildExternalTestModulesTaskProvider = tasks.register("buildExternalTestModu
   outputs.dir "${externalTestOutputs}/modules"
 }
 
-Configuration moduleZip(Project module) {
-  Dependency dep = project.dependencies.project(path: module.path, configuration: 'explodedZip')
-  Configuration config = project.configurations.detachedConfiguration(dep)
-  return config
-}
-
-void copyModule(TaskProvider<Sync> copyTask, Project module) {
-  copyTask.configure {
-    Configuration moduleConfig = moduleZip(module)
-
-    dependsOn moduleConfig
-    from({ moduleConfig.singleFile }) {
-      includeEmptyDirs false
-
-      // these are handled separately in the log4j config tasks below
-      exclude '*/config/log4j2.properties'
-      exclude 'config/log4j2.properties'
-
-      eachFile { details ->
-        String name = module.esplugin.name
-        // Copy all non config/bin files
-        // Note these might be unde a subdirectory in the case of a meta plugin
-        if ((details.relativePath.pathString ==~ /([^\/]+\/)?(config|bin)\/.*/) == false) {
-          details.relativePath = details.relativePath.prepend('modules', name)
-        } else if ((details.relativePath.pathString ==~ /([^\/]+\/)(config|bin)\/.*/)) {
-          // this is the meta plugin case, in which we need to remove the intermediate dir
-          String[] segments = details.relativePath.segments
-          details.relativePath = new RelativePath(true, segments.takeRight(segments.length - 1))
-        }
-      }
-    }
-  }
-}
-
 def buildDefaultLog4jConfigTaskProvider = tasks.register("buildDefaultLog4jConfig") {
   mustRunAfter('processDefaultOutputs')
 
@@ -209,9 +176,9 @@ project.rootProject.subprojects.findAll { it.parent.path == ':modules' }.each { 
     }
   }
 
-  copyModule(processDefaultOutputsTaskProvider, module)
+  distro.copyModule(processDefaultOutputsTaskProvider, module)
   if (module.name.startsWith('transport-')) {
-    copyModule(processIntegTestOutputsTaskProvider, module)
+    distro.copyModule(processIntegTestOutputsTaskProvider, module)
   }
 
   restTestExpansions['expected.modules.count'] += 1
@@ -227,16 +194,16 @@ xpack.subprojects.findAll { it.parent == xpack }.each { Project xpackModule ->
       source xpackModule.file('src/main/java')
     }
   }
-  copyModule(processDefaultOutputsTaskProvider, xpackModule)
+  distro.copyModule(processDefaultOutputsTaskProvider, xpackModule)
   if (xpackModule.name.equals('core') || xpackModule.name.equals('security')) {
-    copyModule(processIntegTestOutputsTaskProvider, xpackModule)
+    distro.copyModule(processIntegTestOutputsTaskProvider, xpackModule)
   }
 }
 
-copyModule(processSystemdOutputsTaskProvider, project(':modules:systemd'))
+distro.copyModule(processSystemdOutputsTaskProvider, project(':modules:systemd'))
 
 project(':test:external-modules').subprojects.each { Project testModule ->
-  copyModule(processExternalTestOutputsTaskProvider, testModule)
+  distro.copyModule(processExternalTestOutputsTaskProvider, testModule)
 }
 
 configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -130,7 +130,7 @@ def buildExternalTestModulesTaskProvider = tasks.register("buildExternalTestModu
 }
 
 Configuration moduleZip(Project module) {
-  Dependency dep = project.dependencies.project(path: module.path, configuration: 'zip')
+  Dependency dep = project.dependencies.project(path: module.path, configuration: 'explodedZip')
   Configuration config = project.configurations.detachedConfiguration(dep)
   return config
 }
@@ -140,7 +140,7 @@ void copyModule(TaskProvider<Sync> copyTask, Project module) {
     Configuration moduleConfig = moduleZip(module)
 
     dependsOn moduleConfig
-    from({ zipTree(moduleConfig.singleFile) }) {
+    from({ moduleConfig.singleFile }) {
       includeEmptyDirs false
 
       // these are handled separately in the log4j config tasks below

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'elasticsearch.internal-cluster-test'
 esplugin {
   description 'Ingest processor that uses lookup geo data based on IP addresses using the MaxMind geo database'
   classname 'org.elasticsearch.ingest.geoip.IngestGeoIpPlugin'
+
+  bundleSpec.from("${project.buildDir}/ingest-geoip") {
+    into '/'
+  }
 }
 
 dependencies {
@@ -55,10 +59,6 @@ tasks.named("internalClusterTest").configure {
   if (useFixture) {
     nonInputProperties.systemProperty "geoip_endpoint", "${-> fixtureAddress()}"
   }
-}
-
-esplugin.bundleSpec.from("${project.buildDir}/ingest-geoip") {
-    into '/'
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -57,10 +57,8 @@ tasks.named("internalClusterTest").configure {
   }
 }
 
-tasks.named("bundlePlugin").configure {
-  from("${project.buildDir}/ingest-geoip") {
+esplugin.bundleSpec.from("${project.buildDir}/ingest-geoip") {
     into '/'
-  }
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -7,55 +7,56 @@
  */
 
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask;
+
 apply plugin: 'elasticsearch.validate-rest-spec'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 esplugin {
-  description 'An easy, safe and fast scripting language for Elasticsearch'
-  classname 'org.elasticsearch.painless.PainlessPlugin'
+    description 'An easy, safe and fast scripting language for Elasticsearch'
+    classname 'org.elasticsearch.painless.PainlessPlugin'
 }
 
 testClusters.configureEach {
-  module ':modules:mapper-extras'
-  systemProperty 'es.scripting.update.ctx_in_params', 'false'
-  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
-  systemProperty 'es.transport.cname_in_publish_address', 'true'
+    module ':modules:mapper-extras'
+    systemProperty 'es.scripting.update.ctx_in_params', 'false'
+    // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+    systemProperty 'es.transport.cname_in_publish_address', 'true'
 }
 
 configurations {
-  spi
-  compileOnlyApi.extendsFrom(spi)
-  if (isEclipse) {
-    // Eclipse buildship doesn't know about compileOnlyApi
-    api.extendsFrom(spi)
-  }
+    spi
+    compileOnlyApi.extendsFrom(spi)
+    if (isEclipse) {
+        // Eclipse buildship doesn't know about compileOnlyApi
+        api.extendsFrom(spi)
+    }
 }
 
 dependencies {
-  api 'org.antlr:antlr4-runtime:4.5.3'
-  api 'org.ow2.asm:asm-util:7.2'
-  api 'org.ow2.asm:asm-tree:7.2'
-  api 'org.ow2.asm:asm-commons:7.2'
-  api 'org.ow2.asm:asm-analysis:7.2'
-  api 'org.ow2.asm:asm:7.2'
-  spi project('spi')
+    api 'org.antlr:antlr4-runtime:4.5.3'
+    api 'org.ow2.asm:asm-util:7.2'
+    api 'org.ow2.asm:asm-tree:7.2'
+    api 'org.ow2.asm:asm-commons:7.2'
+    api 'org.ow2.asm:asm-analysis:7.2'
+    api 'org.ow2.asm:asm:7.2'
+    spi project('spi')
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /asm-.*/, to: 'asm'
+    mapping from: /asm-.*/, to: 'asm'
 }
 
 restResources {
-  restApi {
-    include '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get', 'bulk', 'update',
+    restApi {
+        include '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get', 'bulk', 'update',
                 'scripts_painless_execute', 'put_script', 'delete_script'
-  }
+    }
 }
 
 tasks.named("test").configure {
-  // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
-  jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
+    // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
+    jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
 }
 
 tasks.named("yamlRestTestV7CompatTest").configure {
@@ -102,28 +103,26 @@ tasks.named("yamlRestTestV7CompatTest").configure {
 /* Build Javadoc for the Java classes in Painless's public API that are in the
  * Painless plugin */
 tasks.register("apiJavadoc", Javadoc) {
-  source = sourceSets.main.allJava
-  classpath = sourceSets.main.compileClasspath + sourceSets.main.output
-  include '**/org/elasticsearch/painless/api/'
-  destinationDir = new File(docsDir, 'apiJavadoc')
+    source = sourceSets.main.allJava
+    classpath = sourceSets.main.compileClasspath + sourceSets.main.output
+    include '**/org/elasticsearch/painless/api/'
+    destinationDir = new File(docsDir, 'apiJavadoc')
 }
 
 tasks.register("apiJavadocJar", Jar) {
-  archiveClassifier = 'apiJavadoc'
-  from apiJavadoc
+    archiveClassifier = 'apiJavadoc'
+    from apiJavadoc
 }
 
 tasks.named("assemble").configure {
-  dependsOn "apiJavadocJar"
+    dependsOn "apiJavadocJar"
 }
 tasks.named("check").configure {
-  dependsOn "apiJavadocJar"
+    dependsOn "apiJavadocJar"
 }
 
-tasks.named("bundlePlugin").configure {
-  it.into("spi") {
+esplugin.bundleSpec.into("spi") {
     from(configurations.spi)
-  }
 }
 
 /**********************************************
@@ -131,39 +130,39 @@ tasks.named("bundlePlugin").configure {
  **********************************************/
 
 sourceSets {
-  doc
+    doc
 }
 
 dependencies {
-  docImplementation project(':server')
-  docImplementation project(':modules:lang-painless')
-  docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
-  docImplementation 'org.jsoup:jsoup:1.13.1'
-  if (isEclipse) {
-    /*
-     * Eclipse isn't quite "with it" enough to understand the different
-     * source sets. This adds the dependency to all source sets so it
-     * can compile the doc java files.
-     */
-    implementation 'com.github.javaparser:javaparser-core:3.18.0'
-    implementation 'org.jsoup:jsoup:1.13.1'
-  }
+    docImplementation project(':server')
+    docImplementation project(':modules:lang-painless')
+    docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
+    docImplementation 'org.jsoup:jsoup:1.13.1'
+    if (isEclipse) {
+        /*
+         * Eclipse isn't quite "with it" enough to understand the different
+         * source sets. This adds the dependency to all source sets so it
+         * can compile the doc java files.
+         */
+        implementation 'com.github.javaparser:javaparser-core:3.18.0'
+        implementation 'org.jsoup:jsoup:1.13.1'
+    }
 }
 
 def generateContextCluster = testClusters.register("generateContextCluster") {
-  testDistribution = 'DEFAULT'
+    testDistribution = 'DEFAULT'
 }
 
 tasks.register("generateContextDoc", DefaultTestClustersTask) {
-  dependsOn sourceSets.doc.runtimeClasspath
-  useCluster generateContextCluster
-  doFirst {
-    project.javaexec {
-      mainClass = 'org.elasticsearch.painless.ContextDocGenerator'
-      classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> generateContextCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
-    }.assertNormalExitValue()
-  }
+    dependsOn sourceSets.doc.runtimeClasspath
+    useCluster generateContextCluster
+    doFirst {
+        project.javaexec {
+            mainClass = 'org.elasticsearch.painless.ContextDocGenerator'
+            classpath = sourceSets.doc.runtimeClasspath
+            systemProperty "cluster.uri", "${-> generateContextCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
+        }.assertNormalExitValue()
+    }
 }
 /**********************************************
  *           Context JSON Generation          *
@@ -173,17 +172,17 @@ def generateContextApiSpecCluster = testClusters.register("generateContextApiSpe
 }
 
 tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
-  dependsOn sourceSets.doc.runtimeClasspath
-  useCluster generateContextApiSpecCluster
-  doFirst {
-    project.javaexec {
-      mainClass = 'org.elasticsearch.painless.ContextApiSpecGenerator'
-      classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> generateContextApiSpecCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
-      systemProperty "jdksrc", providers.systemProperty("jdksrc").getOrNull()
-      systemProperty "packageSources", providers.systemProperty("packageSources").getOrNull()
-    }.assertNormalExitValue()
-  }
+    dependsOn sourceSets.doc.runtimeClasspath
+    useCluster generateContextApiSpecCluster
+    doFirst {
+        project.javaexec {
+            mainClass = 'org.elasticsearch.painless.ContextApiSpecGenerator'
+            classpath = sourceSets.doc.runtimeClasspath
+            systemProperty "cluster.uri", "${-> generateContextApiSpecCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
+            systemProperty "jdksrc", providers.systemProperty("jdksrc").getOrNull()
+            systemProperty "packageSources", providers.systemProperty("packageSources").getOrNull()
+        }.assertNormalExitValue()
+    }
 }
 
 /**********************************************
@@ -191,11 +190,11 @@ tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
  **********************************************/
 
 configurations {
-  regenerate
+    regenerate
 }
 
 dependencies {
-  regenerate 'org.antlr:antlr4:4.5.3'
+    regenerate 'org.antlr:antlr4:4.5.3'
 }
 
 String grammarPath = 'src/main/antlr'
@@ -204,86 +203,86 @@ String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/painless/antlr'
 
 pluginManager.withPlugin('com.diffplug.spotless') {
-  spotless {
-    java {
-      targetExclude "${outputPath}/*.java"
+    spotless {
+        java {
+            targetExclude "${outputPath}/*.java"
+        }
     }
-  }
 }
 
 tasks.register("cleanGenerated", Delete) {
-  delete fileTree(grammarPath) {
-    include '*Painless*.tokens'
-  }
-  delete fileTree(outputPath) {
-    include 'Painless*.java'
-  }
+    delete fileTree(grammarPath) {
+        include '*Painless*.tokens'
+    }
+    delete fileTree(outputPath) {
+        include 'Painless*.java'
+    }
 }
 
 tasks.register("regenLexer", JavaExec) {
-  dependsOn "cleanGenerated"
-  mainClass = 'org.antlr.v4.Tool'
-  classpath = configurations.regenerate
-  systemProperty 'file.encoding', 'UTF-8'
-  systemProperty 'user.language', 'en'
-  systemProperty 'user.country', 'US'
-  systemProperty 'user.variant', ''
-  args '-Werror',
-    '-package', 'org.elasticsearch.painless.antlr',
-    '-o', outputPath,
-    "${file(grammarPath)}/PainlessLexer.g4"
+    dependsOn "cleanGenerated"
+    mainClass = 'org.antlr.v4.Tool'
+    classpath = configurations.regenerate
+    systemProperty 'file.encoding', 'UTF-8'
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+    systemProperty 'user.variant', ''
+    args '-Werror',
+            '-package', 'org.elasticsearch.painless.antlr',
+            '-o', outputPath,
+            "${file(grammarPath)}/PainlessLexer.g4"
 }
 
 tasks.register("regenParser", JavaExec) {
-  dependsOn "regenLexer"
-  mainClass = 'org.antlr.v4.Tool'
-  classpath = configurations.regenerate
-  systemProperty 'file.encoding', 'UTF-8'
-  systemProperty 'user.language', 'en'
-  systemProperty 'user.country', 'US'
-  systemProperty 'user.variant', ''
-  args '-Werror',
-    '-package', 'org.elasticsearch.painless.antlr',
-    '-no-listener',
-    '-visitor',
-    // '-Xlog',
-    '-o', outputPath,
-    "${file(grammarPath)}/PainlessParser.g4"
+    dependsOn "regenLexer"
+    mainClass = 'org.antlr.v4.Tool'
+    classpath = configurations.regenerate
+    systemProperty 'file.encoding', 'UTF-8'
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+    systemProperty 'user.variant', ''
+    args '-Werror',
+            '-package', 'org.elasticsearch.painless.antlr',
+            '-no-listener',
+            '-visitor',
+            // '-Xlog',
+            '-o', outputPath,
+            "${file(grammarPath)}/PainlessParser.g4"
 }
 
 tasks.register("regen") {
-  dependsOn "regenParser"
-  doLast {
-    // moves token files to grammar directory for use with IDE's
-    ant.move(file: "${outputPath}/PainlessLexer.tokens", toDir: grammarPath)
-    ant.move(file: "${outputPath}/PainlessParser.tokens", toDir: grammarPath)
-    // make the generated classes package private
-    ant.replaceregexp(match: 'public ((interface|class) \\QPainless\\E\\w+)',
-      replace: '\\1',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
+    dependsOn "regenParser"
+    doLast {
+        // moves token files to grammar directory for use with IDE's
+        ant.move(file: "${outputPath}/PainlessLexer.tokens", toDir: grammarPath)
+        ant.move(file: "${outputPath}/PainlessParser.tokens", toDir: grammarPath)
+        // make the generated classes package private
+        ant.replaceregexp(match: 'public ((interface|class) \\QPainless\\E\\w+)',
+                replace: '\\1',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // make the lexer abstract
+        ant.replaceregexp(match: '(class \\QPainless\\ELexer)',
+                replace: 'abstract \\1',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'PainlessLexer.java')
+        }
+        // nuke timestamps/filenames in generated files
+        ant.replaceregexp(match: '\\Q// Generated from \\E.*',
+                replace: '\\/\\/ ANTLR GENERATED CODE: DO NOT EDIT',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // remove tabs in antlr generated files
+        ant.replaceregexp(match: '\t', flags: 'g', replace: '  ', encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // fix line endings
+        ant.fixcrlf(srcdir: outputPath, eol: 'lf') {
+            patternset(includes: 'Painless*.java')
+        }
     }
-    // make the lexer abstract
-    ant.replaceregexp(match: '(class \\QPainless\\ELexer)',
-      replace: 'abstract \\1',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'PainlessLexer.java')
-    }
-    // nuke timestamps/filenames in generated files
-    ant.replaceregexp(match: '\\Q// Generated from \\E.*',
-      replace: '\\/\\/ ANTLR GENERATED CODE: DO NOT EDIT',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
-    }
-    // remove tabs in antlr generated files
-    ant.replaceregexp(match: '\t', flags: 'g', replace: '  ', encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
-    }
-    // fix line endings
-    ant.fixcrlf(srcdir: outputPath, eol: 'lf') {
-      patternset(includes: 'Painless*.java')
-    }
-  }
 }
 
 /**********************************************

--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -71,10 +71,8 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jaxb-.*/, to: 'jaxb'
 }
 
-tasks.named("bundlePlugin").configure {
-  from('config/repository-s3') {
+esplugin.bundleSpec.from('config/repository-s3') {
     into 'config'
-  }
 }
 
 boolean useFixture = false

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -45,10 +45,8 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
-tasks.named("bundlePlugin").configure {
-  from('config/discovery-ec2') {
+esplugin.bundleSpec.from('config/discovery-ec2') {
     into 'config'
-  }
 }
 
 tasks.register("writeTestJavaPolicy") {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -3,33 +3,33 @@ apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 esplugin {
-    name 'x-pack-ml'
-    description 'Elasticsearch Expanded Pack Plugin - Machine Learning'
-    classname 'org.elasticsearch.xpack.ml.MachineLearning'
-    hasNativeController true
-    extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
+  name 'x-pack-ml'
+  description 'Elasticsearch Expanded Pack Plugin - Machine Learning'
+  classname 'org.elasticsearch.xpack.ml.MachineLearning'
+  hasNativeController true
+  extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
 
 repositories {
-    exclusiveContent {
-        forRepository {
-            ivy {
-                name "ml-cpp"
-                url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
-                metadataSources {
-                    // no repository metadata, look directly for the artifact
-                    artifact()
-                }
-                patternLayout {
-                    artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/ml-cpp-[revision].[ext]"
-                }
-            }
+  exclusiveContent {
+    forRepository {
+      ivy {
+        name "ml-cpp"
+        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
+        metadataSources {
+          // no repository metadata, look directly for the artifact
+          artifact()
         }
         patternLayout {
           artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
         }
+      }
     }
+    filter {
+      includeGroup 'org.elasticsearch.ml'
+    }
+  }
 }
 
 configurations {
@@ -38,21 +38,24 @@ configurations {
   }
 }
 
-tasks.named("bundlePlugin").configure {
-  dependsOn configurations.nativeBundle
-  from {
-    configurations.nativeBundle.files.collect { zipTree(it) }
-  }
+["bundlePlugin", "explodedBundlePlugin"].each { bundleTaskName ->
+    tasks.named(bundleTaskName).configure {
+        dependsOn configurations.nativeBundle
+        from {
+            configurations.nativeBundle.files.collect { zipTree(it) }
+        }
 
-  // We don't ship the individual nativeBundle licenses - instead
-  // they get combined into the top level NOTICES file we ship
-  exclude 'platform/licenses/**'
+        // We don't ship the individual nativeBundle licenses - instead
+        // they get combined into the top level NOTICES file we ship
+        exclude 'platform/licenses/**'
+    }
 }
-// TODO remove code duplication
+
+// TODO look into removing duplication here
 tasks.named("explodedBundlePlugin").configure {
     dependsOn configurations.nativeBundle
     from {
-        project.zipTree(configurations.nativeBundle.singleFile)
+        configurations.nativeBundle.files.collect { zipTree(it) }
     }
 
     // We don't ship the individual nativeBundle licenses - instead
@@ -90,8 +93,8 @@ dependencies {
 }
 
 artifacts {
-    // normal es plugins do not publish the jar but we need to since users need it for extensions
-    archives tasks.named("jar")
+  // normal es plugins do not publish the jar but we need to since users need it for extensions
+  archives tasks.named("jar")
 }
 
 tasks.register("extractNativeLicenses", Copy) {
@@ -103,18 +106,18 @@ tasks.register("extractNativeLicenses", Copy) {
   include 'platform/licenses/**'
 }
 project.afterEvaluate {
-    // Add an extra licenses directory to the combined notices
-    tasks.named('generateNotice').configure {
-        dependsOn "extractNativeLicenses"
-        licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
-        outputs.upToDateWhen {
-            extractNativeLicenses.didWork
-        }
+  // Add an extra licenses directory to the combined notices
+  tasks.named('generateNotice').configure {
+    dependsOn "extractNativeLicenses"
+    licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
+    outputs.upToDateWhen {
+      extractNativeLicenses.didWork
     }
+  }
 }
 
 tasks.named("dependencyLicenses").configure {
-    mapping from: /lucene-.*/, to: 'lucene'
+  mapping from: /lucene-.*/, to: 'lucene'
 }
 
 addQaCheckDependencies()

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -38,16 +38,17 @@ configurations {
   }
 }
 
+esplugin.bundleSpec.from {
+  configurations.nativeBundle.files.collect { zipTree(it) }
+}
+
+// We don't ship the individual nativeBundle licenses - instead
+// they get combined into the top level NOTICES file we ship
+esplugin.bundleSpec.exclude 'platform/licenses/**'
+
 ["bundlePlugin", "explodedBundlePlugin"].each { bundleTaskName ->
     tasks.named(bundleTaskName).configure {
         dependsOn configurations.nativeBundle
-        from {
-            configurations.nativeBundle.files.collect { zipTree(it) }
-        }
-
-        // We don't ship the individual nativeBundle licenses - instead
-        // they get combined into the top level NOTICES file we ship
-        exclude 'platform/licenses/**'
     }
 }
 

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -51,18 +51,6 @@ configurations {
     }
 }
 
-// TODO look into removing duplication here
-tasks.named("explodedBundlePlugin").configure {
-    dependsOn configurations.nativeBundle
-    from {
-        configurations.nativeBundle.files.collect { zipTree(it) }
-    }
-
-    // We don't ship the individual nativeBundle licenses - instead
-    // they get combined into the top level NOTICES file we ship
-    exclude 'platform/licenses/**'
-}
-
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'))

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -3,33 +3,33 @@ apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 esplugin {
-  name 'x-pack-ml'
-  description 'Elasticsearch Expanded Pack Plugin - Machine Learning'
-  classname 'org.elasticsearch.xpack.ml.MachineLearning'
-  hasNativeController true
-  extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
+    name 'x-pack-ml'
+    description 'Elasticsearch Expanded Pack Plugin - Machine Learning'
+    classname 'org.elasticsearch.xpack.ml.MachineLearning'
+    hasNativeController true
+    extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
 
 repositories {
-  exclusiveContent {
-    forRepository {
-      ivy {
-        name "ml-cpp"
-        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
-        metadataSources {
-          // no repository metadata, look directly for the artifact
-          artifact()
+    exclusiveContent {
+        forRepository {
+            ivy {
+                name "ml-cpp"
+                url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
+                metadataSources {
+                    // no repository metadata, look directly for the artifact
+                    artifact()
+                }
+                patternLayout {
+                    artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/ml-cpp-[revision].[ext]"
+                }
+            }
         }
         patternLayout {
           artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
         }
-      }
     }
-    filter {
-      includeGroup 'org.elasticsearch.ml'
-    }
-  }
 }
 
 configurations {
@@ -47,6 +47,17 @@ tasks.named("bundlePlugin").configure {
   // We don't ship the individual nativeBundle licenses - instead
   // they get combined into the top level NOTICES file we ship
   exclude 'platform/licenses/**'
+}
+// TODO remove code duplication
+tasks.named("explodedBundlePlugin").configure {
+    dependsOn configurations.nativeBundle
+    from {
+        project.zipTree(configurations.nativeBundle.singleFile)
+    }
+
+    // We don't ship the individual nativeBundle licenses - instead
+    // they get combined into the top level NOTICES file we ship
+    exclude 'platform/licenses/**'
 }
 
 dependencies {
@@ -79,8 +90,8 @@ dependencies {
 }
 
 artifacts {
-  // normal es plugins do not publish the jar but we need to since users need it for extensions
-  archives tasks.named("jar")
+    // normal es plugins do not publish the jar but we need to since users need it for extensions
+    archives tasks.named("jar")
 }
 
 tasks.register("extractNativeLicenses", Copy) {
@@ -92,18 +103,18 @@ tasks.register("extractNativeLicenses", Copy) {
   include 'platform/licenses/**'
 }
 project.afterEvaluate {
-  // Add an extra licenses directory to the combined notices
-  tasks.named('generateNotice').configure {
-    dependsOn "extractNativeLicenses"
-    licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
-    outputs.upToDateWhen {
-      extractNativeLicenses.didWork
+    // Add an extra licenses directory to the combined notices
+    tasks.named('generateNotice').configure {
+        dependsOn "extractNativeLicenses"
+        licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
+        outputs.upToDateWhen {
+            extractNativeLicenses.didWork
+        }
     }
-  }
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /lucene-.*/, to: 'lucene'
+    mapping from: /lucene-.*/, to: 'lucene'
 }
 
 addQaCheckDependencies()

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -48,10 +48,8 @@ dependencies {
  * in $ES_HOME/bin/x-pack/. This is useful because it is an
  * executable jar that can be moved wherever it is needed.
  */
-tasks.named("bundlePlugin").configure {
-  from(configurations.bin) {
+esplugin.bundleSpec.from({configurations.bin}) {
     into 'bin'
-  }
 }
 
 addQaCheckDependencies()


### PR DESCRIPTION
This removes the overhead of zipping up modules that are immediately unzipped again when packaging
the elasticsearch distribution. 
We also move some logic for packaging the elasticsearch distribution into a plugin and remove some outdated 
overhead dealing with 'meta plugins' when copying modules into a distribution.  

Another follow up and related optimization out of scope of this PR is, to also not zip unzip modules declared
for usage in our test cluster setups.

This partially addresses #76726.
