### PR TITLE
docs: chmod Elasticsearch PGP after importing

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -22,7 +22,7 @@ include::key.asciidoc[]
 
 [source,sh]
 -------------------------
-wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg && sudo chmod 0644 /usr/share/keyrings/elasticsearch-keyring.gpg
 -------------------------
 
 [[deb-repo]]


### PR DESCRIPTION
On Ubuntu 20.04 (and perhaps other distribution), adding the PGP key per the documentation does not ensure it is created with the correct permissions, preventing `apt` from using it. Example:

```console
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.4 LTS
Release:	20.04
Codename:	focal
$ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
$ ls -la /usr/share/keyrings/
total 72
drwxr-xr-x   2 root root  4096 Mar 14 10:30 .
drwxr-xr-x 256 root root 12288 Feb 16 14:54 ..
-rw-r-----   1 root root  1220 Mar 14 10:30 elasticsearch-keyring.gpg
-rw-r--r--   1 root root  2247 Jan 20 13:02 ubuntu-advantage-cc-eal.gpg
-rw-r--r--   1 root root  2274 Jan 20 13:02 ubuntu-advantage-cis.gpg
-rw-r--r--   1 root root  2236 Jan 20 13:02 ubuntu-advantage-esm-apps.gpg
-rw-r--r--   1 root root  2264 Jan 20 13:02 ubuntu-advantage-esm-infra-trusty.gpg
-rw-r--r--   1 root root  2275 Jan 20 13:02 ubuntu-advantage-fips.gpg
-rw-r--r--   1 root root  2235 Jan 20 13:02 ubuntu-advantage-ros.gpg
-rw-r--r--   1 root root  7399 Sep 17  2018 ubuntu-archive-keyring.gpg
-rw-r--r--   1 root root  6713 Oct 27  2016 ubuntu-archive-removed-keys.gpg
-rw-r--r--   1 root root  4097 Feb  6  2018 ubuntu-cloudimage-keyring.gpg
-rw-r--r--   1 root root     0 Jan 17  2018 ubuntu-cloudimage-removed-keys.gpg
-rw-r--r--   1 root root  1227 May 27  2010 ubuntu-master-keyring.gpg
$ sudo apt update
Hit:1 https://artifacts.elastic.co/packages/7.x/apt stable InRelease
Hit:2 https://artifacts.elastic.co/packages/8.x/apt stable InRelease                                                                                                                                                                             
Err:1 https://artifacts.elastic.co/packages/7.x/apt stable InRelease                                                                                                                                                                             
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
Get:3 https://pkgs.tailscale.com/stable/ubuntu focal InRelease                                                                                                                                                                       
Err:2 https://artifacts.elastic.co/packages/8.x/apt stable InRelease                                                                                                                                                                
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
Hit:4 http://us.archive.ubuntu.com/ubuntu focal InRelease                                                                                                                                                     
Get:5 https://packages.fluentbit.io/ubuntu/focal focal InRelease [10.9 kB]                                                                       
Hit:6 http://us.archive.ubuntu.com/ubuntu focal-updates InRelease                                                              
Hit:7 http://security.ubuntu.com/ubuntu focal-security InRelease                            
Hit:8 http://us.archive.ubuntu.com/ubuntu focal-backports InRelease                         
Hit:9 https://esm.ubuntu.com/cis/ubuntu focal InRelease               
Hit:10 https://esm.ubuntu.com/infra/ubuntu focal-infra-security InRelease
Hit:11 https://esm.ubuntu.com/infra/ubuntu focal-infra-updates InRelease
Fetched 16.4 kB in 1s (15.4 kB/s)
Reading package lists... Done
Building dependency tree       
Reading state information... Done
5 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://artifacts.elastic.co/packages/7.x/apt stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://artifacts.elastic.co/packages/8.x/apt stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
W: Failed to fetch https://artifacts.elastic.co/packages/7.x/apt/dists/stable/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
W: Failed to fetch https://artifacts.elastic.co/packages/8.x/apt/dists/stable/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D27D666CD88E42B4
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

After this change:

```console
$ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg && sudo chmod 0644 /usr/share/keyrings/elasticsearch-keyring.gpg
$ sudo apt update
Hit:1 https://artifacts.elastic.co/packages/7.x/apt stable InRelease
Hit:2 https://artifacts.elastic.co/packages/8.x/apt stable InRelease                                                                                                             
Hit:3 http://us.archive.ubuntu.com/ubuntu focal InRelease                                                                                                                                                        
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease                                                                                    
Hit:5 http://us.archive.ubuntu.com/ubuntu focal-updates InRelease                             
Get:6 https://packages.fluentbit.io/ubuntu/focal focal InRelease [10.9 kB]                   
Hit:7 http://us.archive.ubuntu.com/ubuntu focal-backports InRelease                                       
Get:8 https://pkgs.tailscale.com/stable/ubuntu focal InRelease         
Hit:9 https://esm.ubuntu.com/cis/ubuntu focal InRelease
Hit:10 https://esm.ubuntu.com/infra/ubuntu focal-infra-security InRelease
Hit:11 https://esm.ubuntu.com/infra/ubuntu focal-infra-updates InRelease
Fetched 16.4 kB in 1s (16.6 kB/s)
Reading package lists... Done
Building dependency tree       
Reading state information... Done
5 packages can be upgraded. Run 'apt list --upgradable' to see them.
```