### PR TITLE
reorder and merge data management and ILM doc pages

### DIFF
--- a/docs/reference/data-management.asciidoc
+++ b/docs/reference/data-management.asciidoc
@@ -30,6 +30,7 @@ for your older indices while reducing operating costs and maintaining search per
 * Perform <<async-search-intro, asynchronous searches>> of data stored on less-performant hardware.
 --
 
+include::ilm/index.asciidoc[]
+
 include::datatiers.asciidoc[]
 
-include::indices/index-mgmt.asciidoc[]

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -2,8 +2,9 @@
 
 [[example-using-index-lifecycle-policy]]
 === Tutorial: Customize built-in {ilm-init} policies
+
 ++++
-<titleabbrev>Customize built-in {ilm-init} policies</titleabbrev>
+<titleabbrev>Tutorial: Customize bult-in policies</titleabbrev>
 ++++
 
 {es} includes the following built-in {ilm-init} policies:

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -3,7 +3,7 @@
 == Tutorial: Automate rollover with {ilm-init}
 
 ++++
-<titleabbrev>Automate rollover</titleabbrev>
+<titleabbrev>Tutorial: Automate rollover</titleabbrev>
 ++++
 
 When you continuously index timestamped documents into {es},

--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[index-lifecycle-management]]
-= {ilm-init}: Manage the index lifecycle
+== {ilm-init}: Manage the index lifecycle
 
-[partintro]
+// [partintro]
 --
 You can configure {ilm} ({ilm-init}) policies to automatically manage indices
 according to your performance, resiliency, and retention requirements.
@@ -12,9 +12,10 @@ For example, you could use {ilm-init} to:
 * Create a new index each day, week, or month and archive previous ones
 * Delete stale indices to enforce data retention standards
 
-You can create and manage index lifecycle policies through {kib} Management or the {ilm-init} APIs.
-When you enable {ilm} for {beats} or the {ls} {es} output plugin,
-default policies are configured automatically.
+You can create and manage index lifecycle policies through {kib} Management
+or the {ilm-init} APIs. Default {ilm} policies are created automatically
+when you use {agent}, {beats}, or the {ls} {es} output plugin to send data
+to the {stack}.
 
 [role="screenshot"]
 image:images/ilm/index-lifecycle-policies.png[]
@@ -23,10 +24,10 @@ image:images/ilm/index-lifecycle-policies.png[]
 To automatically back up your indices and manage snapshots, use
 <<automate-snapshots-slm,snapshot lifecycle policies>>.
 
+* <<example-using-index-lifecycle-policy>>
+* <<getting-started-index-lifecycle-management>>
 * <<overview-index-lifecycle-management>>
 * <<ilm-concepts>>
-* <<getting-started-index-lifecycle-management>>
-* <<example-using-index-lifecycle-policy>>
 * <<set-up-lifecycle-policy>>
 * <<migrate-index-allocation-filters>>
 * <<index-lifecycle-error-handling>>
@@ -38,13 +39,15 @@ To automatically back up your indices and manage snapshots, use
 * <<ilm-actions>>
 
 --
-include::ilm-overview.asciidoc[]
-
-include::ilm-concepts.asciidoc[]
+include::example-index-lifecycle-policy.asciidoc[leveloffset=-1]
 
 include::ilm-tutorial.asciidoc[]
 
-include::example-index-lifecycle-policy.asciidoc[leveloffset=-1]
+include::../indices/index-mgmt.asciidoc[]
+
+include::ilm-overview.asciidoc[]
+
+include::ilm-concepts.asciidoc[]
 
 include::ilm-actions.asciidoc[]
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -49,8 +49,6 @@ include::scripting.asciidoc[]
 
 include::data-management.asciidoc[]
 
-include::ilm/index.asciidoc[]
-
 include::autoscaling/index.asciidoc[]
 
 include::monitoring/index.asciidoc[]

--- a/docs/reference/indices/index-mgmt.asciidoc
+++ b/docs/reference/indices/index-mgmt.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[index-mgmt]]
-== Index management
+== Index management in {kib}
 
 {kib}'s *Index Management* features are an easy, convenient way to manage your
 cluster's indices, <<data-streams,data streams>>, and <<index-templates,index


### PR DESCRIPTION
Combines Data Management and ILM entries in the TOC:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/25182304/156835098-ff2a9341-cd92-4467-a934-335acd28e161.png">

Moves the tutorial and Kibana based pages to the beginning of the new section:
<img width="359" alt="2022-03-04_15-15-31" src="https://user-images.githubusercontent.com/25182304/156835669-3eab6dd5-98bd-4778-925e-5b415556cbc4.png">

