### PR TITLE
Note restricted indices in access denied message

### DIFF
--- a/docs/changelog/85013.yaml
+++ b/docs/changelog/85013.yaml
@@ -1,0 +1,5 @@
+pr: 85013
+summary: Note restricted indices in access denied message
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
@@ -64,7 +64,7 @@ public class IndicesAccessControl {
         return granted;
     }
 
-    public Collection<?> getDeniedIndices() {
+    public Collection<String> getDeniedIndices() {
         return this.indexPermissions.entrySet()
             .stream()
             .filter(e -> e.getValue().granted == false)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngineTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngineTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authz;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.hamcrest.Matchers.is;
+
+public class AuthorizationEngineTests extends ESTestCase {
+
+    public void testIndexAuthorizationResultFailureMessage() {
+        final Predicate<String> restrictedIndex = s -> s.startsWith(".");
+        assertThat(
+            AuthorizationEngine.IndexAuthorizationResult.getFailureDescription(List.of("index-1", "index-2", ".index-3"), restrictedIndex),
+            is("on indices [index-1,index-2] and restricted indices [.index-3]")
+        );
+
+        assertThat(
+            AuthorizationEngine.IndexAuthorizationResult.getFailureDescription(List.of("index-1"), restrictedIndex),
+            is("on indices [index-1]")
+        );
+
+        assertThat(
+            AuthorizationEngine.IndexAuthorizationResult.getFailureDescription(
+                List.of(".index-1", ".index-2", ".index-3"),
+                restrictedIndex
+            ),
+            is("on restricted indices [.index-1,.index-2,.index-3]")
+        );
+    }
+
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -773,7 +773,10 @@ public class AuthorizationService {
                                     authentication,
                                     itemAction,
                                     request,
-                                    AuthorizationEngine.IndexAuthorizationResult.getFailureDescription(List.of(resolvedIndex)),
+                                    AuthorizationEngine.IndexAuthorizationResult.getFailureDescription(
+                                        List.of(resolvedIndex),
+                                        indicesAndAliasesResolver.getRestrictedIndicesPredicate()
+                                    ),
                                     null
                                 )
                             );
@@ -960,7 +963,11 @@ public class AuthorizationService {
                     failureConsumer.accept(e);
                 }
             } else {
-                handleFailure(result.isAuditable(), result.getFailureContext(), null);
+                handleFailure(
+                    result.isAuditable(),
+                    result.getFailureContext(indicesAndAliasesResolver.getRestrictedIndicesPredicate()),
+                    null
+                );
             }
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -30,6 +30,7 @@ import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authz.ResolvedIndices;
+import org.elasticsearch.xpack.core.security.support.Automatons;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField.NO_INDEX_PLACEHOLDER;
@@ -59,6 +61,14 @@ class IndicesAndAliasesResolver {
         this.nameExpressionResolver = resolver;
         this.indexAbstractionResolver = new IndexAbstractionResolver(resolver);
         this.remoteClusterResolver = new RemoteClusterResolver(settings, clusterService.getClusterSettings());
+    }
+
+    public IndexNameExpressionResolver getIndexNameExpressionResolver() {
+        return nameExpressionResolver;
+    }
+
+    public Predicate<String> getRestrictedIndicesPredicate() {
+        return Automatons.predicate(nameExpressionResolver.getSystemNameAutomaton());
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -63,10 +63,6 @@ class IndicesAndAliasesResolver {
         this.remoteClusterResolver = new RemoteClusterResolver(settings, clusterService.getClusterSettings());
     }
 
-    public IndexNameExpressionResolver getIndexNameExpressionResolver() {
-        return nameExpressionResolver;
-    }
-
     public Predicate<String> getRestrictedIndicesPredicate() {
         return Automatons.predicate(nameExpressionResolver.getSystemNameAutomaton());
     }


### PR DESCRIPTION
When security prevents access to an index, it indicates the action
that was attempted, the indices it was applied to and the privileges
that would grant that access.

However, if the index is a restricted index, that message was
insufficient.
Even if the user was granted "all" on "*", they would still be
prevented from performing actions on restricted indices such as
".security" or ".kibana".
Access to those indices would require a role that grants access
with the allow_restricted_indices field set to true

This change expands the error message to note which indices are
"restricted" as a way of guiding users towards the necessary solution.
