### PR TITLE
Update intellij security policy for later versions of IDEA

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/intellij.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/intellij.policy
@@ -3,4 +3,7 @@ grant codeBase "${codebase.junit-rt.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-
+grant codeBase "${codebase.idea_rt.jar}" {
+  // allows IntelliJ IDEA JUnit test runner to control number of test iterations
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};


### PR DESCRIPTION
Later versions of IntelliJ IDEA need slightly different security policies for some features like repeated execution of unit tests. This adds those permissions to the appropriate codebases.