### PR TITLE
Remove build plugin from additional QA projects

### DIFF
--- a/x-pack/qa/freeze-plugin/build.gradle
+++ b/x-pack/qa/freeze-plugin/build.gradle
@@ -6,7 +6,7 @@
  */
 
 
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 
 esplugin {
   name = 'freeze-plugin'
@@ -19,6 +19,3 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(path: xpackModule('core'))
 }
-
-//this plugin is only for testing purposes -- there are no unit tests
-tasks.named("testingConventions").configure { enabled = false }

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -10,7 +10,7 @@
 
 import org.elasticsearch.gradle.Version
 
-apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.java'
 
 dependencies {
   api project(":test:yaml-rest-runner")

--- a/x-pack/qa/security-example-spi-extension/build.gradle
+++ b/x-pack/qa/security-example-spi-extension/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.util.GradleUtils
-
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.base-internal-es-plugin'
 

--- a/x-pack/qa/security-example-spi-extension/build.gradle
+++ b/x-pack/qa/security-example-spi-extension/build.gradle
@@ -12,6 +12,7 @@ esplugin {
 
 dependencies {
   compileOnly project(':x-pack:plugin:core')
+  testImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':client:rest-high-level')
   // let the javaRestTest see the classpath of main

--- a/x-pack/qa/security-example-spi-extension/build.gradle
+++ b/x-pack/qa/security-example-spi-extension/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.util.GradleUtils
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
-apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.base-internal-es-plugin'
 
 esplugin {
   name 'spi-extension'


### PR DESCRIPTION
Follow up to #84890 where we missed a couple of spots.