### PR TITLE
TSDB: Speed up _id query

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -390,6 +390,21 @@ public abstract class IndexRouting {
             return hashToShardId(ByteUtils.readIntLE(idBytes, 0));
         }
 
+        public byte[] idToSuffix(String id) {
+            byte[] idBytes;
+            try {
+                idBytes = Base64.getUrlDecoder().decode(id);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+            if (idBytes.length < 4) {
+                return null;
+            }
+            byte[] suffix = new byte[idBytes.length - 4];
+            System.arraycopy(idBytes, 4, suffix, 0, suffix.length);
+            return suffix;
+        }
+
         @Override
         public void checkIndexSplitAllowed() {
             throw new IllegalArgumentException(error("index-split"));


### PR DESCRIPTION
This speeds up the `term` query on `_id` in time series indices by
skipping segments that don't contain any matching `@timestamp`s.
