### PR TITLE
Add known issue for audit logging with fitered fields

### DIFF
--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -16,24 +16,27 @@ In 8.1.0, a bug {es-issue}84784[#84784] prevents APIs using requests with filter
 when request body auditing is enabled. Using these APIs can result into a `401` HTTP
 error with a `null_pointer_exception` being the underlying cause.
 
-Audit logging can be configured to print the request body of incoming requests.
-Certain requests can contain sensitive information, e.g. a password, that must not
+When `xpack.security.audit.logfile.events.emit_request_body` is `true`, audit
+logs include the request body of incoming requests for certain events.
+These requests can contain sensitive information, such as passwords, that must not
 be logged. Fields containing such information are filtered out before logging.
 The REST APIs that use requests with filtered fields are:
 
-* <<security-api-change-password>>
-* <<cluster-nodes-reload-secure-settings>>
-* <<security-api-put-user>>
-* <<security-api-get-token>>
-* <<security-api-invalidate-token>>
-* <<security-api-grant-api-key>>
-* <<watcher-api-put-watch>>
-* <<watcher-api-execute-watch>>
-* <<security-api-saml-authenticate>>
-* <<security-api-oidc-authenticate>>
+* <<security-api-change-password,Change passwords API>>
+* <<cluster-nodes-reload-secure-settings,Node reload settings API>>
+* <<security-api-put-user,Create or updates users API>>
+* <<security-api-get-token,Get token API>>
+* <<security-api-invalidate-token,Invalidate token API>>
+* <<security-api-grant-api-key,Grant API key API>>
+* <<watcher-api-put-watch,Create or update watch API>>
+* <<watcher-api-execute-watch,Execute watch API>>
+* <<security-api-saml-authenticate,SAML authenticate API>>
+* <<security-api-oidc-authenticate,OpenID Connect authenticate API>>
 * <<docs-reindex,Reindex API>>
 
-Please note `emit_request_body` defaults to `false`. Also note request body is only logged for
+Please note the `xpack.security.audit.logfile.events.emit_request_body` cluster
+setting defaults to `false`. If the setting is `true`, audit logs only include
+the request body for the
 following events (not all of these events are enabled by default):
 
 * `authentication_success`

--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -12,7 +12,7 @@ Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 * If audit logging is configured to `emit_request_body`, it can prevent some APIs from working.
 +
 --
-In 8.1, a bug {es-issue}84784[#84784] prevents APIs using requests with filtered fields from working
+In 8.1.0, a bug {es-issue}84784[#84784] prevents APIs using requests with filtered fields from working
 when request body auditing is enabled. Using these APIs can result into a `401` HTTP
 error with a `null_pointer_exception` being the underlying cause.
 

--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -9,12 +9,11 @@ Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 [float]
 === Known issues
 
-* If audit logging is configured to `emit_request_body`, it can result into `NullPointerException` for
-requests that have filtered fields.
+* If audit logging is configured to `emit_request_body`, it can prevent some APIs from working.
 +
 --
 Audit logging can be configured to print the request body of incoming requests.
-Certain requests can contain sensitive information, e.g. password, that must not
+Certain requests can contain sensitive information, e.g. a password, that must not
 be logged. Fields containing such information are filtered out before logging.
 The REST APIs that use requests with filtered fields are:
 
@@ -30,12 +29,12 @@ The REST APIs that use requests with filtered fields are:
 * <<security-api-oidc-authenticate>>
 * <<docs-reindex,Reindex API>>
 
-In 8.1, a bug {es-issue}84784[#84784] prevents request with filtered fields work
+In 8.1, a bug {es-issue}84784[#84784] prevents request with filtered fields from working
 correctly with auditing request body. Using above APIs can result into a `401` HTTP
 error with a `null_pointer_exception` being the underlying cause.
 
 Please note `emit_request_body` defaults to `false`. Also note request body is only logged for
-following events (most of them are not enabled by default either):
+following events (not all of these events are enabled by default):
 
 * `authentication_success`
 * `authentication_failed`

--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -9,13 +9,12 @@ Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 [float]
 === Known issues
 
-* If audit logging is configured to `emit_request_body`, it can prevent some APIs from working.
+* In 8.1.0, a bug ({es-issue}84784[#84784]) can cause APIs that use filtered fields
+to return a `null_pointer_exception` error with a `401` HTTP status code when
+the `xpack.security.audit.logfile.events.emit_request_body` cluster setting is
+`true`.
 +
 --
-In 8.1.0, a bug {es-issue}84784[#84784] prevents APIs using requests with filtered fields from working
-when request body auditing is enabled. Using these APIs can result into a `401` HTTP
-error with a `null_pointer_exception` being the underlying cause.
-
 When `xpack.security.audit.logfile.events.emit_request_body` is `true`, audit
 logs include the request body of incoming requests for certain events.
 These requests can contain sensitive information, such as passwords, that must not
@@ -45,6 +44,17 @@ following events (not all of these events are enabled by default):
 * `tampered_request`
 * `run_as_denied`
 * `anonymous_access_denied`
+
+To work around this issue, you can disable the request body auditing using the cluster settings API:
+[source,console]
+----
+PUT /_cluster/settings
+{
+  "transient": {
+    "xpack.security.audit.logfile.events.emit_request_body": false
+  }
+}
+----
 --
 
 [[breaking-8.1.0]]

--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -12,6 +12,10 @@ Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 * If audit logging is configured to `emit_request_body`, it can prevent some APIs from working.
 +
 --
+In 8.1, a bug {es-issue}84784[#84784] prevents APIs using requests with filtered fields from working
+when request body auditing is enabled. Using these APIs can result into a `401` HTTP
+error with a `null_pointer_exception` being the underlying cause.
+
 Audit logging can be configured to print the request body of incoming requests.
 Certain requests can contain sensitive information, e.g. a password, that must not
 be logged. Fields containing such information are filtered out before logging.
@@ -28,10 +32,6 @@ The REST APIs that use requests with filtered fields are:
 * <<security-api-saml-authenticate>>
 * <<security-api-oidc-authenticate>>
 * <<docs-reindex,Reindex API>>
-
-In 8.1, a bug {es-issue}84784[#84784] prevents request with filtered fields from working
-correctly with auditing request body. Using above APIs can result into a `401` HTTP
-error with a `null_pointer_exception` being the underlying cause.
 
 Please note `emit_request_body` defaults to `false`. Also note request body is only logged for
 following events (not all of these events are enabled by default):

--- a/docs/reference/release-notes/8.1.asciidoc
+++ b/docs/reference/release-notes/8.1.asciidoc
@@ -5,6 +5,46 @@ coming[8.1.0]
 
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 
+[[known-issues-8.1.0]]
+[float]
+=== Known issues
+
+* If audit logging is configured to `emit_request_body`, it can result into `NullPointerException` for
+requests that have filtered fields.
++
+--
+Audit logging can be configured to print the request body of incoming requests.
+Certain requests can contain sensitive information, e.g. password, that must not
+be logged. Fields containing such information are filtered out before logging.
+The REST APIs that use requests with filtered fields are:
+
+* <<security-api-change-password>>
+* <<cluster-nodes-reload-secure-settings>>
+* <<security-api-put-user>>
+* <<security-api-get-token>>
+* <<security-api-invalidate-token>>
+* <<security-api-grant-api-key>>
+* <<watcher-api-put-watch>>
+* <<watcher-api-execute-watch>>
+* <<security-api-saml-authenticate>>
+* <<security-api-oidc-authenticate>>
+* <<docs-reindex,Reindex API>>
+
+In 8.1, a bug {es-issue}84784[#84784] prevents request with filtered fields work
+correctly with auditing request body. Using above APIs can result into a `401` HTTP
+error with a `null_pointer_exception` being the underlying cause.
+
+Please note `emit_request_body` defaults to `false`. Also note request body is only logged for
+following events (most of them are not enabled by default either):
+
+* `authentication_success`
+* `authentication_failed`
+* `realm_authentication_failed`
+* `tampered_request`
+* `run_as_denied`
+* `anonymous_access_denied`
+--
+
 [[breaking-8.1.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
Users can encounter 401 HTTP error with NPE as the underlying cause when
using audit logging with `emit_request_body` and requests with filtered
fields. This PR adds this issue to known issues of the 8.1 release
notes.

Relates: #84784

docs-preview: https://elasticsearch_84786.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/release-notes-8.1.0.html
