### PR TITLE
Preventing multiple indicators with the same name in a health API component

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -52,11 +52,11 @@ public class HealthService {
         Set<String> duplicateIndicatorNames = findDuplicatesByName(indicators);
         assert duplicateIndicatorNames.isEmpty()
             : String.format(
-            Locale.ROOT,
-            "Found multiple indicators with the same name within the %s component: %s",
-            indicators.get(0).component(),
-            duplicateIndicatorNames
-        );
+                Locale.ROOT,
+                "Found multiple indicators with the same name within the %s component: %s",
+                indicators.get(0).component(),
+                duplicateIndicatorNames
+            );
         return new HealthComponentResult(
             indicators.get(0).component(),
             HealthStatus.merge(indicators.stream().map(HealthIndicatorResult::status)),

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -45,17 +45,17 @@ public class HealthService {
         );
     }
 
-    private static HealthComponentResult createComponentFromIndicators(List<HealthIndicatorResult> indicators) {
+    // Non-private for testing purposes
+    static HealthComponentResult createComponentFromIndicators(List<HealthIndicatorResult> indicators) {
         assert indicators.size() > 0 : "Component should not be non empty";
         assert indicators.stream().map(HealthIndicatorResult::component).distinct().count() == 1L
             : "Should not mix indicators from different components";
-        Set<String> duplicateIndicatorNames = findDuplicatesByName(indicators);
-        assert duplicateIndicatorNames.isEmpty()
+        assert findDuplicatesByName(indicators).isEmpty()
             : String.format(
                 Locale.ROOT,
                 "Found multiple indicators with the same name within the %s component: %s",
                 indicators.get(0).component(),
-                duplicateIndicatorNames
+                findDuplicatesByName(indicators)
             );
         return new HealthComponentResult(
             indicators.get(0).component(),

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -8,8 +8,12 @@
 
 package org.elasticsearch.health;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
@@ -45,10 +49,23 @@ public class HealthService {
         assert indicators.size() > 0 : "Component should not be non empty";
         assert indicators.stream().map(HealthIndicatorResult::component).distinct().count() == 1L
             : "Should not mix indicators from different components";
+        Set<String> duplicateIndicatorNames = findDuplicatesByName(indicators);
+        assert duplicateIndicatorNames.isEmpty()
+            : String.format(
+            Locale.ROOT,
+            "Found multiple indicators with the same name within the %s component: %s",
+            indicators.get(0).component(),
+            duplicateIndicatorNames
+        );
         return new HealthComponentResult(
             indicators.get(0).component(),
             HealthStatus.merge(indicators.stream().map(HealthIndicatorResult::status)),
             indicators
         );
+    }
+
+    private static Set<String> findDuplicatesByName(List<HealthIndicatorResult> indicators) {
+        Set<String> items = new HashSet<>();
+        return indicators.stream().map(HealthIndicatorResult::name).filter(name -> items.add(name) == false).collect(Collectors.toSet());
     }
 }

--- a/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
@@ -54,26 +54,7 @@ public class HealthServiceTests extends ESTestCase {
         // Same component, same indicator name, should throw exception:
         var indicator1 = new HealthIndicatorResult("indicator1", "component1", GREEN, null, null);
         var indicator2 = new HealthIndicatorResult("indicator1", "component1", YELLOW, null, null);
-
-        var service1 = new HealthService(
-            List.of(createMockHealthIndicatorService(indicator1), createMockHealthIndicatorService(indicator2))
-        );
-        expectThrows(AssertionError.class, () -> service1.getHealth());
-
-        // Different component, same indicator name, everything is OK:
-        var indicator3 = new HealthIndicatorResult("indicator1", "component3", YELLOW, null, null);
-        var service2 = new HealthService(
-            List.of(createMockHealthIndicatorService(indicator1), createMockHealthIndicatorService(indicator3))
-        );
-        assertThat(
-            service2.getHealth(),
-            anyOf(
-                hasItems(
-                    new HealthComponentResult("component1", GREEN, List.of(indicator1)),
-                    new HealthComponentResult("component3", YELLOW, List.of(indicator3))
-                )
-            )
-        );
+        expectThrows(AssertionError.class, () -> HealthService.createComponentFromIndicators(List.of(indicator1, indicator2)));
     }
 
     private static HealthIndicatorService createMockHealthIndicatorService(HealthIndicatorResult result) {


### PR DESCRIPTION
This prevents adding two indicators to the same health API component with the same name. Without this check, one
of the indicators is silently dropped.