### PR TITLE
Ensure API key can only see itself with QueryApiKey API

### DIFF
--- a/docs/changelog/84859.yaml
+++ b/docs/changelog/84859.yaml
@@ -1,0 +1,5 @@
+pr: 84859
+summary: Ensure API key can only see itself with `QueryApiKey` API
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
@@ -213,13 +213,13 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
             apiKeys.forEach(k -> assertThat(k, not(hasKey("_sort"))));
         });
 
-        // limitKey gets only keys owned by the original user, not including the derived keys since they are not
-        // owned by the user (realm_name is _es_api_key).
+        // limitKey gets only itself. It cannot view other keys owned by the owner user. This is consistent with how
+        // get api key works
         assertQuery(limitKeyAuthHeader, "", apiKeys -> {
-            assertThat(apiKeys.size(), equalTo(2));
+            assertThat(apiKeys.size(), equalTo(1));
             assertThat(
                 apiKeys.stream().map(m -> (String) m.get("name")).collect(Collectors.toUnmodifiableSet()),
-                equalTo(Set.of("power-key-1", "limit-key-1"))
+                equalTo(Set.of("limit-key-1"))
             );
             apiKeys.forEach(k -> assertThat(k, not(hasKey("_sort"))));
         });

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
 
 import java.io.IOException;
@@ -288,6 +289,17 @@ public class ApiKeyBoolQueryBuilderTests extends ESTestCase {
         } finally {
             verify(context1).setAllowedFields(any());
         }
+    }
+
+    public void testWillFilterForApiKeyId() {
+        final String apiKeyId = randomAlphaOfLength(20);
+        final Authentication authentication = AuthenticationTests.randomApiKeyAuthentication(
+            new User(randomAlphaOfLengthBetween(5, 8)),
+            apiKeyId
+        );
+        final ApiKeyBoolQueryBuilder apiKeyQb = ApiKeyBoolQueryBuilder.build(randomFrom(randomSimpleQuery("name"), null), authentication);
+        assertThat(apiKeyQb.filter(), hasItem(QueryBuilders.termQuery("doc_type", "api_key")));
+        assertThat(apiKeyQb.filter(), hasItem(QueryBuilders.idsQuery().addIds(apiKeyId)));
     }
 
     private void testAllowedIndexFieldName(Predicate<String> predicate) {


### PR DESCRIPTION
This PR ensures an API key with manage_own_api_key privilege can only
view itself with QueryApiKey API. It will not be able to see other keys
created by the same owner user.
