### PR TITLE
DotExpandingXContentParser to expose the original token location

### DIFF
--- a/docs/changelog/84970.yaml
+++ b/docs/changelog/84970.yaml
@@ -1,0 +1,5 @@
+pr: 84970
+summary: '`DotExpandingXContentParser` to expose the original token location'
+area: Search
+type: bug
+issues: []

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
@@ -166,4 +166,78 @@ public class DotExpandingXContentParserTests extends ESTestCase {
             {"first.dot":{"second.dot":"value","third":"value"},"nodots":"value"}\
             """);
     }
+
+    public void test() throws IOException {
+        String jsonInput = """
+            {"first.dot":{"second.dot":"value",
+            "value":null}}\
+            """;
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(createParser(JsonXContent.jsonXContent, jsonInput));
+
+        dotExpandedParser.nextToken();
+        XContentParser.Token token;
+        while ((token = dotExpandedParser.nextToken()) != null) {
+            System.out.println(token + " - " + dotExpandedParser.currentName());
+        }
+    }
+
+    public void testGetTokenLocation() throws IOException {
+        String jsonInput = """
+            {"first.dot":{"second.dot":"value",
+            "value":null}}\
+            """;
+        XContentParser expectedParser = createParser(JsonXContent.jsonXContent, jsonInput);
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(createParser(JsonXContent.jsonXContent, jsonInput));
+
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.START_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("first", dotExpandedParser.currentName());
+        assertEquals("first.dot", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals("dot", dotExpandedParser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("second", dotExpandedParser.currentName());
+        assertEquals("second.dot", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals("dot", dotExpandedParser.currentName());
+        assertEquals(XContentParser.Token.VALUE_STRING, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.VALUE_STRING, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("value", dotExpandedParser.currentName());
+        assertEquals("value", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.VALUE_NULL, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.VALUE_NULL, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.END_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.END_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertNull(dotExpandedParser.nextToken());
+        assertNull(expectedParser.nextToken());
+    }
 }

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
@@ -167,20 +167,6 @@ public class DotExpandingXContentParserTests extends ESTestCase {
             """);
     }
 
-    public void test() throws IOException {
-        String jsonInput = """
-            {"first.dot":{"second.dot":"value",
-            "value":null}}\
-            """;
-        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(createParser(JsonXContent.jsonXContent, jsonInput));
-
-        dotExpandedParser.nextToken();
-        XContentParser.Token token;
-        while ((token = dotExpandedParser.nextToken()) != null) {
-            System.out.println(token + " - " + dotExpandedParser.currentName());
-        }
-    }
-
     public void testGetTokenLocation() throws IOException {
         String jsonInput = """
             {"first.dot":{"second.dot":"value",


### PR DESCRIPTION
With #79922 we have introduced a parser that expands dots in fields names on the fly, so that the expansion no longer needs to be handled by consumers.

The token location exposed by such parser can be confusing to interpret: consumers are parsing the expanded version which requires jumping ahead reading tokens and exposing additional field names and start objects, while users have sent the unexpanded version and would like errors to refer to the original content.

This commit adds a test for this scenario and tweaks the DotExpandingXContentParser to cache the token location before jumping ahead to expand dots in field names.