### PR TITLE
Fix FieldCapabilitiesTests#testBuilderMixedMetricType

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
@@ -262,7 +262,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
         if (metricTypes.isEmpty()) {
             assertNull(fieldCaps.getMetricType());
             assertNull(fieldCaps.metricConflictsIndices());
-        } else if (metricTypes.size() == indices.size() && metricTypes.values().size() == 1) {
+        } else if (metricTypes.size() == indices.size() && metricTypes.values().stream().distinct().count() == 1) {
             assertThat(fieldCaps.getMetricType(), equalTo(Iterables.get(metricTypes.values(), 0)));
             assertNull(fieldCaps.metricConflictsIndices());
         } else {


### PR DESCRIPTION
The test condition is that all indices have the same metric type, but we wrongly check for its size instead.

Relates #83704