### PR TITLE
Deprecate xpack.searchable.snapshot.allocate_on_rolling_restart

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
@@ -37,7 +37,7 @@ public class SearchableSnapshotEnableAllocationDecider extends AllocationDecider
     );
 
     static {
-        // TODO remove this temporary setting in the next major
+        // TODO xpack.searchable.snapshot.allocate_on_rolling_restart was only temporary, remove it in the next major
         assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.searchablesnapshots.allocation.decider;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -31,8 +32,14 @@ public class SearchableSnapshotEnableAllocationDecider extends AllocationDecider
         "xpack.searchable.snapshot.allocate_on_rolling_restart",
         false,
         Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Deprecated
     );
+
+    static {
+        // TODO remove this temporary setting in the next major
+        assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
+    }
 
     private volatile EnableAllocationDecider.Allocation enableAllocation;
     private volatile boolean allocateOnRollingRestart;


### PR DESCRIPTION
This internal setting was added as a temporary escape hatch when working
on the allocation logic for searchable snapshots. Now it's no longer
needed, we can remove it.