### PR TITLE
Use child-first delelgation in EmbeddedImplClassLoader

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/internal/EmbeddedImplClassLoader.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/internal/EmbeddedImplClassLoader.java
@@ -89,7 +89,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
     }
 
     private EmbeddedImplClassLoader(ClassLoader parent, Map<String, CodeSource> prefixToCodeBase) {
-        super(parent);
+        super(null);
         this.prefixes = prefixToCodeBase.keySet().stream().toList();
         this.prefixToCodeBase = prefixToCodeBase;
         this.parent = parent;
@@ -130,7 +130,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
                 throw new UncheckedIOException(e);
             }
         }
-        return super.findClass(name);
+        return parent.loadClass(name);
     }
 
     @Override
@@ -140,7 +140,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
         if (url != null) {
             return url;
         }
-        return super.findResource(name);
+        return parent.getResource(name);
     }
 
     @Override
@@ -151,7 +151,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
         for (int i = 0; i < size; i++) {
             tmp[i] = parent.getResources(prefixes.get(i) + "/" + name);
         }
-        tmp[size] = super.findResources(name);
+        tmp[size] = parent.getResources(name);
         return new CompoundEnumeration<>(tmp);
     }
 


### PR DESCRIPTION
The embedded impl classloader is meant to be self sufficient. However,
by using the default parent-first delelgation, if Jackson is on the
classpath anywhere, jar hell can occur and cause runtime errors when the
same class is found in the system classloader. This commit changes to
child-first delegation by specifying a null parent loader, and
delelgating directly to the parent after checking the embedded impl.