### PR TITLE
Cleanup some Inefficiencies in JavaDateFormatter

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.common.time;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.SuppressForbidden;
 
 import java.time.Instant;
@@ -43,13 +41,6 @@ import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 public class DateFormatters {
-    // DateFormatters is being used even before the logging is initialized.
-    // If LogManager.getLogger is called before logging config is loaded
-    // it results in errors sent to status logger and startup to fail.
-    // Hence a lazy initialization.
-    private static final LazyInitializable<DeprecationLogger, RuntimeException> deprecationLogger = new LazyInitializable<>(
-        () -> DeprecationLogger.getLogger(FormatNames.class)
-    );
 
     public static final WeekFields WEEK_FIELDS_ROOT = WeekFields.of(Locale.ROOT);
 


### PR DESCRIPTION
Fixes a couple of smaller inefficiencies that I found in profiling and otherwise.
* Iteration over the parsers is faster if we just use an array.
* Make some of the object construction more efficient since formats aren't always constants, like
in e.g. the index name resolver and the short streams etc. are just needless allocations
* Fix non-static initializer block running useless puts into the static mutable map on every instantiation
  * no need to even have the map, just inline what it does and save some code, indirection and the
iteration over the mutable map
