### PR TITLE
Fix snapshot status messages on node-left

### DIFF
--- a/docs/changelog/85021.yaml
+++ b/docs/changelog/85021.yaml
@@ -1,0 +1,5 @@
+pr: 85021
+summary: Fix snapshot status messages on node-left
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1344,11 +1344,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 } else {
                     // TODO: Restart snapshot on another node?
                     snapshotChanged = true;
-                    logger.warn("failing snapshot of shard [{}] on closed node [{}]", shardId, shardStatus.nodeId());
+                    logger.warn("failing snapshot of shard [{}] on departed node [{}]", shardId, shardStatus.nodeId());
                     final ShardSnapshotStatus failedState = new ShardSnapshotStatus(
                         shardStatus.nodeId(),
                         ShardState.FAILED,
-                        "node shutdown",
+                        "node left the cluster during snapshot",
                         shardStatus.generation()
                     );
                     shards.put(shardId, failedState);


### PR DESCRIPTION
Today we report `node shutdown` if a node leaves the cluster during a
snapshot. That's not the only reason for a node to leave the cluster, it
might have been a network disconnect or health check failure or similar.
This commit generalizes the message.