### PR TITLE
Support mail, name, and dn claims for role mapping.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/jwt/JwtRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/jwt/JwtRealmSettings.java
@@ -129,6 +129,12 @@ public class JwtRealmSettings {
                 CLAIMS_PRINCIPAL.getPattern(),
                 CLAIMS_GROUPS.getClaim(),
                 CLAIMS_GROUPS.getPattern(),
+                CLAIMS_DN.getClaim(),
+                CLAIMS_DN.getPattern(),
+                CLAIMS_MAIL.getClaim(),
+                CLAIMS_MAIL.getPattern(),
+                CLAIMS_NAME.getClaim(),
+                CLAIMS_NAME.getPattern(),
                 POPULATE_USER_METADATA
             )
         );
@@ -204,6 +210,9 @@ public class JwtRealmSettings {
     // Note: ClaimSetting is a wrapper for two individual settings: getClaim(), getPattern()
     public static final ClaimSetting CLAIMS_PRINCIPAL = new ClaimSetting(TYPE, "principal");
     public static final ClaimSetting CLAIMS_GROUPS = new ClaimSetting(TYPE, "groups");
+    public static final ClaimSetting CLAIMS_DN = new ClaimSetting(TYPE, "dn");
+    public static final ClaimSetting CLAIMS_MAIL = new ClaimSetting(TYPE, "mail");
+    public static final ClaimSetting CLAIMS_NAME = new ClaimSetting(TYPE, "name");
 
     public static final Setting.AffixSetting<Boolean> POPULATE_USER_METADATA = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
@@ -72,6 +72,9 @@ public class JwtRealm extends Realm implements CachingRealm, Releasable {
     final Boolean populateUserMetadata;
     final ClaimParser claimParserPrincipal;
     final ClaimParser claimParserGroups;
+    final ClaimParser claimParserDn;
+    final ClaimParser claimParserMail;
+    final ClaimParser claimParserName;
     final JwtRealmSettings.ClientAuthenticationType clientAuthenticationType;
     final SecureString clientAuthenticationSharedSecret;
     DelegatedAuthorizationSupport delegatedAuthorizationSupport = null;
@@ -86,6 +89,9 @@ public class JwtRealm extends Realm implements CachingRealm, Releasable {
         this.allowedClockSkew = realmConfig.getSetting(JwtRealmSettings.ALLOWED_CLOCK_SKEW);
         this.claimParserPrincipal = ClaimParser.forSetting(LOGGER, JwtRealmSettings.CLAIMS_PRINCIPAL, realmConfig, true);
         this.claimParserGroups = ClaimParser.forSetting(LOGGER, JwtRealmSettings.CLAIMS_GROUPS, realmConfig, false);
+        this.claimParserDn = ClaimParser.forSetting(LOGGER, JwtRealmSettings.CLAIMS_DN, realmConfig, false);
+        this.claimParserMail = ClaimParser.forSetting(LOGGER, JwtRealmSettings.CLAIMS_MAIL, realmConfig, false);
+        this.claimParserName = ClaimParser.forSetting(LOGGER, JwtRealmSettings.CLAIMS_NAME, realmConfig, false);
         this.populateUserMetadata = realmConfig.getSetting(JwtRealmSettings.POPULATE_USER_METADATA);
         this.clientAuthenticationType = realmConfig.getSetting(JwtRealmSettings.CLIENT_AUTHENTICATION_TYPE);
         final SecureString sharedSecret = realmConfig.getSetting(JwtRealmSettings.CLIENT_AUTHENTICATION_SHARED_SECRET);
@@ -363,17 +369,6 @@ public class JwtRealm extends Realm implements CachingRealm, Releasable {
                 listener.onResponse(AuthenticationResult.unsuccessful(msg, null));
                 return;
             }
-            final List<String> groups = this.claimParserGroups.getClaimValues(claimsSet);
-            final Map<String, Object> userMetadata;
-            try {
-                userMetadata = this.populateUserMetadata ? JwtUtil.toUserMetadata(jwt) : Map.of();
-            } catch (Exception e) {
-                final String msg = "Realm [" + super.name() + "] parse metadata failed for principal=[" + principal + "].";
-                final AuthenticationResult<User> unsuccessful = AuthenticationResult.unsuccessful(msg, e);
-                LOGGER.debug(msg, e);
-                listener.onResponse(unsuccessful);
-                return;
-            }
 
             // Delegated role lookup: If enabled, lookup in authz realms. Otherwise, fall through to JWT realm role mapping.
             if (this.delegatedAuthorizationSupport.hasDelegation()) {
@@ -395,17 +390,30 @@ public class JwtRealm extends Realm implements CachingRealm, Releasable {
                 return;
             }
 
+            // User metadata: If enabled, extract metadata from JWT claims set. Use it in UserRoleMapper.UserData and User constructors.
+            final Map<String, Object> userMetadata;
+            try {
+                userMetadata = this.populateUserMetadata ? JwtUtil.toUserMetadata(jwt) : Map.of();
+            } catch (Exception e) {
+                final String msg = "Realm [" + super.name() + "] parse metadata failed for principal=[" + principal + "].";
+                final AuthenticationResult<User> unsuccessful = AuthenticationResult.unsuccessful(msg, e);
+                LOGGER.debug(msg, e);
+                listener.onResponse(unsuccessful);
+                return;
+            }
+
             // Role resolution: Handle role mapping in JWT Realm.
-            final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(principal, null, groups, userMetadata, super.config);
+            final List<String> groups = this.claimParserGroups.getClaimValues(claimsSet);
+            final String dn = this.claimParserDn.getClaimValue(claimsSet);
+            final String mail = this.claimParserMail.getClaimValue(claimsSet);
+            final String name = this.claimParserName.getClaimValue(claimsSet);
+            final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(principal, dn, groups, userMetadata, super.config);
             this.userRoleMapper.resolveRoles(userData, ActionListener.wrap(rolesSet -> {
-                // Intercept the role mapper listener response to log the resolved roles here. Empty is OK.
-                final String[] rolesArray = rolesSet.toArray(new String[0]);
-                final User user = new User(principal, rolesArray, null, null, userData.getMetadata(), true);
-                final String rolesString = Arrays.toString(rolesArray);
-                LOGGER.debug("Realm [" + super.name() + "] mapped roles " + rolesString + " for principal=[" + principal + "].");
+                final User user = new User(principal, rolesSet.toArray(Strings.EMPTY_ARRAY), name, mail, userData.getMetadata(), true);
+                LOGGER.debug("Realm [" + super.name() + "] roles " + String.join(",", rolesSet) + " for principal=[" + principal + "].");
                 listener.onResponse(AuthenticationResult.success(user));
             }, e -> {
-                final String msg = "Realm [" + super.name() + "] mapped roles failed for principal=[" + principal + "].";
+                final String msg = "Realm [" + super.name() + "] roles failed for principal=[" + principal + "].";
                 LOGGER.warn(msg, e);
                 listener.onResponse(AuthenticationResult.unsuccessful(msg, e));
             }));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmGenerateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmGenerateTests.java
@@ -241,6 +241,7 @@ public class JwtRealmGenerateTests extends JwtRealmTestCase {
             .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.ALLOWED_SIGNATURE_ALGORITHMS), "HS256,HS384")
             .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLAIMS_PRINCIPAL.getClaim()), "email")
             .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLAIMS_PRINCIPAL.getPattern()), "^(.*)@[^.]*[.]example[.]com$")
+            .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLAIMS_MAIL.getClaim()), "email")
             .put(
                 RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLIENT_AUTHENTICATION_TYPE),
                 JwtRealmSettings.ClientAuthenticationType.SHARED_SECRET.value()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmSettingsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmSettingsTests.java
@@ -146,7 +146,10 @@ public class JwtRealmSettingsTests extends JwtTestCase {
     public void testClaimNames() {
         for (final Setting.AffixSetting<String> setting : List.of(
             JwtRealmSettings.CLAIMS_PRINCIPAL.getClaim(),
-            JwtRealmSettings.CLAIMS_GROUPS.getClaim()
+            JwtRealmSettings.CLAIMS_GROUPS.getClaim(),
+            JwtRealmSettings.CLAIMS_DN.getClaim(),
+            JwtRealmSettings.CLAIMS_MAIL.getClaim(),
+            JwtRealmSettings.CLAIMS_NAME.getClaim()
         )) {
             final String realmName = "jwt" + randomIntBetween(1, 9);
             final String settingKey = RealmSettings.getFullSettingKey(realmName, setting);
@@ -171,7 +174,10 @@ public class JwtRealmSettingsTests extends JwtTestCase {
     public void testClaimPatterns() {
         for (final Setting.AffixSetting<String> setting : List.of(
             JwtRealmSettings.CLAIMS_PRINCIPAL.getPattern(),
-            JwtRealmSettings.CLAIMS_GROUPS.getPattern()
+            JwtRealmSettings.CLAIMS_GROUPS.getPattern(),
+            JwtRealmSettings.CLAIMS_DN.getPattern(),
+            JwtRealmSettings.CLAIMS_MAIL.getPattern(),
+            JwtRealmSettings.CLAIMS_NAME.getPattern()
         )) {
             final String realmName = "jwt" + randomIntBetween(1, 9);
             final String settingKey = RealmSettings.getFullSettingKey(realmName, setting);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmTestCase.java
@@ -250,6 +250,39 @@ public abstract class JwtRealmTestCase extends JwtTestCase {
             }
         }
         if (randomBoolean()) {
+            // dn claim name is optional
+            authcSettings.put(
+                RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_DN.getClaim()),
+                authcRealmName + "_dn"
+            );
+            if (randomBoolean()) {
+                // if dn claim name is set, dn claim pattern is optional
+                authcSettings.put(RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_DN.getPattern()), "^(.*)$");
+            }
+        }
+        if (randomBoolean()) {
+            // mail claim name is optional
+            authcSettings.put(
+                RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_MAIL.getClaim()),
+                authcRealmName + "_mail"
+            );
+            if (randomBoolean()) {
+                // if mail claim name is set, dn claim pattern is optional
+                authcSettings.put(RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_MAIL.getPattern()), "^(.*)$");
+            }
+        }
+        if (randomBoolean()) {
+            // full name claim name is optional
+            authcSettings.put(
+                RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_NAME.getClaim()),
+                authcRealmName + "_name"
+            );
+            if (randomBoolean()) {
+                // if full name claim name is set, name claim pattern is optional
+                authcSettings.put(RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.CLAIMS_NAME.getPattern()), "^(.*)$");
+            }
+        }
+        if (randomBoolean()) {
             // allow default to be picked, or explicitly set true or false
             authcSettings.put(RealmSettings.getFullSettingKey(authcRealmName, JwtRealmSettings.POPULATE_USER_METADATA), randomBoolean());
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtTestCase.java
@@ -148,13 +148,19 @@ public abstract class JwtTestCase extends ESTestCase {
             )
             .put(
                 RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_PRINCIPAL.getPattern()),
-                randomBoolean() ? null : randomFrom("^(.*)$", "^([^@]+)@example\\.com$")
+                randomBoolean() ? null : randomFrom("^(.+)$", "^([^@]+)@example\\.com$")
             )
             .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_GROUPS.getClaim()), randomFrom("group", "roles", "other"))
             .put(
                 RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_GROUPS.getPattern()),
-                randomBoolean() ? null : randomFrom("^(.*)$", "^Group-(.*)$")
+                randomBoolean() ? null : randomFrom("^(.+)$", "^Group-(.+)$")
             )
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_DN.getClaim()), randomFrom("dn", "subjectDN"))
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_DN.getPattern()), "^CN=(.+?),?.*$")
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_MAIL.getClaim()), randomFrom("mail", "email"))
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_MAIL.getPattern()), randomBoolean() ? null : "^.+$")
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_NAME.getClaim()), randomFrom("name", "fullname"))
+            .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLAIMS_NAME.getPattern()), randomBoolean() ? null : "^.+$")
             .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.POPULATE_USER_METADATA), populateUserMetadata)
             // Client settings for incoming connections
             .put(RealmSettings.getFullSettingKey(name, JwtRealmSettings.CLIENT_AUTHENTICATION_TYPE), clientAuthenticationType)


### PR DESCRIPTION
This PR adds claims set parsing for name and mail, for compatibility with User Profiles feature.

OpenIdConnectRealm.java has 5 claim parsers for principal, groups, name, mail, and DN. JwtRealm.java has principal and groups. Only mail and name are required for User Profiles compatibility, but adding DN is a small incremental change so I included it.

One of the realms being generated for integration tests uses a principal parser on an email claim. I updated it to add the email parser for the same claim.