### PR TITLE
Fixing random sampler test by improving error rate accuracy

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -105,7 +105,6 @@ public class RandomSamplerIT extends ESIntegTestCase {
         assertThat(Math.abs(sampleRandomValue - trueRandom), lessThan(trueRandom * 0.1));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84595")
     public void testRandomSamplerHistogram() {
         Map<String, Double> sampleMonotonicValue = new HashMap<>();
         Map<String, Double> sampleRandomValue = new HashMap<>();
@@ -154,7 +153,8 @@ public class RandomSamplerIT extends ESIntegTestCase {
         Histogram histogram = trueValueResponse.getAggregations().get("histo");
         for (Histogram.Bucket bucket : histogram.getBuckets()) {
             long numDocs = bucket.getDocCount();
-            double countError = (numDocs * 0.5) * 0.1;
+            double errorRate = Math.pow(1.0/(0.5*numDocs), 0.5);
+            double countError = errorRate * numDocs;
             assertThat(Math.abs(sampledDocCount.get(bucket.getKeyAsString()) - numDocs), lessThan(countError));
             double trueMonotonic = ((Avg) bucket.getAggregations().get("mean_monotonic")).getValue();
             double trueRandom = ((Avg) bucket.getAggregations().get("mean_numeric")).getValue();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -153,7 +153,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
         Histogram histogram = trueValueResponse.getAggregations().get("histo");
         for (Histogram.Bucket bucket : histogram.getBuckets()) {
             long numDocs = bucket.getDocCount();
-            double errorRate = Math.pow(1.0/(0.5*numDocs), 0.35);
+            double errorRate = Math.pow(1.0 / (0.5 * numDocs), 0.35);
             double countError = errorRate * numDocs;
             assertThat(Math.abs(sampledDocCount.get(bucket.getKeyAsString()) - numDocs), lessThan(countError));
             double trueMonotonic = ((Avg) bucket.getAggregations().get("mean_monotonic")).getValue();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -153,13 +153,13 @@ public class RandomSamplerIT extends ESIntegTestCase {
         Histogram histogram = trueValueResponse.getAggregations().get("histo");
         for (Histogram.Bucket bucket : histogram.getBuckets()) {
             long numDocs = bucket.getDocCount();
-            double errorRate = Math.pow(1.0/(0.5*numDocs), 0.5);
+            double errorRate = Math.pow(1.0/(0.5*numDocs), 0.35);
             double countError = errorRate * numDocs;
             assertThat(Math.abs(sampledDocCount.get(bucket.getKeyAsString()) - numDocs), lessThan(countError));
             double trueMonotonic = ((Avg) bucket.getAggregations().get("mean_monotonic")).getValue();
             double trueRandom = ((Avg) bucket.getAggregations().get("mean_numeric")).getValue();
-            assertThat(Math.abs(sampleMonotonicValue.get(bucket.getKeyAsString()) - trueMonotonic), lessThan(trueMonotonic * 0.1));
-            assertThat(Math.abs(sampleRandomValue.get(bucket.getKeyAsString()) - trueRandom), lessThan(trueRandom * 0.1));
+            assertThat(Math.abs(sampleMonotonicValue.get(bucket.getKeyAsString()) - trueMonotonic), lessThan(trueMonotonic * errorRate));
+            assertThat(Math.abs(sampleRandomValue.get(bucket.getKeyAsString()) - trueRandom), lessThan(trueRandom * errorRate));
         }
     }
 


### PR DESCRIPTION
Have random sampler tests use empirically determined error rate function.

closes: https://github.com/elastic/elasticsearch/issues/84595