### PR TITLE
[8.1] Update intellij security policy for later versions of IDEA (#84681)

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/intellij.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/intellij.policy
@@ -3,4 +3,7 @@ grant codeBase "${codebase.junit-rt.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-
+grant codeBase "${codebase.idea_rt.jar}" {
+  // allows IntelliJ IDEA JUnit test runner to control number of test iterations
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Update intellij security policy for later versions of IDEA (#84681)