### PR TITLE
[8.0] Update painless-reindex-context.asciidoc (#84444)

### DIFF
--- a/docs/painless/painless-contexts/painless-reindex-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-reindex-context.asciidoc
@@ -32,7 +32,7 @@ reindexed into a target index.
 *Side Effects*
 
 `ctx['op']`::
-        Use the default of `index` to update a document. Set to `none` to
+        Use the default of `index` to update a document. Set to `noop` to
         specify no operation or `delete` to delete the current document from
         the index.
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Update painless-reindex-context.asciidoc (#84444)