### PR TITLE
Remove unnecessary test cluster plugin installation

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -250,7 +250,6 @@ if (useFixture) {
     keystore 's3.client.integration_test_permanent.access_key', s3PermanentAccessKey
     keystore 's3.client.integration_test_permanent.secret_key', s3PermanentSecretKey
     setting 's3.client.integration_test_permanent.endpoint', { "${-> fixtureAddress('minio-fixture', 'minio-fixture', '9000')}" }, IGNORE_VALUE
-    plugin tasks.bundlePlugin.archiveFile
   }
 }
 
@@ -275,7 +274,6 @@ if (useFixture) {
 
   testClusters.matching { it.name == "yamlRestTestECS" }.configureEach {
     setting 's3.client.integration_test_ecs.endpoint', { "${-> fixtureAddress('s3-fixture', 's3-fixture-with-ecs', '80')}" }, IGNORE_VALUE
-    plugin tasks.bundlePlugin.archiveFile
     environment 'AWS_CONTAINER_CREDENTIALS_FULL_URI', { "${-> fixtureAddress('s3-fixture', 's3-fixture-with-ecs', '80')}/ecs_credentials_endpoint" }, IGNORE_VALUE
   }
 }


### PR DESCRIPTION
Some fallout from e5116dc68ec4a67b8cf7372858b0d394b60ce6b3 is that we now are registering duplicate plugins on certain test suites. This looks to be just an issue with the 7.17 backport since in later branches these projects have been converted from plugins to modules. This PR addresses the final instance of this problem... I think.