### PR TITLE
No need to wait for green in IndexDiskUsageAnalyzerIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -100,7 +100,6 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
             .setMapping(mapping)
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)))
             .get();
-        ensureGreen(index);
 
         int numDocs = randomIntBetween(10, 100);
         for (int i = 0; i < numDocs; i++) {
@@ -160,7 +159,6 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 1))
             )
             .get();
-        ensureGreen(indexName);
         int numDocs = randomIntBetween(1, 10);
         for (int i = 0; i < numDocs; i++) {
             int value = randomIntBetween(1, 10);


### PR DESCRIPTION
The test `testFailOnFlush` fails if the number of replicas is one and the cluster has a single data node. We don't need to wait for indices to be green in these tests.

Closes #84789