### PR TITLE
Do not send default ignore_throttled parameter since it is deprecated

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -1086,7 +1086,9 @@ final class RequestConverters {
                     expandWildcards = joiner.toString();
                 }
                 putParam("expand_wildcards", expandWildcards);
-                putParam("ignore_throttled", Boolean.toString(indicesOptions.ignoreThrottled()));
+                if (indicesOptions.ignoreThrottled() == false) {
+                    putParam("ignore_throttled", Boolean.toString(indicesOptions.ignoreThrottled()));
+                }
             }
             return this;
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -125,7 +125,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.nullValue;
 
 public class RequestConvertersTests extends ESTestCase {
@@ -1774,7 +1773,10 @@ public class RequestConvertersTests extends ESTestCase {
         endpoint.add("_field_caps");
 
         assertEquals(endpoint.toString(), request.getEndpoint());
-        int expectedSize = expectedParameterCount(FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS, fieldCapabilitiesRequest.indicesOptions());
+        int expectedSize = expectedParameterCount(
+            FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS,
+            fieldCapabilitiesRequest.indicesOptions()
+        );
         assertEquals(expectedSize, request.getParameters().size());
 
         // Note that we don't check the field param value explicitly, as field names are
@@ -1815,7 +1817,10 @@ public class RequestConvertersTests extends ESTestCase {
         endpoint.add("_field_caps");
 
         assertEquals(endpoint.toString(), request.getEndpoint());
-        int expectedSize = expectedParameterCount(FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS, fieldCapabilitiesRequest.indicesOptions());
+        int expectedSize = expectedParameterCount(
+            FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS,
+            fieldCapabilitiesRequest.indicesOptions()
+        );
         assertEquals(expectedSize, request.getParameters().size());
 
         // Note that we don't check the field param value explicitly, as field names are
@@ -2242,7 +2247,7 @@ public class RequestConvertersTests extends ESTestCase {
         } else {
             expectedParams.put("expand_wildcards", "none");
         }
-        if (!getter.get().ignoreThrottled()) {
+        if (getter.get().ignoreThrottled() == false) {
             expectedParams.put("ignore_throttled", Boolean.toString(getter.get().ignoreThrottled()));
         }
     }
@@ -2271,7 +2276,7 @@ public class RequestConvertersTests extends ESTestCase {
         } else {
             expectedParams.put("expand_wildcards", "none");
         }
-        if (!indicesOptions.ignoreThrottled()) {
+        if (indicesOptions.ignoreThrottled() == false) {
             expectedParams.put("ignore_throttled", Boolean.toString(indicesOptions.ignoreThrottled()));
         }
         return indicesOptions;

--- a/docs/changelog/84827.yaml
+++ b/docs/changelog/84827.yaml
@@ -1,0 +1,5 @@
+pr: 84827
+summary: Do not send default ignore_throttled parameter since it is deprecated
+area: Java High Level REST Client
+type: bug
+issues: []


### PR DESCRIPTION
# Why

When setting indices options in the (now deprecated) `RestHighLevelClient`, even if we do not explicitly set `ignore_throttled`, the client sends the `ignore_throttled` parameter to the server. Since 7.16, this parameter is deprecated, and so the server sends back a warning header which is unconditionally logged.

This is extremely spammy in our environments because we usually set non-deprecated indices options, and so all of our requests are sending (without our control) the `ignore_throttled` parameter.

The `RestHighLevelClient` should not send the deprecated `ignore_throttled` parameter unless it is set to the non default value of `false`.

# What

This PR changes the `RequestConverters` to only send the `ignore_throttled` parameter when it is set to a non-default value. Otherwise it does not include it.

# Other notes

Happy to submit this against `master` however this should most definitely be available in the version where the deprecation was introduced (7.16) so I targeted that branch.