### PR TITLE
Remove ImmutableOpenMap.toMap()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -628,7 +628,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
         public Builder(DiscoveryNodes nodes) {
             this.masterNodeId = nodes.getMasterNodeId();
             this.localNodeId = nodes.getLocalNodeId();
-            this.nodes = new HashMap<>(nodes.getNodes().toMap());
+            this.nodes = new HashMap<>(nodes.getNodes());
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -381,13 +381,6 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType>, 
         return map.toString();
     }
 
-    /**
-     * Convert this ImmutableOpenMap to an immutable Java collection Map
-     */
-    public Map<KType, VType> toMap() {
-        return entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
     @Override
     @SuppressWarnings("rawtypes")
     public boolean equals(Object o) {

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 


### PR DESCRIPTION
Since ImmutableOpenMap now implements Map, the conversion method to a
Map is no longer necessary.