### PR TITLE
[8.1] DotExpandingXContentParser to expose the original token location (#84970)

### DIFF
--- a/docs/changelog/84970.yaml
+++ b/docs/changelog/84970.yaml
@@ -1,0 +1,5 @@
+pr: 84970
+summary: '`DotExpandingXContentParser` to expose the original token location'
+area: Search
+type: bug
+issues: []

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/DotExpandingXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/DotExpandingXContentParser.java
@@ -15,7 +15,8 @@ import java.util.Deque;
 /**
  * An XContentParser that reinterprets field names containing dots as an object structure.
  *
- * A fieldname named {@code "foo.bar.baz":...} will be parsed instead as {@code 'foo':{'bar':{'baz':...}}}
+ * A field name named {@code "foo.bar.baz":...} will be parsed instead as {@code 'foo':{'bar':{'baz':...}}}.
+ * The token location is preserved so that error messages refer to the original content being parsed.
  */
 public class DotExpandingXContentParser extends FilterXContentParser {
 
@@ -59,13 +60,14 @@ public class DotExpandingXContentParser extends FilterXContentParser {
             if (subpaths.length == 1 && field.endsWith(".") == false) {
                 return;
             }
+            XContentLocation location = delegate().getTokenLocation();
             Token token = delegate().nextToken();
             if (token == Token.START_OBJECT || token == Token.START_ARRAY) {
-                parsers.push(new DotExpandingXContentParser(new XContentSubParser(delegate()), delegate(), subpaths));
+                parsers.push(new DotExpandingXContentParser(new XContentSubParser(delegate()), delegate(), subpaths, location));
             } else if (token == Token.END_OBJECT || token == Token.END_ARRAY) {
                 throw new IllegalStateException("Expecting START_OBJECT or START_ARRAY or VALUE but got [" + token + "]");
             } else {
-                parsers.push(new DotExpandingXContentParser(new SingletonValueXContentParser(delegate()), delegate(), subpaths));
+                parsers.push(new DotExpandingXContentParser(new SingletonValueXContentParser(delegate()), delegate(), subpaths, location));
             }
         }
 
@@ -118,14 +120,16 @@ public class DotExpandingXContentParser extends FilterXContentParser {
     final String[] subPaths;
     final XContentParser subparser;
 
+    private XContentLocation currentLocation;
     private int expandedTokens = 0;
     private int innerLevel = -1;
     private State state = State.EXPANDING_START_OBJECT;
 
-    private DotExpandingXContentParser(XContentParser subparser, XContentParser root, String[] subPaths) {
+    private DotExpandingXContentParser(XContentParser subparser, XContentParser root, String[] subPaths, XContentLocation startLocation) {
         super(root);
         this.subPaths = subPaths;
         this.subparser = subparser;
+        this.currentLocation = startLocation;
     }
 
     @Override
@@ -158,11 +162,20 @@ public class DotExpandingXContentParser extends FilterXContentParser {
             if (token != null) {
                 return token;
             }
+            currentLocation = getTokenLocation();
             state = State.ENDING_EXPANDED_OBJECT;
         }
         assert expandedTokens % 2 == 1;
         expandedTokens -= 2;
         return expandedTokens < 0 ? null : Token.END_OBJECT;
+    }
+
+    @Override
+    public XContentLocation getTokenLocation() {
+        if (state == State.PARSING_ORIGINAL_CONTENT) {
+            return super.getTokenLocation();
+        }
+        return currentLocation;
     }
 
     @Override

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/DotExpandingXContentParserTests.java
@@ -166,4 +166,64 @@ public class DotExpandingXContentParserTests extends ESTestCase {
             {"first.dot":{"second.dot":"value","third":"value"},"nodots":"value"}\
             """);
     }
+
+    public void testGetTokenLocation() throws IOException {
+        String jsonInput = """
+            {"first.dot":{"second.dot":"value",
+            "value":null}}\
+            """;
+        XContentParser expectedParser = createParser(JsonXContent.jsonXContent, jsonInput);
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(createParser(JsonXContent.jsonXContent, jsonInput));
+
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.START_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("first", dotExpandedParser.currentName());
+        assertEquals("first.dot", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals("dot", dotExpandedParser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("second", dotExpandedParser.currentName());
+        assertEquals("second.dot", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals("dot", dotExpandedParser.currentName());
+        assertEquals(XContentParser.Token.VALUE_STRING, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.VALUE_STRING, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.FIELD_NAME, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("value", dotExpandedParser.currentName());
+        assertEquals("value", expectedParser.currentName());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.VALUE_NULL, expectedParser.nextToken());
+        assertEquals(XContentParser.Token.VALUE_NULL, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.END_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertEquals(XContentParser.Token.END_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.END_OBJECT, expectedParser.nextToken());
+        assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
+        assertNull(dotExpandedParser.nextToken());
+        assertNull(expectedParser.nextToken());
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - DotExpandingXContentParser to expose the original token location (#84970)