### PR TITLE
Allow refresh aliases with only privileges over aliases

### DIFF
--- a/docs/changelog/84754.yaml
+++ b/docs/changelog/84754.yaml
@@ -1,0 +1,5 @@
+pr: 84754
+summary: Allow refresh aliases with only privileges over aliases
+area: Authorization
+type: bug
+issues: []

--- a/docs/changelog/84754.yaml
+++ b/docs/changelog/84754.yaml
@@ -1,5 +1,6 @@
+area: Authorization
+issues:
+ - 84626
 pr: 84754
 summary: Allow refresh aliases with only privileges over aliases
-area: Authorization
 type: bug
-issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -58,6 +58,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchTransportService;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.TransportReplicationActionTests;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
@@ -642,8 +643,12 @@ public class IndicesRequestIT extends ESIntegTestCase {
             }
             for (TransportRequest internalRequest : requests) {
                 IndicesRequest indicesRequest = convertRequest(internalRequest);
-                for (String index : indicesRequest.indices()) {
-                    assertThat(indices, hasItem(index));
+                if (indicesRequest instanceof final ReplicationRequest replicationRequest) {
+                    assertThat(indices, hasItem(replicationRequest.shardId().getIndexName()));
+                } else {
+                    for (String index : indicesRequest.indices()) {
+                        assertThat(indices, hasItem(index));
+                    }
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -643,7 +643,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
             }
             for (TransportRequest internalRequest : requests) {
                 IndicesRequest indicesRequest = convertRequest(internalRequest);
-                if (indicesRequest instanceof final ReplicationRequest replicationRequest) {
+                if (indicesRequest instanceof final ReplicationRequest<?> replicationRequest) {
                     assertThat(indices, hasItem(replicationRequest.shardId().getIndexName()));
                 } else {
                     for (String index : indicesRequest.indices()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.admin.indices.flush;
 
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,6 +34,16 @@ public class ShardFlushRequest extends ReplicationRequest<ShardFlushRequest> {
 
     FlushRequest getRequest() {
         return request;
+    }
+
+    @Override
+    public String[] indices() {
+        return request.indices();
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return request.indicesOptions();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -59,7 +59,7 @@ public class TransportRefreshAction extends TransportBroadcastReplicationAction<
 
     @Override
     protected BasicReplicationRequest newShardRequest(RefreshRequest request, ShardId shardId) {
-        BasicReplicationRequest replicationRequest = new BasicReplicationRequest(shardId);
+        BasicReplicationRequest replicationRequest = new BasicReplicationRequest(shardId, request);
         replicationRequest.waitForActiveShards(ActiveShardCount.NONE);
         return replicationRequest;
     }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -265,7 +265,7 @@ public class BroadcastReplicationTests extends ESTestCase {
 
         @Override
         protected BasicReplicationRequest newShardRequest(DummyBroadcastRequest request, ShardId shardId) {
-            return new BasicReplicationRequest(shardId);
+            return new BasicReplicationRequest(shardId, request);
         }
 
         @Override


### PR DESCRIPTION
If a user only has privileges for aliases and request refresh or flush
for the aliases, the actions should be authorized similar to how read is
authorized for aliases.

Resolves: #84626
