### PR TITLE
Improve failure logging in recovery-from-snapshot

### DIFF
--- a/docs/changelog/84910.yaml
+++ b/docs/changelog/84910.yaml
@@ -1,0 +1,5 @@
+pr: 84910
+summary: Improve failure logging in recovery-from-snapshot
+area: Recovery
+type: enhancement
+issues: []


### PR DESCRIPTION
If a recovery-from-snapshot encounters an exception then today we record
this in the logs at `WARN` level. However sometimes the exception is
because the recovery was cancelled: perhaps the index was deleted or
perhaps the node left the cluster. In this case there's no need for a
warning about the recovery exception. This commit addresses that.