### PR TITLE
[ML] improve zero_shot_classification tokenization performance

### DIFF
--- a/docs/changelog/84988.yaml
+++ b/docs/changelog/84988.yaml
@@ -1,0 +1,6 @@
+pr: 84988
+summary: Improve `zero_shot_classification` tokenization performance
+area: Machine Learning
+type: enhancement
+issues:
+ - 84820

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
@@ -110,9 +110,16 @@ public class ZeroShotClassificationProcessor extends NlpTask.Processor {
             }
             List<TokenizationResult.Tokens> tokenizations = new ArrayList<>(labels.length);
             int seqId = 0;
+            NlpTokenizer.InnerTokenization firstSequenceTokenization = tokenizer.innerTokenize(inputs.get(0));
             for (String label : labels) {
                 tokenizations.add(
-                    tokenizer.tokenize(inputs.get(0), LoggerMessageFormat.format(null, hypothesisTemplate, label), truncate, seqId++)
+                    tokenizer.tokenize(
+                        inputs.get(0),
+                        firstSequenceTokenization,
+                        LoggerMessageFormat.format(null, hypothesisTemplate, label),
+                        truncate,
+                        seqId++
+                    )
                 );
             }
             TokenizationResult result = tokenizer.buildTokenizationResult(tokenizations);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
@@ -212,7 +212,7 @@ public class BertTokenizer extends NlpTokenizer {
     }
 
     @Override
-    InnerTokenization innerTokenize(String seq) {
+    public InnerTokenization innerTokenize(String seq) {
         List<Integer> tokenPositionMap = new ArrayList<>();
         try (TokenStream ts = wordPieceAnalyzer.tokenStream("input", seq)) {
             ts.reset();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
@@ -127,8 +127,35 @@ public abstract class NlpTokenizer implements Releasable {
         return toReturn;
     }
 
+    /**
+     * Tokenize the sequence pair
+     * @param seq1 The first sequence in the pair
+     * @param seq2 The second sequence
+     * @param truncate truncate settings
+     * @param sequenceId The unique id for this tokenization request
+     * @return tokenization result for the sequence pair
+     */
     public TokenizationResult.Tokens tokenize(String seq1, String seq2, Tokenization.Truncate truncate, int sequenceId) {
-        var innerResultSeq1 = innerTokenize(seq1);
+        return tokenize(seq1, innerTokenize(seq1), seq2, truncate, sequenceId);
+    }
+
+    /**
+     * The same as {@link NlpTokenizer#tokenize(String, String, Tokenization.Truncate, int)} but allows for tokenizing the first sequence
+     * only once. Useful for zero shot classification.
+     * @param seq1 The first sequence
+     * @param innerResultSeq1 The tokenization of the first sequence
+     * @param seq2 The second sequence in the pair
+     * @param truncate truncate settings
+     * @param sequenceId The unique id for this tokenization request
+     * @return tokenization result for the sequence pair
+     */
+    public TokenizationResult.Tokens tokenize(
+        String seq1,
+        InnerTokenization innerResultSeq1,
+        String seq2,
+        Tokenization.Truncate truncate,
+        int sequenceId
+    ) {
         List<? extends DelimitedToken.Encoded> tokenIdsSeq1 = innerResultSeq1.tokens;
         List<Integer> tokenPositionMapSeq1 = innerResultSeq1.tokenPositionMap;
         var innerResultSeq2 = innerTokenize(seq2);
@@ -206,7 +233,7 @@ public abstract class NlpTokenizer implements Releasable {
 
     abstract TokenizationResult.TokensBuilder createTokensBuilder(int clsTokenId, int sepTokenId, boolean withSpecialTokens);
 
-    abstract InnerTokenization innerTokenize(String seq);
+    public abstract InnerTokenization innerTokenize(String seq);
 
     public static NlpTokenizer build(Vocabulary vocabulary, Tokenization params) {
         ExceptionsHelper.requireNonNull(params, TOKENIZATION);
@@ -223,5 +250,5 @@ public abstract class NlpTokenizer implements Releasable {
         throw new IllegalArgumentException("unknown tokenization type [" + params.getName() + "]");
     }
 
-    record InnerTokenization(List<? extends DelimitedToken.Encoded> tokens, List<Integer> tokenPositionMap) {}
+    public record InnerTokenization(List<? extends DelimitedToken.Encoded> tokens, List<Integer> tokenPositionMap) {}
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
@@ -164,7 +164,7 @@ public class RobertaTokenizer extends NlpTokenizer {
     }
 
     @Override
-    InnerTokenization innerTokenize(String seq) {
+    public InnerTokenization innerTokenize(String seq) {
         List<Integer> tokenPositionMap = new ArrayList<>();
         try (TokenStream ts = bpeAnalyzer.tokenStream("input", seq)) {
             ts.reset();


### PR DESCRIPTION
Zero shot classification needs to combine the tokens from multiple sequences together to make a prediction.

This commit changes the naive tokenization that is done with one that only tokenizes the unique sequences only once per inference call. Improving throughput, inference time, and memory usage.

closes https://github.com/elastic/elasticsearch/issues/84820