### PR TITLE
[8.0] Avoid overhead of zip / unzip modules when packaging distribution (#84660)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -32,6 +32,10 @@ gradlePlugin {
       id = 'elasticsearch.build'
       implementationClass = 'org.elasticsearch.gradle.internal.BuildPlugin'
     }
+    distro {
+      id = 'elasticsearch.distro'
+      implementationClass = 'org.elasticsearch.gradle.internal.distribution.ElasticsearchDistributionPlugin'
+    }
     distroTest {
       id = 'elasticsearch.distro-test'
       implementationClass = 'org.elasticsearch.gradle.internal.test.DistroTestPlugin'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.distibution
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class ElasticsearchDistributionPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "copied modules are resolved from explodedBundleZip"() {
+        given:
+        moduleSubProject()
+
+        buildFile << """plugins {
+                id 'elasticsearch.distro'
+            }
+            
+            def someCopy = tasks.register('someCopy', Sync) {
+                into 'build/targetDir'
+            }
+            
+            distro.copyModule(someCopy, project(":module"))
+            """
+        when:
+        def result = gradleRunner("someCopy").build()
+
+        then:
+        result.task(":someCopy").outcome == TaskOutcome.SUCCESS
+        file('build/targetDir/modules/some-test-module/some-test-module.jar').exists()
+        file('build/targetDir/modules/some-test-module/plugin-descriptor.properties').exists()
+    }
+
+    private File moduleSubProject() {
+        settingsFile << "include 'module'"
+        file('module/build.gradle') << """
+            plugins {
+                id 'elasticsearch.esplugin'
+            }
+            
+            esplugin {
+                name = 'some-test-module'
+                classname = 'org.acme.never.used.TestPluginClass'
+                description = 'some plugin description'
+            }
+            
+            // for testing purposes only
+            configurations.compileOnly.dependencies.clear()
+        """
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -20,7 +20,6 @@ import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.bundling.Zip;
 
 import java.util.Optional;
 
@@ -111,11 +110,12 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
     protected static void addNoticeGeneration(final Project project, PluginPropertiesExtension extension) {
         final var licenseFile = extension.getLicenseFile();
         var tasks = project.getTasks();
+        var bundleSpec = extension.getBundleSpec();
         if (licenseFile != null) {
-            tasks.withType(Zip.class).named("bundlePlugin").configure(zip -> zip.from(licenseFile.getParentFile(), copySpec -> {
-                copySpec.include(licenseFile.getName());
-                copySpec.rename(s -> "LICENSE.txt");
-            }));
+            bundleSpec.from(licenseFile.getParentFile(), s -> {
+                s.include(licenseFile.getName());
+                s.rename(f -> "LICENSE.txt");
+            });
         }
 
         final var noticeFile = extension.getNoticeFile();
@@ -124,7 +124,7 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
                 noticeTask.setInputFile(noticeFile);
                 noticeTask.source(Util.getJavaMainSourceSet(project).get().getAllJava());
             });
-            tasks.withType(Zip.class).named("bundlePlugin").configure(task -> task.from(generateNotice));
+            bundleSpec.from(generateNotice);
         }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionExtension.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.distribution;
+
+import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.AbstractCopyTask;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+import static org.elasticsearch.gradle.plugin.PluginBuildPlugin.EXPLODED_BUNDLE_CONFIG;
+
+public class ElasticsearchDistributionExtension {
+    private static final Pattern CONFIG_BIN_REGEX_PATTERN = Pattern.compile("([^\\/]+\\/)?(config|bin)\\/.*");
+
+    private final Project project;
+
+    public ElasticsearchDistributionExtension(Project project) {
+        this.project = project;
+    }
+
+    private Configuration moduleZip(Project module) {
+        var moduleConfigurationCoords = Map.of("path", module.getPath(), "configuration", EXPLODED_BUNDLE_CONFIG);
+        var dep = project.getDependencies().project(moduleConfigurationCoords);
+        return project.getConfigurations().detachedConfiguration(dep);
+    }
+
+    public void copyModule(TaskProvider<AbstractCopyTask> copyTask, Project module) {
+        copyTask.configure(sync -> {
+            var moduleConfig = moduleZip(module);
+            sync.dependsOn(moduleConfig);
+            Callable<File> callableSingleFile = () -> moduleConfig.getSingleFile();
+            sync.from(callableSingleFile, spec -> {
+                spec.setIncludeEmptyDirs(false);
+                // these are handled separately in the log4j config tasks in the :distribution plugin
+                spec.exclude("*/config/log4j2.properties");
+                spec.exclude("config/log4j2.properties");
+
+                // This adds a implicit dependency for 'module' to PluginBuildPlugin which is fine as we just fail
+                // in case an invalid 'module' not applying this plugin is passed here
+                var moduleName = module.getExtensions().getByType(PluginPropertiesExtension.class).getName();
+
+                spec.eachFile(d -> {
+                    if (CONFIG_BIN_REGEX_PATTERN.matcher(d.getRelativePath().getPathString()).matches() == false) {
+                        d.setRelativePath(d.getRelativePath().prepend("modules", moduleName));
+                    }
+                });
+            });
+        });
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPlugin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.distribution;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Provides an extension named 'distro' to provide common operations used when setting up and bundling
+ * elasticsearch distributions. Having those here instead of in the build scripts makes testing and maintaining
+ * this common functionality easier
+ * */
+public class ElasticsearchDistributionPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().create("distro", ElasticsearchDistributionExtension.class, project);
+    }
+}

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.plugin
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "can assemble plugin via #taskName"() {
+        given:
+        buildFile << """plugins {
+                id 'elasticsearch.esplugin'
+            }
+            
+            esplugin { 
+                description = 'test plugin'
+                classname = 'com.acme.plugin.TestPlugin'
+            }
+            
+            // for testing purposes only
+            configurations.compileOnly.dependencies.clear()
+            """
+
+        when:
+        def result = gradleRunner(taskName).build()
+
+        then:
+        result.task(taskName).outcome == TaskOutcome.SUCCESS
+        file(expectedOutputPath).exists()
+
+        where:
+        expectedOutputPath                    | taskName
+        "build/distributions/hello-world.zip" | ":bundlePlugin"
+        "build/explodedBundle/"               | ":explodedBundlePlugin"
+
+    }
+
+    def "can resolve plugin as directory without intermediate zipping "() {
+        given:
+        buildFile << """plugins {
+                id 'elasticsearch.esplugin'
+            }
+            
+            esplugin { 
+                name = 'sample-plugin'
+                description = 'test plugin'
+                classname = 'com.acme.plugin.TestPlugin'
+            }
+            
+            // for testing purposes only
+            configurations.compileOnly.dependencies.clear()
+            """
+
+        file('settings.gradle') << "include 'module-consumer'"
+        file('module-consumer/build.gradle') << """
+            configurations {
+                consume
+            }
+            
+            dependencies {
+                consume project(path:':', configuration:'${PluginBuildPlugin.EXPLODED_BUNDLE_CONFIG}')
+            }
+            
+            tasks.register("resolveModule", Copy) {
+                from configurations.consume
+                into "build/resolved"
+            }
+        """
+        when:
+        def result = gradleRunner(":module-consumer:resolveModule").build()
+
+        then:
+        result.task(":module-consumer:resolveModule").outcome == TaskOutcome.SUCCESS
+        result.task(":explodedBundlePlugin").outcome == TaskOutcome.SUCCESS
+        file("module-consumer/build/resolved/sample-plugin.jar").exists()
+        file("module-consumer/build/resolved/plugin-descriptor.properties").exists()
+    }
+}

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.gradle.plugin;
 
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 
@@ -54,6 +55,7 @@ public class PluginPropertiesExtension {
     private File noticeFile;
 
     private final Project project;
+    private CopySpec bundleSpec;
 
     public PluginPropertiesExtension(Project project) {
         this.project = project;
@@ -167,5 +169,13 @@ public class PluginPropertiesExtension {
 
     public void setExtendedPlugins(List<String> extendedPlugins) {
         this.extendedPlugins = extendedPlugins;
+    }
+
+    public void setBundleSpec(CopySpec bundleSpec) {
+        this.bundleSpec = bundleSpec;
+    }
+
+    public CopySpec getBundleSpec() {
+        return bundleSpec;
     }
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -20,6 +20,7 @@ import java.nio.file.Path
 
 plugins {
   id 'base'
+  id 'elasticsearch.distro'
 }
 
 configurations {
@@ -129,40 +130,6 @@ def buildExternalTestModulesTaskProvider = tasks.register("buildExternalTestModu
   outputs.dir "${externalTestOutputs}/modules"
 }
 
-Configuration moduleZip(Project module) {
-  Dependency dep = project.dependencies.project(path: module.path, configuration: 'zip')
-  Configuration config = project.configurations.detachedConfiguration(dep)
-  return config
-}
-
-void copyModule(TaskProvider<Sync> copyTask, Project module) {
-  copyTask.configure {
-    Configuration moduleConfig = moduleZip(module)
-
-    dependsOn moduleConfig
-    from({ zipTree(moduleConfig.singleFile) }) {
-      includeEmptyDirs false
-
-      // these are handled separately in the log4j config tasks below
-      exclude '*/config/log4j2.properties'
-      exclude 'config/log4j2.properties'
-
-      eachFile { details ->
-        String name = module.plugins.hasPlugin('elasticsearch.internal-es-plugin') ? module.esplugin.name : module.es_meta_plugin.name
-        // Copy all non config/bin files
-        // Note these might be unde a subdirectory in the case of a meta plugin
-        if ((details.relativePath.pathString ==~ /([^\/]+\/)?(config|bin)\/.*/) == false) {
-          details.relativePath = details.relativePath.prepend('modules', name)
-        } else if ((details.relativePath.pathString ==~ /([^\/]+\/)(config|bin)\/.*/)) {
-          // this is the meta plugin case, in which we need to remove the intermediate dir
-          String[] segments = details.relativePath.segments
-          details.relativePath = new RelativePath(true, segments.takeRight(segments.length - 1))
-        }
-      }
-    }
-  }
-}
-
 def buildDefaultLog4jConfigTaskProvider = tasks.register("buildDefaultLog4jConfig") {
   mustRunAfter('processDefaultOutputs')
 
@@ -209,9 +176,9 @@ project.rootProject.subprojects.findAll { it.parent.path == ':modules' }.each { 
     }
   }
 
-  copyModule(processDefaultOutputsTaskProvider, module)
+  distro.copyModule(processDefaultOutputsTaskProvider, module)
   if (module.name.startsWith('transport-')) {
-    copyModule(processIntegTestOutputsTaskProvider, module)
+    distro.copyModule(processIntegTestOutputsTaskProvider, module)
   }
 
   restTestExpansions['expected.modules.count'] += 1
@@ -227,16 +194,16 @@ xpack.subprojects.findAll { it.parent == xpack }.each { Project xpackModule ->
       source xpackModule.file('src/main/java')
     }
   }
-  copyModule(processDefaultOutputsTaskProvider, xpackModule)
+  distro.copyModule(processDefaultOutputsTaskProvider, xpackModule)
   if (xpackModule.name.equals('core') || xpackModule.name.equals('security')) {
-    copyModule(processIntegTestOutputsTaskProvider, xpackModule)
+    distro.copyModule(processIntegTestOutputsTaskProvider, xpackModule)
   }
 }
 
-copyModule(processSystemdOutputsTaskProvider, project(':modules:systemd'))
+distro.copyModule(processSystemdOutputsTaskProvider, project(':modules:systemd'))
 
 project(':test:external-modules').subprojects.each { Project testModule ->
-  copyModule(processExternalTestOutputsTaskProvider, testModule)
+  distro.copyModule(processExternalTestOutputsTaskProvider, testModule)
 }
 
 configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'elasticsearch.internal-cluster-test'
 esplugin {
   description 'Ingest processor that uses lookup geo data based on IP addresses using the MaxMind geo database'
   classname 'org.elasticsearch.ingest.geoip.IngestGeoIpPlugin'
+
+  bundleSpec.from("${project.buildDir}/ingest-geoip") {
+    into '/'
+  }
 }
 
 dependencies {
@@ -53,12 +57,6 @@ if (useFixture) {
 tasks.named("internalClusterTest").configure {
   if (useFixture) {
     nonInputProperties.systemProperty "geoip_endpoint", "${-> fixtureAddress()}"
-  }
-}
-
-tasks.named("bundlePlugin").configure {
-  from("${project.buildDir}/ingest-geoip") {
-    into '/'
   }
 }
 

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -7,55 +7,56 @@
  */
 
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask;
+
 apply plugin: 'elasticsearch.validate-rest-spec'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 esplugin {
-  description 'An easy, safe and fast scripting language for Elasticsearch'
-  classname 'org.elasticsearch.painless.PainlessPlugin'
+    description 'An easy, safe and fast scripting language for Elasticsearch'
+    classname 'org.elasticsearch.painless.PainlessPlugin'
 }
 
 testClusters.configureEach {
-  module ':modules:mapper-extras'
-  systemProperty 'es.scripting.update.ctx_in_params', 'false'
-  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
-  systemProperty 'es.transport.cname_in_publish_address', 'true'
+    module ':modules:mapper-extras'
+    systemProperty 'es.scripting.update.ctx_in_params', 'false'
+    // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+    systemProperty 'es.transport.cname_in_publish_address', 'true'
 }
 
 configurations {
-  spi
-  compileOnlyApi.extendsFrom(spi)
-  if (isEclipse) {
-    // Eclipse buildship doesn't know about compileOnlyApi
-    api.extendsFrom(spi)
-  }
+    spi
+    compileOnlyApi.extendsFrom(spi)
+    if (isEclipse) {
+        // Eclipse buildship doesn't know about compileOnlyApi
+        api.extendsFrom(spi)
+    }
 }
 
 dependencies {
-  api 'org.antlr:antlr4-runtime:4.5.3'
-  api 'org.ow2.asm:asm-util:7.2'
-  api 'org.ow2.asm:asm-tree:7.2'
-  api 'org.ow2.asm:asm-commons:7.2'
-  api 'org.ow2.asm:asm-analysis:7.2'
-  api 'org.ow2.asm:asm:7.2'
-  spi project('spi')
+    api 'org.antlr:antlr4-runtime:4.5.3'
+    api 'org.ow2.asm:asm-util:7.2'
+    api 'org.ow2.asm:asm-tree:7.2'
+    api 'org.ow2.asm:asm-commons:7.2'
+    api 'org.ow2.asm:asm-analysis:7.2'
+    api 'org.ow2.asm:asm:7.2'
+    spi project('spi')
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /asm-.*/, to: 'asm'
+    mapping from: /asm-.*/, to: 'asm'
 }
 
 restResources {
-  restApi {
-    include '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get', 'bulk', 'update',
+    restApi {
+        include '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get', 'bulk', 'update',
                 'scripts_painless_execute', 'put_script', 'delete_script'
-  }
+    }
 }
 
 tasks.named("test").configure {
-  // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
-  jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
+    // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
+    jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
 }
 
 tasks.named("yamlRestTestV7CompatTest").configure {
@@ -102,28 +103,26 @@ tasks.named("yamlRestTestV7CompatTest").configure {
 /* Build Javadoc for the Java classes in Painless's public API that are in the
  * Painless plugin */
 tasks.register("apiJavadoc", Javadoc) {
-  source = sourceSets.main.allJava
-  classpath = sourceSets.main.compileClasspath + sourceSets.main.output
-  include '**/org/elasticsearch/painless/api/'
-  destinationDir = new File(docsDir, 'apiJavadoc')
+    source = sourceSets.main.allJava
+    classpath = sourceSets.main.compileClasspath + sourceSets.main.output
+    include '**/org/elasticsearch/painless/api/'
+    destinationDir = new File(docsDir, 'apiJavadoc')
 }
 
 tasks.register("apiJavadocJar", Jar) {
-  archiveClassifier = 'apiJavadoc'
-  from apiJavadoc
+    archiveClassifier = 'apiJavadoc'
+    from apiJavadoc
 }
 
 tasks.named("assemble").configure {
-  dependsOn "apiJavadocJar"
+    dependsOn "apiJavadocJar"
 }
 tasks.named("check").configure {
-  dependsOn "apiJavadocJar"
+    dependsOn "apiJavadocJar"
 }
 
-tasks.named("bundlePlugin").configure {
-  it.into("spi") {
+esplugin.bundleSpec.into("spi") {
     from(configurations.spi)
-  }
 }
 
 /**********************************************
@@ -131,39 +130,39 @@ tasks.named("bundlePlugin").configure {
  **********************************************/
 
 sourceSets {
-  doc
+    doc
 }
 
 dependencies {
-  docImplementation project(':server')
-  docImplementation project(':modules:lang-painless')
-  docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
-  docImplementation 'org.jsoup:jsoup:1.13.1'
-  if (isEclipse) {
-    /*
-     * Eclipse isn't quite "with it" enough to understand the different
-     * source sets. This adds the dependency to all source sets so it
-     * can compile the doc java files.
-     */
-    implementation 'com.github.javaparser:javaparser-core:3.18.0'
-    implementation 'org.jsoup:jsoup:1.13.1'
-  }
+    docImplementation project(':server')
+    docImplementation project(':modules:lang-painless')
+    docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
+    docImplementation 'org.jsoup:jsoup:1.13.1'
+    if (isEclipse) {
+        /*
+         * Eclipse isn't quite "with it" enough to understand the different
+         * source sets. This adds the dependency to all source sets so it
+         * can compile the doc java files.
+         */
+        implementation 'com.github.javaparser:javaparser-core:3.18.0'
+        implementation 'org.jsoup:jsoup:1.13.1'
+    }
 }
 
 def generateContextCluster = testClusters.register("generateContextCluster") {
-  testDistribution = 'DEFAULT'
+    testDistribution = 'DEFAULT'
 }
 
 tasks.register("generateContextDoc", DefaultTestClustersTask) {
-  dependsOn sourceSets.doc.runtimeClasspath
-  useCluster generateContextCluster
-  doFirst {
-    project.javaexec {
-      mainClass = 'org.elasticsearch.painless.ContextDocGenerator'
-      classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> generateContextCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
-    }.assertNormalExitValue()
-  }
+    dependsOn sourceSets.doc.runtimeClasspath
+    useCluster generateContextCluster
+    doFirst {
+        project.javaexec {
+            mainClass = 'org.elasticsearch.painless.ContextDocGenerator'
+            classpath = sourceSets.doc.runtimeClasspath
+            systemProperty "cluster.uri", "${-> generateContextCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
+        }.assertNormalExitValue()
+    }
 }
 /**********************************************
  *           Context JSON Generation          *
@@ -173,17 +172,17 @@ def generateContextApiSpecCluster = testClusters.register("generateContextApiSpe
 }
 
 tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
-  dependsOn sourceSets.doc.runtimeClasspath
-  useCluster generateContextApiSpecCluster
-  doFirst {
-    project.javaexec {
-      mainClass = 'org.elasticsearch.painless.ContextApiSpecGenerator'
-      classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> generateContextApiSpecCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
-      systemProperty "jdksrc", providers.systemProperty("jdksrc").getOrNull()
-      systemProperty "packageSources", providers.systemProperty("packageSources").getOrNull()
-    }.assertNormalExitValue()
-  }
+    dependsOn sourceSets.doc.runtimeClasspath
+    useCluster generateContextApiSpecCluster
+    doFirst {
+        project.javaexec {
+            mainClass = 'org.elasticsearch.painless.ContextApiSpecGenerator'
+            classpath = sourceSets.doc.runtimeClasspath
+            systemProperty "cluster.uri", "${-> generateContextApiSpecCluster.get().singleNode().getAllHttpSocketURI().get(0)}"
+            systemProperty "jdksrc", providers.systemProperty("jdksrc").getOrNull()
+            systemProperty "packageSources", providers.systemProperty("packageSources").getOrNull()
+        }.assertNormalExitValue()
+    }
 }
 
 /**********************************************
@@ -191,11 +190,11 @@ tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
  **********************************************/
 
 configurations {
-  regenerate
+    regenerate
 }
 
 dependencies {
-  regenerate 'org.antlr:antlr4:4.5.3'
+    regenerate 'org.antlr:antlr4:4.5.3'
 }
 
 String grammarPath = 'src/main/antlr'
@@ -204,86 +203,86 @@ String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/painless/antlr'
 
 pluginManager.withPlugin('com.diffplug.spotless') {
-  spotless {
-    java {
-      targetExclude "${outputPath}/*.java"
+    spotless {
+        java {
+            targetExclude "${outputPath}/*.java"
+        }
     }
-  }
 }
 
 tasks.register("cleanGenerated", Delete) {
-  delete fileTree(grammarPath) {
-    include '*Painless*.tokens'
-  }
-  delete fileTree(outputPath) {
-    include 'Painless*.java'
-  }
+    delete fileTree(grammarPath) {
+        include '*Painless*.tokens'
+    }
+    delete fileTree(outputPath) {
+        include 'Painless*.java'
+    }
 }
 
 tasks.register("regenLexer", JavaExec) {
-  dependsOn "cleanGenerated"
-  mainClass = 'org.antlr.v4.Tool'
-  classpath = configurations.regenerate
-  systemProperty 'file.encoding', 'UTF-8'
-  systemProperty 'user.language', 'en'
-  systemProperty 'user.country', 'US'
-  systemProperty 'user.variant', ''
-  args '-Werror',
-    '-package', 'org.elasticsearch.painless.antlr',
-    '-o', outputPath,
-    "${file(grammarPath)}/PainlessLexer.g4"
+    dependsOn "cleanGenerated"
+    mainClass = 'org.antlr.v4.Tool'
+    classpath = configurations.regenerate
+    systemProperty 'file.encoding', 'UTF-8'
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+    systemProperty 'user.variant', ''
+    args '-Werror',
+            '-package', 'org.elasticsearch.painless.antlr',
+            '-o', outputPath,
+            "${file(grammarPath)}/PainlessLexer.g4"
 }
 
 tasks.register("regenParser", JavaExec) {
-  dependsOn "regenLexer"
-  mainClass = 'org.antlr.v4.Tool'
-  classpath = configurations.regenerate
-  systemProperty 'file.encoding', 'UTF-8'
-  systemProperty 'user.language', 'en'
-  systemProperty 'user.country', 'US'
-  systemProperty 'user.variant', ''
-  args '-Werror',
-    '-package', 'org.elasticsearch.painless.antlr',
-    '-no-listener',
-    '-visitor',
-    // '-Xlog',
-    '-o', outputPath,
-    "${file(grammarPath)}/PainlessParser.g4"
+    dependsOn "regenLexer"
+    mainClass = 'org.antlr.v4.Tool'
+    classpath = configurations.regenerate
+    systemProperty 'file.encoding', 'UTF-8'
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+    systemProperty 'user.variant', ''
+    args '-Werror',
+            '-package', 'org.elasticsearch.painless.antlr',
+            '-no-listener',
+            '-visitor',
+            // '-Xlog',
+            '-o', outputPath,
+            "${file(grammarPath)}/PainlessParser.g4"
 }
 
 tasks.register("regen") {
-  dependsOn "regenParser"
-  doLast {
-    // moves token files to grammar directory for use with IDE's
-    ant.move(file: "${outputPath}/PainlessLexer.tokens", toDir: grammarPath)
-    ant.move(file: "${outputPath}/PainlessParser.tokens", toDir: grammarPath)
-    // make the generated classes package private
-    ant.replaceregexp(match: 'public ((interface|class) \\QPainless\\E\\w+)',
-      replace: '\\1',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
+    dependsOn "regenParser"
+    doLast {
+        // moves token files to grammar directory for use with IDE's
+        ant.move(file: "${outputPath}/PainlessLexer.tokens", toDir: grammarPath)
+        ant.move(file: "${outputPath}/PainlessParser.tokens", toDir: grammarPath)
+        // make the generated classes package private
+        ant.replaceregexp(match: 'public ((interface|class) \\QPainless\\E\\w+)',
+                replace: '\\1',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // make the lexer abstract
+        ant.replaceregexp(match: '(class \\QPainless\\ELexer)',
+                replace: 'abstract \\1',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'PainlessLexer.java')
+        }
+        // nuke timestamps/filenames in generated files
+        ant.replaceregexp(match: '\\Q// Generated from \\E.*',
+                replace: '\\/\\/ ANTLR GENERATED CODE: DO NOT EDIT',
+                encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // remove tabs in antlr generated files
+        ant.replaceregexp(match: '\t', flags: 'g', replace: '  ', encoding: 'UTF-8') {
+            fileset(dir: outputPath, includes: 'Painless*.java')
+        }
+        // fix line endings
+        ant.fixcrlf(srcdir: outputPath, eol: 'lf') {
+            patternset(includes: 'Painless*.java')
+        }
     }
-    // make the lexer abstract
-    ant.replaceregexp(match: '(class \\QPainless\\ELexer)',
-      replace: 'abstract \\1',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'PainlessLexer.java')
-    }
-    // nuke timestamps/filenames in generated files
-    ant.replaceregexp(match: '\\Q// Generated from \\E.*',
-      replace: '\\/\\/ ANTLR GENERATED CODE: DO NOT EDIT',
-      encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
-    }
-    // remove tabs in antlr generated files
-    ant.replaceregexp(match: '\t', flags: 'g', replace: '  ', encoding: 'UTF-8') {
-      fileset(dir: outputPath, includes: 'Painless*.java')
-    }
-    // fix line endings
-    ant.fixcrlf(srcdir: outputPath, eol: 'lf') {
-      patternset(includes: 'Painless*.java')
-    }
-  }
 }
 
 /**********************************************

--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -71,10 +71,8 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jaxb-.*/, to: 'jaxb'
 }
 
-tasks.named("bundlePlugin").configure {
-  from('config/repository-s3') {
+esplugin.bundleSpec.from('config/repository-s3') {
     into 'config'
-  }
 }
 
 boolean useFixture = false

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -43,10 +43,8 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
-tasks.named("bundlePlugin").configure {
-  from('config/discovery-ec2') {
+esplugin.bundleSpec.from('config/discovery-ec2') {
     into 'config'
-  }
 }
 
 tasks.register("writeTestJavaPolicy") {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -43,15 +43,18 @@ configurations {
   }
 }
 
-tasks.named("bundlePlugin").configure {
-  dependsOn configurations.nativeBundle
-  from {
-    project.zipTree(configurations.nativeBundle.singleFile)
-  }
+esplugin.bundleSpec.from {
+  project.zipTree(configurations.nativeBundle.singleFile)
+}
 
-  // We don't ship the individual nativeBundle licenses - instead
-  // they get combined into the top level NOTICES file we ship
-  exclude 'platform/licenses/**'
+// We don't ship the individual nativeBundle licenses - instead
+// they get combined into the top level NOTICES file we ship
+esplugin.bundleSpec.exclude 'platform/licenses/**'
+
+["bundlePlugin", "explodedBundlePlugin"].each { bundleTaskName ->
+    tasks.named(bundleTaskName).configure {
+        dependsOn configurations.nativeBundle
+    }
 }
 
 dependencies {

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -48,10 +48,8 @@ dependencies {
  * in $ES_HOME/bin/x-pack/. This is useful because it is an
  * executable jar that can be moved wherever it is needed.
  */
-tasks.named("bundlePlugin").configure {
-  from(configurations.bin) {
+esplugin.bundleSpec.from({configurations.bin}) {
     into 'bin'
-  }
 }
 
 addQaCheckDependencies()


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Avoid overhead of zip / unzip modules when packaging distribution (#84660)