### PR TITLE
[master] Typo in example of the filter_path option (#84551)

### DIFF
--- a/docs/reference/rest-api/common-options.asciidoc
+++ b/docs/reference/rest-api/common-options.asciidoc
@@ -118,8 +118,8 @@ Responds:
 --------------------------------------------------
 
 And the `**` wildcard can be used to include fields without knowing the
-exact path of the field. For example, we can return the Lucene version
-of every segment with this request:
+exact path of the field. For example, we can return the state
+of every shard with this request:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
# Backport

This is an automatic backport to `master` of:
 - #84551

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)