### PR TITLE
[7.17] Pin specific pip py modules used by connector SDK (#84757)

### DIFF
--- a/x-pack/plugin/sql/connectors/tableau/package.sh
+++ b/x-pack/plugin/sql/connectors/tableau/package.sh
@@ -77,6 +77,8 @@ function package() {
 
     # install environment
     cd $SDK_DIR/connector-packager
+    # apply pip-installed modules version pinning
+    patch setup.py $MY_TOP_DIR/setup.py.diff
     python3 -m venv .venv
     source .venv/bin/activate
     python3 setup.py install

--- a/x-pack/plugin/sql/connectors/tableau/setup.py.diff
+++ b/x-pack/plugin/sql/connectors/tableau/setup.py.diff
@@ -1,0 +1,13 @@
+diff --git a/connector-packager/setup.py b/connector-packager/setup.py
+index 1601492..eb1cc27 100644
+--- a/connector-packager/setup.py
++++ b/connector-packager/setup.py
+@@ -16,7 +16,7 @@ setup(
+     description='A Python module for packaging a Tableau connector.',
+     test_suite='tests',
+     python_requires='>3.7',
+-    install_requires=['xmlschema', 'defusedxml'],
++    install_requires=['elementpath==2.4.0', 'xmlschema==1.9.2', 'defusedxml==0.7.1'],
+     tests_require=['six'],
+     include_package_data=True
+ )


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Pin specific pip py modules used by connector SDK (#84757)