### PR TITLE
Remove hppc uses from AwarenessAllocationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.cluster.allocation;
 
-import com.carrotsearch.hppc.ObjectIntHashMap;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -27,7 +25,9 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -95,11 +95,11 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertThat("Some indices not closed", notClosedIndices, empty());
 
             // verify that we have all the primaries on node3
-            ObjectIntHashMap<String> counts = new ObjectIntHashMap<>();
+            Map<String, Integer> counts = new HashMap<>();
             for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                     for (ShardRouting shardRouting : indexShardRoutingTable) {
-                        counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
+                        counts.merge(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1, Integer::sum);
                     }
                 }
             }
@@ -151,15 +151,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(health.isTimedOut(), equalTo(false));
 
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
-        ObjectIntHashMap<String> counts = new ObjectIntHashMap<>();
+        Map<String, Integer> counts = computeShardCounts(clusterState);
 
-        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
-                }
-            }
-        }
         assertThat(counts.get(A_1), anyOf(equalTo(2), equalTo(3)));
         assertThat(counts.get(B_1), anyOf(equalTo(2), equalTo(3)));
         assertThat(counts.get(A_0), anyOf(equalTo(2), equalTo(3)));
@@ -201,15 +194,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
-        ObjectIntHashMap<String> counts = new ObjectIntHashMap<>();
+        Map<String, Integer> counts = computeShardCounts(clusterState);
 
-        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
-                }
-            }
-        }
         assertThat(counts.get(A_0), equalTo(5));
         assertThat(counts.get(B_0), equalTo(5));
         logger.info("--> starting another node in zone 'b'");
@@ -240,16 +226,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         assertThat(health.isTimedOut(), equalTo(false));
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        counts = computeShardCounts(clusterState);
 
-        counts = new ObjectIntHashMap<>();
-
-        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
-                }
-            }
-        }
         assertThat(counts.get(A_0), equalTo(5));
         assertThat(counts.get(B_0), equalTo(3));
         assertThat(counts.get(B_1), equalTo(2));
@@ -280,16 +258,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         assertThat(health.isTimedOut(), equalTo(false));
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
-
-        counts = new ObjectIntHashMap<>();
-
-        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
-                }
-            }
-        }
+        counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
         assertThat(counts.get(B_0), equalTo(3));
@@ -315,16 +284,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         assertThat(health.isTimedOut(), equalTo(false));
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
-
-        counts = new ObjectIntHashMap<>();
-
-        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    counts.addTo(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1);
-                }
-            }
-        }
+        counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(3));
         assertThat(counts.get(B_0), equalTo(3));
@@ -370,5 +330,18 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             ).getMessage(),
             containsString("[cluster.routing.allocation.awareness.force.attr.values.junk]")
         );
+    }
+
+    Map<String, Integer> computeShardCounts(ClusterState clusterState) {
+        Map<String, Integer> counts = new HashMap<>();
+
+        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                for (ShardRouting shardRouting : indexShardRoutingTable) {
+                    counts.merge(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1, Integer::sum);
+                }
+            }
+        }
+        return counts;
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -95,14 +95,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertThat("Some indices not closed", notClosedIndices, empty());
 
             // verify that we have all the primaries on node3
-            Map<String, Integer> counts = new HashMap<>();
-            for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-                for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                    for (ShardRouting shardRouting : indexShardRoutingTable) {
-                        counts.merge(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1, Integer::sum);
-                    }
-                }
-            }
+            Map<String, Integer> counts = computeShardCounts(clusterState);
+            
             assertThat(counts.get(node3), equalTo(totalPrimaries));
         }, 10, TimeUnit.SECONDS);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -96,7 +96,6 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
             // verify that we have all the primaries on node3
             Map<String, Integer> counts = computeShardCounts(clusterState);
-            
             assertThat(counts.get(node3), equalTo(totalPrimaries));
         }, 10, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
This commit cleanups up allocation awareness integration tests to not
use hppc.

relates #84735