### PR TITLE
[8.1] Remove Eclipse IDE contributor documentation (#84724)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ script on Windows in the root of the repository. The examples below show the
 usage on Unix.
 
 We support development in IntelliJ versions IntelliJ 2020.1 and
-onwards and Eclipse 2021-12 and onwards.
+onwards.
 
 [Docker](https://docs.docker.com/install/) is required for building some Elasticsearch artifacts and executing certain test suites. You can run Elasticsearch without building all the artifacts with:
 
@@ -180,13 +180,12 @@ action is required.
 
 #### Formatting
 
-We are in the process of migrating towards automatic formatting Java file
-using [spotless], backed by the Eclipse formatter. **We strongly recommend
-installing using the [Eclipse Code Formatter] plugin** so that you can
-apply the correct formatting directly in IntelliJ.  The configuration for
-the plugin is held in `.idea/eclipseCodeFormatter.xml` and should be
-automatically applied, but manual instructions are below in case you you
-need them.
+Elasticsearch code is automatically formatted with [spotless], backed by the
+Eclipse formatter. You can do the same in IntelliJ with the
+[Eclipse Code Formatter] so that you can apply the correct formatting directly in
+your IDE.  The configuration for the plugin is held in
+`.idea/eclipseCodeFormatter.xml` and should be automatically applied, but manual
+instructions are below in case you need them.
 
    1. Open **Preferences > Other Settings > Eclipse Code Formatter**
    2. Click "Use the Eclipse Code Formatter"
@@ -202,60 +201,6 @@ Alternative manual steps for IntelliJ.
    2. Gear icon > Import Scheme > Eclipse XML Profile
    3. Navigate to the file `build-conventions/formatterConfig.xml`
    4. Click "OK"
-
-Note that only some sub-projects in the Elasticsearch project are currently
-fully-formatted. You can see a list of project that **are not**
-automatically formatted in
-[FormattingPrecommitPlugin.java](build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java).
-
-### Importing the project into Eclipse
-
-Elasticsearch builds using Gradle and Java 17. You'll need to point
-[eclipse.ini](https://wiki.eclipse.org/Eclipse.ini)'s `-vm` to Java 17.
-
- - Select **File > Import...**
- - Select **Existing Gradle Project**
- - Select **Next** then **Next** again
- - Set the **Project root directory** to the root of your elasticsearch clone
- - Click **Finish**
-
-This will spin for a long, long time but you'll see many errors about circular
-dependencies. Fix them:
-
- - Select **Window > Preferences**
- - Select **Java > Compiler > Building**
- - Look under **Build Path Problems**
- - Set **Circular dependencies** to **Warning**
- - Apply that and let the build spin away for a while
-
-Next you'll want to import our auto-formatter:
-
- - Select **Window > Preferences**
- - Select **Java > Code Style > Formatter**
- - Click **Import**
- - Import the file at **build-conventions/formatterConfig.xml**
- - Make sure it is the **Active profile**
-
-Finally, set up import order:
-
- - Select **Window > Preferences**
- - Select **Java > Code Style > Organize Imports**
- - Click **Import...**
- - Import the file at **build-conventions/elastic.importorder**
- - Set the **Number of imports needed for `.*`** to ***9999***
- - Set the **Number of static imports needed for `.*`** to ***9999*** as well
- - Apply that
-
-IMPORTANT: There is an option in **Gradle** for **Automatic Project Synchronization**.
-           As convenient as it'd be for the projects to always be perfect this
-           tends to add many many seconds to every branch change. Instead, you
-           should manually right click on a project and
-           **Gradle > Refresh Gradle Project** if the configuration is out of
-           date.
-
-As we add more subprojects you might have to re-import the gradle project (the
-first step) again. There is no need to blow away the existing projects before
-doing that.
 
 ### REST Endpoint Conventions
 

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -57,8 +57,7 @@ to suspend and initiate a debug connection on port incrementing from `5005`.
 As such the IDE needs to be instructed to listen for connections on this port.
 Since we might run multiple JVMs as part of configuring and starting the cluster it's
 recommended to configure the IDE to initiate multiple listening attempts. In case of IntelliJ, this option
-is called "Auto restart" and needs to be checked. In case of Eclipse, "Connection limit" setting
-needs to be configured with a greater value (ie 10 or more).
+is called "Auto restart" and needs to be checked.
 
 NOTE: If you have imported the project into IntelliJ according to the instructions in
 link:/CONTRIBUTING.md#importing-the-project-into-intellij-idea[CONTRIBUTING.md] then a debug run configuration
@@ -765,8 +764,7 @@ care.
 
 Generating test coverage reports for Elasticsearch is currently not possible through Gradle.
 However, it _is_ possible to gain insight in code coverage using IntelliJ's built-in coverage
-analysis tool that can measure coverage upon executing specific tests. Eclipse may also be able
-to do the same using the EclEmma plugin.
+analysis tool that can measure coverage upon executing specific tests.
 
 Test coverage reporting used to be possible with JaCoCo when Elasticsearch was using Maven
 as its build system. Since the switch to Gradle though, this is no longer possible, seeing as


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Remove Eclipse IDE contributor documentation (#84724)