### PR TITLE
java version checker targetCompatibility Java 9

### DIFF
--- a/distribution/tools/java-version-checker/build.gradle
+++ b/distribution/tools/java-version-checker/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'elasticsearch.build'
 
-targetCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_9
 
 // java_version_checker do not depend on core so only JDK signatures should be checked
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
I would like to bump the targetCompatibility of the java version
checker, from 7 to 9. I understand that we want this code targeting the
lowest possible byte code version, but 7 is very very old at this point.
I chose 9 as that is the minimum required to support Java Module
declarations, which we use over on the modules branch.