### PR TITLE
Remove usages of elasticsearch.build plugin in non-production projects

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -79,6 +79,10 @@ gradlePlugin {
       id = 'elasticsearch.internal-es-plugin'
       implementationClass = 'org.elasticsearch.gradle.internal.InternalPluginBuildPlugin'
     }
+    internalBasePlugin {
+      id = 'elasticsearch.base-internal-es-plugin'
+      implementationClass = 'org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin'
+    }
     internalTestArtifact {
       id = 'elasticsearch.internal-test-artifact'
       implementationClass = 'org.elasticsearch.gradle.internal.InternalTestArtifactPlugin'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import groovy.lang.Closure;
+
+import org.elasticsearch.gradle.internal.conventions.util.Util;
+import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
+import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
+import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.bundling.Zip;
+
+import java.util.Optional;
+
+/**
+ * Base plugin for building internal plugins or modules. This plugin should only be directly applied by internal test-only plugins or
+ * modules. That is, plugins not externally published and modules only included in snapshot builds. Otherwise
+ * {@link InternalPluginBuildPlugin} should be used.
+ */
+public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(PluginBuildPlugin.class);
+        // Clear default dependencies added by public PluginBuildPlugin as we add our
+        // own project dependencies for internal builds
+        // TODO remove once we removed default dependencies from PluginBuildPlugin
+        project.getConfigurations().getByName("compileOnly").getDependencies().clear();
+        project.getConfigurations().getByName("testImplementation").getDependencies().clear();
+
+        project.getPluginManager().apply(RestTestBasePlugin.class);
+        var extension = project.getExtensions().getByType(PluginPropertiesExtension.class);
+
+        // We've ported this from multiple build scripts where we see this pattern into
+        // an extension method as a first step of consolidation.
+        // We might want to port this into a general pattern later on.
+        project.getExtensions()
+            .getExtraProperties()
+            .set("addQaCheckDependencies", new Closure<Object>(BaseInternalPluginBuildPlugin.this, BaseInternalPluginBuildPlugin.this) {
+                public void doCall(Object it) {
+                    project.afterEvaluate(project1 -> {
+                        // let check depend on check tasks of qa sub-projects
+                        final var checkTaskProvider = project1.getTasks().named("check");
+                        Optional<Project> qaSubproject = project1.getSubprojects()
+                            .stream()
+                            .filter(p -> p.getPath().equals(project1.getPath() + ":qa"))
+                            .findFirst();
+                        qaSubproject.ifPresent(
+                            qa -> qa.getSubprojects()
+                                .forEach(p -> checkTaskProvider.configure(task -> task.dependsOn(p.getPath() + ":check")))
+                        );
+                    });
+                }
+
+                public void doCall() {
+                    doCall(null);
+                }
+            });
+
+        project.afterEvaluate(p -> {
+            boolean isModule = GradleUtils.isModuleProject(p.getPath());
+            boolean isXPackModule = isModule && p.getPath().startsWith(":x-pack");
+            if (isModule == false || isXPackModule) {
+                addNoticeGeneration(p, extension);
+            }
+
+            @SuppressWarnings("unchecked")
+            NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
+                .getExtensions()
+                .getByName(TestClustersPlugin.EXTENSION_NAME);
+            p.getExtensions().getByType(PluginPropertiesExtension.class).getExtendedPlugins().forEach(pluginName -> {
+                // Auto add any dependent modules
+                findModulePath(project, pluginName).ifPresent(
+                    path -> testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.module(path))
+                );
+            });
+        });
+    }
+
+    Optional<String> findModulePath(Project project, String pluginName) {
+        return project.getRootProject()
+            .getAllprojects()
+            .stream()
+            .filter(p -> GradleUtils.isModuleProject(p.getPath()))
+            .filter(p -> p.getPlugins().hasPlugin(PluginBuildPlugin.class))
+            .filter(p -> p.getExtensions().getByType(PluginPropertiesExtension.class).getName().equals(pluginName))
+            .findFirst()
+            .map(Project::getPath);
+    }
+
+    /**
+     * Configure the pom for the main jar of this plugin
+     */
+    protected static void addNoticeGeneration(final Project project, PluginPropertiesExtension extension) {
+        final var licenseFile = extension.getLicenseFile();
+        var tasks = project.getTasks();
+        if (licenseFile != null) {
+            tasks.withType(Zip.class).named("bundlePlugin").configure(zip -> zip.from(licenseFile.getParentFile(), copySpec -> {
+                copySpec.include(licenseFile.getName());
+                copySpec.rename(s -> "LICENSE.txt");
+            }));
+        }
+
+        final var noticeFile = extension.getNoticeFile();
+        if (noticeFile != null) {
+            final var generateNotice = tasks.register("generateNotice", NoticeTask.class, noticeTask -> {
+                noticeTask.setInputFile(noticeFile);
+                noticeTask.source(Util.getJavaMainSourceSet(project).get().getAllJava());
+            });
+            tasks.withType(Zip.class).named("bundlePlugin").configure(task -> task.from(generateNotice));
+        }
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -8,61 +8,14 @@
 
 package org.elasticsearch.gradle.internal;
 
-import groovy.lang.Closure;
-
-import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.elasticsearch.gradle.internal.precommit.TestingConventionsTasks;
-import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
-import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
-import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
-import org.elasticsearch.gradle.util.GradleUtils;
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.bundling.Zip;
-
-import java.util.Optional;
 
 public class InternalPluginBuildPlugin implements InternalPlugin {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(BuildPlugin.class);
-        project.getPluginManager().apply(PluginBuildPlugin.class);
-        // Clear default dependencies added by public PluginBuildPlugin as we add our
-        // own project dependencies for internal builds
-        // TODO remove once we removed default dependencies from PluginBuildPlugin
-        project.getConfigurations().getByName("compileOnly").getDependencies().clear();
-        project.getConfigurations().getByName("testImplementation").getDependencies().clear();
-
-        project.getPluginManager().apply(RestTestBasePlugin.class);
-        var extension = project.getExtensions().getByType(PluginPropertiesExtension.class);
-
-        // We've ported this from multiple build scripts where we see this pattern into
-        // an extension method as a first step of consolidation.
-        // We might want to port this into a general pattern later on.
-        project.getExtensions()
-            .getExtraProperties()
-            .set("addQaCheckDependencies", new Closure<Object>(InternalPluginBuildPlugin.this, InternalPluginBuildPlugin.this) {
-                public void doCall(Object it) {
-                    project.afterEvaluate(project1 -> {
-                        // let check depend on check tasks of qa sub-projects
-                        final var checkTaskProvider = project1.getTasks().named("check");
-                        Optional<Project> qaSubproject = project1.getSubprojects()
-                            .stream()
-                            .filter(p -> p.getPath().equals(project1.getPath() + ":qa"))
-                            .findFirst();
-                        qaSubproject.ifPresent(
-                            qa -> qa.getSubprojects()
-                                .forEach(p -> checkTaskProvider.configure(task -> task.dependsOn(p.getPath() + ":check")))
-                        );
-                    });
-                }
-
-                public void doCall() {
-                    doCall(null);
-                }
-            });
+        project.getPluginManager().apply(BaseInternalPluginBuildPlugin.class);
 
         project.getTasks().withType(TestingConventionsTasks.class).named("testingConventions").configure(t -> {
             t.getNaming().clear();
@@ -74,58 +27,5 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
                 testingConventionRule.baseClass("org.elasticsearch.test.ESSingleNodeTestCase");
             });
         });
-
-        project.afterEvaluate(p -> {
-            boolean isModule = GradleUtils.isModuleProject(p.getPath());
-            boolean isXPackModule = isModule && p.getPath().startsWith(":x-pack");
-            if (isModule == false || isXPackModule) {
-                addNoticeGeneration(p, extension);
-            }
-
-            @SuppressWarnings("unchecked")
-            NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
-                .getExtensions()
-                .getByName(TestClustersPlugin.EXTENSION_NAME);
-            p.getExtensions().getByType(PluginPropertiesExtension.class).getExtendedPlugins().forEach(pluginName -> {
-                // Auto add any dependent modules
-                findModulePath(project, pluginName).ifPresent(
-                    path -> testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.module(path))
-                );
-            });
-        });
-    }
-
-    Optional<String> findModulePath(Project project, String pluginName) {
-        return project.getRootProject()
-            .getAllprojects()
-            .stream()
-            .filter(p -> GradleUtils.isModuleProject(p.getPath()))
-            .filter(p -> p.getPlugins().hasPlugin(PluginBuildPlugin.class))
-            .filter(p -> p.getExtensions().getByType(PluginPropertiesExtension.class).getName().equals(pluginName))
-            .findFirst()
-            .map(Project::getPath);
-    }
-
-    /**
-     * Configure the pom for the main jar of this plugin
-     */
-    protected static void addNoticeGeneration(final Project project, PluginPropertiesExtension extension) {
-        final var licenseFile = extension.getLicenseFile();
-        var tasks = project.getTasks();
-        if (licenseFile != null) {
-            tasks.withType(Zip.class).named("bundlePlugin").configure(zip -> zip.from(licenseFile.getParentFile(), copySpec -> {
-                copySpec.include(licenseFile.getName());
-                copySpec.rename(s -> "LICENSE.txt");
-            }));
-        }
-
-        final var noticeFile = extension.getNoticeFile();
-        if (noticeFile != null) {
-            final var generateNotice = tasks.register("generateNotice", NoticeTask.class, noticeTask -> {
-                noticeTask.setInputFile(noticeFile);
-                noticeTask.source(Util.getJavaMainSourceSet(project).get().getAllJava());
-            });
-            tasks.withType(Zip.class).named("bundlePlugin").configure(task -> task.from(generateNotice));
-        }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -96,7 +96,7 @@ public class DistroTestPlugin implements Plugin<Project> {
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
         project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
         project.getPlugins().apply(JdkDownloadPlugin.class);
-        project.getPluginManager().apply("elasticsearch.build");
+        project.getPluginManager().apply("elasticsearch.java");
 
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(
             project.getGradle().getSharedServices(),

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
@@ -82,7 +82,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
 
         project.getTasks().withType(StandaloneRestIntegTestTask.class).configureEach(t ->
         // if this a module or plugin, it may have an associated zip file with it's contents, add that to the test cluster
-        project.getPluginManager().withPlugin("elasticsearch.internal-es-plugin", plugin -> {
+        project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
             TaskProvider<Zip> bundle = project.getTasks().withType(Zip.class).named("bundlePlugin");
             t.dependsOn(bundle);
             if (GradleUtils.isModuleProject(project.getPath())) {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ plugins {
   id 'elasticsearch.run'
   id 'elasticsearch.release-tools'
   id 'elasticsearch.versions'
-  id 'elasticsearch.verify-publications'
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ import org.elasticsearch.gradle.util.GradleUtils
 
 import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency
-import org.elasticsearch.gradle.internal.InternalPluginBuildPlugin
+import org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin
 import org.elasticsearch.gradle.internal.ResolveAllDependencies
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
@@ -46,6 +46,7 @@ plugins {
   id 'elasticsearch.run'
   id 'elasticsearch.release-tools'
   id 'elasticsearch.versions'
+  id 'elasticsearch.verify-publications'
 }
 
 /**
@@ -174,7 +175,7 @@ allprojects {
   // e.g. see https://github.com/elastic/elasticsearch/issues/72169
   // apply plugin:'elasticsearch.internal-test-rerun'
 
-  plugins.withType(InternalPluginBuildPlugin).whenPluginAdded {
+  plugins.withType(BaseInternalPluginBuildPlugin).whenPluginAdded {
     project.dependencies {
       compileOnly project(":server")
       testImplementation project(":test:framework")

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -148,7 +148,7 @@ void copyModule(TaskProvider<Sync> copyTask, Project module) {
       exclude 'config/log4j2.properties'
 
       eachFile { details ->
-        String name = module.plugins.hasPlugin('elasticsearch.internal-es-plugin') ? module.esplugin.name : module.es_meta_plugin.name
+        String name = module.esplugin.name
         // Copy all non config/bin files
         // Note these might be unde a subdirectory in the case of a meta plugin
         if ((details.relativePath.pathString ==~ /([^\/]+\/)?(config|bin)\/.*/) == false) {

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -30,20 +30,8 @@ dependencies {
   testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
 }
 
-tasks.named('forbiddenApisTest').configure {
-  replaceSignatureFiles 'jdk-signatures'
-}
-
 // we don't have additional tests for the tests themselves
 tasks.named("test").configure { enabled = false }
-// Tests are destructive and meant to run in a VM, they don't adhere to general conventions
-tasks.named("testingConventions").configure { enabled = false }
-
-// this project doesn't get published
-tasks.named("dependencyLicenses").configure { enabled = false }
-tasks.named("dependenciesInfo").configure {enabled = false }
-
-tasks.named("thirdPartyAudit").configure { ignoreMissingClasses() }
 
 tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'

--- a/qa/system-indices/build.gradle
+++ b/qa/system-indices/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
@@ -15,11 +15,6 @@ esplugin {
   classname 'org.elasticsearch.system.indices.SystemIndicesQA'
   licenseFile rootProject.file('licenses/SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
   noticeFile rootProject.file('NOTICE.txt')
-}
-
-tasks.named("test").configure { enabled = false }
-tasks.named("javaRestTest").configure {
-  dependsOn "buildZip"
 }
 
 testClusters.configureEach {

--- a/test/external-modules/build.gradle
+++ b/test/external-modules/build.gradle
@@ -1,8 +1,8 @@
 
-import org.elasticsearch.gradle.internal.info.BuildParams;
+import org.elasticsearch.gradle.internal.info.BuildParams
 
 subprojects {
-  apply plugin: 'elasticsearch.internal-es-plugin'
+  apply plugin: 'elasticsearch.base-internal-es-plugin'
   apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
   esplugin {

--- a/x-pack/plugin/async-search/qa/rest/build.gradle
+++ b/x-pack/plugin/async-search/qa/rest/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
@@ -21,9 +21,7 @@ testClusters.configureEach {
   setting 'xpack.security.enabled', 'false'
 }
 
-tasks.named("test").configure { enabled = false }
-
-if (BuildParams.inFipsJvm){
-  // Test clusters run with security disabled
-  tasks.named("yamlRestTest").configure{enabled = false }
+// Test clusters run with security disabled
+tasks.named("yamlRestTest") {
+  onlyIf { BuildParams.inFipsJvm == false }
 }

--- a/x-pack/plugin/ccr/qa/build.gradle
+++ b/x-pack/plugin/ccr/qa/build.gradle
@@ -1,17 +1,15 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   api project(':test:framework')
 }
-gradle.projectsEvaluated {
-  subprojects {
-    tasks.withType(Test).configureEach {
-      // These fail in CI but only when run as part of checkPart2 and not individually.
-      // Tracked in : https://github.com/elastic/elasticsearch/issues/66661
-      onlyIf { BuildParams.inFipsJvm == false}
-    }
+
+subprojects {
+  tasks.withType(Test).configureEach {
+    // These fail in CI but only when run as part of checkPart2 and not individually.
+    // Tracked in : https://github.com/elastic/elasticsearch/issues/66661
+    onlyIf { BuildParams.inFipsJvm == false }
   }
 }

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -58,8 +58,3 @@ tasks.register("follow-cluster", RestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }
-
-// We can't run in FIPS mode with a basic license
-tasks.withType(Test).configureEach {
-  onlyIf { BuildParams.inFipsJvm == false}
-}

--- a/x-pack/plugin/deprecation/qa/common/build.gradle
+++ b/x-pack/plugin/deprecation/qa/common/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.java'
+
 dependencies {
   implementation project(':test:framework')
 }

--- a/x-pack/plugin/deprecation/qa/early-deprecation-rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/early-deprecation-rest/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
@@ -33,9 +33,8 @@ testClusters.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
 }
 
-tasks.named("test").configure { enabled = false }
-
-if (BuildParams.inFipsJvm){
-  // Test clusters run with security disabled
-  tasks.named("javaRestTest").configure{enabled = false }
+// Test clusters run with security disabled
+tasks.named("javaRestTest") {
+  onlyIf { BuildParams.inFipsJvm == false }
 }
+

--- a/x-pack/plugin/deprecation/qa/rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/rest/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
@@ -32,9 +32,7 @@ testClusters.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
 }
 
-tasks.named("test").configure { enabled = false }
-
-if (BuildParams.inFipsJvm){
-  // Test clusters run with security disabled
-  tasks.named("javaRestTest").configure{enabled = false }
+// Test clusters run with security disabled
+tasks.named("javaRestTest") {
+  onlyIf { BuildParams.inFipsJvm == false }
 }

--- a/x-pack/plugin/enrich/qa/common/build.gradle
+++ b/x-pack/plugin/enrich/qa/common/build.gradle
@@ -1,12 +1,5 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   api project(':test:framework')
-}
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'basic'
-  setting 'xpack.security.enabled', 'false'
 }

--- a/x-pack/plugin/eql/qa/common/build.gradle
+++ b/x-pack/plugin/eql/qa/common/build.gradle
@@ -1,10 +1,9 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   api project(':test:framework')
-  api project(path: xpackModule('core'))
-  api(testArtifact(project(xpackModule('core'))))
+  api project(xpackModule('core'))
+  api testArtifact(project(xpackModule('core')))
   api project(xpackModule('ql:test-fixtures'))
   implementation project(":client:rest-high-level")
   // TOML parser for EqlActionIT tests

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -1,7 +1,6 @@
+apply plugin: 'elasticsearch.java'
 apply plugin: 'elasticsearch.internal-java-rest-test'
-apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.internal-testclusters'
-tasks.named("test").configure { enabled = false }
 
 import org.elasticsearch.gradle.testclusters.RunTask
 import org.elasticsearch.gradle.internal.info.BuildParams
@@ -23,11 +22,6 @@ Boolean preserveData = providers.systemProperty('eql.test.preserve.data')
   .map { s -> Boolean.parseBoolean(s) }
   .getOrElse(false)
 
-if (BuildParams.inFipsJvm){
-  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
-  tasks.named("javaRestTest").configure{ enabled = false }
-}
-
 testClusters.configureEach {
     if (serviceAccountFile) {
       keystore 'gcs.client.eql_test.credentials_file', serviceAccountFile
@@ -47,7 +41,7 @@ def runTaskCluster = testClusters.register('runTask') {
 }
 
 tasks.named('javaRestTest').configure {
-  onlyIf { serviceAccountFile }
+  onlyIf { serviceAccountFile && BuildParams.inFipsJvm == false }
 
   testLogging {
     showStandardStreams = true

--- a/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.Version
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -1,10 +1,6 @@
-description = 'Integration tests for SQL'
-apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.java'
 
-// the main files are actually test files, so use the appropriate forbidden api sigs
-tasks.named('forbiddenApisMain').configure {
-  replaceSignatureFiles 'es-all-signatures', 'es-test-signatures'
-}
+description = 'Integration tests for SQL'
 
 dependencies {
   api project(":test:framework")
@@ -35,19 +31,12 @@ dependencies {
   testRuntimeOnly "net.java.dev.jna:jna:${versions.jna}"
 }
 
-// this is just a test fixture used by other projects and not in production
-['test', 'dependencyLicenses', 'thirdPartyAudit', 'dependenciesInfo', 'dependenciesGraph'].each {
-  tasks.named(it).configure {
-    enabled = false
-  }
-}
-
 subprojects {
   if (subprojects.isEmpty()) {
     // leaf project
     apply plugin: 'elasticsearch.standalone-rest-test'
   } else {
-    apply plugin: 'elasticsearch.build'
+    apply plugin: 'elasticsearch.java'
   }
 
   dependencies {

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -7,9 +7,6 @@ dependencies {
 
 Project mainProject = project
 
-// Tests are pushed down to subprojects and will be checked there.
-tasks.named("testingConventions").configure { enabled = false }
-
 subprojects {
   // Use tests from the root security qa project in subprojects
   configurations.create('testArtifacts').transitive(false)

--- a/x-pack/plugin/watcher/qa/common/build.gradle
+++ b/x-pack/plugin/watcher/qa/common/build.gradle
@@ -1,5 +1,4 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   implementation project(':test:framework')

--- a/x-pack/qa/build.gradle
+++ b/x-pack/qa/build.gradle
@@ -1,8 +1,7 @@
 // this file must exist so that qa projects are found
 // by the elasticsearch x-plugins include mechanism
 
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   api project(':test:framework')

--- a/x-pack/qa/freeze-plugin/build.gradle
+++ b/x-pack/qa/freeze-plugin/build.gradle
@@ -8,7 +8,6 @@
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 
-
 esplugin {
   name = 'freeze-plugin'
   description = 'Provides freeze-index endpoint for testing purposes only'

--- a/x-pack/test/smb-fixture/build.gradle
+++ b/x-pack/test/smb-fixture/build.gradle
@@ -1,4 +1,1 @@
-apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.test.fixtures'
-
-tasks.named("test").configure { enabled = false }


### PR DESCRIPTION
Replaces usages of `elasticsearch.build` with `elasticsearch.java` in QA projects. These are test-only, non-production code projects and don't require the additional ceremony provided by the build plugin.