### PR TITLE
Make sure the random generated shape can be indexed in GeoTilerTests

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
+import org.apache.lucene.geo.Tessellator;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -106,7 +107,8 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
             int precision = randomIntBetween(0, 3);
             Geometry geometry = GeometryNormalizer.apply(Orientation.CCW, randomValueOtherThanMany(g -> {
                 try {
-                    GeometryNormalizer.apply(Orientation.CCW, g);
+                    // make sure is a valid shape
+                    new GeoShapeIndexer(Orientation.CCW, "test").indexShape(g);
                     return false;
                 } catch (Exception e) {
                     return true;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.apache.lucene.geo.Tessellator;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;


### PR DESCRIPTION
Test is failing because the generated random geometry is degenerated and cannot be tessellated. The current check that prevents this situation is not valid any more as we move the checks to the tessellator, therefore let's use the GeometryIndexer to make sure we don't fail in closing a random geometry.

fixes #84981