### PR TITLE
[ML] Return all Datafeeds with GET Anomaly Detector 

### DIFF
--- a/docs/changelog/84759.yaml
+++ b/docs/changelog/84759.yaml
@@ -1,0 +1,5 @@
+pr: 84759
+summary: Return all Datafeeds with GET Anomaly Detector
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -25,9 +25,11 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -432,6 +434,31 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(datafeedIdsHolder.get(), contains("bar-1", "foo-1"));
     }
 
+    public void testFindDatafeedIdsForJobIds_ManyJobs() throws Exception {
+        var jobIds = new ArrayList<String>();
+        var dfIds = new HashSet<String>();
+        for (int i = 0; i < 13; i++) {
+            String id = Integer.toString(i);
+            var dfId = "df-" + id;
+            var jobId = "j-" + id;
+            putDatafeedConfig(createDatafeedConfig(dfId, jobId), Collections.emptyMap());
+            dfIds.add(dfId);
+            jobIds.add(jobId);
+        }
+
+        client().admin().indices().prepareRefresh(MlConfigIndex.indexName()).get();
+
+        AtomicReference<Set<String>> datafeedIdsHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedIdsForJobIds(jobIds, actionListener),
+            datafeedIdsHolder,
+            exceptionHolder
+        );
+        assertEquals(dfIds, datafeedIdsHolder.get());
+    }
+
     public void testFindDatafeedsForJobIds() throws Exception {
         putDatafeedConfig(createDatafeedConfig("foo-1", "j1"), Collections.emptyMap());
         putDatafeedConfig(createDatafeedConfig("foo-2", "j2"), Collections.emptyMap());
@@ -465,6 +492,29 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(datafeedMapHolder.get(), allOf(hasKey("j3"), hasKey("j1")));
         assertThat(datafeedMapHolder.get().get("j3").getId(), equalTo("bar-1"));
         assertThat(datafeedMapHolder.get().get("j1").getId(), equalTo("foo-1"));
+    }
+
+    public void testFindDatafeedsForJobIds_ManyJobs() throws Exception {
+        var jobIds = new ArrayList<String>();
+        for (int i = 0; i < 13; i++) {
+            String id = Integer.toString(i);
+            var dfId = "df-" + id;
+            var jobId = "j-" + id;
+            putDatafeedConfig(createDatafeedConfig(dfId, jobId), Collections.emptyMap());
+            jobIds.add(jobId);
+        }
+
+        client().admin().indices().prepareRefresh(MlConfigIndex.indexName()).get();
+
+        AtomicReference<Map<String, DatafeedConfig.Builder>> datafeedMapHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedsByJobIds(jobIds, actionListener),
+            datafeedMapHolder,
+            exceptionHolder
+        );
+        assertThat(datafeedMapHolder.get().entrySet(), hasSize(jobIds.size()));
     }
 
     public void testHeadersAreOverwritten() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -182,11 +182,11 @@ public class DatafeedConfigProvider {
     public void findDatafeedIdsForJobIds(Collection<String> jobIds, ActionListener<Set<String>> listener) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds));
         sourceBuilder.fetchSource(false);
+        sourceBuilder.size(jobIds.size());
         sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName(), null);
 
         SearchRequest searchRequest = client.prepareSearch(MlConfigIndex.indexName())
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setSize(jobIds.size())
             .setSource(sourceBuilder)
             .request();
 
@@ -213,8 +213,7 @@ public class DatafeedConfigProvider {
     public void findDatafeedsByJobIds(Collection<String> jobIds, ActionListener<Map<String, DatafeedConfig.Builder>> listener) {
         SearchRequest searchRequest = client.prepareSearch(MlConfigIndex.indexName())
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setSize(jobIds.size())
-            .setSource(new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds)))
+            .setSource(new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds)).size(jobIds.size()))
             .request();
 
         executeAsyncWithOrigin(


### PR DESCRIPTION
Fixes a bug where only the first 10 datafeeds were included

Backport of https://github.com/elastic/elasticsearch/pull/84759