### PR TITLE
[ML] Return all datafeeds in get anomaly detection jobs API

### DIFF
--- a/docs/changelog/84759.yaml
+++ b/docs/changelog/84759.yaml
@@ -1,0 +1,5 @@
+pr: 84759
+summary: Return all Datafeeds with GET Anomaly Detector
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -30,9 +30,11 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -440,6 +442,31 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(datafeedIdsHolder.get(), contains("bar-1", "foo-1"));
     }
 
+    public void testFindDatafeedIdsForJobIds_ManyJobs() throws Exception {
+        var jobIds = new ArrayList<String>();
+        var dfIds = new HashSet<String>();
+        for (int i = 0; i < 13; i++) {
+            String id = Integer.toString(i);
+            var dfId = "df-" + id;
+            var jobId = "j-" + id;
+            putDatafeedConfig(createDatafeedConfig(dfId, jobId), Collections.emptyMap());
+            dfIds.add(dfId);
+            jobIds.add(jobId);
+        }
+
+        client().admin().indices().prepareRefresh(MlConfigIndex.indexName()).get();
+
+        AtomicReference<Set<String>> datafeedIdsHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedIdsForJobIds(jobIds, actionListener),
+            datafeedIdsHolder,
+            exceptionHolder
+        );
+        assertEquals(dfIds, datafeedIdsHolder.get());
+    }
+
     public void testFindDatafeedsForJobIds() throws Exception {
         putDatafeedConfig(createDatafeedConfig("foo-1", "j1"), Collections.emptyMap());
         putDatafeedConfig(createDatafeedConfig("foo-2", "j2"), Collections.emptyMap());
@@ -473,6 +500,29 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(datafeedMapHolder.get(), allOf(hasKey("j3"), hasKey("j1")));
         assertThat(datafeedMapHolder.get().get("j3").getId(), equalTo("bar-1"));
         assertThat(datafeedMapHolder.get().get("j1").getId(), equalTo("foo-1"));
+    }
+
+    public void testFindDatafeedsForJobIds_ManyJobs() throws Exception {
+        var jobIds = new ArrayList<String>();
+        for (int i = 0; i < 13; i++) {
+            String id = Integer.toString(i);
+            var dfId = "df-" + id;
+            var jobId = "j-" + id;
+            putDatafeedConfig(createDatafeedConfig(dfId, jobId), Collections.emptyMap());
+            jobIds.add(jobId);
+        }
+
+        client().admin().indices().prepareRefresh(MlConfigIndex.indexName()).get();
+
+        AtomicReference<Map<String, DatafeedConfig.Builder>> datafeedMapHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedsByJobIds(jobIds, actionListener),
+            datafeedMapHolder,
+            exceptionHolder
+        );
+        assertThat(datafeedMapHolder.get().entrySet(), hasSize(jobIds.size()));
     }
 
     public void testHeadersAreOverwritten() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -187,11 +187,11 @@ public class DatafeedConfigProvider {
     public void findDatafeedIdsForJobIds(Collection<String> jobIds, ActionListener<Set<String>> listener) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds));
         sourceBuilder.fetchSource(false);
+        sourceBuilder.size(jobIds.size());
         sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName(), null);
 
         SearchRequest searchRequest = client.prepareSearch(MlConfigIndex.indexName())
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setSize(jobIds.size())
             .setSource(sourceBuilder)
             .request();
 
@@ -218,8 +218,7 @@ public class DatafeedConfigProvider {
     public void findDatafeedsByJobIds(Collection<String> jobIds, ActionListener<Map<String, DatafeedConfig.Builder>> listener) {
         SearchRequest searchRequest = client.prepareSearch(MlConfigIndex.indexName())
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setSize(jobIds.size())
-            .setSource(new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds)))
+            .setSource(new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds)).size(jobIds.size()))
             .request();
 
         executeAsyncWithOrigin(


### PR DESCRIPTION
GET anomaly_detectors includes the datafeed config with the anomaly detectors
but due to the default search size being used only the first 10 datafeeds were included. 