### PR TITLE
Fix check-running docs

### DIFF
--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -5,7 +5,7 @@ You can test that your {es} node is running by sending an HTTPS request to port
 
 ["source","sh",subs="attributes"]
 ----
-curl --cacert {os-dir}{slash}config{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
+curl --cacert {es-conf}{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
 ----
 // NOTCONSOLE
 <1> Ensure that you use `https` in your call, or the request will fail.

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -149,7 +149,7 @@ include::systemd.asciidoc[]
 
 [[deb-check-running]]
 
-:os-dir:       /etc/elasticsearch
+:es-conf:       /etc/elasticsearch
 :slash:        /
 
 include::check-running.asciidoc[]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -142,7 +142,7 @@ include::systemd.asciidoc[]
 
 [[rpm-check-running]]
 
-:os-dir:       /etc/elasticsearch
+:es-config:       /etc/elasticsearch
 :slash:        /
 
 include::check-running.asciidoc[]

--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -80,7 +80,7 @@ endif::include-xpack[]
 [[targz-running]]
 include::targz-start.asciidoc[]
 
-:os-dir:       $ES_HOME
+:es-conf:       $ES_PATH_CONF
 :slash:        /
 
 include::check-running.asciidoc[]

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -81,7 +81,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
-:os-dir:       %ES_HOME%
+:es-config:       %ES_PATH_CONF%
 :slash:        \
 
 include::check-running.asciidoc[]


### PR DESCRIPTION
The way this specific doc was structured meant that the path for
DEB/RPM packages was wrong (an extra `config` was added to the
dir path). This commit changes the structure to be relevant to the
ES_CONF_PATH env variable that should work uniformly for all of
our installation means.