### PR TITLE
[8.1] Fix NullPointerException in SystemIndexMetadataUpgradeService hidden alias handling (#84780)

### DIFF
--- a/docs/changelog/84780.yaml
+++ b/docs/changelog/84780.yaml
@@ -1,0 +1,7 @@
+pr: 84780
+summary: Fix `NullPointerException` in `SystemIndexMetadataUpgradeService` hidden
+  alias handling
+area: Infra/Core
+type: bug
+issues:
+ - 81411

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -100,9 +100,9 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
                         builder.settings(Settings.builder().put(indexMetadata.getSettings()).put(IndexMetadata.SETTING_INDEX_HIDDEN, true));
                         updated = true;
                     }
-                    if (isSystem && indexMetadata.getAliases().values().stream().anyMatch(a -> a.isHidden() == false)) {
+                    if (isSystem && indexMetadata.getAliases().values().stream().anyMatch(a -> Boolean.FALSE.equals(a.isHidden()))) {
                         for (AliasMetadata aliasMetadata : indexMetadata.getAliases().values()) {
-                            if (aliasMetadata.isHidden() == false) {
+                            if (Boolean.FALSE.equals(aliasMetadata.isHidden())) {
                                 builder.removeAlias(aliasMetadata.alias());
                                 builder.putAlias(
                                     AliasMetadata.builder(aliasMetadata.alias())

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -98,7 +98,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         assertThat(toStr(client().performRequest(getRequest)), containsString(doc));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81411")
     public void testSecurityNativeRealm() throws Exception {
         if (isRunningAgainstOldCluster()) {
             createUser(true);


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Fix NullPointerException in SystemIndexMetadataUpgradeService hidden alias handling (#84780)