### PR TITLE
Mute testMlIndicesBecomeHidde re #84844

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -66,6 +66,7 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractFullClusterRest
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84844")
     public void testMlIndicesBecomeHidden() throws Exception {
         if (isRunningAgainstOldCluster()) {
             // trigger ML indices creation


### PR DESCRIPTION
Failure:
```
REPRODUCE WITH: ./gradlew ':x-pack:qa:full-cluster-restart:v7.5.0#oldClusterTest' -Dtests.class="org.elasticsearch.xpack.restart.MlHiddenIndicesFullClusterRestartIT" -Dtests.method="testMlIndicesBecomeHidden" -Dtests.seed=4FFA771EABDBA9FB -Dtests.bwc=true -Dtests.locale=th-TH-u-nu-thai-x-lvariant-TH -Dtests.timezone=Pacific/Funafuti -Druntime.java=17

org.elasticsearch.xpack.restart.MlHiddenIndicesFullClusterRestartIT > testMlIndicesBecomeHidden FAILED
    org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:43203], URI [/_ml/anomaly_detectors/ml-hidden-indices-old-cluster-job/_open], status line [HTTP/1.1 500 Internal Server Error]
    {"error":{"root_cause":[{"type":"exception","reason":"Unexpected job state [failed] while waiting for job to be opened"}],"type":"exception","reason":"Unexpected job state [failed] while waiting for job to be opened"},"status":500}
        at __randomizedtesting.SeedInfo.seed([4FFA771EABDBA9FB:53259B6157740C09]:0)
        at app//org.elasticsearch.client.RestClient.convertResponse(RestClient.java:346)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:312)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:287)
        at app//org.elasticsearch.xpack.restart.MlHiddenIndicesFullClusterRestartIT.openAnomalyDetectorJob(MlHiddenIndicesFullClusterRestartIT.java:185)
        at app//org.elasticsearch.xpack.restart.MlHiddenIndicesFullClusterRestartIT.testMlIndicesBecomeHidden(MlHiddenIndicesFullClusterRestartIT.java:73)
```