### PR TITLE
[8.0] Instructions to retrieve keystore pwd (#84340)

### DIFF
--- a/docs/reference/setup/install/security-files-reference.asciidoc
+++ b/docs/reference/setup/install/security-files-reference.asciidoc
@@ -16,3 +16,21 @@ Keystore that contains the key and certificate for the HTTP layer for this node.
 `transport.p12`::
 Keystore that contains the key and certificate for the transport layer for all
 the nodes in your cluster.
+
+`http.p12` and `transport.p12` are password-protected PKCS#12 keystores. {es}
+stores the passwords for these keystores as  <<secure-settings,secure
+settings>>. To retrieve the passwords so that you can inspect or change the
+keystore contents, use the
+<<elasticsearch-keystore,`bin/elasticsearch-keystore`>> tool.
+
+Use the following command to retrieve the password for `http.p12`:
+[source,sh]
+-------------------------
+bin/elasticsearch-keystore show xpack.security.http.ssl.keystore.secure_password
+-------------------------
+
+Use the following command to retrieve the password for `transport.p12`:
+[source,sh]
+-------------------------
+bin/elasticsearch-keystore show xpack.security.transport.ssl.keystore.secure_password
+-------------------------


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #84340

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)