### PR TITLE
Configure required IDEA plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,12 @@ build-idea/
 out/
 
 # include shared intellij config
-!.idea/scopes/x_pack.xml
+!.idea/checkstyle-idea.xml
+!.idea/eclipseCodeFormatter.xml
+!.idea/externalDependencies.xml
 !.idea/inspectionProfiles/Project_Default.xml
 !.idea/runConfigurations/Debug_Elasticsearch.xml
-!.idea/checkstyle-idea.xml
+!.idea/scopes/x_pack.xml
 
 # These files are generated in the main tree by IntelliJ
 benchmarks/src/main/generated/*

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="EclipseCodeFormatter" />
+    <plugin id="CheckStyle-IDEA" />
+  </component>
+</project>


### PR DESCRIPTION
Closes #53812.

The CheckStyle-IDEA and EcliseCodeFormatter IDEA plugins are to all
intents and purposes required when using IntelliJ to work on
Elasticsearch, so add configuration that marks then as required.

We already version configuration snippets for both plugins.