### PR TITLE
[s3-repository] Don't fail if there no symlink for AWS Web Identity Token (#84697)

### DIFF
--- a/docs/changelog/84697.yaml
+++ b/docs/changelog/84697.yaml
@@ -1,0 +1,5 @@
+pr: 84697
+summary: Don't fail if there no symlink for AWS Web Identity Token
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -292,9 +292,14 @@ class S3Service implements Closeable {
                 return;
             }
             // Make sure that a readable symlink to the token file exists in the plugin config directory
+            // AWS_WEB_IDENTITY_TOKEN_FILE exists but we only use Web Identity Tokens if a corresponding symlink exists and is readable
             Path webIdentityTokenFileSymlink = environment.configFile().resolve("repository-s3/aws-web-identity-token-file");
             if (Files.exists(webIdentityTokenFileSymlink) == false) {
-                throw new IllegalStateException("A Web Identity Token symlink in the config directory doesn't exist");
+                LOGGER.warn(
+                    "Cannot use AWS Web Identity Tokens: AWS_WEB_IDENTITY_TOKEN_FILE is defined but no corresponding symlink exists "
+                        + "in the config directory"
+                );
+                return;
             }
             if (Files.isReadable(webIdentityTokenFileSymlink) == false) {
                 throw new IllegalStateException("Unable to read a Web Identity Token symlink in the config directory");


### PR DESCRIPTION
Backports #84697 to 8.0

* Make sure users can use the static credentials even if there is a service account with IAM roles configured on the system.
  See https://github.com/elastic/elasticsearch/issues/52625#issuecomment-1060154207

