### PR TITLE
[DOCS] Fix a typo: "bult-in" ~> "built-in"

### DIFF
--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -4,7 +4,7 @@
 === Tutorial: Customize built-in {ilm-init} policies
 
 ++++
-<titleabbrev>Tutorial: Customize bult-in policies</titleabbrev>
+<titleabbrev>Tutorial: Customize built-in policies</titleabbrev>
 ++++
 
 {es} includes the following built-in {ilm-init} policies:


### PR DESCRIPTION
I spotted this when I saw the link to the tutorial in https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html