### PR TITLE
[8.1] Wait for green before checking index stats (#84646)

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -185,6 +185,9 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
         });
 
+        // Waiting for shards to stabilize if indices were moved around
+        ensureGreen();
+
         assertTrue("the pre-migration hook wasn't actually called", preUpgradeHookCalled.get());
         assertTrue("the post-migration hook wasn't actually called", postUpgradeHookCalled.get());
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Wait for green before checking index stats (#84646)