### PR TITLE
[8.0] Invoke initial AsyncActionStep for newly created indices (#84541)

### DIFF
--- a/docs/changelog/84541.yaml
+++ b/docs/changelog/84541.yaml
@@ -1,0 +1,6 @@
+pr: 84541
+summary: Invoke initial `AsyncActionStep` for newly created indices
+area: ILM+SLM
+type: bug
+issues:
+ - 77269

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateActionStep.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 
 /**
@@ -19,4 +20,14 @@ public abstract class ClusterStateActionStep extends Step {
     }
 
     public abstract ClusterState performAction(Index index, ClusterState clusterState);
+
+    /**
+     * Returns a tuple of index name to step key for an index *other* than the
+     * index ILM is currently processing. This is used when a new index is
+     * spawned by ILM and its initial action needs to be to invoked in the event
+     * that it is an {@link AsyncActionStep}.
+     */
+    public Tuple<String, StepKey> indexForAsyncInvocation() {
+        return null;
+    }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -14,17 +14,22 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xpack.core.ilm.ClusterStateActionStep;
 import org.elasticsearch.xpack.core.ilm.ClusterStateWaitStep;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Step;
 import org.elasticsearch.xpack.core.ilm.TerminalPolicyStep;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.LongSupplier;
 
 public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask {
@@ -34,6 +39,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
     private final PolicyStepsRegistry policyStepsRegistry;
     private final IndexLifecycleRunner lifecycleRunner;
     private final LongSupplier nowSupplier;
+    private final Map<String, Step.StepKey> indexToStepKeysForAsyncActions;
     private Step.StepKey nextStepKey = null;
     private Exception failure = null;
 
@@ -51,6 +57,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
         this.policyStepsRegistry = policyStepsRegistry;
         this.nowSupplier = nowSupplier;
         this.lifecycleRunner = lifecycleRunner;
+        this.indexToStepKeysForAsyncActions = new HashMap<>();
     }
 
     String getPolicy() {
@@ -101,7 +108,14 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
                         currentStep.getKey()
                     );
                     try {
-                        state = ((ClusterStateActionStep) currentStep).performAction(index, state);
+                        ClusterStateActionStep actionStep = (ClusterStateActionStep) currentStep;
+                        state = actionStep.performAction(index, state);
+                        // If this step (usually a CopyExecutionStateStep step) has brought the
+                        // index to where it needs to have async actions invoked, then add that
+                        // index to the list so that when the new cluster state has been
+                        // processed, the new indices will have their async actions invoked.
+                        Optional.ofNullable(actionStep.indexForAsyncInvocation())
+                            .ifPresent(tuple -> indexToStepKeysForAsyncActions.put(tuple.v1(), tuple.v2()));
                     } catch (Exception exception) {
                         return moveToErrorStep(state, currentStep.getKey(), exception);
                     }
@@ -207,7 +221,8 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
 
     @Override
     public void onClusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        IndexMetadata indexMetadata = newState.metadata().index(index);
+        final Metadata metadata = newState.metadata();
+        final IndexMetadata indexMetadata = metadata.index(index);
         if (indexMetadata != null) {
 
             LifecycleExecutionState exState = indexMetadata.getLifecycleExecutionState();
@@ -228,6 +243,25 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
                 // to a new step, we need to conditionally execute the step iff
                 // it is an `AsyncAction` so that it is executed exactly once.
                 lifecycleRunner.maybeRunAsyncAction(newState, indexMetadata, policy, nextStepKey);
+            }
+        }
+        assert indexToStepKeysForAsyncActions.size() <= 1 : "we expect a maximum of one single spawned index currently";
+        for (Map.Entry<String, Step.StepKey> indexAndStepKey : indexToStepKeysForAsyncActions.entrySet()) {
+            final String indexName = indexAndStepKey.getKey();
+            final Step.StepKey nextStep = indexAndStepKey.getValue();
+            final IndexMetadata indexMeta = metadata.index(indexName);
+            if (indexMeta != null) {
+                final String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMeta.getSettings());
+                if (Strings.hasText(policyName) && nextStep != null && nextStep != TerminalPolicyStep.KEY) {
+                    logger.trace(
+                        "[{}] index has been spawed from a different index's ({}) "
+                            + "ILM execution, running next step {} if it is an async action",
+                        indexName,
+                        index,
+                        nextStep
+                    );
+                    lifecycleRunner.maybeRunAsyncAction(newState, indexMeta, policyName, nextStep);
+                }
             }
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Invoke initial AsyncActionStep for newly created indices (#84541)