### PR TITLE
[TEST] Precache LDAP authentication

### DIFF
--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.security.authc.ldap;
 
 import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.DocWriteResponse;
@@ -24,6 +25,8 @@ import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
+import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
 import org.elasticsearch.xpack.core.security.authc.ldap.ActiveDirectorySessionFactorySettings;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.junit.After;
@@ -38,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -53,6 +57,7 @@ import static org.elasticsearch.xpack.security.authc.ldap.AbstractActiveDirector
 import static org.elasticsearch.xpack.security.authc.ldap.AbstractActiveDirectoryTestCase.AD_LDAP_PORT;
 import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 /**
  * This test assumes all subclass tests will be of type SUITE.  It picks a random realm configuration for the tests, and
@@ -246,6 +251,11 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
 
     protected void assertAccessAllowed(String user, String index) throws IOException {
         Client client = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, userHeader(user, PASSWORD)));
+
+        // Force an authentication to populate the cache.
+        // We can safely re-try this if it fails, which makes it less likely that the index request will fail
+        authenticateUser(client, user, 3);
+
         IndexResponse indexResponse = client.prepareIndex(index)
             .setSource(jsonBuilder().startObject().field("name", "value").endObject())
             .execute()
@@ -265,12 +275,13 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
     }
 
     protected void assertAccessDenied(String user, String index) throws IOException {
+        final Client client = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, userHeader(user, PASSWORD)));
+        // Force an authentication to populate the cache.
+        // We can safely re-try this if it fails, which means we can be more confident that the index request failed for the correct reason
+        authenticateUser(client, user, 3);
+
         try {
-            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, userHeader(user, PASSWORD)))
-                .prepareIndex(index)
-                .setSource(jsonBuilder().startObject().field("name", "value").endObject())
-                .execute()
-                .actionGet();
+            client.prepareIndex(index).setSource(jsonBuilder().startObject().field("name", "value").endObject()).execute().actionGet();
             fail("Write access to index " + index + " should not be allowed for user " + user);
         } catch (ElasticsearchSecurityException e) {
             // expected
@@ -280,6 +291,23 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
 
     protected static String userHeader(String username, String password) {
         return UsernamePasswordToken.basicAuthHeaderValue(username, new SecureString(password.toCharArray()));
+    }
+
+    private void authenticateUser(Client client, String username, int retryCount) {
+        for (int i = 1; i <= retryCount; i++) {
+            try {
+                final AuthenticateResponse response = new AuthenticateRequestBuilder(client).username(username)
+                    .execute()
+                    .actionGet(10, TimeUnit.SECONDS);
+                assertThat(response.authentication().getUser().principal(), is(username));
+                return;
+            } catch (ElasticsearchException e) {
+                if (i == retryCount) {
+                    throw e;
+                }
+                logger.info("Failed to authenticate [{}] - [{}], retrying", username, e.toString());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
GroupMappingIT would somtimes due to a timeout when authenticating
against the SMB fixture.

This changes the test to first perform an "authenticate" request,
with retries in order to cache the user's credentials before
performing the access checks.

This means that the access checks should pass/fail due to true
authorization behaviour rather than authentication behaviour.

Resolves: #84586, #83144