### PR TITLE
Use local zlib archive in Iron Bank Docker builds

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -38,14 +38,19 @@ RUN <%= retry.loop(package_manager, "${package_manager} update && DEBIAN_FRONTEN
 RUN <%= retry.loop(package_manager, "${package_manager} install -y curl gcc make tar gzip") %>
 <% } %>
 
-<%
+WORKDIR /tmp
+<% if (docker_base == 'iron_bank') {
+// Iron Bank always copies local artifacts
+%>
+COPY zlib-${zlib_version}.tar.gz /tmp
+<% } else {
 // Fetch the zlib source.  Keep this command on one line - it is replaced
 // with a `COPY` during local builds.
 %>
-WORKDIR /tmp
 RUN curl --retry 10 -S -L -o zlib-${zlib_version}.tar.gz https://github.com/cloudflare/zlib/archive/refs/tags/v${zlib_version}.tar.gz
 RUN echo "7e393976368975446b263ae4143fb404bc33bf3b436e72007700b5b88e5be332cd461cdec42d31a4b6dffdca2368550f01b9fa1165d81c0aa818bbf2b1ac191e zlib-${zlib_version}.tar.gz" \\
       | sha512sum --check -
+<% } %>
 RUN tar xf zlib-${zlib_version}.tar.gz
 
 WORKDIR /tmp/zlib-${zlib_version}

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -47,6 +47,11 @@ resources:
     validation:
       type: "sha256"
       value: "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"
+  - filename: "zlib-${zlib_version}.tar.gz"
+    url: "https://github.com/cloudflare/zlib/archive/refs/tags/v${zlib_version}.tar.gz"
+    validation:
+      type: "sha512"
+      value: "7e393976368975446b263ae4143fb404bc33bf3b436e72007700b5b88e5be332cd461cdec42d31a4b6dffdca2368550f01b9fa1165d81c0aa818bbf2b1ac191e"
 
 # List of project maintainers
 maintainers:

--- a/docs/changelog/84670.yaml
+++ b/docs/changelog/84670.yaml
@@ -1,0 +1,5 @@
+pr: 84670
+summary: Use local zlib archive in Iron Bank Docker builds
+area: Packaging
+type: bug
+issues: []


### PR DESCRIPTION
These builds can't pull binaries from the internet, so follow the same
pattern as for the ES artifact, and always copy a local zlib artifact
when building Iron Bank images.