### PR TITLE
Remove hppc uses from server integ tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.search.aggregations;
 
-import com.carrotsearch.hppc.IntIntHashMap;
-import com.carrotsearch.hppc.IntIntMap;
-
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
@@ -20,7 +17,9 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
@@ -44,7 +43,7 @@ public class CombiIT extends ESIntegTestCase {
 
         createIndex("idx");
         IndexRequestBuilder[] builders = new IndexRequestBuilder[randomInt(30)];
-        IntIntMap values = new IntIntHashMap();
+        Map<Integer, Integer> values = new HashMap<>();
         long missingValues = 0;
         for (int i = 0; i < builders.length; i++) {
             String name = "name_" + randomIntBetween(1, 10);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.aggregations;
 
-import com.carrotsearch.hppc.IntHashSet;
-
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -39,9 +37,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
@@ -207,7 +207,7 @@ public class EquivalenceIT extends ESIntegTestCase {
         final int numDocs = scaledRandomIntBetween(1000, 2000);
         final int maxNumTerms = randomIntBetween(10, 5000);
 
-        final IntHashSet valuesSet = new IntHashSet();
+        final Set<Integer> valuesSet = new HashSet<>();
         cluster().wipeIndices("idx");
         prepareCreate("idx").setMapping(
             jsonBuilder().startObject()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -7,10 +7,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import com.carrotsearch.hppc.ObjectIntHashMap;
-import com.carrotsearch.hppc.ObjectIntMap;
-import com.carrotsearch.hppc.cursors.ObjectIntCursor;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -29,8 +25,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -53,8 +51,8 @@ public class GeoHashGridIT extends ESIntegTestCase {
 
     private Version version = VersionUtils.randomIndexCompatibleVersion(random());
 
-    static ObjectIntMap<String> expectedDocCountsForGeoHash = null;
-    static ObjectIntMap<String> multiValuedExpectedDocCountsForGeoHash = null;
+    static Map<String, Integer> expectedDocCountsForGeoHash = null;
+    static Map<String, Integer> multiValuedExpectedDocCountsForGeoHash = null;
     static int numDocs = 100;
 
     static String smallestGeoHash = null;
@@ -82,7 +80,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
 
         List<IndexRequestBuilder> cities = new ArrayList<>();
         Random random = random();
-        expectedDocCountsForGeoHash = new ObjectIntHashMap<>(numDocs * 2);
+        expectedDocCountsForGeoHash = new HashMap<>(numDocs * 2);
         for (int i = 0; i < numDocs; i++) {
             // generate random point
             double lat = (180d * random.nextDouble()) - 90d;
@@ -107,7 +105,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
         );
 
         cities = new ArrayList<>();
-        multiValuedExpectedDocCountsForGeoHash = new ObjectIntHashMap<>(numDocs * 2);
+        multiValuedExpectedDocCountsForGeoHash = new HashMap<>(numDocs * 2);
         for (int i = 0; i < numDocs; i++) {
             final int numPoints = random.nextInt(4);
             List<String> points = new ArrayList<>();
@@ -256,9 +254,9 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 String geohash = cell.getKeyAsString();
                 long bucketCount = cell.getDocCount();
                 int expectedBucketCount = 0;
-                for (ObjectIntCursor<String> cursor : expectedDocCountsForGeoHash) {
-                    if (cursor.key.length() == precision) {
-                        expectedBucketCount = Math.max(expectedBucketCount, cursor.value);
+                for (var entry : expectedDocCountsForGeoHash.entrySet()) {
+                    if (entry.getKey().length() == precision) {
+                        expectedBucketCount = Math.max(expectedBucketCount, entry.getValue());
                     }
                 }
                 assertNotSame(bucketCount, 0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import com.carrotsearch.hppc.LongHashSet;
-
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -38,8 +36,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
@@ -373,7 +373,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet buckets = new LongHashSet();
+        Set<Long> buckets = new HashSet<>();
         List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
         long previousCount = Long.MIN_VALUE;
         for (int i = 0; i < numValueBuckets; ++i) {
@@ -400,7 +400,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet buckets = new LongHashSet();
+        Set<Long> buckets = new HashSet<>();
         List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
         long previousCount = Long.MAX_VALUE;
         for (int i = 0; i < numValueBuckets; ++i) {
@@ -474,7 +474,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet visited = new LongHashSet();
+        Set<Long> visited = new HashSet<>();
         double previousSum = Double.NEGATIVE_INFINITY;
         List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
@@ -516,7 +516,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet visited = new LongHashSet();
+        Set<Long> visited = new HashSet<>();
         double previousSum = Double.POSITIVE_INFINITY;
         List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
@@ -558,7 +558,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet visited = new LongHashSet();
+        Set<Long> visited = new HashSet<>();
         double previousSum = Double.POSITIVE_INFINITY;
 
         List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
@@ -602,7 +602,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        LongHashSet visited = new LongHashSet();
+        Set<Long> visited = new HashSet<>();
         double prevMax = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import com.carrotsearch.hppc.LongHashSet;
-import com.carrotsearch.hppc.LongSet;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -99,7 +97,7 @@ public class MinDocCountIT extends AbstractTermsTestCase {
         cardinality = randomIntBetween(8, 30);
         final List<IndexRequestBuilder> indexRequests = new ArrayList<>();
         final Set<String> stringTerms = new HashSet<>();
-        final LongSet longTerms = new LongHashSet();
+        final Set<Long> longTerms = new HashSet<>();
         for (int i = 0; i < cardinality; ++i) {
             String stringTerm;
             do {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.scroll;
 
-import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -26,6 +25,8 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
@@ -124,7 +125,7 @@ public class DuelScrollIT extends ESIntegTestCase {
         boolean unevenRouting = randomBoolean();
 
         int numMissingDocs = scaledRandomIntBetween(0, numDocs / 100);
-        IntHashSet missingDocs = new IntHashSet(numMissingDocs);
+        Set<Integer> missingDocs = new HashSet<>(numMissingDocs);
         for (int i = 0; i < numMissingDocs; i++) {
             while (missingDocs.add(randomInt(numDocs)) == false) {
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.snapshots;
 
-import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.IntSet;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,8 +76,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -440,7 +439,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         ensureGreen("test-idx");
 
-        IntSet reusedShards = new IntHashSet();
+        Set<Integer> reusedShards = new HashSet<>();
         List<RecoveryState> recoveryStates = client().admin()
             .indices()
             .prepareRecoveries("test-idx")


### PR DESCRIPTION
A handful of server integ tests used hppc for local state to compare
with. None of these should be performance critical. This commit converts
remaining uses within server integ tests to Java collections.

relates #84735