### PR TITLE
Separate failure path from onAllNodesAcked

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -42,6 +41,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
 
         final AtomicBoolean allNodesAcked = new AtomicBoolean(false);
+        final AtomicBoolean ackFailure = new AtomicBoolean(false);
         final AtomicBoolean ackTimeout = new AtomicBoolean(false);
         final AtomicBoolean onFailure = new AtomicBoolean(false);
         final AtomicBoolean executed = new AtomicBoolean(false);
@@ -56,8 +56,14 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
+                public void onAllNodesAcked() {
                     allNodesAcked.set(true);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onAckFailure(Exception e) {
+                    ackFailure.set(true);
                     latch.countDown();
                 }
 
@@ -92,6 +98,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
 
         assertThat(allNodesAcked.get(), equalTo(true));
+        assertThat(ackFailure.get(), equalTo(false));
         assertThat(ackTimeout.get(), equalTo(false));
         assertThat(executed.get(), equalTo(true));
         assertThat(onFailure.get(), equalTo(false));
@@ -104,6 +111,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
 
         final AtomicBoolean allNodesAcked = new AtomicBoolean(false);
+        final AtomicBoolean ackFailure = new AtomicBoolean(false);
         final AtomicBoolean ackTimeout = new AtomicBoolean(false);
         final AtomicBoolean onFailure = new AtomicBoolean(false);
         final AtomicBoolean executed = new AtomicBoolean(false);
@@ -113,8 +121,14 @@ public class ClusterServiceIT extends ESIntegTestCase {
             "test",
             new AckedClusterStateUpdateTask(MasterServiceTests.ackedRequest(TEN_SECONDS, TEN_SECONDS), null) {
                 @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
+                public void onAllNodesAcked() {
                     allNodesAcked.set(true);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onAckFailure(Exception e) {
+                    ackFailure.set(true);
                     latch.countDown();
                 }
 
@@ -149,6 +163,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
 
         assertThat(allNodesAcked.get(), equalTo(true));
+        assertThat(ackFailure.get(), equalTo(false));
         assertThat(ackTimeout.get(), equalTo(false));
         assertThat(executed.get(), equalTo(true));
         assertThat(onFailure.get(), equalTo(false));
@@ -161,6 +176,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
 
         final AtomicBoolean allNodesAcked = new AtomicBoolean(false);
+        final AtomicBoolean ackFailure = new AtomicBoolean(false);
         final AtomicBoolean ackTimeout = new AtomicBoolean(false);
         final AtomicBoolean onFailure = new AtomicBoolean(false);
         final AtomicBoolean executed = new AtomicBoolean(false);
@@ -175,8 +191,14 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
+                public void onAllNodesAcked() {
                     allNodesAcked.set(true);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onAckFailure(Exception e) {
+                    ackFailure.set(true);
                     latch.countDown();
                 }
 
@@ -209,6 +231,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
 
         assertThat(allNodesAcked.get(), equalTo(true));
+        assertThat(ackFailure.get(), equalTo(false));
         assertThat(ackTimeout.get(), equalTo(false));
         assertThat(executed.get(), equalTo(true));
         assertThat(onFailure.get(), equalTo(false));
@@ -219,6 +242,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
 
         final AtomicBoolean allNodesAcked = new AtomicBoolean(false);
+        final AtomicBoolean ackFailure = new AtomicBoolean(false);
         final AtomicBoolean ackTimeout = new AtomicBoolean(false);
         final AtomicBoolean onFailure = new AtomicBoolean(false);
         final AtomicBoolean executed = new AtomicBoolean(false);
@@ -233,8 +257,14 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public void onAllNodesAcked(@Nullable Exception e) {
+                public void onAllNodesAcked() {
                     allNodesAcked.set(true);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onAckFailure(Exception e) {
+                    ackFailure.set(true);
                     latch.countDown();
                 }
 
@@ -269,6 +299,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
 
         assertThat(allNodesAcked.get(), equalTo(false));
+        assertThat(ackFailure.get(), equalTo(false));
         assertThat(ackTimeout.get(), equalTo(true));
         assertThat(executed.get(), equalTo(true));
         assertThat(onFailure.get(), equalTo(false));

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -153,11 +152,20 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
             }
 
             @Override
-            public void onAllNodesAcked(@Nullable Exception e) {
+            public void onAllNodesAcked() {
                 if (changed) {
                     reroute(true);
                 } else {
-                    super.onAllNodesAcked(e);
+                    super.onAllNodesAcked();
+                }
+            }
+
+            @Override
+            public void onAckFailure(Exception e) {
+                if (changed) {
+                    reroute(true);
+                } else {
+                    super.onAckFailure(e);
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -173,18 +173,19 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     }
 
                     @Override
-                    public void onAllNodesAcked(Exception e) {
-                        if (e == null) {
-                            activeShardsObserver.waitForActiveShards(
-                                new String[] { indexName },
-                                ActiveShardCount.DEFAULT,
-                                request.timeout(),
-                                shardsAcked -> listener.onResponse(new CreateIndexResponse(true, shardsAcked, indexName)),
-                                listener::onFailure
-                            );
-                        } else {
-                            listener.onResponse(new CreateIndexResponse(false, false, indexName));
-                        }
+                    public void onAllNodesAcked() {
+                        activeShardsObserver.waitForActiveShards(
+                            new String[] { indexName },
+                            ActiveShardCount.DEFAULT,
+                            request.timeout(),
+                            shardsAcked -> listener.onResponse(new CreateIndexResponse(true, shardsAcked, indexName)),
+                            listener::onFailure
+                        );
+                    }
+
+                    @Override
+                    public void onAckFailure(Exception e) {
+                        listener.onResponse(new CreateIndexResponse(false, false, indexName));
                     }
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 /**
@@ -49,14 +48,14 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
         return true;
     }
 
-    /**
-     * Called once all the nodes have acknowledged the cluster state update request. Must be
-     * very lightweight execution, since it gets executed on the cluster service thread.
-     *
-     * @param e optional error that might have been thrown
-     */
-    public void onAllNodesAcked(@Nullable Exception e) {
-        listener.onResponse(newResponse(e == null));
+    @Override
+    public void onAllNodesAcked() {
+        listener.onResponse(newResponse(true));
+    }
+
+    @Override
+    public void onAckFailure(Exception e) {
+        listener.onResponse(newResponse(false));
     }
 
     protected AcknowledgedResponse newResponse(boolean acknowledged) {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateAckListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateAckListener.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.cluster;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 /**
@@ -34,10 +33,16 @@ public interface ClusterStateAckListener {
     /**
      * Called once all the nodes have acknowledged the cluster state update request. Must be
      * very lightweight execution, since it gets executed on the cluster service thread.
+     */
+    void onAllNodesAcked();
+
+    /**
+     * Called after all the nodes have acknowledged the cluster state update request but at least one of them failed. Must be
+     * very lightweight execution, since it gets executed on the cluster service thread.
      *
      * @param e optional error that might have been thrown
      */
-    void onAllNodesAcked(@Nullable Exception e);
+    void onAckFailure(Exception e);
 
     /**
      * Called once the acknowledgement timeout defined by
@@ -46,7 +51,7 @@ public interface ClusterStateAckListener {
     void onAckTimeout();
 
     /**
-     * Acknowledgement timeout, maximum time interval to wait for acknowledgements
+     * @return acknowledgement timeout, maximum time interval to wait for acknowledgements
      */
     TimeValue ackTimeout();
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -57,7 +57,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -1234,8 +1233,13 @@ public class MetadataIndexStateService {
         }
 
         @Override
-        public void onAllNodesAcked(@Nullable Exception e) {
-            listener.onResponse(AcknowledgedResponse.of(e == null));
+        public void onAllNodesAcked() {
+            listener.onResponse(AcknowledgedResponse.of(true));
+        }
+
+        @Override
+        public void onAckFailure(Exception e) {
+            listener.onResponse(AcknowledgedResponse.of(false));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.Index;
@@ -73,8 +72,13 @@ public class MetadataMappingService {
         }
 
         @Override
-        public void onAllNodesAcked(@Nullable Exception e) {
-            listener.onResponse(AcknowledgedResponse.of(e == null));
+        public void onAllNodesAcked() {
+            listener.onResponse(AcknowledgedResponse.of(true));
+        }
+
+        @Override
+        public void onAckFailure(Exception e) {
+            listener.onResponse(AcknowledgedResponse.of(false));
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -99,7 +99,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
             );
         ClusterState execute = task.execute(clusterState);
         assertSame(execute, clusterState); // dry-run
-        task.onAllNodesAcked(null);
+        task.onAllNodesAcked();
         assertNotSame(responseRef.get().getState(), execute);
 
         req.dryRun(false);// now we allocate
@@ -138,7 +138,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         // without retry_failed we won't allocate that shard
         ClusterState newState = task.execute(clusterState);
         assertNotSame(newState, clusterState); // dry-run=false
-        task.onAllNodesAcked(null);
+        task.onAllNodesAcked();
         assertSame(responseRef.get().getState(), newState);
         RoutingTable routingTable = clusterState.routingTable();
         assertEquals(routingTable.index("idx").shards().size(), 1);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -177,7 +177,7 @@ public class LicenseServiceTests extends ESTestCase {
 
             final ClusterStateUpdateTask task = taskCaptor.getValue();
             assertThat(task, instanceOf(AckedClusterStateUpdateTask.class));
-            ((AckedClusterStateUpdateTask) task).onAllNodesAcked(null);
+            ((AckedClusterStateUpdateTask) task).onAllNodesAcked();
 
             assertion.accept(future);
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -72,7 +72,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         Answer<Object> answer = invocationOnMock -> {
             AckedClusterStateUpdateTask updateTask = (AckedClusterStateUpdateTask) invocationOnMock.getArguments()[1];
-            updateTask.onAllNodesAcked(null);
+            updateTask.onAllNodesAcked();
             return null;
         };
         doAnswer(answer).when(clusterService).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class), any());


### PR DESCRIPTION
Today `ClusterStateAckListener#onAllNodesAcked` takes a nullable
exception argument to indicate success/failure. Implementations mostly
just branch on whether this argument is null or not. With this commit we
remove the nullable argument in favour of distinct methods for the
success and failure paths.