### PR TITLE
Lower severity of IDE Checkstyle rules for JavaDoc

### DIFF
--- a/build-tools-internal/src/main/resources/checkstyle_ide_fragment.xml
+++ b/build-tools-internal/src/main/resources/checkstyle_ide_fragment.xml
@@ -12,12 +12,12 @@
     <!-- See CONTRIBUTING.md for our guidelines on Javadoc -->
 
     <module name="MissingJavadocMethod">
-        <property name="severity" value="warning" />
+        <property name="severity" value="info" />
         <!-- Exclude short methods from this check - we don't want to have to document getters -->
-        <property name="minLineCount" value="2" />
+        <property name="minLineCount" value="5" />
         <property name="allowedAnnotations" value="Override,Before,BeforeClass,After,AfterClass,Inject,TaskAction" />
         <property name="ignoreMethodNamesRegex" value="^main$"/>
-        <message key="javadoc.missing" value="Public methods should be documented" />
+        <message key="javadoc.missing" value="Public methods should be documented." />
     </module>
 
     <module name="MissingJavadocPackage">
@@ -30,13 +30,13 @@
     <!-- Use our fork of this Checkstyle rule, so that we can ignore test classes -->
     <module name="org.elasticsearch.gradle.internal.checkstyle.MissingJavadocTypeCheck">
         <property name="ignorePattern" value="^.*(Tests?|IT|TestCase)$"/>
-        <property name="severity" value="warning"/>
+        <property name="severity" value="info"/>
         <message key="javadoc.missing" value="Types should explain their purpose" />
     </module>
 
     <!-- Check the Javadoc for a method e.g that it has the correct parameters, return type etc -->
     <module name="JavadocMethod">
-        <property name="severity" value="warning"/>
+        <property name="severity" value="info"/>
         <property name="accessModifiers" value="public"/>
     </module>
 </module>


### PR DESCRIPTION
Lower the severity from "warning" to "info", and raise the length of methods that we ignore from 2 lines to 5.