### PR TITLE
Improve logging for connect-back failures

### DIFF
--- a/docs/changelog/84915.yaml
+++ b/docs/changelog/84915.yaml
@@ -1,0 +1,5 @@
+pr: 84915
+summary: Improve logging for connect-back failures
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -67,6 +67,7 @@ import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse.Empty;
@@ -80,6 +81,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -559,21 +561,52 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             return;
         }
 
-        transportService.connectToNode(joinRequest.getSourceNode(), ActionListener.wrap(connectionReference -> {
-            boolean retainConnection = false;
-            try {
-                validateJoinRequest(
-                    joinRequest,
-                    ActionListener.runBefore(joinListener, () -> Releasables.close(connectionReference))
-                        .delegateFailure((l, ignored) -> processJoinRequest(joinRequest, l))
-                );
-                retainConnection = true;
-            } finally {
-                if (retainConnection == false) {
-                    Releasables.close(connectionReference);
+        transportService.connectToNode(joinRequest.getSourceNode(), new ActionListener<>() {
+            @Override
+            public void onResponse(Releasable response) {
+                boolean retainConnection = false;
+                try {
+                    validateJoinRequest(
+                        joinRequest,
+                        ActionListener.runBefore(joinListener, () -> Releasables.close(response))
+                            .delegateFailure((l, ignored) -> processJoinRequest(joinRequest, l))
+                    );
+                    retainConnection = true;
+                } catch (Exception e) {
+                    joinListener.onFailure(e);
+                } finally {
+                    if (retainConnection == false) {
+                        Releasables.close(response);
+                    }
                 }
             }
-        }, joinListener::onFailure));
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.warn(
+                    new ParameterizedMessage(
+                        "received join request from [{}] but could not connect back to the joining node",
+                        joinRequest.getSourceNode()
+                    ),
+                    e
+                );
+
+                joinListener.onFailure(
+                    // NodeDisconnectedException mainly to suppress uninteresting stack trace
+                    new NodeDisconnectedException(
+                        joinRequest.getSourceNode(),
+                        String.format(
+                            Locale.ROOT,
+                            "failure when opening connection back from [%s] to [%s]",
+                            getLocalNode().descriptionWithoutAttributes(),
+                            joinRequest.getSourceNode().descriptionWithoutAttributes()
+                        ),
+                        JoinHelper.JOIN_ACTION_NAME,
+                        e
+                    )
+                );
+            }
+        });
     }
 
     private void validateJoinRequest(JoinRequest joinRequest, ActionListener<Void> validateListener) {
@@ -635,7 +668,17 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             TransportRequestOptions.of(null, TransportRequestOptions.Type.STATE),
             new ActionListenerResponseHandler<>(listener.delegateResponse((l, e) -> {
                 logger.warn(() -> new ParameterizedMessage("failed to validate incoming join request from node [{}]", discoveryNode), e);
-                listener.onFailure(new IllegalStateException("failure when sending a validation request to node", e));
+                listener.onFailure(
+                    new IllegalStateException(
+                        String.format(
+                            Locale.ROOT,
+                            "failure when sending a join validation request from [%s] to [%s]",
+                            getLocalNode().descriptionWithoutAttributes(),
+                            discoveryNode.descriptionWithoutAttributes()
+                        ),
+                        e
+                    )
+                );
             }), i -> Empty.INSTANCE, Names.CLUSTER_COORDINATION)
         );
     }
@@ -651,7 +694,17 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     () -> new ParameterizedMessage("failed to ping joining node [{}] on channel type [{}]", discoveryNode, channelType),
                     e
                 );
-                listener.onFailure(new IllegalStateException("failure when sending a join ping request to node", e));
+                listener.onFailure(
+                    new IllegalStateException(
+                        String.format(
+                            Locale.ROOT,
+                            "failure when sending a join ping request from [%s] to [%s]",
+                            getLocalNode().descriptionWithoutAttributes(),
+                            discoveryNode.descriptionWithoutAttributes()
+                        ),
+                        e
+                    )
+                );
             }), i -> Empty.INSTANCE, Names.CLUSTER_COORDINATION)
         );
     }

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -140,7 +140,7 @@ public class ClusterConnectionManager implements ConnectionManager {
             if (failureCount < 10) {
                 logger.trace("concurrent connect/disconnect for [{}] ([{}] failures), will try again", node, failureCount);
                 connection.addRemovedListener(
-                    listener.delegateFailure(
+                    delegate.delegateFailure(
                         (retryDelegate, ignored) -> connectToNodeOrRetry(
                             node,
                             connectionProfile,
@@ -153,7 +153,7 @@ public class ClusterConnectionManager implements ConnectionManager {
             } else {
                 // A run of bad luck this long is probably not bad luck after all: something's broken, just give up.
                 logger.warn("failed to connect to [{}] after [{}] attempts, giving up", node.descriptionWithoutAttributes(), failureCount);
-                listener.onFailure(
+                delegate.onFailure(
                     new ConnectTransportException(
                         node,
                         "concurrently connecting and disconnecting even after [" + failureCount + "] attempts"

--- a/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
@@ -15,6 +15,10 @@ import java.io.IOException;
 
 public class NodeDisconnectedException extends ConnectTransportException {
 
+    public NodeDisconnectedException(DiscoveryNode node, String msg, String action, Exception cause) {
+        super(node, msg, action, cause);
+    }
+
     public NodeDisconnectedException(DiscoveryNode node, String action) {
         super(node, "disconnected", action, null);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -1632,6 +1633,97 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             );
             cluster1.clusterNodes.replaceAll(cn -> cn == newNode ? detachedNode : cn);
             cluster1.stabilise();
+        }
+    }
+
+    @TestLogging(
+        reason = "test includes assertions about logging",
+        value = "org.elasticsearch.cluster.coordination.Coordinator:WARN,org.elasticsearch.cluster.coordination.JoinHelper:INFO"
+    )
+    public void testReportsConnectBackProblemsDuringJoining() throws IllegalAccessException {
+        try (var cluster = new Cluster(3)) {
+            cluster.runRandomly();
+            cluster.stabilise();
+
+            final var partitionedNode = cluster.getAnyNode();
+            partitionedNode.disconnect();
+            cluster.stabilise();
+
+            logger.info("--> healing [{}] but blocking handshakes", partitionedNode);
+            partitionedNode.heal();
+            final var leader = cluster.getAnyLeader();
+            leader.addActionBlock(TransportService.HANDSHAKE_ACTION_NAME);
+
+            final var mockAppender = new MockLogAppender();
+            mockAppender.start();
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "connect-back failure",
+                    Coordinator.class.getCanonicalName(),
+                    Level.WARN,
+                    "*received join request from ["
+                        + partitionedNode.getLocalNode().descriptionWithoutAttributes()
+                        + "] but could not connect back to the joining node"
+                )
+            );
+            mockAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+                boolean matched = false;
+
+                @Override
+                public void match(LogEvent event) {
+                    if (event.getLevel() != Level.INFO) {
+                        return;
+                    }
+                    if (event.getLoggerName().equals(JoinHelper.class.getCanonicalName()) == false) {
+                        return;
+                    }
+
+                    var cause = event.getThrown();
+                    if (cause == null) {
+                        return;
+                    }
+                    cause = cause.getCause();
+                    if (cause == null) {
+                        return;
+                    }
+                    if (Regex.simpleMatch(
+                        "* failure when opening connection back from ["
+                            + leader.getLocalNode().descriptionWithoutAttributes()
+                            + "] to ["
+                            + partitionedNode.getLocalNode().descriptionWithoutAttributes()
+                            + "]",
+                        cause.getMessage()
+                    ) == false) {
+                        return;
+                    }
+                    if (cause.getStackTrace() != null && cause.getStackTrace().length != 0) {
+                        return;
+                    }
+                    matched = true;
+                }
+
+                @Override
+                public void assertMatched() {
+                    assertTrue(matched);
+                }
+            });
+            final var coordinatorLogger = LogManager.getLogger(Coordinator.class);
+            Loggers.addAppender(coordinatorLogger, mockAppender);
+            final var joinHelperLogger = LogManager.getLogger(JoinHelper.class);
+            Loggers.addAppender(joinHelperLogger, mockAppender);
+            try {
+                cluster.runFor(
+                    defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING) + 2 * DEFAULT_DELAY_VARIABILITY,
+                    "allowing time for join attempt"
+                );
+                mockAppender.assertAllExpectationsMatched();
+            } finally {
+                Loggers.removeAppender(joinHelperLogger, mockAppender);
+                Loggers.removeAppender(coordinatorLogger, mockAppender);
+                mockAppender.stop();
+            }
+
+            leader.clearActionBlocks();
         }
     }
 


### PR DESCRIPTION
When a node tries to join the cluster the master starts out by
connecting back to the joining node. It's somewhat common for this
connect-back step to fail, for instance if a user is iteratively
relaxing their firewall rules while setting up a cluster.

Today this is represented in the logs as a `RemoteTransportException`
but this can be pretty tricky to interpret correctly. With this commit
we clarify in the logs that the master is connecting back to the joining
node.