### PR TITLE
[8.1] Publish transport-netty4 module since it's needed for the test framework (#84848)

### DIFF
--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 /*
  TODOs:


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Publish transport-netty4 module since it's needed for the test framework (#84848)