### PR TITLE
Preventing multiple indicators with the same name in a health API component

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
@@ -194,7 +194,7 @@
   - match:
       $body: |
             /^
-              ( \d                  \s+    #usually 0, unless some system index has been recreated before this runs
+              ( 0                   \s+
                 0                   \s+
                 \d+                 \s+
                 (\d+                 \s+)  #always should return value since we filter out non data nodes by default

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
@@ -194,7 +194,7 @@
   - match:
       $body: |
             /^
-              ( 0                   \s+
+              ( \d                  \s+    #usually 0, unless some system index has been recreated before this runs
                 0                   \s+
                 \d+                 \s+
                 (\d+                 \s+)  #always should return value since we filter out non data nodes by default

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -49,7 +49,7 @@ public class HealthService {
         assert indicators.size() > 0 : "Component should not be non empty";
         assert indicators.stream().map(HealthIndicatorResult::component).distinct().count() == 1L
             : "Should not mix indicators from different components";
-        Set<String> duplicateIndicatorNames = findDuplicateByName(indicators);
+        Set<String> duplicateIndicatorNames = findDuplicatesByName(indicators);
         assert duplicateIndicatorNames.isEmpty()
             : String.format(
                 Locale.ROOT,
@@ -64,7 +64,7 @@ public class HealthService {
         );
     }
 
-    private static Set<String> findDuplicateByName(List<HealthIndicatorResult> indicators) {
+    private static Set<String> findDuplicatesByName(List<HealthIndicatorResult> indicators) {
         Set<String> items = new HashSet<>();
         return indicators.stream().map(HealthIndicatorResult::name).filter(name -> items.add(name) == false).collect(Collectors.toSet());
     }

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -8,8 +8,12 @@
 
 package org.elasticsearch.health;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
@@ -45,10 +49,23 @@ public class HealthService {
         assert indicators.size() > 0 : "Component should not be non empty";
         assert indicators.stream().map(HealthIndicatorResult::component).distinct().count() == 1L
             : "Should not mix indicators from different components";
+        Set<String> duplicateIndicatorNames = findDuplicateByName(indicators);
+        assert duplicateIndicatorNames.isEmpty()
+            : String.format(
+                Locale.ROOT,
+                "Found multiple indicators with the same name within the %s component: %s",
+                indicators.get(0).component(),
+                duplicateIndicatorNames
+            );
         return new HealthComponentResult(
             indicators.get(0).component(),
             HealthStatus.merge(indicators.stream().map(HealthIndicatorResult::status)),
             indicators
         );
+    }
+
+    private static Set<String> findDuplicateByName(List<HealthIndicatorResult> indicators) {
+        Set<String> items = new HashSet<>();
+        return indicators.stream().map(HealthIndicatorResult::name).filter(name -> items.add(name) == false).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
This prevents adding two indicators to the same health API component with the same name. Without this check, one
of the indicators is silently dropped.