### PR TITLE
Improve Logging of Task Listeners

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -321,7 +321,7 @@ public abstract class TransportNodesAction<
 
         @Override
         public String toString() {
-            return "AsyncAction{" + "request=" + request + ", listener=" + listener + '}';
+            return "AsyncAction{request=" + request + ", listener=" + listener + '}';
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -261,6 +261,11 @@ public abstract class TransportNodesAction<
                             public void handleException(TransportException exp) {
                                 onFailure(idx, node.getId(), exp);
                             }
+
+                            @Override
+                            public String toString() {
+                                return "AsyncActionNodeResponseHandler{node=" + node + ", action=" + AsyncAction.this + '}';
+                            }
                         }
                     );
                 } catch (Exception e) {
@@ -312,6 +317,11 @@ public abstract class TransportNodesAction<
             } catch (TaskCancelledException e) {
                 nodeResponseTracker.discardIntermediateResponses(e);
             }
+        }
+
+        @Override
+        public String toString() {
+            return "AsyncAction{" + "request=" + request + ", listener=" + listener + '}';
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -189,10 +189,5 @@ public class NodeClient extends AbstractClient {
                 throw ex;
             }
         }
-
-        @Override
-        public String toString() {
-            return this.getClass().getName() + "{" + listener + "}";
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -110,22 +110,13 @@ public class NodeClient extends AbstractClient {
         Request request,
         ActionListener<Response> listener
     ) {
-        return taskManager.registerAndExecute("transport", transportAction(action), request, localConnection, (t, r) -> {
-            try {
-                listener.onResponse(r);
-            } catch (Exception e) {
-                assert false : new AssertionError("callback must handle its own exceptions", e);
-                throw e;
-            }
-        }, (t, e) -> {
-            try {
-                listener.onFailure(e);
-            } catch (Exception ex) {
-                ex.addSuppressed(e);
-                assert false : new AssertionError("callback must handle its own exceptions", ex);
-                throw ex;
-            }
-        });
+        return taskManager.registerAndExecute(
+            "transport",
+            transportAction(action),
+            request,
+            localConnection,
+            new ActionResponseTaskListener<>(listener)
+        );
     }
 
     /**
@@ -139,14 +130,7 @@ public class NodeClient extends AbstractClient {
         Request request,
         TaskListener<Response> listener
     ) {
-        return taskManager.registerAndExecute(
-            "transport",
-            transportAction(action),
-            request,
-            localConnection,
-            listener::onResponse,
-            listener::onFailure
-        );
+        return taskManager.registerAndExecute("transport", transportAction(action), request, localConnection, listener);
     }
 
     /**
@@ -181,5 +165,34 @@ public class NodeClient extends AbstractClient {
 
     public NamedWriteableRegistry getNamedWriteableRegistry() {
         return namedWriteableRegistry;
+    }
+
+    private record ActionResponseTaskListener<Response> (ActionListener<Response> listener) implements TaskListener<Response> {
+
+        @Override
+        public void onResponse(Task task, Response response) {
+            try {
+                listener.onResponse(response);
+            } catch (Exception e) {
+                assert false : new AssertionError("callback must handle its own exceptions", e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void onFailure(Task task, Exception e) {
+            try {
+                listener.onFailure(e);
+            } catch (Exception ex) {
+                ex.addSuppressed(e);
+                assert false : new AssertionError("callback must handle its own exceptions", ex);
+                throw ex;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.getClass().getName() + "{" + listener + "}";
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -193,6 +193,29 @@ public class Task {
         return null;
     }
 
+    @Override
+    public String toString() {
+        return "Task{"
+            + "id="
+            + id
+            + ", type='"
+            + type
+            + '\''
+            + ", action='"
+            + action
+            + '\''
+            + ", description='"
+            + description
+            + '\''
+            + ", parentTask="
+            + parentTask
+            + ", startTime="
+            + startTime
+            + ", startTimeNanos="
+            + startTimeNanos
+            + '}';
+    }
+
     /**
      * Report of the internal status of a task. These can vary wildly from task
      * to task because each task is implemented differently but we should try

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -195,19 +195,15 @@ public class Task {
 
     @Override
     public String toString() {
-        return "Task{"
-            + "id="
+        return "Task{id="
             + id
             + ", type='"
             + type
-            + '\''
-            + ", action='"
+            + "', action='"
             + action
-            + '\''
-            + ", description='"
+            + "', description='"
             + description
-            + '\''
-            + ", parentTask="
+            + "', parentTask="
             + parentTask
             + ", startTime="
             + startTime

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -57,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -150,8 +149,7 @@ public class TaskManager implements ClusterStateApplier {
         TransportAction<Request, Response> action,
         Request request,
         Transport.Connection localConnection,
-        BiConsumer<Task, Response> onResponse,
-        BiConsumer<Task, Exception> onFailure
+        TaskListener<Response> taskListener
     ) {
         final Releasable unregisterChildNode;
         if (request.getParentTask().isSet()) {
@@ -171,19 +169,28 @@ public class TaskManager implements ClusterStateApplier {
             @Override
             public void onResponse(Response response) {
                 try {
-                    Releasables.close(unregisterChildNode, () -> unregister(task));
+                    release();
                 } finally {
-                    onResponse.accept(task, response);
+                    taskListener.onResponse(task, response);
                 }
             }
 
             @Override
             public void onFailure(Exception e) {
                 try {
-                    Releasables.close(unregisterChildNode, () -> unregister(task));
+                    release();
                 } finally {
-                    onFailure.accept(task, e);
+                    taskListener.onFailure(task, e);
                 }
+            }
+
+            @Override
+            public String toString() {
+                return this.getClass().getName() + "{" + taskListener + "}{" + task + "}";
+            }
+
+            private void release() {
+                Releasables.close(unregisterChildNode, () -> unregister(task));
             }
         });
         return task;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -250,8 +250,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
                 actions[0],
                 request,
                 testNodes[0].transportService.getLocalNodeConnection(),
-                (t, r) -> listener.onResponse(r),
-                (t, e) -> listener.onFailure(e)
+                ActionTestUtils.wrapAsTaskListener(listener)
             );
         if (waitForActionToStart) {
             logger.info("Awaiting for all actions to start");
@@ -435,8 +434,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
                 testAction,
                 childRequest,
                 testNodes[0].transportService.getLocalNodeConnection(),
-                (task, response) -> {},
-                (task, e) -> {}
+                ActionTestUtils.wrapAsTaskListener(ActionListener.wrap(() -> {}))
             )
         );
         assertThat(cancelledException.getMessage(), equalTo("task cancelled before starting [test]"));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -295,8 +295,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                 actions[0],
                 request,
                 testNodes[0].transportService.getLocalNodeConnection(),
-                (t, r) -> listener.onResponse(r),
-                (t, e) -> listener.onFailure(e)
+                ActionTestUtils.wrapAsTaskListener(listener)
             );
         logger.info("Awaiting for all actions to start");
         assertTrue(actionLatch.await(10, TimeUnit.SECONDS));


### PR DESCRIPTION
Adding more logging to get a better log message here and there when a transport response listener
is logged in particular.
