### PR TITLE
Remove hppc from ImmmutableOpenMap.Builder signatures

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -10,14 +10,9 @@ package org.elasticsearch.common.collect;
 
 import com.carrotsearch.hppc.ObjectCollection;
 import com.carrotsearch.hppc.ObjectContainer;
-import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
-import com.carrotsearch.hppc.ObjectObjectMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import com.carrotsearch.hppc.predicates.ObjectObjectPredicate;
-import com.carrotsearch.hppc.predicates.ObjectPredicate;
-import com.carrotsearch.hppc.procedures.ObjectObjectProcedure;
 
 import java.util.AbstractCollection;
 import java.util.AbstractSet;

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -28,7 +28,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * An immutable map implementation based on open hash map.
@@ -354,7 +356,7 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType> {
         return new Builder<>(map);
     }
 
-    public static class Builder<KType, VType> implements ObjectObjectMap<KType, VType> {
+    public static class Builder<KType, VType> {
         private ObjectObjectHashMap<KType, VType> map;
 
         @SuppressWarnings("unchecked")
@@ -397,29 +399,22 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType> {
             return this;
         }
 
-        @Override
         public VType put(KType key, VType value) {
             return map.put(key, value);
         }
 
-        @Override
         public VType get(KType key) {
             return map.get(key);
         }
 
-        @Override
         public VType getOrDefault(KType kType, VType vType) {
             return map.getOrDefault(kType, vType);
         }
 
-        @Override
-        public int putAll(ObjectObjectAssociativeContainer<? extends KType, ? extends VType> container) {
-            return map.putAll(container);
-        }
-
-        @Override
-        public int putAll(Iterable<? extends ObjectObjectCursor<? extends KType, ? extends VType>> iterable) {
-            return map.putAll(iterable);
+        public void putAll(Builder<KType, VType> builder) {
+            for (var entry : builder.map) {
+                map.put(entry.key, entry.value);
+            }
         }
 
         /**
@@ -430,39 +425,24 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType> {
             return this;
         }
 
-        @Override
         public VType remove(KType key) {
             return map.remove(key);
         }
 
-        @Override
-        public Iterator<ObjectObjectCursor<KType, VType>> iterator() {
-            return map.iterator();
-        }
-
-        @Override
         public boolean containsKey(KType key) {
             return map.containsKey(key);
         }
 
-        @Override
         public int size() {
             return map.size();
         }
 
-        @Override
         public boolean isEmpty() {
             return map.isEmpty();
         }
 
-        @Override
-        public int removeAll(ObjectContainer<? super KType> container) {
-            return map.removeAll(container);
-        }
-
-        @Override
-        public int removeAll(ObjectPredicate<? super KType> predicate) {
-            return map.removeAll(predicate);
+        public int removeAll(Predicate<? super KType> predicate) {
+            return map.removeAll(predicate::test);
         }
 
         public void removeAllFromCollection(Collection<KType> collection) {
@@ -471,22 +451,14 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType> {
             }
         }
 
-        @Override
-        public <T extends ObjectObjectProcedure<? super KType, ? super VType>> T forEach(T procedure) {
-            return map.forEach(procedure);
-        }
-
-        @Override
         public void clear() {
             map.clear();
         }
 
-        @Override
         public ObjectCollection<KType> keys() {
             return map.keys();
         }
 
-        @Override
         public ObjectContainer<VType> values() {
             return map.values();
         }
@@ -496,47 +468,34 @@ public final class ImmutableOpenMap<KType, VType> implements Map<KType, VType> {
             return (Builder) this;
         }
 
-        @Override
-        public int removeAll(ObjectObjectPredicate<? super KType, ? super VType> predicate) {
-            return map.removeAll(predicate);
+        public int removeAll(BiPredicate<? super KType, ? super VType> predicate) {
+            return map.removeAll(predicate::test);
         }
 
-        @Override
-        public <T extends ObjectObjectPredicate<? super KType, ? super VType>> T forEach(T predicate) {
-            return map.forEach(predicate);
-        }
-
-        @Override
         public int indexOf(KType key) {
             return map.indexOf(key);
         }
 
-        @Override
         public boolean indexExists(int index) {
             return map.indexExists(index);
         }
 
-        @Override
         public VType indexGet(int index) {
             return map.indexGet(index);
         }
 
-        @Override
         public VType indexReplace(int index, VType newValue) {
             return map.indexReplace(index, newValue);
         }
 
-        @Override
         public void indexInsert(int index, KType key, VType value) {
             map.indexInsert(index, key, value);
         }
 
-        @Override
         public void release() {
             map.release();
         }
 
-        @Override
         public String visualizeKeyDistribution(int characters) {
             return map.visualizeKeyDistribution(characters);
         }


### PR DESCRIPTION
The builder for ImmutableOpenMap leaks hppc classes from some of its
methods. This commit removes the super interface and unused methods, as
well as converts remaining methods to use standard Java classes like
Predicate.

relates #84735