### PR TITLE
[8.1] Revert test workaround for #82837 (#84843)

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -411,17 +411,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
             // read is ok
             final Request searchRequest = new Request("GET", ".security/_search");
-            // TODO: change the warning expectation to be always once #82837 is fixed
-            // Configure the warning to be optional due to #82837, it is ok since this test is for something else
-            searchRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
-                if (warnings.isEmpty()) {
-                    return false;
-                } else if (warnings.size() == 1) {
-                    return false == warnings.get(0).startsWith("this request accesses system indices: [.security-7]");
-                } else {
-                    return true;
-                }
-            }).addHeader("Authorization", apiKeyAuthHeader));
+            searchRequest.setOptions(
+                expectWarnings(
+                    "this request accesses system indices: [.security-7], but in a future major "
+                        + "version, direct access to system indices will be prevented by default"
+                ).toBuilder().addHeader("Authorization", apiKeyAuthHeader)
+            );
             assertOK(client().performRequest(searchRequest));
 
             // write must not be allowed
@@ -430,7 +425,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 {
                   "doc_type": "foo"
                 }""");
-            indexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", apiKeyAuthHeader));
+            indexRequest.setOptions(
+                expectWarnings(
+                    "this request accesses system indices: [.security-7], but in a future major "
+                        + "version, direct access to system indices will be prevented by default"
+                ).toBuilder().addHeader("Authorization", apiKeyAuthHeader)
+            );
             final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(indexRequest));
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
             assertThat(e.getMessage(), containsString("is unauthorized"));


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Revert test workaround for #82837 (#84843)