### PR TITLE
fix: yaml test random results

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
@@ -62,7 +62,7 @@ setup:
           aggs:
             significant_texts:
               sampler:
-                shard_size: 200
+                shard_size: 7
               aggs:
                 keywords:
                   significant_text:
@@ -107,7 +107,7 @@ setup:
           aggs:
             significant_texts:
               sampler:
-                shard_size: 200
+                shard_size: 7
               aggs:
                 keywords:
                   significant_text:
@@ -147,7 +147,7 @@ setup:
           aggs:
             significant_texts:
               sampler:
-                shard_size: 200
+                shard_size: 7
               aggs:
                 keywords:
                   significant_text:
@@ -183,7 +183,7 @@ setup:
           aggs:
             significant_texts:
               sampler:
-                shard_size: 200
+                shard_size: 7
               aggs:
                 keywords:
                   significant_text:
@@ -226,7 +226,7 @@ setup:
           aggs:
             significant_texts:
               sampler:
-                shard_size: 200
+                shard_size: 7
               aggs:
                 keywords:
                   significant_text:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
@@ -21,22 +21,26 @@ setup:
         index: test
         refresh: true
         body:
-          - { "index": {} }
+          - { "index": { _id: 1 } }
           - { "full_text": "the apple a banana a pear the melon" }
-          - { "index": {} }
+          - { "index": { _id: 2 } }
           - { "full_text": "an apple a banana the pear" }
-          - { "index": { } }
+          - { "index": { _id: 3 } }
           - { "full_text": "the apple the banana the melon" }
-          - { "index": { } }
+          - { "index": { _id: 4 } }
           - { "full_text": "an apple a pear a melon" }
-          - { "index": { } }
+          - { "index": { _id: 5 } }
           - { "full_text": "an apple a melon" }
-          - { "index": { } }
+          - { "index": { _id: 6 } }
           - { "full_text": "elma muz armut kavun" }
-          - { "index": { } }
+          - { "index": { _id: 7 } }
           - { "full_text": "elma muz armut" }
-          - { "index": { } }
+          - { "index": { _id: 8} }
           - { "full_text": "elma armut kavun" }
+          - { "index": { _id: 9 } }
+          - { "full_text": "the quick brown fox" }
+          - { "index": { _id: 10 } }
+          - { "full_text": "jumps over the lazy dog" }
 
 
 ---
@@ -48,22 +52,29 @@ setup:
       search:
         body:
           query:
-            match_all: {}
+            terms:
+              full_text:
+                - apple
+                - banana
+                - melon
+                - pear
           size: 0
           aggs:
             significant_texts:
               sampler:
-                shard_size: 7
+                shard_size: 200
               aggs:
                 keywords:
                   significant_text:
                     field: full_text.eng
+                    jlh: {}
+                    min_doc_count: 1
 
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 5 }
   - match: { hits.total.relation: "eq" }
   - length: { aggregations.significant_texts.keywords.buckets: 4 }
-  - match: { aggregations.significant_texts.keywords.doc_count: 7 }
-  - match: { aggregations.significant_texts.keywords.bg_count: 8 }
+  - match: { aggregations.significant_texts.keywords.doc_count: 5 }
+  - match: { aggregations.significant_texts.keywords.bg_count: 10 }
   - match: { aggregations.significant_texts.keywords.buckets.0.key: "apple" }
   - match: { aggregations.significant_texts.keywords.buckets.0.doc_count: 5 }
   - match: { aggregations.significant_texts.keywords.buckets.0.bg_count: 5 }
@@ -86,23 +97,30 @@ setup:
       search:
         body:
           query:
-            match_all: {}
+            terms:
+              full_text:
+                - apple
+                - banana
+                - melon
+                - pear
           size: 0
           aggs:
             significant_texts:
               sampler:
-                shard_size: 7
+                shard_size: 200
               aggs:
                 keywords:
                   significant_text:
                     field: full_text.eng
                     size: 2
+                    jlh: {}
+                    min_doc_count: 1
 
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 5 }
   - match: { hits.total.relation: "eq" }
   - length: { aggregations.significant_texts.keywords.buckets: 2 }
-  - match: { aggregations.significant_texts.keywords.doc_count: 7 }
-  - match: { aggregations.significant_texts.keywords.bg_count: 8 }
+  - match: { aggregations.significant_texts.keywords.doc_count: 5 }
+  - match: { aggregations.significant_texts.keywords.bg_count: 10 }
   - match: { aggregations.significant_texts.keywords.buckets.0.key: "apple" }
   - match: { aggregations.significant_texts.keywords.buckets.0.doc_count: 5 }
   - match: { aggregations.significant_texts.keywords.buckets.0.bg_count: 5 }
@@ -119,23 +137,29 @@ setup:
       search:
         body:
           query:
-            match_all: {}
+            terms:
+              full_text:
+                - apple
+                - banana
+                - melon
+                - pear
           size: 0
           aggs:
             significant_texts:
               sampler:
-                shard_size: 7
+                shard_size: 200
               aggs:
                 keywords:
                   significant_text:
                     field: full_text.eng
                     min_doc_count: 5
+                    jlh: {}
 
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 5 }
   - match: { hits.total.relation: "eq" }
   - length: { aggregations.significant_texts.keywords.buckets: 1 }
-  - match: { aggregations.significant_texts.keywords.doc_count: 7 }
-  - match: { aggregations.significant_texts.keywords.bg_count: 8 }
+  - match: { aggregations.significant_texts.keywords.doc_count: 5 }
+  - match: { aggregations.significant_texts.keywords.bg_count: 10 }
   - match: { aggregations.significant_texts.keywords.buckets.0.key: "apple" }
   - match: { aggregations.significant_texts.keywords.buckets.0.doc_count: 5 }
   - match: { aggregations.significant_texts.keywords.buckets.0.bg_count: 5 }
@@ -149,23 +173,30 @@ setup:
       search:
         body:
           query:
-            match_all: {}
+            terms:
+              full_text:
+                - apple
+                - banana
+                - melon
+                - pear
           size: 0
           aggs:
             significant_texts:
               sampler:
-                shard_size: 7
+                shard_size: 200
               aggs:
                 keywords:
                   significant_text:
                     field: full_text.eng
                     exclude: "app.*"
+                    jlh: {}
+                    min_doc_count: 1
 
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 5 }
   - match: { hits.total.relation: "eq" }
   - length: { aggregations.significant_texts.keywords.buckets: 3 }
-  - match: { aggregations.significant_texts.keywords.doc_count: 7 }
-  - match: { aggregations.significant_texts.keywords.bg_count: 8 }
+  - match: { aggregations.significant_texts.keywords.doc_count: 5 }
+  - match: { aggregations.significant_texts.keywords.bg_count: 10 }
   - match: { aggregations.significant_texts.keywords.buckets.0.key: "melon" }
   - match: { aggregations.significant_texts.keywords.buckets.0.doc_count: 4 }
   - match: { aggregations.significant_texts.keywords.buckets.0.bg_count: 4 }
@@ -185,23 +216,30 @@ setup:
       search:
         body:
           query:
-            match_all: {}
+            terms:
+              full_text:
+                - apple
+                - banana
+                - melon
+                - pear
           size: 0
           aggs:
             significant_texts:
               sampler:
-                shard_size: 7
+                shard_size: 200
               aggs:
                 keywords:
                   significant_text:
                     field: full_text.eng
                     include: ["melon", "banana"]
+                    jlh: {}
+                    min_doc_count: 1
 
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 5 }
   - match: { hits.total.relation: "eq" }
   - length: { aggregations.significant_texts.keywords.buckets: 2 }
-  - match: { aggregations.significant_texts.keywords.doc_count: 7 }
-  - match: { aggregations.significant_texts.keywords.bg_count: 8 }
+  - match: { aggregations.significant_texts.keywords.doc_count: 5 }
+  - match: { aggregations.significant_texts.keywords.bg_count: 10 }
   - match: { aggregations.significant_texts.keywords.buckets.0.key: "melon" }
   - match: { aggregations.significant_texts.keywords.buckets.0.doc_count: 4 }
   - match: { aggregations.significant_texts.keywords.buckets.0.bg_count: 4 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
@@ -21,25 +21,25 @@ setup:
         index: test
         refresh: true
         body:
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "the apple a banana a pear the melon" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "an apple a banana the pear" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "the apple the banana the melon" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "an apple a pear a melon" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "an apple a melon" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "elma muz armut kavun" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "elma muz armut" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "elma armut kavun" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "the quick brown fox" }
-          - { "index": { } }
+          - { "index": {} }
           - { "full_text": "jumps over the lazy dog" }
 
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/470_significant_texts.yml
@@ -21,25 +21,25 @@ setup:
         index: test
         refresh: true
         body:
-          - { "index": { _id: 1 } }
+          - { "index": { } }
           - { "full_text": "the apple a banana a pear the melon" }
-          - { "index": { _id: 2 } }
+          - { "index": { } }
           - { "full_text": "an apple a banana the pear" }
-          - { "index": { _id: 3 } }
+          - { "index": { } }
           - { "full_text": "the apple the banana the melon" }
-          - { "index": { _id: 4 } }
+          - { "index": { } }
           - { "full_text": "an apple a pear a melon" }
-          - { "index": { _id: 5 } }
+          - { "index": { } }
           - { "full_text": "an apple a melon" }
-          - { "index": { _id: 6 } }
+          - { "index": { } }
           - { "full_text": "elma muz armut kavun" }
-          - { "index": { _id: 7 } }
+          - { "index": { } }
           - { "full_text": "elma muz armut" }
-          - { "index": { _id: 8} }
+          - { "index": { } }
           - { "full_text": "elma armut kavun" }
-          - { "index": { _id: 9 } }
+          - { "index": { } }
           - { "full_text": "the quick brown fox" }
-          - { "index": { _id: 10 } }
+          - { "index": { } }
           - { "full_text": "jumps over the lazy dog" }
 
 


### PR DESCRIPTION
The fix includes the following changes:
* shard_size is set to limit the result of the sampler
* more documents are added to make significant text search meaningful
* a terms query is included to limit the query scope
* jlh score is used to fix the heuristic used for score calculation

This is a fix for issue #84927 