### PR TITLE
[8.0] Correctly return _type field for documents in V7 compatiblity mode (#84873)

### DIFF
--- a/docs/changelog/84873.yaml
+++ b/docs/changelog/84873.yaml
@@ -1,0 +1,6 @@
+pr: 84873
+summary: Correctly return `_type` field for documents in V7 compatiblity mode
+area: Infra/REST API
+type: bug
+issues:
+ - 84173

--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -288,9 +288,6 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (builder.getRestApiVersion() == RestApiVersion.V_7) {
-            builder.field(MapperService.TYPE_FIELD_NAME, MapperService.SINGLE_MAPPING_NAME);
-        }
         innerToXContent(builder, params);
         builder.endObject();
         return builder;
@@ -307,6 +304,9 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         if (getSeqNo() >= 0) {
             builder.field(_SEQ_NO, getSeqNo());
             builder.field(_PRIMARY_TERM, getPrimaryTerm());
+        }
+        if (builder.getRestApiVersion() == RestApiVersion.V_7) {
+            builder.field(MapperService.TYPE_FIELD_NAME, MapperService.SINGLE_MAPPING_NAME);
         }
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -14,23 +14,51 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
 import org.elasticsearch.action.delete.DeleteResponseTests;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.IndexResponseTests;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.action.update.UpdateResponseTests;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static org.elasticsearch.ElasticsearchExceptionTests.assertDeepEquals;
 import static org.elasticsearch.ElasticsearchExceptionTests.randomExceptions;
 import static org.hamcrest.Matchers.containsString;
 
 public class BulkItemResponseTests extends ESTestCase {
+
+    public void testBulkItemResponseShouldContainTypeInV7CompatibilityMode() throws IOException {
+        BulkItemResponse bulkItemResponse = BulkItemResponse.success(
+            randomInt(),
+            DocWriteRequest.OpType.INDEX,
+            new IndexResponse(
+                new ShardId(randomAlphaOfLength(8), UUID.randomUUID().toString(), randomInt()),
+                randomAlphaOfLength(4),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                true
+            )
+        );
+        XContentBuilder xContentBuilder = bulkItemResponse.toXContent(
+            XContentBuilder.builder(JsonXContent.jsonXContent, RestApiVersion.V_7),
+            ToXContent.EMPTY_PARAMS
+        );
+
+        String json = BytesReference.bytes(xContentBuilder).utf8ToString();
+        assertThat(json, containsString("\"_type\":\"_doc\""));
+    }
 
     public void testFailureToString() {
         Failure failure = new Failure("index", "id", new RuntimeException("test"));


### PR DESCRIPTION
Backports #84873 to 8.0

* Currently, it's not returned for bulk indexing, because BulkItemResponse calls DocWriteResponse.innerToXContent instead of DocWriteResponse.toXContent.