### PR TITLE
Remove anonymous subclass of JoinTaskExecutor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.coordination.Coordinator.Mode;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -68,17 +67,18 @@ public class JoinHelper {
     public static final String JOIN_VALIDATE_ACTION_NAME = "internal:cluster/coordination/join/validate";
     public static final String JOIN_PING_ACTION_NAME = "internal:cluster/coordination/join/ping";
 
+    private final AllocationService allocationService;
     private final MasterService masterService;
     private final TransportService transportService;
     private volatile JoinTaskExecutor joinTaskExecutor;
+    private final LongSupplier currentTermSupplier;
+    private final RerouteService rerouteService;
     private final NodeHealthService nodeHealthService;
     private final JoinReasonService joinReasonService;
 
     private final Set<Tuple<DiscoveryNode, JoinRequest>> pendingOutgoingJoins = Collections.synchronizedSet(new HashSet<>());
     private final AtomicReference<FailedJoinAttempt> lastFailedJoinAttempt = new AtomicReference<>();
     private final Map<DiscoveryNode, Releasable> joinConnections = new HashMap<>(); // synchronized on itself
-
-    private final Supplier<JoinTaskExecutor> joinTaskExecutorGenerator;
 
     JoinHelper(
         Settings settings,
@@ -94,40 +94,13 @@ public class JoinHelper {
         NodeHealthService nodeHealthService,
         JoinReasonService joinReasonService
     ) {
+        this.allocationService = allocationService;
         this.masterService = masterService;
         this.transportService = transportService;
+        this.currentTermSupplier = currentTermSupplier;
+        this.rerouteService = rerouteService;
         this.nodeHealthService = nodeHealthService;
         this.joinReasonService = joinReasonService;
-        this.joinTaskExecutorGenerator = () -> new JoinTaskExecutor(allocationService, rerouteService) {
-
-            private final long term = currentTermSupplier.getAsLong();
-
-            @Override
-            public ClusterState execute(ClusterState currentState, List<TaskContext<JoinTask>> joinTaskContexts) throws Exception {
-                // The current state that MasterService uses might have been updated by a (different) master in a higher term already
-                // Stop processing the current cluster state update, as there's no point in continuing to compute it as
-                // it will later be rejected by Coordinator.publish(...) anyhow
-                if (currentState.term() > term) {
-                    logger.trace("encountered higher term {} than current {}, there is a newer master", currentState.term(), term);
-                    throw new NotMasterException(
-                        "Higher term encountered (current: " + currentState.term() + " > used: " + term + "), there is a newer master"
-                    );
-                } else if (currentState.nodes().getMasterNodeId() == null
-                    && joinTaskContexts.stream().anyMatch(t -> t.getTask().isBecomingMaster())) {
-                        assert currentState.term() < term : "there should be at most one become master task per election (= by term)";
-                        final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder(currentState.coordinationMetadata())
-                            .term(term)
-                            .build();
-                        final Metadata metadata = Metadata.builder(currentState.metadata())
-                            .coordinationMetadata(coordinationMetadata)
-                            .build();
-                        currentState = ClusterState.builder(currentState).metadata(metadata).build();
-                    } else if (currentState.nodes().isLocalNodeElectedMaster()) {
-                        assert currentState.term() == term : "term should be stable for the same master";
-                    }
-                return super.execute(currentState, joinTaskContexts);
-            }
-        };
 
         transportService.registerRequestHandler(
             JOIN_ACTION_NAME,
@@ -435,7 +408,7 @@ public class JoinHelper {
                     );
                 }));
 
-                joinTaskExecutor = joinTaskExecutorGenerator.get();
+                joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, currentTermSupplier.getAsLong());
                 masterService.submitStateUpdateTask(
                     "elected-as-master ([" + joinTask.nodeCount() + "] nodes joined)",
                     joinTask,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -42,32 +41,44 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
 
     private final AllocationService allocationService;
     private final RerouteService rerouteService;
+    private final long term;
 
-    public JoinTaskExecutor(AllocationService allocationService, RerouteService rerouteService) {
+    public JoinTaskExecutor(AllocationService allocationService, RerouteService rerouteService, long term) {
         this.allocationService = allocationService;
         this.rerouteService = rerouteService;
+        this.term = term;
     }
 
     @Override
     public ClusterState execute(ClusterState currentState, List<TaskContext<JoinTask>> joinTaskContexts) throws Exception {
+        // The current state that MasterService uses might have been updated by a (different) master in a higher term already. If so, stop
+        // processing the current cluster state update, there's no point in continuing to compute it as it will later be rejected by
+        // Coordinator#publish anyhow.
+        if (currentState.term() > term) {
+            logger.trace("encountered higher term {} than current {}, there is a newer master", currentState.term(), term);
+            throw new NotMasterException(
+                "Higher term encountered (current: " + currentState.term() + " > used: " + term + "), there is a newer master"
+            );
+        }
 
         final boolean isBecomingMaster = joinTaskContexts.stream().anyMatch(t -> t.getTask().isBecomingMaster());
-
         final DiscoveryNodes currentNodes = currentState.nodes();
         boolean nodesChanged = false;
         ClusterState.Builder newState;
 
         if (currentNodes.getMasterNode() == null && isBecomingMaster) {
+            assert currentState.term() < term : "there should be at most one become master task per election (= by term)";
             // use these joins to try and become the master.
             // Note that we don't have to do any validation of the amount of joining nodes - the commit
             // during the cluster state publishing guarantees that we have enough
             newState = becomeMasterAndTrimConflictingNodes(currentState, joinTaskContexts);
             nodesChanged = true;
-        } else if (currentNodes.isLocalNodeElectedMaster() == false) {
+        } else if (currentNodes.isLocalNodeElectedMaster()) {
+            assert currentState.term() == term : "term should be stable for the same master";
+            newState = ClusterState.builder(currentState);
+        } else {
             logger.trace("processing node joins, but we are not the master. current master: {}", currentNodes.getMasterNode());
             throw new NotMasterException("Node [" + currentNodes.getLocalNode() + "] not master for join request");
-        } else {
-            newState = ClusterState.builder(currentState);
         }
 
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(newState.nodes());
@@ -79,7 +90,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
         // if the cluster is not fully-formed then the min version is not meaningful
         final boolean enforceVersionBarrier = currentState.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false;
         // processing any joins
-        Map<String, String> joiniedNodeNameIds = new HashMap<>();
+        Map<String, String> joinedNodeIdsByNodeName = new HashMap<>();
         for (final var joinTaskContext : joinTaskContexts) {
             final var joinTask = joinTaskContext.getTask();
             final List<Runnable> onTaskSuccess = new ArrayList<>(joinTask.nodeCount());
@@ -101,7 +112,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
                         minClusterNodeVersion = Version.min(minClusterNodeVersion, node.getVersion());
                         maxClusterNodeVersion = Version.max(maxClusterNodeVersion, node.getVersion());
                         if (node.isMasterNode()) {
-                            joiniedNodeNameIds.put(node.getName(), node.getId());
+                            joinedNodeIdsByNodeName.put(node.getName(), node.getId());
                         }
                     } catch (IllegalArgumentException | IllegalStateException e) {
                         onTaskSuccess.add(() -> nodeJoinTask.listener().onFailure(e));
@@ -132,29 +143,28 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
                 ActionListener.wrap(r -> logger.trace("post-join reroute completed"), e -> logger.debug("post-join reroute failed", e))
             );
 
-            if (joiniedNodeNameIds.isEmpty() == false) {
-                Set<CoordinationMetadata.VotingConfigExclusion> currentVotingConfigExclusions = currentState.getVotingConfigExclusions();
-                Set<CoordinationMetadata.VotingConfigExclusion> newVotingConfigExclusions = currentVotingConfigExclusions.stream()
-                    .map(e -> {
-                        // Update nodeId in VotingConfigExclusion when a new node with excluded node name joins
-                        if (CoordinationMetadata.VotingConfigExclusion.MISSING_VALUE_MARKER.equals(e.getNodeId())
-                            && joiniedNodeNameIds.containsKey(e.getNodeName())) {
-                            return new CoordinationMetadata.VotingConfigExclusion(joiniedNodeNameIds.get(e.getNodeName()), e.getNodeName());
-                        } else {
-                            return e;
-                        }
-                    })
-                    .collect(Collectors.toSet());
+            if (joinedNodeIdsByNodeName.isEmpty() == false) {
+                final var currentVotingConfigExclusions = currentState.getVotingConfigExclusions();
+                final var newVotingConfigExclusions = currentVotingConfigExclusions.stream().map(e -> {
+                    // Update nodeId in VotingConfigExclusion when a new node with excluded node name joins
+                    if (CoordinationMetadata.VotingConfigExclusion.MISSING_VALUE_MARKER.equals(e.getNodeId())
+                        && joinedNodeIdsByNodeName.containsKey(e.getNodeName())) {
+                        return new CoordinationMetadata.VotingConfigExclusion(
+                            joinedNodeIdsByNodeName.get(e.getNodeName()),
+                            e.getNodeName()
+                        );
+                    } else {
+                        return e;
+                    }
+                }).collect(Collectors.toSet());
 
                 // if VotingConfigExclusions did get updated
                 if (newVotingConfigExclusions.equals(currentVotingConfigExclusions) == false) {
-                    CoordinationMetadata.Builder coordMetadataBuilder = CoordinationMetadata.builder(currentState.coordinationMetadata())
+                    final var coordMetadataBuilder = CoordinationMetadata.builder(currentState.coordinationMetadata())
+                        .term(term)
                         .clearVotingConfigExclusions();
                     newVotingConfigExclusions.forEach(coordMetadataBuilder::addVotingConfigExclusion);
-                    Metadata newMetadata = Metadata.builder(currentState.metadata())
-                        .coordinationMetadata(coordMetadataBuilder.build())
-                        .build();
-                    return allocationService.adaptAutoExpandReplicas(newState.nodes(nodesBuilder).metadata(newMetadata).build());
+                    newState.metadata(Metadata.builder(currentState.metadata()).coordinationMetadata(coordMetadataBuilder.build()).build());
                 }
             }
 
@@ -179,6 +189,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
         List<TaskContext<JoinTask>> taskContexts
     ) {
         assert currentState.nodes().getMasterNodeId() == null : currentState;
+        assert currentState.term() < term : term + " vs " + currentState;
         DiscoveryNodes currentNodes = currentState.nodes();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentNodes);
         nodesBuilder.masterNodeId(currentState.nodes().getLocalNodeId());
@@ -207,6 +218,11 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
         ClusterState tmpState = ClusterState.builder(currentState)
             .nodes(nodesBuilder)
             .blocks(ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(NoMasterBlockService.NO_MASTER_BLOCK_ID))
+            .metadata(
+                Metadata.builder(currentState.metadata())
+                    .coordinationMetadata(CoordinationMetadata.builder(currentState.coordinationMetadata()).term(term).build())
+                    .build()
+            )
             .build();
         logger.trace("becomeMasterAndTrimConflictingNodes: {}", tmpState.nodes());
         allocationService.cleanCaches();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -11,9 +11,12 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -25,17 +28,27 @@ import org.elasticsearch.test.VersionUtils;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.test.VersionUtils.maxCompatibleVersion;
 import static org.elasticsearch.test.VersionUtils.randomCompatibleVersion;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class JoinTaskExecutorTests extends ESTestCase {
+
+    private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionListener.wrap(
+        () -> { throw new AssertionError("should not complete publication"); }
+    );
 
     public void testPreventJoinClusterWithNewerIndices() {
         Settings.builder().build();
@@ -151,7 +164,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
-        final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, 0L);
 
         final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
 
@@ -185,4 +198,266 @@ public class JoinTaskExecutorTests extends ESTestCase {
 
         assertThat(resultingState.getNodes().get(actualNode.getId()).getRoles(), equalTo(actualNode.getRoles()));
     }
+
+    public void testRejectsStatesWithStaleTerm() {
+        final var allocationService = mock(AllocationService.class);
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final long executorTerm = randomLongBetween(0L, Long.MAX_VALUE - 1);
+        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, executorTerm);
+
+        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()).build())
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(CoordinationMetadata.builder().term(randomLongBetween(executorTerm + 1, Long.MAX_VALUE)).build())
+                    .build()
+            )
+            .build();
+
+        assertThat(
+            expectThrows(
+                NotMasterException.class,
+                () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
+                    clusterState,
+                    joinTaskExecutor,
+                    randomBoolean()
+                        ? List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER))
+                        : List.of(
+                            JoinTask.completingElection(Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER)))
+                        ),
+                    t -> fail("should not succeed"),
+                    (t, e) -> assertThat(e, instanceOf(NotMasterException.class))
+                )
+            ).getMessage(),
+            containsString("there is a newer master")
+        );
+    }
+
+    public void testRejectsStatesWithOtherMaster() {
+        final var allocationService = mock(AllocationService.class);
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final long executorTerm = randomNonNegativeLong();
+        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, executorTerm);
+
+        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var localNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(localNode)
+                    .add(masterNode)
+                    .localNodeId(localNode.getId())
+                    .masterNodeId(masterNode.getId())
+                    .build()
+            )
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(CoordinationMetadata.builder().term(randomLongBetween(0L, executorTerm)).build())
+                    .build()
+            )
+            .build();
+
+        assertThat(
+            expectThrows(
+                NotMasterException.class,
+                () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
+                    clusterState,
+                    joinTaskExecutor,
+                    randomBoolean()
+                        ? List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER))
+                        : List.of(
+                            JoinTask.completingElection(Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER)))
+                        ),
+                    t -> fail("should not succeed"),
+                    (t, e) -> assertThat(e, instanceOf(NotMasterException.class))
+                )
+            ).getMessage(),
+            containsString("not master for join request")
+        );
+    }
+
+    public void testRejectsStatesWithNoMasterIfNotBecomingMaster() {
+        final var allocationService = mock(AllocationService.class);
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final long executorTerm = randomNonNegativeLong();
+        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, executorTerm);
+
+        final var masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).build())
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(CoordinationMetadata.builder().term(randomLongBetween(0L, executorTerm)).build())
+                    .build()
+            )
+            .build();
+
+        assertThat(
+            expectThrows(
+                NotMasterException.class,
+                () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
+                    clusterState,
+                    joinTaskExecutor,
+                    List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER)),
+                    t -> fail("should not succeed"),
+                    (t, e) -> assertThat(e, instanceOf(NotMasterException.class))
+                )
+            ).getMessage(),
+            containsString("not master for join request")
+        );
+    }
+
+    public void testRemovesOlderNodeInstancesWhenBecomingMaster() throws Exception {
+        final var allocationService = mock(AllocationService.class);
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        when(allocationService.disassociateDeadNodes(any(), anyBoolean(), any())).then(
+            invocationOnMock -> invocationOnMock.getArguments()[0]
+        );
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
+        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, executorTerm);
+
+        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var otherNodeOld = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var otherNodeNew = new DiscoveryNode(
+            otherNodeOld.getName(),
+            otherNodeOld.getId(),
+            UUIDs.randomBase64UUID(random()),
+            otherNodeOld.getHostName(),
+            otherNodeOld.getHostAddress(),
+            otherNodeOld.getAddress(),
+            otherNodeOld.getAttributes(),
+            otherNodeOld.getRoles(),
+            otherNodeOld.getVersion()
+        );
+
+        final var afterElectionClusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+            ClusterState.builder(ClusterName.DEFAULT)
+                .nodes(DiscoveryNodes.builder().add(masterNode).add(otherNodeOld).localNodeId(masterNode.getId()).build())
+                .blocks(ClusterBlocks.builder().addGlobalBlock(NoMasterBlockService.NO_MASTER_BLOCK_ALL).build())
+                .metadata(
+                    Metadata.builder()
+                        .coordinationMetadata(CoordinationMetadata.builder().term(randomLongBetween(0, executorTerm - 1)).build())
+                        .build()
+                )
+                .build(),
+            joinTaskExecutor,
+            List.of(
+                JoinTask.completingElection(
+                    Stream.of(
+                        new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER),
+                        new JoinTask.NodeJoinTask(otherNodeNew, "test", NOT_COMPLETED_LISTENER)
+                    )
+                )
+            )
+        );
+        assertThat(afterElectionClusterState.term(), equalTo(executorTerm));
+        assertThat(afterElectionClusterState.nodes().getMasterNode(), equalTo(masterNode));
+        assertFalse(afterElectionClusterState.blocks().hasGlobalBlock(NoMasterBlockService.NO_MASTER_BLOCK_ALL));
+        assertThat(
+            "existing node should be replaced by new one in an election",
+            afterElectionClusterState.nodes().get(otherNodeOld.getId()).getEphemeralId(),
+            equalTo(otherNodeNew.getEphemeralId())
+        );
+
+        assertThat(
+            "existing node should not be replaced if not completing an election",
+            ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+                afterElectionClusterState,
+                joinTaskExecutor,
+                List.of(
+                    JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER),
+                    JoinTask.singleNode(otherNodeOld, "test", NOT_COMPLETED_LISTENER)
+                )
+            ).nodes().get(otherNodeNew.getId()).getEphemeralId(),
+            equalTo(otherNodeNew.getEphemeralId())
+        );
+    }
+
+    public void testUpdatesVotingConfigExclusionsIfNeeded() throws Exception {
+        final var allocationService = mock(AllocationService.class);
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        when(allocationService.disassociateDeadNodes(any(), anyBoolean(), any())).then(
+            invocationOnMock -> invocationOnMock.getArguments()[0]
+        );
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
+        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService, executorTerm);
+
+        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var otherNode = new DiscoveryNode(
+            UUIDs.randomBase64UUID(random()),
+            UUIDs.randomBase64UUID(random()),
+            buildNewFakeTransportAddress(),
+            Map.of(),
+            Set.of(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT
+        );
+
+        var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).build())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(NoMasterBlockService.NO_MASTER_BLOCK_ALL).build())
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(
+                        CoordinationMetadata.builder()
+                            .term(randomLongBetween(0, executorTerm - 1))
+                            .addVotingConfigExclusion(
+                                new CoordinationMetadata.VotingConfigExclusion(
+                                    CoordinationMetadata.VotingConfigExclusion.MISSING_VALUE_MARKER,
+                                    otherNode.getName()
+                                )
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        logger.info("--> {}", clusterState);
+        logger.info("--> {}", otherNode);
+
+        if (randomBoolean()) {
+            clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+                clusterState,
+                joinTaskExecutor,
+                List.of(
+                    JoinTask.completingElection(
+                        Stream.of(
+                            new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER),
+                            new JoinTask.NodeJoinTask(otherNode, "test", NOT_COMPLETED_LISTENER)
+                        )
+                    )
+                )
+            );
+        } else {
+            clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+                clusterState,
+                joinTaskExecutor,
+                List.of(JoinTask.completingElection(Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER))))
+            );
+            clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+                clusterState,
+                joinTaskExecutor,
+                List.of(JoinTask.singleNode(otherNode, "test", NOT_COMPLETED_LISTENER))
+            );
+        }
+
+        assertThat(clusterState.term(), equalTo(executorTerm));
+        assertThat(clusterState.nodes().getMasterNode(), equalTo(masterNode));
+        assertThat(
+            clusterState.coordinationMetadata().getVotingConfigExclusions().iterator().next().getNodeId(),
+            equalTo(otherNode.getId())
+        );
+    }
+
 }


### PR DESCRIPTION
Today in production we subclass `JoinTaskExecutor` to add a little extra
validation and to bump the term in the state that ultimately gets
published. There's no need for this to be hidden away in a subclass, so
with this commit we move all this functionality into the proper
`JoinTaskExecutor`, add tests for it, and drop the unnecessary subclass.