### PR TITLE
[8.1] [DOCS] Fix a typo: "bult-in" ~> "built-in" (#84861)

### DIFF
--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -3,7 +3,7 @@
 [[example-using-index-lifecycle-policy]]
 === Tutorial: Customize built-in {ilm-init} policies
 ++++
-<titleabbrev>Customize built-in {ilm-init} policies</titleabbrev>
+<titleabbrev>Tutorial: Customize built-in policies</titleabbrev>
 ++++
 
 {es} includes the following built-in {ilm-init} policies:


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #84861

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)