### PR TITLE
Optimize Iteration over IndexShardRoutingTable

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -455,12 +455,12 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         assertBusy(() -> {
             ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
             RoutingTable routingTables = clusterStateResponse.getState().routingTable();
-            assertTrue(routingTables.index("target").shard(0).getShards().get(0).unassigned());
+            assertTrue(routingTables.index("target").shard(0).shard(0).unassigned());
             assertEquals(
                 UnassignedInfo.Reason.ALLOCATION_FAILED,
-                routingTables.index("target").shard(0).getShards().get(0).unassignedInfo().getReason()
+                routingTables.index("target").shard(0).shard(0).unassignedInfo().getReason()
             );
-            assertEquals(1, routingTables.index("target").shard(0).getShards().get(0).unassignedInfo().getNumFailedAllocations());
+            assertEquals(1, routingTables.index("target").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
         });
         client().admin()
             .indices()
@@ -472,13 +472,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         refreshClusterInfo();
         // kick off a retry and wait until it's done!
         ClusterRerouteResponse clusterRerouteResponse = client().admin().cluster().prepareReroute().setRetryFailed(true).get();
-        long expectedShardSize = clusterRerouteResponse.getState()
-            .routingTable()
-            .index("target")
-            .shard(0)
-            .getShards()
-            .get(0)
-            .getExpectedShardSize();
+        long expectedShardSize = clusterRerouteResponse.getState().routingTable().index("target").shard(0).shard(0).getExpectedShardSize();
         // we support the expected shard size in the allocator to sum up over the source index shards
         assertTrue("expected shard size must be set but wasn't: " + expectedShardSize, expectedShardSize > 0);
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -223,8 +223,8 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             .index("test")
             .shard(0);
         final List<ShardRouting> shardRoutings = new ArrayList<>(indexShardRoutingTable.size());
-        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-            shardRoutings.add(indexShardRoutingTable.shard(j));
+        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+            shardRoutings.add(indexShardRoutingTable.shard(copy));
         }
 
         InternalTestCluster internalTestCluster = internalCluster();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -40,6 +41,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -210,7 +212,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)).get();
         ensureGreen("test");
 
-        final List<ShardRouting> shardRoutings = client().admin()
+        final IndexShardRoutingTable indexShardRoutingTable = client().admin()
             .cluster()
             .prepareState()
             .clear()
@@ -219,8 +221,11 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             .getState()
             .getRoutingTable()
             .index("test")
-            .shard(0)
-            .shards();
+            .shard(0);
+        final List<ShardRouting> shardRoutings = new ArrayList<>(indexShardRoutingTable.size());
+        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+            shardRoutings.add(indexShardRoutingTable.shard(j));
+        }
 
         InternalTestCluster internalTestCluster = internalCluster();
         InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -309,14 +309,16 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         for (int i = 0; i < original.size(); i++) {
             IndexShardRoutingTable indexShardRoutingTable = original.shard(i);
             Set<String> availableNodes = Sets.newHashSet(nodes);
-            for (ShardRouting shardRouting : indexShardRoutingTable.shards()) {
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                 availableNodes.remove(shardRouting.currentNodeId());
                 if (shardRouting.relocating()) {
                     availableNodes.remove(shardRouting.relocatingNodeId());
                 }
             }
 
-            for (ShardRouting shardRouting : indexShardRoutingTable) {
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                 final ShardRouting updatedShardRouting = randomChange(shardRouting, availableNodes);
                 availableNodes.remove(updatedShardRouting.currentNodeId());
                 if (shardRouting.relocating()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -309,16 +309,16 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         for (int i = 0; i < original.size(); i++) {
             IndexShardRoutingTable indexShardRoutingTable = original.shard(i);
             Set<String> availableNodes = Sets.newHashSet(nodes);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                 availableNodes.remove(shardRouting.currentNodeId());
                 if (shardRouting.relocating()) {
                     availableNodes.remove(shardRouting.relocatingNodeId());
                 }
             }
 
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                 final ShardRouting updatedShardRouting = randomChange(shardRouting, availableNodes);
                 availableNodes.remove(updatedShardRouting.currentNodeId());
                 if (shardRouting.relocating()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata.State;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
@@ -328,8 +328,9 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
-                    counts.merge(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1, Integer::sum);
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    counts.merge(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), 1, Integer::sum);
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -327,10 +327,10 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         Map<String, Integer> counts = new HashMap<>();
 
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    counts.merge(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), 1, Integer::sum);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    counts.merge(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName(), 1, Integer::sum);
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -80,10 +80,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         logger.info("--> verify all are allocated on node1 now");
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_0));
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName(), equalTo(node_0));
                 }
             }
         }
@@ -140,10 +140,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(0));
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_0));
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName(), equalTo(node_0));
                 }
             }
         }
@@ -188,10 +188,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                if ("node1".equals(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName())) {
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                if ("node1".equals(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName())) {
                     numShardsOnNode1++;
                 }
             }
@@ -220,10 +220,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         logger.info("--> verify all shards are allocated on node_1 now");
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         indexRoutingTable = clusterState.routingTable().index("test");
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_1));
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName(), equalTo(node_1));
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -80,8 +81,9 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
-                    assertThat(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_0));
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_0));
                 }
             }
         }
@@ -139,8 +141,9 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(0));
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
-                    assertThat(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_0));
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_0));
                 }
             }
         }
@@ -186,8 +189,9 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
-                if ("node1".equals(clusterState.nodes().get(shardRouting.currentNodeId()).getName())) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                if ("node1".equals(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName())) {
                     numShardsOnNode1++;
                 }
             }
@@ -217,8 +221,9 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         indexRoutingTable = clusterState.routingTable().index("test");
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
-                assertThat(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(node_1));
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(j).currentNodeId()).getName(), equalTo(node_1));
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -197,10 +197,10 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             .getState()
             .getRoutingTable()
             .index(indexName);
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shard = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shard = shardRoutingTable.shard(copy);
                 assertThat(shard.state(), equalTo(ShardRoutingState.STARTED));
                 if (shard.currentNodeId().equals(nodeId)) {
                     shardRoutings.add(shard);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.DiskUsageIntegTestCase;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
@@ -197,7 +198,9 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             .getRoutingTable()
             .index(indexName);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting shard : indexRoutingTable.shard(i).shards()) {
+            final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shard = shardRoutingTable.shard(j);
                 assertThat(shard.state(), equalTo(ShardRoutingState.STARTED));
                 if (shard.currentNodeId().equals(nodeId)) {
                     shardRoutings.add(shard);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gateway;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
@@ -465,12 +466,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         final ClusterService clusterService = internalCluster().clusterService();
         assertBusy(() -> {
             Index index = resolveIndex(indexName);
-            Set<String> activeRetentionLeaseIds = clusterService.state()
-                .routingTable()
-                .index(index)
-                .shard(0)
-                .shards()
-                .stream()
+            Set<String> activeRetentionLeaseIds = RoutingNodesHelper.asStream(clusterService.state().routingTable().index(index).shard(0))
                 .map(shardRouting -> ReplicationTracker.getPeerRecoveryRetentionLeaseId(shardRouting.currentNodeId()))
                 .collect(Collectors.toSet());
             for (String node : internalCluster().nodesInclude(indexName)) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -499,10 +499,10 @@ public class CorruptedFileIT extends ESIntegTestCase {
         // ensure that no shard is actually allocated on the unlucky node
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
         final IndexRoutingTable indexRoutingTable = clusterStateResponse.getState().getRoutingTable().index("test");
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                final ShardRouting routing = indexShardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                final ShardRouting routing = indexShardRoutingTable.shard(copy);
                 if (unluckyNode.getNode().getId().equals(routing.currentNodeId())) {
                     assertThat(routing.state(), not(equalTo(ShardRoutingState.STARTED)));
                     assertThat(routing.state(), not(equalTo(ShardRoutingState.RELOCATING)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -499,7 +500,9 @@ public class CorruptedFileIT extends ESIntegTestCase {
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
         final IndexRoutingTable indexRoutingTable = clusterStateResponse.getState().getRoutingTable().index("test");
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting routing : indexRoutingTable.shard(i)) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                final ShardRouting routing = indexShardRoutingTable.shard(j);
                 if (unluckyNode.getNode().getId().equals(routing.currentNodeId())) {
                     assertThat(routing.state(), not(equalTo(ShardRoutingState.STARTED)));
                     assertThat(routing.state(), not(equalTo(ShardRoutingState.RELOCATING)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -393,8 +393,8 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
                     ShardId docShard = clusterService.operationRouting().shardId(state, "test", id, null);
                     if (docShard.id() == shard) {
                         final IndexShardRoutingTable indexShardRoutingTable = state.routingTable().shardRoutingTable("test", shard);
-                        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+                        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                            ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                             GetResponse response = client().prepareGet("test", id)
                                 .setPreference("_only_nodes:" + shardRouting.currentNodeId())
                                 .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
@@ -391,7 +392,9 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
                 for (String id : ids) {
                     ShardId docShard = clusterService.operationRouting().shardId(state, "test", id, null);
                     if (docShard.id() == shard) {
-                        for (ShardRouting shardRouting : state.routingTable().shardRoutingTable("test", shard)) {
+                        final IndexShardRoutingTable indexShardRoutingTable = state.routingTable().shardRoutingTable("test", shard);
+                        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                             GetResponse response = client().prepareGet("test", id)
                                 .setPreference("_only_nodes:" + shardRouting.currentNodeId())
                                 .get();

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -383,7 +383,7 @@ public class ReplicationOperation<
             return null;
         } else {
             final String resolvedShards = waitForActiveShards == ActiveShardCount.ALL
-                ? Integer.toString(shardRoutingTable.shards().size())
+                ? Integer.toString(shardRoutingTable.size())
                 : waitForActiveShards.toString();
             logger.trace(
                 "[{}] not enough active copies to meet shard count of [{}] (have {}, needed {}), scheduling a retry. op [{}], "

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -525,8 +525,8 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 for (int i = 0; i < indexRoutingTable.size(); i++) {
                     IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
                     builder.startArray(Integer.toString(indexShardRoutingTable.shardId().id()));
-                    for (ShardRouting shardRouting : indexShardRoutingTable) {
-                        shardRouting.toXContent(builder, params);
+                    for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                        indexShardRoutingTable.shard(j).toXContent(builder, params);
                     }
                     builder.endArray();
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -522,11 +522,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             for (IndexRoutingTable indexRoutingTable : routingTable()) {
                 builder.startObject(indexRoutingTable.getIndex().getName());
                 builder.startObject("shards");
-                for (int i = 0; i < indexRoutingTable.size(); i++) {
-                    IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                    IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
                     builder.startArray(Integer.toString(indexShardRoutingTable.shardId().id()));
-                    for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                        indexShardRoutingTable.shard(j).toXContent(builder, params);
+                    for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                        indexShardRoutingTable.shard(copy).toXContent(builder, params);
                     }
                     builder.endArray();
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -85,7 +85,8 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         int computeRelocatingShards = 0;
         int computeInitializingShards = 0;
         int computeUnassignedShards = 0;
-        for (ShardRouting shardRouting : shardRoutingTable) {
+        for (int j = 0; j < shardRoutingTable.size(); j++) {
+            ShardRouting shardRouting = shardRoutingTable.shard(j);
             if (shardRouting.active()) {
                 computeActiveShards++;
                 if (shardRouting.relocating()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -125,7 +125,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                         + "]"
                 );
             }
-            for (ShardRouting shardRouting : indexShardRoutingTable) {
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                 if (shardRouting.index().equals(index) == false) {
                     throw new IllegalStateException(
                         "shard routing has an index [" + shardRouting.index() + "] that is different from the routing table"
@@ -180,7 +181,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
     public int numberOfNodesShardsAreAllocatedOn(String... excludedNodes) {
         Set<String> nodes = new HashSet<>();
         for (IndexShardRoutingTable shardRoutingTable : this.shards) {
-            for (ShardRouting shardRouting : shardRoutingTable) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.assignedToNode()) {
                     String currentNodeId = shardRouting.currentNodeId();
                     boolean excluded = false;
@@ -512,14 +514,16 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                 }
                 // re-add all the current ones
                 IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(indexShard.shardId());
-                for (ShardRouting shardRouting : indexShard) {
+                for (int j = 0; j < indexShard.size(); j++) {
+                    ShardRouting shardRouting = indexShard.shard(j);
                     builder.addShard(shardRouting);
                 }
 
                 boolean removed = false;
                 for (Predicate<ShardRouting> removeClause : PRIORITY_REMOVE_CLAUSES) {
                     if (removed == false) {
-                        for (ShardRouting shardRouting : indexShard) {
+                        for (int j = 0; j < indexShard.size(); j++) {
+                            ShardRouting shardRouting = indexShard.shard(j);
                             if (shardRouting.primary() == false && removeClause.test(shardRouting)) {
                                 builder.removeShard(shardRouting);
                                 removed = true;
@@ -569,8 +573,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                 .append("][")
                 .append(indexShard.shardId().id())
                 .append("]\n");
-            for (ShardRouting shard : indexShard) {
-                sb.append("--------").append(shard.shortSummary()).append("\n");
+            for (int j = 0; j < indexShard.size(); j++) {
+                sb.append("--------").append(indexShard.shard(j).shortSummary()).append("\n");
             }
         }
         return sb.toString();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -125,8 +125,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                         + "]"
                 );
             }
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                 if (shardRouting.index().equals(index) == false) {
                     throw new IllegalStateException(
                         "shard routing has an index [" + shardRouting.index() + "] that is different from the routing table"
@@ -181,8 +181,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
     public int numberOfNodesShardsAreAllocatedOn(String... excludedNodes) {
         Set<String> nodes = new HashSet<>();
         for (IndexShardRoutingTable shardRoutingTable : this.shards) {
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.assignedToNode()) {
                     String currentNodeId = shardRouting.currentNodeId();
                     boolean excluded = false;
@@ -514,16 +514,16 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                 }
                 // re-add all the current ones
                 IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(indexShard.shardId());
-                for (int j = 0; j < indexShard.size(); j++) {
-                    ShardRouting shardRouting = indexShard.shard(j);
+                for (int copy = 0; copy < indexShard.size(); copy++) {
+                    ShardRouting shardRouting = indexShard.shard(copy);
                     builder.addShard(shardRouting);
                 }
 
                 boolean removed = false;
                 for (Predicate<ShardRouting> removeClause : PRIORITY_REMOVE_CLAUSES) {
                     if (removed == false) {
-                        for (int j = 0; j < indexShard.size(); j++) {
-                            ShardRouting shardRouting = indexShard.shard(j);
+                        for (int copy = 0; copy < indexShard.size(); copy++) {
+                            ShardRouting shardRouting = indexShard.shard(copy);
                             if (shardRouting.primary() == false && removeClause.test(shardRouting)) {
                                 builder.removeShard(shardRouting);
                                 removed = true;
@@ -573,8 +573,8 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                 .append("][")
                 .append(indexShard.shardId().id())
                 .append("]\n");
-            for (int j = 0; j < indexShard.size(); j++) {
-                sb.append("--------").append(indexShard.shard(j).shortSummary()).append("\n");
+            for (int copy = 0; copy < indexShard.size(); copy++) {
+                sb.append("--------").append(indexShard.shard(copy).shortSummary()).append("\n");
             }
         }
         return sb.toString();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -112,11 +112,11 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
         // fill in the inverse of node -> shards allocated
         // also fill replicaSet information
         for (IndexRoutingTable indexRoutingTable : routingTable.indicesRouting().values()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable indexShard = indexRoutingTable.shard(i);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);
                 assert indexShard.primary != null;
-                for (int j = 0; j < indexShard.size(); j++) {
-                    final ShardRouting shard = indexShard.shard(j);
+                for (int copy = 0; copy < indexShard.size(); copy++) {
+                    final ShardRouting shard = indexShard.shard(copy);
                     totalShardCount++;
                     // to get all the shards belonging to an index, including the replicas,
                     // we define a replica set and keep track of it. A replica set is identified

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -115,7 +115,8 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable indexShard = indexRoutingTable.shard(i);
                 assert indexShard.primary != null;
-                for (ShardRouting shard : indexShard) {
+                for (int j = 0; j < indexShard.size(); j++) {
+                    final ShardRouting shard = indexShard.shard(j);
                     totalShardCount++;
                     // to get all the shards belonging to an index, including the replicas,
                     // we define a replica set and keep track of it. A replica set is identified

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -196,8 +196,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         }
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (ShardRouting shardRouting : indexShardRoutingTable) {
-                shards.add(shardRouting);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                shards.add(indexShardRoutingTable.shard(j));
             }
         }
         return shards;
@@ -236,7 +236,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             }
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                     if (predicate.test(shardRouting)) {
                         set.add(shardRouting.shardsIt());
                     } else if (includeEmpty) { // we need this for counting properly, just make it an empty one
@@ -275,7 +276,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             }
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (ShardRouting shardRouting : indexShardRoutingTable) {
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                     if (predicate.test(shardRouting)) {
                         shards.add(shardRouting);
                         if (includeRelocationTargets && shardRouting.relocating()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -194,10 +194,10 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         if (indexRoutingTable == null) {
             throw new IndexNotFoundException(index);
         }
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                shards.add(indexShardRoutingTable.shard(j));
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                shards.add(indexShardRoutingTable.shard(copy));
             }
         }
         return shards;
@@ -234,10 +234,10 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 continue;
                 // we simply ignore indices that don't exists (make sense for operations that use it currently)
             }
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                     if (predicate.test(shardRouting)) {
                         set.add(shardRouting.shardsIt());
                     } else if (includeEmpty) { // we need this for counting properly, just make it an empty one
@@ -274,10 +274,10 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 continue;
                 // we simply ignore indices that don't exists (make sense for operations that use it currently)
             }
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                     if (predicate.test(shardRouting)) {
                         shards.add(shardRouting);
                         if (includeRelocationTargets && shardRouting.relocating()) {

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.index.seqno;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.ObjectLongMap;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.GroupedActionListener;
@@ -54,7 +51,6 @@ import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * This class is responsible for tracking the replication group with its progress and safety markers (local and global checkpoints).
@@ -584,25 +580,30 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         /*
          * If any of the peer-recovery retention leases need renewal, it's a good opportunity to renew them all.
          */
-        final boolean renewalNeeded = StreamSupport.stream(routingTable.spliterator(), false)
-            .filter(ShardRouting::assignedToNode)
-            .anyMatch(shardRouting -> {
-                final RetentionLease retentionLease = retentionLeases.get(getPeerRecoveryRetentionLeaseId(shardRouting));
-                if (retentionLease == null) {
-                    /*
-                     * If this shard copy is tracked then we got here here via a rolling upgrade from an older version that doesn't
-                     * create peer recovery retention leases for every shard copy.
-                     */
-                    assert checkpoints.get(shardRouting.allocationId().getId()).tracked == false
-                        || hasAllPeerRecoveryRetentionLeases == false;
-                    return false;
-                }
-                return retentionLease.timestamp() <= renewalTimeMillis
-                    || retentionLease.retainingSequenceNumber() <= checkpoints.get(shardRouting.allocationId().getId()).globalCheckpoint;
-            });
-
+        boolean renewalNeeded = false;
+        for (int i = 0; i < routingTable.size(); i++) {
+            final ShardRouting shardRouting = routingTable.shard(i);
+            if (shardRouting.assignedToNode() == false) {
+                continue;
+            }
+            final RetentionLease retentionLease = retentionLeases.get(getPeerRecoveryRetentionLeaseId(shardRouting));
+            if (retentionLease == null) {
+                /*
+                 * If this shard copy is tracked then we got here here via a rolling upgrade from an older version that doesn't
+                 * create peer recovery retention leases for every shard copy.
+                 */
+                assert checkpoints.get(shardRouting.allocationId().getId()).tracked == false || hasAllPeerRecoveryRetentionLeases == false;
+                continue;
+            }
+            if (retentionLease.timestamp() <= renewalTimeMillis
+                || retentionLease.retainingSequenceNumber() <= checkpoints.get(shardRouting.allocationId().getId()).globalCheckpoint) {
+                renewalNeeded = true;
+                break;
+            }
+        }
         if (renewalNeeded) {
-            for (ShardRouting shardRouting : routingTable) {
+            for (int i = 0; i < routingTable.size(); i++) {
+                final ShardRouting shardRouting = routingTable.shard(i);
                 if (shardRouting.assignedToNode()) {
                     final RetentionLease retentionLease = retentionLeases.get(getPeerRecoveryRetentionLeaseId(shardRouting));
                     if (retentionLease != null) {
@@ -733,7 +734,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     public synchronized Map<String, Long> getInSyncGlobalCheckpoints() {
         assert primaryMode;
         assert handoffInProgress == false;
-        final ObjectLongMap<String> globalCheckpoints = new ObjectLongHashMap<>(checkpoints.size()); // upper bound on the size
+        // upper bound on the size
         return checkpoints.entrySet()
             .stream()
             .filter(e -> e.getValue().inSync)

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -581,8 +581,8 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
          * If any of the peer-recovery retention leases need renewal, it's a good opportunity to renew them all.
          */
         boolean renewalNeeded = false;
-        for (int i = 0; i < routingTable.size(); i++) {
-            final ShardRouting shardRouting = routingTable.shard(i);
+        for (int copy = 0; copy < routingTable.size(); copy++) {
+            final ShardRouting shardRouting = routingTable.shard(copy);
             if (shardRouting.assignedToNode() == false) {
                 continue;
             }
@@ -602,8 +602,8 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             }
         }
         if (renewalNeeded) {
-            for (int i = 0; i < routingTable.size(); i++) {
-                final ShardRouting shardRouting = routingTable.shard(i);
+            for (int copy = 0; copy < routingTable.size(); copy++) {
+                final ShardRouting shardRouting = routingTable.shard(copy);
                 if (shardRouting.assignedToNode()) {
                     final RetentionLease retentionLease = retentionLeases.get(getPeerRecoveryRetentionLeaseId(shardRouting));
                     if (retentionLease != null) {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -695,8 +695,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (indexSettings.isSoftDeleteEnabled() && useRetentionLeasesInPeerRecovery == false) {
             final RetentionLeases retentionLeases = replicationTracker.getRetentionLeases();
             final Set<ShardRouting> shardRoutings = new HashSet<>(routingTable.size());
-            for (int j = 0; j < routingTable.size(); j++) {
-                shardRoutings.add(routingTable.shard(j));
+            for (int copy = 0; copy < routingTable.size(); copy++) {
+                shardRoutings.add(routingTable.shard(copy));
             }
             shardRoutings.addAll(routingTable.assignedShards()); // include relocation targets
             if (shardRoutings.stream()

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -694,7 +694,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
         if (indexSettings.isSoftDeleteEnabled() && useRetentionLeasesInPeerRecovery == false) {
             final RetentionLeases retentionLeases = replicationTracker.getRetentionLeases();
-            final Set<ShardRouting> shardRoutings = new HashSet<>(routingTable.getShards());
+            final Set<ShardRouting> shardRoutings = new HashSet<>(routingTable.size());
+            for (int j = 0; j < routingTable.size(); j++) {
+                shardRoutings.add(routingTable.shard(j));
+            }
             shardRoutings.addAll(routingTable.assignedShards()); // include relocation targets
             if (shardRoutings.stream()
                 .allMatch(

--- a/server/src/main/java/org/elasticsearch/index/shard/ReplicationGroup.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ReplicationGroup.java
@@ -43,7 +43,8 @@ public class ReplicationGroup {
         this.unavailableInSyncShards = Sets.difference(inSyncAllocationIds, routingTable.getAllAllocationIds());
         this.replicationTargets = new ArrayList<>();
         this.skippedShards = new ArrayList<>();
-        for (final ShardRouting shard : routingTable) {
+        for (int j = 0; j < routingTable.size(); j++) {
+            ShardRouting shard = routingTable.shard(j);
             if (shard.unassigned()) {
                 assert shard.primary() == false : "primary shard should not be unassigned in a replication group: " + shard;
                 skippedShards.add(shard);

--- a/server/src/main/java/org/elasticsearch/index/shard/ReplicationGroup.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ReplicationGroup.java
@@ -43,8 +43,8 @@ public class ReplicationGroup {
         this.unavailableInSyncShards = Sets.difference(inSyncAllocationIds, routingTable.getAllAllocationIds());
         this.replicationTargets = new ArrayList<>();
         this.skippedShards = new ArrayList<>();
-        for (int j = 0; j < routingTable.size(); j++) {
-            ShardRouting shard = routingTable.shard(j);
+        for (int copy = 0; copy < routingTable.size(); copy++) {
+            ShardRouting shard = routingTable.shard(copy);
             if (shard.unassigned()) {
                 assert shard.primary() == false : "primary shard should not be unassigned in a replication group: " + shard;
                 skippedShards.add(shard);

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -190,7 +190,8 @@ public class IndicesStore implements ClusterStateListener, Closeable {
             return false;
         }
 
-        for (ShardRouting shardRouting : indexShardRoutingTable) {
+        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
             // be conservative here, check on started, not even active
             if (shardRouting.started() == false) {
                 return false;
@@ -209,7 +210,8 @@ public class IndicesStore implements ClusterStateListener, Closeable {
         List<Tuple<DiscoveryNode, ShardActiveRequest>> requests = new ArrayList<>(indexShardRoutingTable.size());
         String indexUUID = indexShardRoutingTable.shardId().getIndex().getUUID();
         ClusterName clusterName = state.getClusterName();
-        for (ShardRouting shardRouting : indexShardRoutingTable) {
+        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
             assert shardRouting.started() : "expected started shard but was " + shardRouting;
             DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
             requests.add(

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -190,8 +190,8 @@ public class IndicesStore implements ClusterStateListener, Closeable {
             return false;
         }
 
-        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+            ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
             // be conservative here, check on started, not even active
             if (shardRouting.started() == false) {
                 return false;
@@ -210,8 +210,8 @@ public class IndicesStore implements ClusterStateListener, Closeable {
         List<Tuple<DiscoveryNode, ShardActiveRequest>> requests = new ArrayList<>(indexShardRoutingTable.size());
         String indexUUID = indexShardRoutingTable.shardId().getIndex().getUUID();
         ClusterName clusterName = state.getClusterName();
-        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-            ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+            ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
             assert shardRouting.started() : "expected started shard but was " + shardRouting;
             DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
             requests.add(

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -150,11 +150,11 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(clusterState.routingTable());
         for (final IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             final IndexRoutingTable.Builder indexBuilder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
                 final IndexShardRoutingTable.Builder shardBuilder = new IndexShardRoutingTable.Builder(indexShardRoutingTable.shardId());
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                     if (shardRouting.primary() == false || indexRoutingTable.getIndex().getName().equals(redIndex)) {
                         // move all replicas and one primary to unassigned
                         shardBuilder.addShard(

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -153,7 +153,8 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
                 final IndexShardRoutingTable.Builder shardBuilder = new IndexShardRoutingTable.Builder(indexShardRoutingTable.shardId());
-                for (final ShardRouting shardRouting : indexShardRoutingTable) {
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                     if (shardRouting.primary() == false || indexRoutingTable.getIndex().getName().equals(redIndex)) {
                         // move all replicas and one primary to unassigned
                         shardBuilder.addShard(

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -112,11 +112,11 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
             clusterState = newState;
             RoutingTable routingTable = clusterState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
-            assertEquals(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations(), i);
+            assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
+            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i);
             List<FailedShard> failedShards = Collections.singletonList(
                 new FailedShard(
-                    routingTable.index("idx").shard(0).shards().get(0),
+                    routingTable.index("idx").shard(0).shard(0),
                     "boom" + i,
                     new UnsupportedOperationException(),
                     randomBoolean()
@@ -128,11 +128,11 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
             routingTable = clusterState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
             if (i == retries - 1) {
-                assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
+                assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
             } else {
-                assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
+                assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
             }
-            assertEquals(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations(), i + 1);
+            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i + 1);
         }
 
         // without retry_failed we won't allocate that shard
@@ -142,8 +142,8 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         assertSame(responseRef.get().getState(), newState);
         RoutingTable routingTable = clusterState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations(), retries);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), retries);
 
         req.setRetryFailed(true); // now we manually retry and get the shard back into initializing
         newState = task.execute(clusterState);
@@ -151,8 +151,8 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         clusterState = newState;
         routingTable = clusterState.routingTable();
         assertEquals(1, routingTable.index("idx").size());
-        assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shards().get(0).state());
-        assertEquals(0, routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations());
+        assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
+        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
     }
 
     private ClusterState createInitialClusterState(AllocationService service) {
@@ -174,10 +174,10 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         assertEquals(prevRoutingTable.index("idx").size(), 1);
-        assertEquals(prevRoutingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
+        assertEquals(prevRoutingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
 
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
         return clusterState;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -206,10 +206,10 @@ public class ActiveShardCountTests extends ESTestCase {
         RoutingTable routingTable = clusterState.routingTable();
         IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary()) {
                     shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                         .moveToStarted();
@@ -225,13 +225,13 @@ public class ActiveShardCountTests extends ESTestCase {
         RoutingTable routingTable = clusterState.routingTable();
         IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
             assert shardRoutingTable.size() > 2;
             int numToStart = numShardsToStart;
             // want less than half, and primary is already started
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {
@@ -252,12 +252,12 @@ public class ActiveShardCountTests extends ESTestCase {
         RoutingTable routingTable = clusterState.routingTable();
         IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
             assert shardRoutingTable.size() > 2;
             int numToStart = numShardsToStart;
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {
@@ -282,10 +282,10 @@ public class ActiveShardCountTests extends ESTestCase {
         RoutingTable routingTable = clusterState.routingTable();
         IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {

--- a/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -208,7 +208,8 @@ public class ActiveShardCountTests extends ESTestCase {
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary()) {
                     shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                         .moveToStarted();
@@ -226,10 +227,11 @@ public class ActiveShardCountTests extends ESTestCase {
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            assert shardRoutingTable.getSize() > 2;
+            assert shardRoutingTable.size() > 2;
             int numToStart = numShardsToStart;
             // want less than half, and primary is already started
-            for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {
@@ -252,9 +254,10 @@ public class ActiveShardCountTests extends ESTestCase {
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            assert shardRoutingTable.getSize() > 2;
+            assert shardRoutingTable.size() > 2;
             int numToStart = numShardsToStart;
-            for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {
@@ -281,7 +284,8 @@ public class ActiveShardCountTests extends ESTestCase {
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary()) {
                     assertTrue(shardRouting.active());
                 } else {

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -247,8 +247,8 @@ public class ReplicationOperationTests extends ESTestCase {
         Set<String> trackedShards,
         Set<String> untrackedShards
     ) {
-        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-            ShardRouting shr = indexShardRoutingTable.shard(j);
+        for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+            ShardRouting shr = indexShardRoutingTable.shard(copy);
             if (shr.unassigned() == false) {
                 if (shr.initializing()) {
                     if (randomBoolean()) {
@@ -555,8 +555,8 @@ public class ReplicationOperationTests extends ESTestCase {
         String localNodeId = state.nodes().getLocalNodeId();
         if (state.routingTable().hasIndex(shardId.getIndexName())) {
             final IndexShardRoutingTable indexShardRoutingTable = state.routingTable().shardRoutingTable(shardId);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                 if (shardRouting.unassigned()) {
                     continue;
                 }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -247,7 +247,8 @@ public class ReplicationOperationTests extends ESTestCase {
         Set<String> trackedShards,
         Set<String> untrackedShards
     ) {
-        for (ShardRouting shr : indexShardRoutingTable.shards()) {
+        for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+            ShardRouting shr = indexShardRoutingTable.shard(j);
             if (shr.unassigned() == false) {
                 if (shr.initializing()) {
                     if (randomBoolean()) {
@@ -553,7 +554,9 @@ public class ReplicationOperationTests extends ESTestCase {
         Set<ShardRouting> expectedReplicas = new HashSet<>();
         String localNodeId = state.nodes().getLocalNodeId();
         if (state.routingTable().hasIndex(shardId.getIndexName())) {
-            for (ShardRouting shardRouting : state.routingTable().shardRoutingTable(shardId)) {
+            final IndexShardRoutingTable indexShardRoutingTable = state.routingTable().shardRoutingTable(shardId);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                 if (shardRouting.unassigned()) {
                     continue;
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -228,8 +229,7 @@ public class ShardFailedClusterStateTaskExecutorTests extends ESAllocationTestCa
         final var indexShardRoutingTable = resultingState.routingTable().shardRoutingTable(INDEX, 0);
         assertTrue(indexShardRoutingTable.primaryShard().started());
         assertTrue(
-            indexShardRoutingTable.getShards()
-                .stream()
+            RoutingNodesHelper.asStream(indexShardRoutingTable)
                 .anyMatch(sr -> sr.primary() == false && sr.unassigned() == false && (sr.started() || secondReroute == false))
         );
         return resultingState;

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -387,7 +387,8 @@ public class ClusterStateHealthTests extends ESTestCase {
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary()) {
                     newIndexRoutingTable.addShard(shardRouting.initialize(randomFrom(nodeIds), null, shardRouting.getExpectedShardSize()));
                 } else {
@@ -405,7 +406,8 @@ public class ClusterStateHealthTests extends ESTestCase {
         ImmutableOpenIntMap.Builder<Set<String>> allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary() && randomBoolean()) {
                     final ShardRouting newShardRouting = shardRouting.moveToStarted();
                     allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
@@ -431,7 +433,8 @@ public class ClusterStateHealthTests extends ESTestCase {
             newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                for (int j = 0; j < shardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = shardRoutingTable.shard(j);
                     if (shardRouting.primary() && (shardRouting.started() == false || alreadyFailedPrimary == false)) {
                         newIndexRoutingTable.addShard(
                             shardRouting.moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, "unlucky shard"))
@@ -453,7 +456,8 @@ public class ClusterStateHealthTests extends ESTestCase {
         allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary() && shardRouting.started() == false) {
                     final ShardRouting newShardRouting = shardRouting.moveToStarted();
                     allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
@@ -480,7 +484,8 @@ public class ClusterStateHealthTests extends ESTestCase {
             final String primaryNodeId = shardRoutingTable.primaryShard().currentNodeId();
             Set<String> allocatedNodes = new HashSet<>();
             allocatedNodes.add(primaryNodeId);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary() == false) {
                     // give the replica a different node id than the primary
                     String replicaNodeId = randomFrom(Sets.difference(nodeIds, allocatedNodes));
@@ -499,7 +504,8 @@ public class ClusterStateHealthTests extends ESTestCase {
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary() == false && randomBoolean()) {
                     newIndexRoutingTable.addShard(shardRouting.moveToStarted());
                 } else {
@@ -516,7 +522,8 @@ public class ClusterStateHealthTests extends ESTestCase {
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (final ShardRouting shardRouting : shardRoutingTable.getShards()) {
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(j);
                 if (shardRouting.primary() == false && shardRouting.started() == false) {
                     newIndexRoutingTable.addShard(shardRouting.moveToStarted());
                     replicaStateChanged = true;

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -385,10 +385,10 @@ public class ClusterStateHealthTests extends ESTestCase {
         RoutingTable routingTable = originalClusterState.routingTable();
         IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
         IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary()) {
                     newIndexRoutingTable.addShard(shardRouting.initialize(randomFrom(nodeIds), null, shardRouting.getExpectedShardSize()));
                 } else {
@@ -404,10 +404,10 @@ public class ClusterStateHealthTests extends ESTestCase {
         indexRoutingTable = routingTable.index(indexName);
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         ImmutableOpenIntMap.Builder<Set<String>> allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary() && randomBoolean()) {
                     final ShardRouting newShardRouting = shardRouting.moveToStarted();
                     allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
@@ -431,10 +431,10 @@ public class ClusterStateHealthTests extends ESTestCase {
             // some primaries failed to allocate
             indexRoutingTable = routingTable.index(indexName);
             newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < shardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = shardRoutingTable.shard(copy);
                     if (shardRouting.primary() && (shardRouting.started() == false || alreadyFailedPrimary == false)) {
                         newIndexRoutingTable.addShard(
                             shardRouting.moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, "unlucky shard"))
@@ -454,10 +454,10 @@ public class ClusterStateHealthTests extends ESTestCase {
         indexRoutingTable = routingTable.index(indexName);
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
         allocationIds = ImmutableOpenIntMap.<Set<String>>builder();
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary() && shardRouting.started() == false) {
                     final ShardRouting newShardRouting = shardRouting.moveToStarted();
                     allocationIds.fPut(newShardRouting.getId(), Sets.newHashSet(newShardRouting.allocationId().getId()));
@@ -479,13 +479,13 @@ public class ClusterStateHealthTests extends ESTestCase {
         // initialize replicas
         indexRoutingTable = routingTable.index(indexName);
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
             final String primaryNodeId = shardRoutingTable.primaryShard().currentNodeId();
             Set<String> allocatedNodes = new HashSet<>();
             allocatedNodes.add(primaryNodeId);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary() == false) {
                     // give the replica a different node id than the primary
                     String replicaNodeId = randomFrom(Sets.difference(nodeIds, allocatedNodes));
@@ -502,10 +502,10 @@ public class ClusterStateHealthTests extends ESTestCase {
         // some replicas started
         indexRoutingTable = routingTable.index(indexName);
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary() == false && randomBoolean()) {
                     newIndexRoutingTable.addShard(shardRouting.moveToStarted());
                 } else {
@@ -520,10 +520,10 @@ public class ClusterStateHealthTests extends ESTestCase {
         boolean replicaStateChanged = false;
         indexRoutingTable = routingTable.index(indexName);
         newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = shardRoutingTable.shard(copy);
                 if (shardRouting.primary() == false && shardRouting.started() == false) {
                     newIndexRoutingTable.addShard(shardRouting.moveToStarted());
                     replicaStateChanged = true;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.cluster.ClusterStateChanges;
@@ -197,15 +198,14 @@ public class AutoExpandReplicasTests extends ESTestCase {
                 postTable = state.routingTable().index("index").shard(0);
             }
 
-            Set<String> unchangedAllocationIds = preTable.getShards()
-                .stream()
+            Set<String> unchangedAllocationIds = RoutingNodesHelper.asStream(preTable)
                 .filter(shr -> unchangedNodeIds.contains(shr.currentNodeId()))
                 .map(shr -> shr.allocationId().getId())
                 .collect(Collectors.toSet());
 
             assertThat(postTable.toString(), unchangedAllocationIds, everyItem(is(in(postTable.getAllAllocationIds()))));
 
-            postTable.getShards().forEach(shardRouting -> {
+            RoutingNodesHelper.asStream(postTable).forEach(shardRouting -> {
                 if (shardRouting.assignedToNode() && unchangedAllocationIds.contains(shardRouting.allocationId().getId())) {
                     assertTrue("Shard should be active: " + shardRouting, shardRouting.active());
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -454,10 +455,9 @@ public class MetadataIndexStateServiceTests extends ESTestCase {
 
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-            assertThat(shardRoutingTable.shards().stream().allMatch(ShardRouting::unassigned), is(true));
+            assertThat(RoutingNodesHelper.asStream(shardRoutingTable).allMatch(ShardRouting::unassigned), is(true));
             assertThat(
-                shardRoutingTable.shards()
-                    .stream()
+                RoutingNodesHelper.asStream(shardRoutingTable)
                     .map(ShardRouting::unassignedInfo)
                     .map(UnassignedInfo::getReason)
                     .allMatch(info -> info == UnassignedInfo.Reason.INDEX_CLOSED),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
@@ -484,10 +484,10 @@ public class RoutingTableTests extends ESAllocationTestCase {
     /** reverse engineer the in sync aid based on the given indexRoutingTable **/
     public static IndexMetadata updateActiveAllocations(IndexRoutingTable indexRoutingTable, IndexMetadata indexMetadata) {
         IndexMetadata.Builder imdBuilder = IndexMetadata.builder(indexMetadata);
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            IndexShardRoutingTable shardTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < shardTable.size(); j++) {
-                ShardRouting shardRouting = shardTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            IndexShardRoutingTable shardTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < shardTable.size(); copy++) {
+                ShardRouting shardRouting = shardTable.shard(copy);
                 Set<String> insyncAids = shardTable.activeShards()
                     .stream()
                     .map(shr -> shr.allocationId().getId())

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
@@ -486,7 +486,8 @@ public class RoutingTableTests extends ESAllocationTestCase {
         IndexMetadata.Builder imdBuilder = IndexMetadata.builder(indexMetadata);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             IndexShardRoutingTable shardTable = indexRoutingTable.shard(i);
-            for (ShardRouting shardRouting : shardTable) {
+            for (int j = 0; j < shardTable.size(); j++) {
+                ShardRouting shardRouting = shardTable.shard(j);
                 Set<String> insyncAids = shardTable.activeShards()
                     .stream()
                     .map(shr -> shr.allocationId().getId())

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceUnbalancedClusterTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceUnbalancedClusterTests.java
@@ -59,10 +59,10 @@ public class BalanceUnbalancedClusterTests extends CatAllocationTestCase {
         }
         Map<String, Integer> counts = new HashMap<>();
         final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                String s = indexShardRoutingTable.shard(j).currentNodeId();
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                String s = indexShardRoutingTable.shard(copy).currentNodeId();
                 Integer count = counts.get(s);
                 if (count == null) {
                     count = 0;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceUnbalancedClusterTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceUnbalancedClusterTests.java
@@ -14,8 +14,8 @@ import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
@@ -60,8 +60,9 @@ public class BalanceUnbalancedClusterTests extends CatAllocationTestCase {
         Map<String, Integer> counts = new HashMap<>();
         final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting r : indexRoutingTable.shard(i)) {
-                String s = r.currentNodeId();
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                String s = indexShardRoutingTable.shard(j).currentNodeId();
                 Integer count = counts.get(s);
                 if (count == null) {
                     count = 0;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ConcurrentRebalanceRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ConcurrentRebalanceRoutingTests.java
@@ -53,10 +53,10 @@ public class ConcurrentRebalanceRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(5));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("start two nodes and fully start the shards");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -61,20 +61,20 @@ public class IndexBalanceTests extends ESAllocationTestCase {
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         assertThat(clusterState.routingTable().index("test1").size(), equalTo(3));
         for (int i = 0; i < clusterState.routingTable().index("test1").size(); i++) {
             assertThat(clusterState.routingTable().index("test1").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test1").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("Adding three node and performing rerouting");
@@ -186,20 +186,20 @@ public class IndexBalanceTests extends ESAllocationTestCase {
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         assertThat(clusterState.routingTable().index("test1").size(), equalTo(3));
         for (int i = 0; i < clusterState.routingTable().index("test1").size(); i++) {
             assertThat(clusterState.routingTable().index("test1").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test1").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test1").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test1").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("Adding one node and performing rerouting");
@@ -328,10 +328,10 @@ public class IndexBalanceTests extends ESAllocationTestCase {
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("Adding three node and performing rerouting");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -73,10 +73,10 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         assertEquals(prevRoutingTable.index("idx").size(), 1);
-        assertEquals(prevRoutingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
+        assertEquals(prevRoutingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
 
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
         return clusterState;
     }
 
@@ -88,7 +88,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         for (int i = 0; i < retries - 1; i++) {
             List<FailedShard> failedShards = Collections.singletonList(
                 new FailedShard(
-                    routingTable.index("idx").shard(0).shards().get(0),
+                    routingTable.index("idx").shard(0).shard(0),
                     "boom" + i,
                     new UnsupportedOperationException(),
                     randomBoolean()
@@ -99,27 +99,22 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
-            assertEquals(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations(), i + 1);
-            assertThat(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getMessage(), containsString("boom" + i));
+            assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
+            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i + 1);
+            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom" + i));
         }
         // now we go and check that we are actually stick to unassigned on the next failure
         List<FailedShard> failedShards = Collections.singletonList(
-            new FailedShard(
-                routingTable.index("idx").shard(0).shards().get(0),
-                "boom",
-                new UnsupportedOperationException(),
-                randomBoolean()
-            )
+            new FailedShard(routingTable.index("idx").shard(0).shard(0), "boom", new UnsupportedOperationException(), randomBoolean())
         );
         ClusterState newState = strategy.applyFailedShards(clusterState, failedShards);
         assertThat(newState, not(equalTo(clusterState)));
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations(), retries);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
-        assertThat(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), retries);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
 
         // manual resetting of retry count
         newState = strategy.reroute(clusterState, new AllocationCommands(), false, true).clusterState();
@@ -129,19 +124,14 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
 
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(0, routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations());
-        assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shards().get(0).state());
-        assertThat(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+        assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
 
         // again fail it N-1 times
         for (int i = 0; i < retries - 1; i++) {
             failedShards = Collections.singletonList(
-                new FailedShard(
-                    routingTable.index("idx").shard(0).shards().get(0),
-                    "boom",
-                    new UnsupportedOperationException(),
-                    randomBoolean()
-                )
+                new FailedShard(routingTable.index("idx").shard(0).shard(0), "boom", new UnsupportedOperationException(), randomBoolean())
             );
 
             newState = strategy.applyFailedShards(clusterState, failedShards);
@@ -149,28 +139,23 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(i + 1, routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations());
-            assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shards().get(0).state());
-            assertThat(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getMessage(), containsString("boom"));
+            assertEquals(i + 1, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+            assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
+            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
         }
 
         // now we go and check that we are actually stick to unassigned on the next failure
         failedShards = Collections.singletonList(
-            new FailedShard(
-                routingTable.index("idx").shard(0).shards().get(0),
-                "boom",
-                new UnsupportedOperationException(),
-                randomBoolean()
-            )
+            new FailedShard(routingTable.index("idx").shard(0).shard(0), "boom", new UnsupportedOperationException(), randomBoolean())
         );
         newState = strategy.applyFailedShards(clusterState, failedShards);
         assertThat(newState, not(equalTo(clusterState)));
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(retries, routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getNumFailedAllocations());
-        assertEquals(UNASSIGNED, routingTable.index("idx").shard(0).shards().get(0).state());
-        assertThat(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertEquals(retries, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+        assertEquals(UNASSIGNED, routingTable.index("idx").shard(0).shard(0).state());
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
     }
 
     public void testFailedAllocation() {
@@ -181,7 +166,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         for (int i = 0; i < retries - 1; i++) {
             List<FailedShard> failedShards = Collections.singletonList(
                 new FailedShard(
-                    routingTable.index("idx").shard(0).shards().get(0),
+                    routingTable.index("idx").shard(0).shard(0),
                     "boom" + i,
                     new UnsupportedOperationException(),
                     randomBoolean()
@@ -192,7 +177,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shards().get(0);
+            ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
             assertEquals(unassignedPrimary.state(), INITIALIZING);
             assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), i + 1);
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom" + i));
@@ -209,19 +194,14 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         // now we go and check that we are actually stick to unassigned on the next failure
         {
             List<FailedShard> failedShards = Collections.singletonList(
-                new FailedShard(
-                    routingTable.index("idx").shard(0).shards().get(0),
-                    "boom",
-                    new UnsupportedOperationException(),
-                    randomBoolean()
-                )
+                new FailedShard(routingTable.index("idx").shard(0).shard(0), "boom", new UnsupportedOperationException(), randomBoolean())
             );
             ClusterState newState = strategy.applyFailedShards(clusterState, failedShards);
             assertThat(newState, not(equalTo(clusterState)));
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shards().get(0);
+            ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
             assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), retries);
             assertEquals(unassignedPrimary.state(), UNASSIGNED);
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
@@ -261,7 +241,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         routingTable = newState.routingTable();
         // good we are initializing and we are maintaining failure information
         assertEquals(routingTable.index("idx").size(), 1);
-        ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shards().get(0);
+        ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
         assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), retries);
         assertEquals(unassignedPrimary.state(), INITIALIZING);
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
@@ -269,36 +249,31 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         assertEquals(
             Decision.YES,
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                routingTable.index("idx").shard(0).shards().get(0),
+                routingTable.index("idx").shard(0).shard(0),
                 null,
                 new RoutingAllocation(null, clusterState, null, null, 0)
             )
         );
 
         // now we start the shard
-        clusterState = startShardsAndReroute(strategy, clusterState, routingTable.index("idx").shard(0).shards().get(0));
+        clusterState = startShardsAndReroute(strategy, clusterState, routingTable.index("idx").shard(0).shard(0));
         routingTable = clusterState.routingTable();
 
         // all counters have been reset to 0 ie. no unassigned info
         assertEquals(routingTable.index("idx").size(), 1);
-        assertNull(routingTable.index("idx").shard(0).shards().get(0).unassignedInfo());
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), STARTED);
+        assertNull(routingTable.index("idx").shard(0).shard(0).unassignedInfo());
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), STARTED);
 
         // now fail again and see if it has a new counter
         List<FailedShard> failedShards = Collections.singletonList(
-            new FailedShard(
-                routingTable.index("idx").shard(0).shards().get(0),
-                "ZOOOMG",
-                new UnsupportedOperationException(),
-                randomBoolean()
-            )
+            new FailedShard(routingTable.index("idx").shard(0).shard(0), "ZOOOMG", new UnsupportedOperationException(), randomBoolean())
         );
         newState = strategy.applyFailedShards(clusterState, failedShards);
         assertThat(newState, not(equalTo(clusterState)));
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        unassignedPrimary = routingTable.index("idx").shard(0).shards().get(0);
+        unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
         assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), 1);
         assertEquals(unassignedPrimary.state(), UNASSIGNED);
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("ZOOOMG"));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -98,12 +98,12 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(5));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(3));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).currentNodeId(), nullValue());
         }
 
         logger.info("start two nodes and fully start the shards");
@@ -251,12 +251,12 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(5));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(3));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).currentNodeId(), nullValue());
         }
         clusterState = ClusterState.builder(clusterState)
             .nodes(
@@ -294,12 +294,12 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = stabilize(clusterState, service);
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(3));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(STARTED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(STARTED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).state(), equalTo(STARTED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), notNullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), notNullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(2).currentNodeId(), notNullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(STARTED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(STARTED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).state(), equalTo(STARTED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), notNullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), notNullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(2).currentNodeId(), notNullValue());
         }
     }
 
@@ -590,7 +590,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             .nodes(DiscoveryNodes.builder().add(newNode.node()).add(oldNode.node()))
             .build();
 
-        final ShardId shardId = clusterState.routingTable().index("test").shard(0).getShardId();
+        final ShardId shardId = clusterState.routingTable().index("test").shard(0).shardId();
         final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
         final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().get(0);
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
@@ -131,13 +131,13 @@ public class RebalanceAfterActiveTests extends ESAllocationTestCase {
         // we only allow one relocation at a time
         assertThat(shardsWithState(clusterState.getRoutingNodes(), STARTED).size(), equalTo(5));
         assertThat(shardsWithState(clusterState.getRoutingNodes(), RELOCATING).size(), equalTo(5));
-        for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
+        for (int shardId = 0; shardId < clusterState.routingTable().index("test").size(); shardId++) {
             int num = 0;
-            final IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index("test").shard(i);
-            for (int j = 0; j < shardRoutingTable.size(); j++) {
-                ShardRouting routing = shardRoutingTable.shard(j);
+            final IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index("test").shard(shardId);
+            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                ShardRouting routing = shardRoutingTable.shard(copy);
                 if (routing.state() == RELOCATING || routing.state() == INITIALIZING) {
-                    assertEquals(routing.getExpectedShardSize(), sizes[i]);
+                    assertEquals(routing.getExpectedShardSize(), sizes[shardId]);
                     num++;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -72,10 +73,10 @@ public class RebalanceAfterActiveTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(5));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("start two nodes and fully start the shards");
@@ -132,7 +133,9 @@ public class RebalanceAfterActiveTests extends ESAllocationTestCase {
         assertThat(shardsWithState(clusterState.getRoutingNodes(), RELOCATING).size(), equalTo(5));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             int num = 0;
-            for (ShardRouting routing : clusterState.routingTable().index("test").shard(i).shards()) {
+            final IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index("test").shard(i);
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting routing = shardRoutingTable.shard(j);
                 if (routing.state() == RELOCATING || routing.state() == INITIALIZING) {
                     assertEquals(routing.getExpectedShardSize(), sizes[i]);
                     num++;
@@ -148,7 +151,9 @@ public class RebalanceAfterActiveTests extends ESAllocationTestCase {
         assertThat(shardsWithState(clusterState.getRoutingNodes(), STARTED).size(), equalTo(7));
         assertThat(shardsWithState(clusterState.getRoutingNodes(), RELOCATING).size(), equalTo(3));
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
-            for (ShardRouting routing : clusterState.routingTable().index("test").shard(i).shards()) {
+            final IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index("test").shard(i);
+            for (int j = 0; j < shardRoutingTable.size(); j++) {
+                ShardRouting routing = shardRoutingTable.shard(j);
                 if (routing.state() == RELOCATING || routing.state() == INITIALIZING) {
                     assertEquals(routing.getExpectedShardSize(), sizes[i]);
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ReplicaAllocatedAfterPrimaryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ReplicaAllocatedAfterPrimaryTests.java
@@ -50,10 +50,10 @@ public class ReplicaAllocatedAfterPrimaryTests extends ESAllocationTestCase {
         assertThat(routingTable.index("test").size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(2));
-        assertThat(routingTable.index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(routingTable.index("test").shard(0).shards().get(1).state(), equalTo(UNASSIGNED));
-        assertThat(routingTable.index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
-        assertThat(routingTable.index("test").shard(0).shards().get(1).currentNodeId(), nullValue());
+        assertThat(routingTable.index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(routingTable.index("test").shard(0).shard(1).state(), equalTo(UNASSIGNED));
+        assertThat(routingTable.index("test").shard(0).shard(0).currentNodeId(), nullValue());
+        assertThat(routingTable.index("test").shard(0).shard(1).currentNodeId(), nullValue());
 
         logger.info("Adding one node and performing rerouting");
         clusterState = ClusterState.builder(clusterState)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ResizeAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ResizeAllocationDeciderTests.java
@@ -78,25 +78,25 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         assertEquals(prevRoutingTable.index("source").size(), 2);
-        assertEquals(prevRoutingTable.index("source").shard(0).shards().get(0).state(), UNASSIGNED);
-        assertEquals(prevRoutingTable.index("source").shard(1).shards().get(0).state(), UNASSIGNED);
+        assertEquals(prevRoutingTable.index("source").shard(0).shard(0).state(), UNASSIGNED);
+        assertEquals(prevRoutingTable.index("source").shard(1).shard(0).state(), UNASSIGNED);
 
         assertEquals(routingTable.index("source").size(), 2);
 
-        assertEquals(routingTable.index("source").shard(0).shards().get(0).state(), INITIALIZING);
-        assertEquals(routingTable.index("source").shard(1).shards().get(0).state(), INITIALIZING);
+        assertEquals(routingTable.index("source").shard(0).shard(0).state(), INITIALIZING);
+        assertEquals(routingTable.index("source").shard(1).shard(0).state(), INITIALIZING);
 
         if (startShards) {
             clusterState = startShardsAndReroute(
                 strategy,
                 clusterState,
-                routingTable.index("source").shard(0).shards().get(0),
-                routingTable.index("source").shard(1).shards().get(0)
+                routingTable.index("source").shard(0).shard(0),
+                routingTable.index("source").shard(1).shard(0)
             );
             routingTable = clusterState.routingTable();
             assertEquals(routingTable.index("source").size(), 2);
-            assertEquals(routingTable.index("source").shard(0).shards().get(0).state(), STARTED);
-            assertEquals(routingTable.index("source").shard(1).shards().get(0).state(), STARTED);
+            assertEquals(routingTable.index("source").shard(0).shard(0).state(), STARTED);
+            assertEquals(routingTable.index("source").shard(1).shard(0).state(), STARTED);
 
         }
         return clusterState;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.UUIDs;
@@ -424,7 +425,9 @@ public class RoutingNodesIntegrityTests extends ESAllocationTestCase {
         final Map<String, Set<ShardId>> shardsByNode = Maps.newMapWithExpectedSize(nodeCount);
         for (final var indexRoutingTable : clusterState.routingTable()) {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (final var shardRouting : indexRoutingTable.shard(i)) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                     assertTrue(shardRouting.started());
                     shardsByNode.computeIfAbsent(shardRouting.currentNodeId(), ignored -> new HashSet<>()).add(shardRouting.shardId());
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
@@ -424,10 +424,10 @@ public class RoutingNodesIntegrityTests extends ESAllocationTestCase {
 
         final Map<String, Set<ShardId>> shardsByNode = Maps.newMapWithExpectedSize(nodeCount);
         for (final var indexRoutingTable : clusterState.routingTable()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                     assertTrue(shardRouting.started());
                     shardsByNode.computeIfAbsent(shardRouting.currentNodeId(), ignored -> new HashSet<>()).add(shardRouting.shardId());
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
@@ -62,8 +62,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), nullValue());
 
         logger.info("Adding one node and performing rerouting");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
@@ -72,8 +72,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(INITIALIZING));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(INITIALIZING));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
 
         logger.info("Rerouting again, nothing should change");
         clusterState = ClusterState.builder(clusterState).build();
@@ -90,8 +90,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(STARTED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(STARTED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
 
         logger.info("Starting another node and making sure nothing changed");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).add(newNode("node2"))).build();
@@ -102,8 +102,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(STARTED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(STARTED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
 
         logger.info("Killing node1 where the shard is, checking the shard is unassigned");
 
@@ -115,8 +115,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), nullValue());
 
         logger.info("Bring node1 back, and see it's assinged");
 
@@ -128,8 +128,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(INITIALIZING));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(INITIALIZING));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
 
         logger.info("Start another node, make sure that things remain the same (shard is in node2 and initializing)");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).add(newNode("node3"))).build();
@@ -145,8 +145,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(STARTED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(STARTED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
     }
 
     public void testSingleIndexShardFailed() {
@@ -169,8 +169,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), nullValue());
 
         logger.info("Adding one node and rerouting");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
@@ -181,9 +181,9 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).unassigned(), equalTo(false));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(INITIALIZING));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), equalTo("node1"));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).unassigned(), equalTo(false));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(INITIALIZING));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), equalTo("node1"));
 
         logger.info("Marking the shard as failed");
         RoutingNodes routingNodes = clusterState.getRoutingNodes();
@@ -198,8 +198,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), nullValue());
     }
 
     public void testMultiIndexEvenDistribution() {
@@ -235,8 +235,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).currentNodeId(), nullValue());
         }
 
         logger.info("Adding " + (numberOfIndices / 2) + " nodes");
@@ -253,11 +253,11 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).unassigned(), equalTo(false));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(), equalTo(INITIALIZING));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).primary(), equalTo(true));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).unassigned(), equalTo(false));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).state(), equalTo(INITIALIZING));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).primary(), equalTo(true));
             // make sure we still have 2 shards initializing per node on the first 25 nodes
-            String nodeId = clusterState.routingTable().index("test" + i).shard(0).shards().get(0).currentNodeId();
+            String nodeId = clusterState.routingTable().index("test" + i).shard(0).shard(0).currentNodeId();
             int nodeIndex = Integer.parseInt(nodeId.substring("node".length()));
             assertThat(nodeIndex, lessThan(25));
         }
@@ -296,19 +296,19 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).unassigned(), equalTo(false));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).unassigned(), equalTo(false));
             assertThat(
-                clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(),
+                clusterState.routingTable().index("test" + i).shard(0).shard(0).state(),
                 anyOf(equalTo(STARTED), equalTo(RELOCATING))
             );
-            if (clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state() == STARTED) {
+            if (clusterState.routingTable().index("test" + i).shard(0).shard(0).state() == STARTED) {
                 numberOfStartedShards++;
-            } else if (clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state() == RELOCATING) {
+            } else if (clusterState.routingTable().index("test" + i).shard(0).shard(0).state() == RELOCATING) {
                 numberOfRelocatingShards++;
             }
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).primary(), equalTo(true));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).primary(), equalTo(true));
             // make sure we still have 2 shards either relocating or started on the first 25 nodes (still)
-            String nodeId = clusterState.routingTable().index("test" + i).shard(0).shards().get(0).currentNodeId();
+            String nodeId = clusterState.routingTable().index("test" + i).shard(0).shard(0).currentNodeId();
             int nodeIndex = Integer.parseInt(nodeId.substring("node".length()));
             assertThat(nodeIndex, lessThan(25));
         }
@@ -359,7 +359,7 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
-            assertThat(clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(), equalTo(INITIALIZING));
+            assertThat(clusterState.routingTable().index("test" + i).shard(0).shard(0).state(), equalTo(INITIALIZING));
         }
         RoutingNodes routingNodes = clusterState.getRoutingNodes();
         assertThat(numberOfShardsOfType(routingNodes, INITIALIZING), equalTo(numberOfIndices));
@@ -384,7 +384,7 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(
-                clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(),
+                clusterState.routingTable().index("test" + i).shard(0).shard(0).state(),
                 anyOf(equalTo(RELOCATING), equalTo(STARTED))
             );
         }
@@ -403,7 +403,7 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(clusterState.routingTable().index("test" + i).shard(0).size(), equalTo(1));
             assertThat(
-                clusterState.routingTable().index("test" + i).shard(0).shards().get(0).state(),
+                clusterState.routingTable().index("test" + i).shard(0).shard(0).state(),
                 anyOf(equalTo(RELOCATING), equalTo(STARTED))
             );
         }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardOneReplicaRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardOneReplicaRoutingTests.java
@@ -50,10 +50,10 @@ public class SingleShardOneReplicaRoutingTests extends ESAllocationTestCase {
         assertThat(clusterState.routingTable().index("test").size(), equalTo(1));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(2));
         assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(2));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(1).state(), equalTo(UNASSIGNED));
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
-        assertThat(clusterState.routingTable().index("test").shard(0).shards().get(1).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(1).state(), equalTo(UNASSIGNED));
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(0).currentNodeId(), nullValue());
+        assertThat(clusterState.routingTable().index("test").shard(0).shard(1).currentNodeId(), nullValue());
 
         logger.info("Adding one node and performing rerouting");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
@@ -94,7 +94,7 @@ public class StartedShardsRoutingTests extends ESAllocationTestCase {
             newState,
             not(equalTo(state))
         );
-        ShardRouting shardRouting = newState.routingTable().index("test").shard(relocatingShard.id()).getShards().get(0);
+        ShardRouting shardRouting = newState.routingTable().index("test").shard(relocatingShard.id()).shard(0);
         assertThat(shardRouting.state(), equalTo(ShardRoutingState.STARTED));
         assertThat(shardRouting.currentNodeId(), equalTo("node2"));
         assertThat(shardRouting.relocatingNodeId(), nullValue());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TenShardsOneReplicaRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TenShardsOneReplicaRoutingTests.java
@@ -62,10 +62,10 @@ public class TenShardsOneReplicaRoutingTests extends ESAllocationTestCase {
         for (int i = 0; i < clusterState.routingTable().index("test").size(); i++) {
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
             assertThat(clusterState.routingTable().index("test").shard(i).size(), equalTo(2));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).state(), equalTo(UNASSIGNED));
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(0).currentNodeId(), nullValue());
-            assertThat(clusterState.routingTable().index("test").shard(i).shards().get(1).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).state(), equalTo(UNASSIGNED));
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(0).currentNodeId(), nullValue());
+            assertThat(clusterState.routingTable().index("test").shard(i).shard(1).currentNodeId(), nullValue());
         }
 
         logger.info("Adding one node and performing rerouting");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -49,31 +49,27 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
 
         // track the failed nodes if shard is not started
         for (int i = 0; i < maxRetries; i++) {
-            failedNodeIds.add(clusterState.routingTable().index("idx").shard(0).shards().get(0).currentNodeId());
+            failedNodeIds.add(clusterState.routingTable().index("idx").shard(0).shard(0).currentNodeId());
             clusterState = allocationService.applyFailedShard(
                 clusterState,
-                clusterState.routingTable().index("idx").shard(0).shards().get(0),
+                clusterState.routingTable().index("idx").shard(0).shard(0),
                 randomBoolean()
             );
             assertThat(
-                clusterState.routingTable().index("idx").shard(0).shards().get(0).unassignedInfo().getFailedNodeIds(),
+                clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(),
                 equalTo(failedNodeIds)
             );
         }
 
         // reroute with retryFailed=true should discard the failedNodes
-        assertThat(clusterState.routingTable().index("idx").shard(0).shards().get(0).state(), equalTo(ShardRoutingState.UNASSIGNED));
+        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).state(), equalTo(ShardRoutingState.UNASSIGNED));
         clusterState = allocationService.reroute(clusterState, new AllocationCommands(), false, true).clusterState();
-        assertThat(clusterState.routingTable().index("idx").shard(0).shards().get(0).unassignedInfo().getFailedNodeIds(), empty());
+        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(), empty());
 
         // do not track the failed nodes while shard is started
         clusterState = startInitializingShardsAndReroute(allocationService, clusterState);
-        assertThat(clusterState.routingTable().index("idx").shard(0).shards().get(0).state(), equalTo(ShardRoutingState.STARTED));
-        clusterState = allocationService.applyFailedShard(
-            clusterState,
-            clusterState.routingTable().index("idx").shard(0).shards().get(0),
-            false
-        );
-        assertThat(clusterState.routingTable().index("idx").shard(0).shards().get(0).unassignedInfo().getFailedNodeIds(), empty());
+        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).state(), equalTo(ShardRoutingState.STARTED));
+        clusterState = allocationService.applyFailedShard(clusterState, clusterState.routingTable().index("idx").shard(0).shard(0), false);
+        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(), empty());
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
@@ -50,10 +50,10 @@ public class UpdateNumberOfReplicasTests extends ESAllocationTestCase {
         assertThat(initialRoutingTable.index("test").size(), equalTo(1));
         assertThat(initialRoutingTable.index("test").shard(0).size(), equalTo(2));
         assertThat(initialRoutingTable.index("test").shard(0).size(), equalTo(2));
-        assertThat(initialRoutingTable.index("test").shard(0).shards().get(0).state(), equalTo(UNASSIGNED));
-        assertThat(initialRoutingTable.index("test").shard(0).shards().get(1).state(), equalTo(UNASSIGNED));
-        assertThat(initialRoutingTable.index("test").shard(0).shards().get(0).currentNodeId(), nullValue());
-        assertThat(initialRoutingTable.index("test").shard(0).shards().get(1).currentNodeId(), nullValue());
+        assertThat(initialRoutingTable.index("test").shard(0).shard(0).state(), equalTo(UNASSIGNED));
+        assertThat(initialRoutingTable.index("test").shard(0).shard(1).state(), equalTo(UNASSIGNED));
+        assertThat(initialRoutingTable.index("test").shard(0).shard(0).currentNodeId(), nullValue());
+        assertThat(initialRoutingTable.index("test").shard(0).shard(1).currentNodeId(), nullValue());
 
         logger.info("Adding two nodes and performing rerouting");
         clusterState = ClusterState.builder(clusterState)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -64,12 +64,12 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         RoutingTable routingTable = state.routingTable();
 
         // we can initially only allocate on node2
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), INITIALIZING);
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).currentNodeId(), "node2");
-        routingTable = service.applyFailedShard(state, routingTable.index("idx").shard(0).shards().get(0), randomBoolean()).routingTable();
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).currentNodeId(), "node2");
+        routingTable = service.applyFailedShard(state, routingTable.index("idx").shard(0).shard(0), randomBoolean()).routingTable();
         state = ClusterState.builder(state).routingTable(routingTable).build();
-        assertEquals(routingTable.index("idx").shard(0).shards().get(0).state(), UNASSIGNED);
-        assertNull(routingTable.index("idx").shard(0).shards().get(0).currentNodeId());
+        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
+        assertNull(routingTable.index("idx").shard(0).shard(0).currentNodeId());
 
         // after failing the shard we are unassigned since the node is blacklisted and we can't initialize on the other node
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
@@ -133,14 +133,14 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
         allocation.debugDecision(true);
         decision = (Decision.Single) filterAllocationDecider.canAllocate(
-            routingTable.index("idx").shard(0).shards().get(0),
+            routingTable.index("idx").shard(0).shard(0),
             state.getRoutingNodes().node("node2"),
             allocation
         );
         assertEquals(Type.YES, decision.type());
         assertEquals("node passes include/exclude/require filters", decision.getExplanation());
         decision = (Decision.Single) filterAllocationDecider.canAllocate(
-            routingTable.index("idx").shard(0).shards().get(0),
+            routingTable.index("idx").shard(0).shard(0),
             state.getRoutingNodes().node("node1"),
             allocation
         );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -125,10 +125,10 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
 
             IndexRoutingTable indexRoutingTable = routingTable.index("test");
             IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < shardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = shardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = shardRoutingTable.shard(copy);
                     if (shardRouting.primary()) {
                         newIndexRoutingTable.addShard(primary);
                     } else {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -127,7 +127,8 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
             IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                for (int j = 0; j < shardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = shardRoutingTable.shard(j);
                     if (shardRouting.primary()) {
                         newIndexRoutingTable.addShard(primary);
                     } else {

--- a/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -104,7 +105,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         builder.addShard(replicaShardRouting.moveToStarted());
         replicationTracker.updateFromMaster(
             replicationTracker.appliedClusterStateVersion + 1,
-            replicationTracker.routingTable.shards().stream().map(sr -> sr.allocationId().getId()).collect(Collectors.toSet()),
+            RoutingNodesHelper.asStream(replicationTracker.routingTable).map(sr -> sr.allocationId().getId()).collect(Collectors.toSet()),
             builder.build()
         );
     }
@@ -124,8 +125,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         assertThat(
             leaseIds,
             equalTo(
-                replicationTracker.routingTable.shards()
-                    .stream()
+                RoutingNodesHelper.asStream(replicationTracker.routingTable)
                     .map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
                     .collect(Collectors.toSet())
             )
@@ -155,7 +155,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
             equalTo(
                 Stream.concat(
                     Stream.of(ReplicationTracker.getPeerRecoveryRetentionLeaseId(unknownNodeId)),
-                    replicationTracker.routingTable.shards().stream().map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
+                    RoutingNodesHelper.asStream(replicationTracker.routingTable).map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
                 ).collect(Collectors.toSet())
             )
         );
@@ -186,8 +186,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         assertThat(
             leaseIds,
             equalTo(
-                replicationTracker.routingTable.shards()
-                    .stream()
+                RoutingNodesHelper.asStream(replicationTracker.routingTable)
                     .map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
                     .collect(Collectors.toSet())
             )
@@ -214,8 +213,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         assertThat(
             leaseIds,
             equalTo(
-                replicationTracker.routingTable.shards()
-                    .stream()
+                RoutingNodesHelper.asStream(replicationTracker.routingTable)
                     .map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
                     .collect(Collectors.toSet())
             )
@@ -240,8 +238,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         assertThat(
             leaseIds,
             equalTo(
-                replicationTracker.routingTable.shards()
-                    .stream()
+                RoutingNodesHelper.asStream(replicationTracker.routingTable)
                     .map(ReplicationTracker::getPeerRecoveryRetentionLeaseId)
                     .collect(Collectors.toSet())
             )

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
@@ -10,6 +10,8 @@ package org.elasticsearch.cluster.routing;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public final class RoutingNodesHelper {
 
@@ -47,4 +49,7 @@ public final class RoutingNodesHelper {
         return shards;
     }
 
+    public static Stream<ShardRouting> asStream(IndexShardRoutingTable indexShardRoutingTable) {
+        return IntStream.range(0, indexShardRoutingTable.size()).mapToObj(indexShardRoutingTable::shard);
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
@@ -49,6 +49,13 @@ public final class RoutingNodesHelper {
         return shards;
     }
 
+    /**
+     * Returns a stream over all {@link ShardRouting} in a {@link IndexShardRoutingTable}. This is not part of production code on purpose
+     * as its too costly to iterate the table like this in many production use cases.
+     *
+     * @param indexShardRoutingTable index shard routing table to iterate over
+     * @return stream over {@link ShardRouting}
+     */
     public static Stream<ShardRouting> asStream(IndexShardRoutingTable indexShardRoutingTable) {
         return IntStream.range(0, indexShardRoutingTable.size()).mapToObj(indexShardRoutingTable::shard);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -2142,10 +2142,10 @@ public abstract class ESIntegTestCase extends ESTestCase {
         Set<String> nodes = new HashSet<>();
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShard = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShard.size(); j++) {
-                    ShardRouting shardRouting = indexShard.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShard.size(); copy++) {
+                    ShardRouting shardRouting = indexShard.shard(copy);
                     if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndexName())) {
                         String name = clusterState.nodes().get(shardRouting.currentNodeId()).getName();
                         nodes.add(name);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -66,6 +66,7 @@ import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
@@ -2142,7 +2143,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
+                final IndexShardRoutingTable indexShard = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShard.size(); j++) {
+                    ShardRouting shardRouting = indexShard.shard(j);
                     if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndexName())) {
                         String name = clusterState.nodes().get(shardRouting.currentNodeId()).getName();
                         nodes.add(name);

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
@@ -154,7 +154,8 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (ShardRouting shard : shardRoutingTable) {
+                for (int j = 0; j < shardRoutingTable.size(); j++) {
+                    ShardRouting shard = shardRoutingTable.shard(j);
                     assertNotNull(shard.currentNodeId());
                     final DiscoveryNode assignedNode = state.nodes().get(shard.currentNodeId());
                     assertThat(shardRoutingTable.toString(), assignedNode.getName(), in(dataOnlyNodes));
@@ -170,7 +171,8 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (ShardRouting shard : shardRoutingTable) {
+                for (int j = 0; j < shardRoutingTable.size(); j++) {
+                    ShardRouting shard = shardRoutingTable.shard(j);
                     assertNotNull(shard.currentNodeId());
                     final DiscoveryNode assignedNode = state.nodes().get(shard.currentNodeId());
                     assertThat(shardRoutingTable.toString(), assignedNode.getName(), in(dataOnlyNodes));

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
@@ -152,10 +152,10 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         assertBusy(() -> {
             final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < shardRoutingTable.size(); j++) {
-                    ShardRouting shard = shardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                    ShardRouting shard = shardRoutingTable.shard(copy);
                     assertNotNull(shard.currentNodeId());
                     final DiscoveryNode assignedNode = state.nodes().get(shard.currentNodeId());
                     assertThat(shardRoutingTable.toString(), assignedNode.getName(), in(dataOnlyNodes));
@@ -169,10 +169,10 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         assertBusy(() -> {
             final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < shardRoutingTable.size(); j++) {
-                    ShardRouting shard = shardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
+                    ShardRouting shard = shardRoutingTable.shard(copy);
                     assertNotNull(shard.currentNodeId());
                     final DiscoveryNode assignedNode = state.nodes().get(shard.currentNodeId());
                     assertThat(shardRoutingTable.toString(), assignedNode.getName(), in(dataOnlyNodes));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
@@ -160,10 +160,10 @@ public class TransportReloadAnalyzersAction extends TransportBroadcastByNodeActi
         for (String index : concreteIndices) {
             Set<String> nodesCovered = new HashSet<>();
             IndexRoutingTable indexRoutingTable = routingTable.index(index);
-            for (int i = 0; i < indexRoutingTable.size(); i++) {
-                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                     if (nodesCovered.contains(shardRouting.currentNodeId()) == false) {
                         shards.add(shardRouting);
                         nodesCovered.add(shardRouting.currentNodeId());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.PlainShardsIterator;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -160,7 +161,9 @@ public class TransportReloadAnalyzersAction extends TransportBroadcastByNodeActi
             Set<String> nodesCovered = new HashSet<>();
             IndexRoutingTable indexRoutingTable = routingTable.index(index);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
-                for (ShardRouting shardRouting : indexRoutingTable.shard(i)) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+                for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                     if (nodesCovered.contains(shardRouting.currentNodeId()) == false) {
                         shards.add(shardRouting);
                         nodesCovered.add(shardRouting.currentNodeId());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -93,10 +93,10 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
         int allocationPendingAllShards = 0;
 
         final IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(index);
-        for (int i = 0; i < indexRoutingTable.size(); i++) {
-            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
-            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
-                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
+        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+            for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
                 String currentNodeId = shardRouting.currentNodeId();
                 boolean canRemainOnCurrentNode = allocationDeciders.canRemain(
                     shardRouting,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
@@ -93,7 +94,9 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
 
         final IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(index);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            for (ShardRouting shardRouting : indexRoutingTable.shard(i).shards()) {
+            final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
+            for (int j = 0; j < indexShardRoutingTable.size(); j++) {
+                ShardRouting shardRouting = indexShardRoutingTable.shard(j);
                 String currentNodeId = shardRouting.currentNodeId();
                 boolean canRemainOnCurrentNode = allocationDeciders.canRemain(
                     shardRouting,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
@@ -338,7 +338,7 @@ final class WatcherIndexingListener implements IndexingOperationListener, Cluste
 
             // find all allocation ids for this shard id in the cluster state
             List<String> allocationIds = routingTable.shard(shardId.getId())
-                .getActiveShards()
+                .activeShards()
                 .stream()
                 .map(ShardRouting::allocationId)
                 .map(AllocationId::getId)


### PR DESCRIPTION
Move this to array as well like in #84955. This comes with a measurable speedup to reroute
as we iterate lots of very small lists in nested loops here where the iterator overhead hurts.

relates #77466
