### PR TITLE
[8.1] [ML] Fix Kibana date format and similar overrides in text structure endpoint (#84967)

### DIFF
--- a/docs/changelog/84967.yaml
+++ b/docs/changelog/84967.yaml
@@ -1,0 +1,5 @@
+pr: 84967
+summary: Fix Kibana date format and similar overrides in text structure endpoint
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinderTests.java
@@ -1179,8 +1179,8 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
         validateTimestampMatch(
             "May 15, 2018 @ 17:14:56.374",
             "CUSTOM_TIMESTAMP",
-            "\\b[A-Z]\\S{2} \\d{2}, \\d{4} @ \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b",
-            "MMM dd, yyyy @ HH:mm:ss.SSS",
+            "\\b[A-Z]\\S{2} \\d{1,2}, \\d{4} @ \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b",
+            "MMM d, yyyy @ HH:mm:ss.SSS",
             1526400896374L
         );
     }
@@ -1270,6 +1270,20 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
             Collections.singletonMap(
                 TimestampFormatFinder.CUSTOM_TIMESTAMP_GROK_NAME,
                 "%{MONTHDAY}\\.%{MONTHNUM2}\\. %{YEAR} %{HOUR}:%{MINUTE}:%{SECOND}"
+            )
+        );
+
+        validateCustomOverrideNotMatchingBuiltInFormat(
+            // This pattern is very close to HTTPDERROR_DATE, differing only because it contains a "d" instead of a "dd".
+            // This test therefore proves that we don't decide that this override can be replaced with the built in
+            // HTTPDERROR_DATE format, but do preserve it as a custom format.
+            "EEE MMM d HH:mm:ss yyyy",
+            "Mon Mar 7 15:03:23 2022",
+            "\\b[A-Z]\\S{2} [A-Z]\\S{2} \\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4}\\b",
+            "CUSTOM_TIMESTAMP",
+            Collections.singletonMap(
+                TimestampFormatFinder.CUSTOM_TIMESTAMP_GROK_NAME,
+                "%{DAY} %{MONTH} %{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND} %{YEAR}"
             )
         );
     }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ML] Fix Kibana date format and similar overrides in text structure endpoint (#84967)