### PR TITLE
[Test] Ensure profile index exists before test of racing

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileDomainIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileDomainIntegTests.java
@@ -261,12 +261,9 @@ public class ProfileDomainIntegTests extends AbstractProfileIntegTestCase {
         assertThat(future1.actionGet().uid(), equalTo(profile1.uid()));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84980")
     public void testConcurrentCreationOfNewProfiles() throws InterruptedException {
-        // The profile index may or may not exist
-        if (randomBoolean()) {
-            indexDocument();
-        }
+        // Ensure the index exists because racing on creating and writing to the index could fail with UnavailableShardsException
+        indexDocument();
 
         final String username = randomAlphaOfLengthBetween(5, 12);
         final Authentication.RealmRef realmRef = AuthenticationTests.randomRealmRef(randomBoolean());


### PR DESCRIPTION
Attempting to create and write to the profile index (wrapped by
`SecurityIndexManager`) concurrently could lead to some threads fail with
`UnavailableShardsException`. This is because the index could exist in the
clusterState while the shard is still being allocated. It is mostly a
test issue and not practical in production. Since this particular test
does not gain any extra value from the "index-not-yet-exists" scenario,
this PR simply remove the randomisation to ensure the profile index
always exists before the test begins.

Resolves: #84980
