### PR TITLE
Add missing explicit no-args ctors

### DIFF
--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersion.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersion.java
@@ -17,6 +17,8 @@ public class JavaVersion {
     public static final List<Integer> CURRENT = parse(System.getProperty("java.specification.version"));
     public static final List<Integer> JAVA_17 = parse("17");
 
+    private JavaVersion() {}
+
     static List<Integer> parse(final String value) {
         if (value.matches("^0*[0-9]+(\\.[0-9]+)*$") == false) {
             throw new IllegalArgumentException(value);

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/BootstrapJvmOptions.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/BootstrapJvmOptions.java
@@ -25,6 +25,9 @@ import java.util.stream.Collectors;
  * additional JVM options, in order to configure the bootstrap plugins.
  */
 public class BootstrapJvmOptions {
+
+    private BootstrapJvmOptions() {}
+
     public static List<String> bootstrapJvmOptions(Path plugins) throws IOException {
         if (Files.isDirectory(plugins) == false) {
             throw new IllegalArgumentException("Plugins path " + plugins + " must be a directory");

--- a/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
@@ -19,6 +19,8 @@ public abstract class AbstractRefCounted implements RefCounted {
 
     private final AtomicInteger refCount = new AtomicInteger(1);
 
+    protected AbstractRefCounted() {}
+
     @Override
     public final void incRef() {
         if (tryIncRef() == false) {

--- a/libs/core/src/main/java/org/elasticsearch/core/CompletableContext.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/CompletableContext.java
@@ -20,6 +20,8 @@ import java.util.function.BiConsumer;
  */
 public class CompletableContext<T> {
 
+    public CompletableContext() {}
+
     private final CompletableFuture<T> completableFuture = new CompletableFuture<>();
 
     public void addListener(BiConsumer<T, ? super Exception> listener) {

--- a/libs/core/src/main/java/org/elasticsearch/core/Glob.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Glob.java
@@ -13,6 +13,8 @@ package org.elasticsearch.core;
  */
 public class Glob {
 
+    private Glob() {}
+
     /**
      * Match a String against the given pattern, supporting the following simple
      * pattern styles: "xxx*", "*xxx", "*xxx*" and "xxx*yyy" matches (with an

--- a/libs/core/src/main/java/org/elasticsearch/core/Types.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Types.java
@@ -13,6 +13,8 @@ package org.elasticsearch.core;
  */
 public abstract class Types {
 
+    private Types() {}
+
     /**
      * There are some situations where we cannot appease javac's type checking, and we
      * need to forcibly cast an object's type. Please don't use this method unless you

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/net/NetUtils.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/net/NetUtils.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
  */
 public class NetUtils {
 
+    private NetUtils() {}
+
     /**
      * Returns the extended TCP_KEEPIDLE socket option, if available on this JDK
      */

--- a/libs/core/src/main/java/org/elasticsearch/jdk/JdkJarHellCheck.java
+++ b/libs/core/src/main/java/org/elasticsearch/jdk/JdkJarHellCheck.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 public class JdkJarHellCheck {
 
+    private JdkJarHellCheck() {}
+
     private Set<String> detected = new HashSet<>();
 
     private void scanForJDKJarHell(Path root) throws IOException {

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/BitUtil.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/BitUtil.java
@@ -11,6 +11,9 @@ package org.elasticsearch.geometry.utils;
  * Utilities for common Bit twiddling methods. Borrowed heavily from Lucene (org.apache.lucene.util.BitUtil).
  */
 public class BitUtil {  // magic numbers for bit interleaving
+
+    private BitUtil() {}
+
     private static final long MAGIC[] = {
         0x5555555555555555L,
         0x3333333333333333L,

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/AbstractObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/AbstractObjectParser.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
  */
 public abstract class AbstractObjectParser<Value, Context> {
 
+    protected AbstractObjectParser() {}
+
     /**
      * Declare some field. Usually it is easier to use {@link #declareString(BiConsumer, ParseField)} or
      * {@link #declareObject(BiConsumer, ContextParser, ParseField)} rather than call this directly.

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/FilterXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/FilterXContentParser.java
@@ -24,6 +24,8 @@ import java.util.function.Supplier;
  */
 public abstract class FilterXContentParser implements XContentParser {
 
+    protected FilterXContentParser() {}
+
     protected abstract XContentParser delegate();
 
     @Override

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/MediaTypeRegistry.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/MediaTypeRegistry.java
@@ -31,6 +31,8 @@ import java.util.regex.Pattern;
  */
 public class MediaTypeRegistry<T extends MediaType> {
 
+    public MediaTypeRegistry() {}
+
     private Map<String, T> queryParamToMediaType = new HashMap<>();
     private Map<String, T> typeWithSubtypeToMediaType = new HashMap<>();
     private Map<String, Map<String, Pattern>> parametersMap = new HashMap<>();

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParseField.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParseField.java
@@ -210,5 +210,7 @@ public class ParseField {
         public static final ParseField FORMAT = new ParseField("format");
         public static final ParseField MISSING = new ParseField("missing");
         public static final ParseField TIME_ZONE = new ParseField("time_zone");
+
+        protected CommonFields() {}
     }
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentFactory.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentFactory.java
@@ -24,6 +24,8 @@ public class XContentFactory {
 
     public static final int GUESS_HEADER_LENGTH = 20;
 
+    private XContentFactory() {}
+
     /**
      * Returns a content builder using JSON format ({@link org.elasticsearch.xcontent.XContentType#JSON}.
      */

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/json/JsonStringEncoder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/json/JsonStringEncoder.java
@@ -15,6 +15,8 @@ import org.elasticsearch.xcontent.spi.XContentProvider;
  */
 public abstract class JsonStringEncoder {
 
+    protected JsonStringEncoder() {}
+
     private static final JsonStringEncoder INSTANCE = XContentProvider.provider().getJsonStringEncoder();
 
     /**


### PR DESCRIPTION
In order to reduce the number of explicit suppressions for _missing-explicit-ctor_ in the modules branch (see [JDK-8249634][1]), we add an explicit no-args ctor with the narrowest possible access modifier.

[1]: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8249634