### PR TITLE
Publish transport-netty4 module since it's needed for the test framework

### DIFF
--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 /*
  TODOs:


### PR DESCRIPTION
We added the `transport-netty4` module as a dependency to our test framework library as part of https://github.com/elastic/elasticsearch/pull/82088 but that breaks external users as we aren't publishing that module to Maven Central. This pull request adds the required build logic to publish that artifact.