### PR TITLE
Update start with security enabled docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -207,6 +207,7 @@ You now have a test {es} environment set up. Before you start
 serious development or go into production with {es}, review the
 <<docker-prod-prerequisites,requirements and recommendations>> to apply when running {es} in Docker in production.
 
+[[elasticsearch-security-certificates]]
 include::security-files-reference.asciidoc[]
 
 [[docker-compose-file]]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -207,26 +207,7 @@ You now have a test {es} environment set up. Before you start
 serious development or go into production with {es}, review the
 <<docker-prod-prerequisites,requirements and recommendations>> to apply when running {es} in Docker in production.
 
-[[elasticsearch-security-certificates]]
-===== Security certificates and keys
-
-When you start {es} for the first time, the following certificates and keys are
-generated in the
-`/usr/share/elasticsearch/config/certs`
-directory in the Docker container, and allow you to connect a {kib} instance
-to your secured {es} cluster and encrypt internode communication. The files are
-listed here for reference.
-
-`http_ca.crt`::
-The CA certificate that is used to sign the certificates for the HTTP layer of
-this {es} cluster.
-
-`http.p12`::
-Keystore that contains the key and certificate for the HTTP layer for this node.
-
-`transport.p12`::
-Keystore that contains the key and certificate for the transport layer for all
-the nodes in your cluster.
+include::security-files-reference.asciidoc[]
 
 [[docker-compose-file]]
 ==== Start a multi-node cluster with Docker Compose

--- a/docs/reference/setup/install/security-files-reference.asciidoc
+++ b/docs/reference/setup/install/security-files-reference.asciidoc
@@ -18,7 +18,7 @@ Keystore that contains the key and certificate for the transport layer for all
 the nodes in your cluster.
 
 `http.p12` and `transport.p12` are password-protected PKCS#12 keystores. {es}
-stores the passwords for these keystores as  <<secure-settings,secure
+stores the passwords for these keystores as <<secure-settings,secure
 settings>>. To retrieve the passwords so that you can inspect or change the
 keystore contents, use the
 <<elasticsearch-keystore,`bin/elasticsearch-keystore`>> tool.

--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -18,11 +18,11 @@ security configuration to `kibana.yml`.
 [discrete]
 === Prerequisites
 
-* https://www.elastic.co/downloads/elasticsearch#preview-release[Download] and
-unpack the `elasticsearch 8.0.0-beta` package distribution for your
+* https://www.elastic.co/downloads/elasticsearch[Download] and
+unpack the `elasticsearch` package distribution for your
 environment.
-* https://www.elastic.co/downloads/kibana#preview-release[Download] and unpack
-the `kibana 8.0.0-beta` package distribution for your environment.
+* https://www.elastic.co/downloads/kibana[Download] and unpack
+the `kibana` package distribution for your environment.
 
 [discrete]
 [[stack-start-with-security]]
@@ -97,26 +97,7 @@ Congratulations! You've successfully started the {stack} with security enabled.
 communication is encrypted. If you want to enable HTTPS for web traffic, you
 can <<encrypt-kibana-browser,encrypt traffic between your browser and {kib}>>.
 
-[discrete]
-[[stack-security-certificates]]
-=== Security certificates and keys
-
-When you start {es} for the first time, the following certificates and keys are
-generated in the `config/certs` directory,
-which are used to connect a {kib} instance to your secured {es} cluster and
-to encrypt internode communication. The files are listed here for reference.
-
-`http_ca.crt`::
-The CA certificate that is used to sign the certificates for the HTTP layer of
-this {es} cluster. You can use this CA certificate to configure any client to
-trust the certificate that {es} uses for HTTPS.
-
-`http.p12`::
-Keystore that contains the key and certificate for the HTTP layer for this node.
-
-`transport.p12`::
-Keystore that contains the key and certificate for the transport layer for all
-the nodes in your cluster.
+include::{es-ref-dir}/setup/install/security-files-reference.asciidoc[leveloffset=-2]
 
 Additionally, when you use the enrollment token to connect {kib} to a secured {es} cluster, the HTTP layer CA certificate is retrieved from {es} and stored in the
 {kib} `/data` directory. This file establishes trust between {kib} and the {es}

--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -97,6 +97,8 @@ Congratulations! You've successfully started the {stack} with security enabled.
 communication is encrypted. If you want to enable HTTPS for web traffic, you
 can <<encrypt-kibana-browser,encrypt traffic between your browser and {kib}>>.
 
+[discrete]
+[[stack-security-certificates]]
 include::{es-ref-dir}/setup/install/security-files-reference.asciidoc[leveloffset=-2]
 
 Additionally, when you use the enrollment token to connect {kib} to a secured {es} cluster, the HTTP layer CA certificate is retrieved from {es} and stored in the


### PR DESCRIPTION
In #84340 we adjusted the docs to show instructions on how to
retrieve TLS keystores passwords from the elasticsearch keystore
but the security-files-reference.asciidoc was not referenced in
all places where the instructions should be used. This commit
changes that and also removes references for beta versions.