### PR TITLE
Resolve wildcards in disk usage API

### DIFF
--- a/docs/changelog/84832.yaml
+++ b/docs/changelog/84832.yaml
@@ -1,0 +1,5 @@
+pr: 84832
+summary: Resolve wildcards in disk usage API
+area: Search
+type: feature
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
@@ -109,6 +109,10 @@ setup:
 
 ---
 "Star":
+  - skip:
+      version: " - 8.1.99"
+      reason: star is resolved in 8.2+
+
   - do:
       indices.disk_usage:
         index: "*"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
@@ -4,8 +4,6 @@ setup:
       version: " - 7.14.99"
       reason: analyze index disk usage API is introduced in 7.15
 
----
-"Disk usage stats":
   - do:
       indices.create:
         index: testindex
@@ -40,8 +38,13 @@ setup:
       index:
         index: testindex
         body: { "name": "foobar", "quantity": 1000, "genre": "country" }
+
+---
+"Name the index":
   - do:
-      indices.disk_usage: { index: "testindex", "run_expensive_tasks": true }
+      indices.disk_usage:
+        index: testindex
+        run_expensive_tasks: true
 
   - gt: { testindex.store_size_in_bytes: 100 }
   # all_fields
@@ -103,3 +106,19 @@ setup:
   - gt: { testindex.fields._seq_no.points_in_bytes: 0 }
   - match: { testindex.fields._seq_no.norms_in_bytes: 0 }
   - match: { testindex.fields._seq_no.term_vectors_in_bytes: 0 }
+
+---
+"Star":
+  - do:
+      indices.disk_usage:
+        index: "*"
+        run_expensive_tasks: true
+
+  - gt: { testindex.store_size_in_bytes: 100 }
+  # all_fields
+  - gt: { testindex.all_fields.total_in_bytes: 0 }
+  - gt: { testindex.all_fields.inverted_index.total_in_bytes: 0 }
+  - gt: { testindex.all_fields.stored_fields_in_bytes: 0 }
+  - gt: { testindex.all_fields.doc_values_in_bytes: 0 }
+  - gt: { testindex.all_fields.points_in_bytes: 0 }
+  - match: { testindex.all_fields.term_vectors_in_bytes: 0 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageRequest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class AnalyzeIndexDiskUsageRequest extends BroadcastRequest<AnalyzeIndexDiskUsageRequest> {
-    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, true);
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, true);
     final boolean flush;
 
     public AnalyzeIndexDiskUsageRequest(String[] indices, IndicesOptions indicesOptions, boolean flush) {


### PR DESCRIPTION
This allows the disk usage API to match wildcards so you can fetch the
disk usage of all indices with something like:
```
POST /*/_disk_usage?run_expensive_tasks=true
```
