### PR TITLE
Handle role descriptor retrieval for internal users

### DIFF
--- a/docs/changelog/85049.yaml
+++ b/docs/changelog/85049.yaml
@@ -1,0 +1,5 @@
+pr: 85049
+summary: Handle role descriptor retrieval for internal users
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/UsernamesField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/UsernamesField.java
@@ -15,7 +15,7 @@ public final class UsernamesField {
     public static final String SYSTEM_NAME = "_system";
     public static final String SYSTEM_ROLE = "_system";
     public static final String XPACK_SECURITY_NAME = "_xpack_security";
-    public static final String XPACK_SECURITY_ROLE = "superuser";
+    public static final String XPACK_SECURITY_ROLE = "_xpack_security";
     public static final String XPACK_NAME = "_xpack";
     public static final String XPACK_ROLE = "_xpack";
     public static final String LOGSTASH_NAME = "logstash_system";

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/enrollment/EnrollmentSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/enrollment/EnrollmentSingleNodeTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.junit.BeforeClass;
 import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
@@ -36,6 +37,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.spy;
 
 public class EnrollmentSingleNodeTests extends SecuritySingleNodeTestCase {
+
+    @BeforeClass
+    public static void muteInFips() {
+        assumeFalse("Enrollment is not supported in FIPS 140-2 as we are using PKCS#12 keystores", inFipsJvm());
+    }
 
     @Override
     protected Settings nodeSettings() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/enrollment/EnrollmentSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/enrollment/EnrollmentSingleNodeTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.enrollment;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.SecuritySingleNodeTestCase;
+import org.elasticsearch.xpack.core.security.EnrollmentToken;
+import org.elasticsearch.xpack.core.security.action.enrollment.KibanaEnrollmentAction;
+import org.elasticsearch.xpack.core.security.action.enrollment.KibanaEnrollmentRequest;
+import org.elasticsearch.xpack.core.security.action.enrollment.KibanaEnrollmentResponse;
+import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
+import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
+import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForStore;
+import static org.elasticsearch.xpack.core.XPackSettings.ENROLLMENT_ENABLED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.spy;
+
+public class EnrollmentSingleNodeTests extends SecuritySingleNodeTestCase {
+
+    @Override
+    protected Settings nodeSettings() {
+        Settings.Builder builder = Settings.builder().put(super.nodeSettings());
+        addSSLSettingsForStore(
+            builder,
+            "xpack.security.http.",
+            "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/httpCa.p12",
+            "password",
+            false
+        );
+        builder.put("xpack.security.http.ssl.enabled", true).put(ENROLLMENT_ENABLED.getKey(), "true");
+        // Need at least 2 threads because enrollment token creator internally uses a client
+        builder.put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 2);
+        return builder.build();
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // enable http
+    }
+
+    @Override
+    protected boolean transportSSLEnabled() {
+        return true;
+    }
+
+    public void testKibanaEnrollmentTokenCreation() throws Exception {
+        final SSLService sslService = getInstanceFromNode(SSLService.class);
+
+        final InternalEnrollmentTokenGenerator internalEnrollmentTokenGenerator = spy(
+            new InternalEnrollmentTokenGenerator(
+                newEnvironment(Settings.builder().put(ENROLLMENT_ENABLED.getKey(), "true").build()),
+                sslService,
+                node().client()
+            )
+        );
+        // Mock the getHttpsCaFingerprint method because the real method requires createClassLoader permission
+        Mockito.doReturn("fingerprint").when(internalEnrollmentTokenGenerator).getHttpsCaFingerprint();
+
+        final SetOnce<EnrollmentToken> enrollmentTokenSetOnce = new SetOnce<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        // Create the kibana enrollment token and wait for the process to complete
+        internalEnrollmentTokenGenerator.createKibanaEnrollmentToken(enrollmentToken -> {
+            enrollmentTokenSetOnce.set(enrollmentToken);
+            latch.countDown();
+        }, List.of(TimeValue.timeValueMillis(500)).iterator());
+        latch.await(20, TimeUnit.SECONDS);
+
+        // The API key is created by the right user and should work
+        final Client apiKeyClient = client().filterWithHeader(
+            Map.of(
+                "Authorization",
+                "ApiKey " + Base64.getEncoder().encodeToString(enrollmentTokenSetOnce.get().getApiKey().getBytes(StandardCharsets.UTF_8))
+            )
+        );
+        final AuthenticateResponse authenticateResponse1 = apiKeyClient.execute(
+            AuthenticateAction.INSTANCE,
+            new AuthenticateRequest("_xpack_security")
+        ).actionGet();
+        assertThat(authenticateResponse1.authentication().getUser().principal(), equalTo("_xpack_security"));
+
+        final KibanaEnrollmentResponse kibanaEnrollmentResponse = apiKeyClient.execute(
+            KibanaEnrollmentAction.INSTANCE,
+            new KibanaEnrollmentRequest()
+        ).actionGet();
+
+        // The service token should work
+        final Client kibanaClient = client().filterWithHeader(
+            Map.of("Authorization", "Bearer " + kibanaEnrollmentResponse.getTokenValue())
+        );
+
+        final AuthenticateResponse authenticateResponse2 = kibanaClient.execute(
+            AuthenticateAction.INSTANCE,
+            new AuthenticateRequest("elastic/kibana")
+        ).actionGet();
+        assertThat(authenticateResponse2.authentication().getUser().principal(), equalTo("elastic/kibana"));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
@@ -51,7 +51,7 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
     public InternalEnrollmentTokenGenerator(Environment environment, SSLService sslService, Client client) {
         this.environment = environment;
         this.sslService = sslService;
-        // enrollment tokens API keys will be owned by the "_xpack_security" system user ("superuser" role)
+        // enrollment tokens API keys will be owned by the "_xpack_security" system user ("_xpack_security" role)
         this.client = new OriginSettingClient(client, SECURITY_ORIGIN);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -257,7 +257,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         }
     }
 
-    private static void addSSLSettingsForStore(
+    public static void addSSLSettingsForStore(
         Settings.Builder builder,
         String prefix,
         String resourcePathToStore,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1909,9 +1909,10 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
         final Subject subject = mock(Subject.class);
         when(subject.getUser()).thenReturn(SystemUser.INSTANCE);
-        final PlainActionFuture<Collection<Set<RoleDescriptor>>> future1 = new PlainActionFuture<>();
-        compositeRolesStore.getRoleDescriptorsList(subject, future1);
-        final IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, future1::actionGet);
+        final IllegalArgumentException e1 = expectThrows(
+            IllegalArgumentException.class,
+            () -> compositeRolesStore.getRoleDescriptorsList(subject, new PlainActionFuture<>())
+        );
         assertThat(e1.getMessage(), containsString("system user and we should never try to get its role descriptors"));
 
         when(subject.getUser()).thenReturn(XPackSecurityUser.INSTANCE);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1893,6 +1893,33 @@ public class CompositeRolesStoreTests extends ESTestCase {
         }
     }
 
+    public void testGetRoleDescriptorsListForInternalUsers() {
+        final CompositeRolesStore compositeRolesStore = buildCompositeRolesStore(
+            SECURITY_ENABLED_SETTINGS,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            mock(ServiceAccountService.class),
+            null,
+            null
+        );
+
+        final Subject subject = mock(Subject.class);
+        when(subject.getUser()).thenReturn(SystemUser.INSTANCE);
+        final PlainActionFuture<Collection<Set<RoleDescriptor>>> future1 = new PlainActionFuture<>();
+        compositeRolesStore.getRoleDescriptorsList(subject, future1);
+        final IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, future1::actionGet);
+        assertThat(e1.getMessage(), containsString("system user and we should never try to get its role descriptors"));
+
+        when(subject.getUser()).thenReturn(XPackSecurityUser.INSTANCE);
+        final PlainActionFuture<Collection<Set<RoleDescriptor>>> future2 = new PlainActionFuture<>();
+        compositeRolesStore.getRoleDescriptorsList(subject, future2);
+        assertThat(future2.actionGet(), equalTo(List.of(Set.of(XPackSecurityUser.ROLE_DESCRIPTOR))));
+    }
+
     private void getRoleForRoleNames(CompositeRolesStore rolesStore, Collection<String> roleNames, ActionListener<Role> listener) {
         final Subject subject = mock(Subject.class);
         when(subject.getRoleReferenceIntersection(any())).thenReturn(


### PR DESCRIPTION
Internal users have hard-coded role descriptors which are not registered
with any role store. This means they cannot simply be retrieved by
names. This PR adds logic to check for internal users and return their
role descriptor accordingly. This change also makes it possible to
finally correct the role name used by the _xpack_security user. A test
for enrollment token is also added to ensure the change to
_xpack_security user do not break the enrollment flow.

Relates: #83627, #84096
