### PR TITLE
[ML] Unmute MlHiddenIndicesFullClusterRestartIT.testMlIndicesBecomeHidden

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -66,7 +66,6 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractFullClusterRest
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84844")
     public void testMlIndicesBecomeHidden() throws Exception {
         if (isRunningAgainstOldCluster()) {
             // trigger ML indices creation


### PR DESCRIPTION
This test was muted in #84874 based on consistent failures on
Arch Linux. But Arch Linux is not a supported platform and the
test does not fail on the supported platforms that CI runs on,
so it should not be muted.