### PR TITLE
fix flaky tsdb/30_snapshot.yaml spec

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -34,6 +34,7 @@ setup:
         wait_for_completion: true
         body:
           indices: "test_index"
+          feature_states: ["none"]
 
   - match: { snapshot.snapshot: test_snapshot_1 }
   - match: { snapshot.state : SUCCESS }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -102,7 +102,8 @@ teardown:
         snapshot: test_restore_tsdb
         wait_for_completion: true
         body:
-          indices: test_index
+          indices: "test_index"
+          feature_states: ["none"]
 
   - match: { snapshot.snapshot: test_restore_tsdb }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
Feature state indices are added to the snapshot implicitly even if they
are not listed int the indices field. This change is disabling
snapshotting features explicitly to avoid .tasks index in the snapshot.

Closes: #84426
