### PR TITLE
[8.1] Remove existing indices/datastreams/aliases before simulating index template (#84675)

### DIFF
--- a/docs/changelog/84675.yaml
+++ b/docs/changelog/84675.yaml
@@ -1,0 +1,6 @@
+pr: 84675
+summary: Remove existing indices/datastreams/aliases before simulating index template
+area: Indices APIs
+type: bug
+issues:
+ - 84256

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/180_simulate_existing_data_stream.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/180_simulate_existing_data_stream.yml
@@ -1,0 +1,34 @@
+---
+"Simulate an index with the same name as a data stream that already exists":
+  - skip:
+      version: " - 8.1.99"
+      reason: "simulating index template API for an existing index has not yet been backported"
+      features: ["default_shards"]
+
+  - do:
+      indices.put_index_template:
+        name: dstest
+        body:
+          index_patterns: myds
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field:
+                  type: keyword
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: myds
+
+  - do:
+      indices.simulate_index_template:
+        name: myds
+
+  - match: {template.settings.index.number_of_shards: "1"}
+  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.mappings.properties.field.type: "keyword"}
+  - match: {overlapping: []}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Simulate index template without new template in the body":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "simulate index template API is only in 7.8.0+"
       features: ["default_shards"]
 
   - do:
@@ -31,8 +31,8 @@
 ---
 "Simulate index template specifying a new template":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "simulate index template API is only in 7.8.0+"
       features: ["default_shards"]
 
   - do:
@@ -86,8 +86,8 @@
 ---
 "Simulate index template with index not matching any template":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "simulate index template API is only in 7.8.0+"
       features: allowed_warnings
 
   - do:
@@ -116,8 +116,8 @@
 ---
 "Simulate index matches overlapping legacy and composable templates":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "simulate index template API is only in 7.8.0+"
       features: ["allowed_warnings", "default_shards"]
 
   - do:
@@ -175,3 +175,51 @@
   - match: {overlapping.0.index_patterns: ["t*", "t1*"]}
   - match: {overlapping.1.name: v2_template}
   - match: {overlapping.1.index_patterns: ["te*"]}
+
+---
+"Simulate an index for and index or alias that already exists":
+  - skip:
+      version: " - 8.1.99"
+      reason: "simulating index template API for an existing index has not yet been backported"
+      features: ["default_shards"]
+
+  - do:
+      indices.put_index_template:
+        name: test
+        body:
+          index_patterns: [te*]
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field:
+                  type: keyword
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index.number_of_shards: 2
+          aliases:
+            test_alias: {}
+
+  - do:
+      indices.simulate_index_template:
+        name: test_index
+
+  - match: {template.settings.index.number_of_shards: "1"}
+  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.mappings.properties.field.type: "keyword"}
+  - match: {overlapping: []}
+
+  - do:
+      indices.simulate_index_template:
+        name: test_alias
+
+  - match: {template.settings.index.number_of_shards: "1"}
+  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.mappings.properties.field.type: "keyword"}
+  - match: {overlapping: []}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -111,14 +111,17 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
                 simulateTemplateToAdd,
                 request.getIndexTemplateRequest().indexTemplate()
             );
-            stateWithTemplate = indexTemplateService.addIndexTemplateV2(
-                state,
-                request.getIndexTemplateRequest().create(),
-                simulateTemplateToAdd,
-                request.getIndexTemplateRequest().indexTemplate()
+            stateWithTemplate = removeExistingAbstractions(
+                indexTemplateService.addIndexTemplateV2(
+                    state,
+                    request.getIndexTemplateRequest().create(),
+                    simulateTemplateToAdd,
+                    request.getIndexTemplateRequest().indexTemplate()
+                ),
+                request.getIndexName()
             );
         } else {
-            stateWithTemplate = state;
+            stateWithTemplate = removeExistingAbstractions(state, request.getIndexName());
         }
 
         String matchingTemplate = findV2Template(stateWithTemplate.metadata(), request.getIndexName(), false);
@@ -146,6 +149,16 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         overlapping.putAll(findConflictingV2Templates(tempClusterState, matchingTemplate, templateV2.indexPatterns()));
 
         listener.onResponse(new SimulateIndexTemplateResponse(template, overlapping));
+    }
+
+    /**
+     * Removes the alias, data stream, or existing index from the cluster state if it matches the given index name
+     */
+    private static ClusterState removeExistingAbstractions(ClusterState state, String indexName) {
+        Metadata metadata = state.metadata();
+        return ClusterState.builder(state)
+            .metadata(Metadata.builder(metadata).removeDataStream(indexName).removeAllIndices().build())
+            .build();
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Remove existing indices/datastreams/aliases before simulating index template (#84675)