### PR TITLE
Remove the valuesIt() method of immutable maps

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
@@ -79,7 +79,7 @@ public class SearchReplicaSelectionIT extends ESIntegTestCase {
         ImmutableOpenMap<String, DiscoveryNode> coordinatingNodes = clusterStateResponse.getState().nodes().getCoordinatingOnlyNodes();
         assertEquals(1, coordinatingNodes.size());
 
-        String coordinatingNodeId = coordinatingNodes.valuesIt().next().getId();
+        String coordinatingNodeId = coordinatingNodes.values().iterator().next().getId();
         NodesStatsResponse statsResponse = client.admin().cluster().prepareNodesStats().setAdaptiveSelection(true).get();
         NodeStats nodeStats = statsResponse.getNodesMap().get(coordinatingNodeId);
         assertNotNull(nodeStats);

--- a/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -76,7 +76,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
 
     @Override
     public Iterator<Entry> iterator() {
-        return entries.valuesIt();
+        return entries.values().iterator();
     }
 
     public static final class Builder {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -129,7 +129,10 @@ public class ClusterFormationFailureHelper {
             }
 
             final StringBuilder clusterStateNodes = new StringBuilder();
-            DiscoveryNodes.addCommaSeparatedNodesWithoutAttributes(clusterState.nodes().getMasterNodes().valuesIt(), clusterStateNodes);
+            DiscoveryNodes.addCommaSeparatedNodesWithoutAttributes(
+                clusterState.nodes().getMasterNodes().values().iterator(),
+                clusterStateNodes
+            );
 
             final String discoveryWillContinueDescription = String.format(
                 Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -896,7 +896,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
 
     @Override
     public Iterator<IndexMetadata> iterator() {
-        return indices.valuesIt();
+        return indices.values().iterator();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -89,7 +89,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
 
     @Override
     public Iterator<DiscoveryNode> iterator() {
-        return nodes.valuesIt();
+        return nodes.values().iterator();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -170,7 +170,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable>, Ite
 
     @Override
     public Iterator<IndexShardRoutingTable> iterator() {
-        return shards.valuesIt();
+        return shards.values().iterator();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -87,7 +87,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
     @Override
     public Iterator<IndexRoutingTable> iterator() {
-        return indicesRouting.valuesIt();
+        return indicesRouting.values().iterator();
     }
 
     public boolean hasIndex(String index) {

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -192,14 +192,12 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
         };
     }
 
-    /**
-     * @return Returns a container with all values stored in this map.
-     */
+    @Override
     public Collection<VType> values() {
         return new AbstractCollection<VType>() {
             @Override
             public Iterator<VType> iterator() {
-                return valuesIt();
+                return ImmutableOpenMap.iterator(map.values());
             }
 
             @Override
@@ -209,13 +207,7 @@ public final class ImmutableOpenIntMap<VType> implements Map<Integer, VType>, It
         };
     }
 
-    /**
-     * Returns a direct iterator over the keys.
-     */
-    public Iterator<VType> valuesIt() {
-        return ImmutableOpenMap.iterator(map.values());
-    }
-
+    @Override
     public Set<Map.Entry<Integer, VType>> entrySet() {
         Set<Map.Entry<Integer, VType>> es;
         return (es = entrySet) == null ? (entrySet = new EntrySet()) : es;

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -311,22 +311,12 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType>, 
         };
     }
 
-    /**
-     * Returns a direct iterator over the keys.
-     */
-    public Iterator<VType> valuesIt() {
-        return iterator(map.values());
-    }
-
-    /**
-     * Returns a {@link Collection} view of the values contained in the map.
-     */
     @Override
     public Collection<VType> values() {
         return new AbstractCollection<VType>() {
             @Override
             public Iterator<VType> iterator() {
-                return valuesIt();
+                return ImmutableOpenMap.iterator(map.values());
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -367,7 +367,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
         @Override
         public void handleResponse(ClusterStateResponse response) {
-            handleNodes(response.getState().nodes().getNodes().valuesIt());
+            handleNodes(response.getState().nodes().getNodes().values().iterator());
         }
 
         private void handleNodes(Iterator<DiscoveryNode> nodesIter) {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -272,7 +272,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         GetSettingsResponse docValueLimitSetting = client().admin().indices().getSettings(getSettingsRequest).actionGet();
         int docValueLimit = IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.get(
-            docValueLimitSetting.getIndexToSettings().valuesIt().next()
+            docValueLimitSetting.getIndexToSettings().values().iterator().next()
         );
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -273,7 +273,7 @@ public final class DestinationIndex {
         assert getIndexResponse.indices().length == 1;
 
         // Fetch mappings from destination index
-        Map<String, Object> destMappingsAsMap = getIndexResponse.mappings().valuesIt().next().sourceAsMap();
+        Map<String, Object> destMappingsAsMap = getIndexResponse.mappings().values().iterator().next().sourceAsMap();
         Map<String, Object> destPropertiesAsMap = (Map<String, Object>) destMappingsAsMap.getOrDefault(PROPERTIES, Collections.emptyMap());
 
         // Verify that the results field does not exist in the dest index

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -109,7 +109,10 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
         GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
-        XContentSource source = new XContentSource(response.getMappings().valuesIt().next().source().uncompressed(), XContentType.JSON);
+        XContentSource source = new XContentSource(
+            response.getMappings().values().iterator().next().source().uncompressed(),
+            XContentType.JSON
+        );
         // lets make sure the body fields are disabled
         if (useChained) {
             String chainedPath = SINGLE_MAPPING_NAME
@@ -150,7 +153,10 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
         GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
-        XContentSource source = new XContentSource(response.getMappings().valuesIt().next().source().uncompressed(), XContentType.JSON);
+        XContentSource source = new XContentSource(
+            response.getMappings().values().iterator().next().source().uncompressed(),
+            XContentType.JSON
+        );
 
         // lets make sure the body fields are disabled
         if (useChained) {
@@ -208,7 +214,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         // also ensure that the status field is disabled in the watch history
         GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
         XContentSource mappingSource = new XContentSource(
-            response.getMappings().valuesIt().next().source().uncompressed(),
+            response.getMappings().values().iterator().next().source().uncompressed(),
             XContentType.JSON
         );
         assertThat(mappingSource.getValue(SINGLE_MAPPING_NAME + ".properties.status.enabled"), is(false));


### PR DESCRIPTION
The values iterator method on immutable maps predates the values()
collection accessor. This commit converts existing uses of valuesIt() to
values().iterator() and removes the valuesIt() method.