### PR TITLE
[7.17] Invoke initial AsyncActionStep for newly created indices (#84541)

### DIFF
--- a/docs/changelog/84541.yaml
+++ b/docs/changelog/84541.yaml
@@ -1,0 +1,6 @@
+pr: 84541
+summary: Invoke initial `AsyncActionStep` for newly created indices
+area: ILM+SLM
+type: bug
+issues:
+ - 77269

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateActionStep.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 
 /**
@@ -19,4 +20,14 @@ public abstract class ClusterStateActionStep extends Step {
     }
 
     public abstract ClusterState performAction(Index index, ClusterState clusterState);
+
+    /**
+     * Returns a tuple of index name to step key for an index *other* than the
+     * index ILM is currently processing. This is used when a new index is
+     * spawned by ILM and its initial action needs to be to invoked in the event
+     * that it is an {@link AsyncActionStep}.
+     */
+    public Tuple<String, StepKey> indexForAsyncInvocation() {
+        return null;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 
 import java.util.Objects;
@@ -33,6 +35,7 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
 
     private final BiFunction<String, LifecycleExecutionState, String> targetIndexNameSupplier;
     private final StepKey targetNextStepKey;
+    private final SetOnce<String> calculatedTargetIndexName = new SetOnce<>();
 
     public CopyExecutionStateStep(
         StepKey key,
@@ -59,6 +62,12 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
     }
 
     @Override
+    public Tuple<String, StepKey> indexForAsyncInvocation() {
+        assert calculatedTargetIndexName.get() != null : "attempted to retrieve the index for async invocation before it was set";
+        return new Tuple<>(calculatedTargetIndexName.get(), targetNextStepKey);
+    }
+
+    @Override
     public ClusterState performAction(Index index, ClusterState clusterState) {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
@@ -69,6 +78,7 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
         // get target index
         LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(indexMetadata);
         String targetIndexName = targetIndexNameSupplier.apply(index.getName(), lifecycleState);
+        calculatedTargetIndexName.set(targetIndexName);
         IndexMetadata targetIndexMetadata = clusterState.metadata().index(targetIndexName);
 
         if (targetIndexMetadata == null) {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ilm.AllocateAction;
 import org.elasticsearch.xpack.core.ilm.DeleteAction;
 import org.elasticsearch.xpack.core.ilm.ForceMergeAction;
 import org.elasticsearch.xpack.core.ilm.FreezeAction;
@@ -678,5 +679,46 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         Map<String, Object> hotIndexSettings = getIndexSettingsAsMap(restoredIndex);
         // searchable snapshots mounted in the hot phase should be pinned to hot nodes
         assertThat(hotIndexSettings.get(DataTier.TIER_PREFERENCE), is("data_hot"));
+    }
+
+    // See: https://github.com/elastic/elasticsearch/issues/77269
+    public void testSearchableSnapshotInvokesAsyncActionOnNewIndex() throws Exception {
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        Map<String, LifecycleAction> coldActions = new HashMap<>(2);
+        coldActions.put(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()));
+        // Normally putting an allocate action in the cold phase with a searchable snapshot action
+        // would cause the new index to get "stuck" since the async action would never be invoked
+        // for the new index.
+        coldActions.put(AllocateAction.NAME, new AllocateAction(null, 1, null, null, null));
+        Phase coldPhase = new Phase("cold", TimeValue.ZERO, coldActions);
+        createPolicy(client(), policy, null, null, coldPhase, null, null);
+
+        createComposableTemplate(
+            client(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            dataStream,
+            new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null)
+        );
+
+        indexDocument(client(), dataStream, true);
+
+        // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1L);
+        String restoredIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + backingIndexName;
+        assertTrue(waitUntil(() -> {
+            try {
+                return indexExists(restoredIndexName);
+            } catch (IOException e) {
+                return false;
+            }
+        }, 30, TimeUnit.SECONDS));
+
+        assertBusy(
+            () -> assertThat(explainIndex(client(), restoredIndexName).get("step"), is(PhaseCompleteStep.NAME)),
+            30,
+            TimeUnit.SECONDS
+        );
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Invoke initial AsyncActionStep for newly created indices (#84541)