### PR TITLE
Test mute SSLServiceTests testDeprecationOfTruststoreWithNoTrustedEntries

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
@@ -878,6 +878,7 @@ public class SSLServiceTests extends ESTestCase {
         assertThat(sslService.wrapWithDiagnostics(wrappedTrustManager, sslConfiguration), sameInstance(wrappedTrustManager));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84703")
     public void testDeprecationOfTruststoreWithNoTrustedEntries() throws IllegalAccessException {
         final String keystoreName;
         final String password;


### PR DESCRIPTION
test mute for issue #84703 