### PR TITLE
Don't run the runtime field YAML tests over TSDB aggs

### DIFF
--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -7,8 +7,8 @@
  */
 
 
+
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.build'
 
@@ -95,6 +95,8 @@ subprojects {
           'search.aggregation/20_terms/Global ordinals are loaded with the global_ordinals execution hint',
           'search.aggregation/170_cardinality_metric/profiler string',
           'search.aggregation/235_composite_sorted/*',
+          // timeseries dimensions can't be runtime fields
+          'search.aggregation/450_time_series/*',
           // The error messages are different
           'search/330_fetch_fields/error includes field name',
           'search/330_fetch_fields/error includes glob pattern',


### PR DESCRIPTION
Runtime fields don't support `dimension` parameters so we can't shadow
keyword fields in the normal way for TSDB yaml tests.