### PR TITLE
Experiment with more aggressive build parallelization

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -88,7 +88,7 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
         Provider<TestClustersThrottle> throttleProvider = GradleUtils.getBuildService(serviceRegistry, THROTTLE_SERVICE_NAME);
         SharedResource resource = serviceRegistry.forService(throttleProvider);
 
-        int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
+        int nodeCount = Math.min(clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum(), 2);
         if (nodeCount > 0) {
             locks.add(resource.getResourceLock(Math.min(nodeCount, resource.getMaxUsages())));
         }


### PR DESCRIPTION
Trying some tweaks so multi-node tests aren't so detrimental to build parallelization