### PR TITLE
Change deprecationIssue level to critical for slow log level

### DIFF
--- a/docs/changelog/85062.yaml
+++ b/docs/changelog/85062.yaml
@@ -1,0 +1,6 @@
+pr: 85062
+summary: Change `deprecationIssue` level to critical for slow log level
+area: Infra/Settings
+type: bug
+issues:
+ - 84992

--- a/docs/changelog/85062.yaml
+++ b/docs/changelog/85062.yaml
@@ -2,5 +2,4 @@ pr: 85062
 summary: Change `deprecationIssue` level to critical for slow log level
 area: Infra/Settings
 type: bug
-issues:
- - 84992
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -600,7 +600,7 @@ public class IndexDeprecationChecks {
                 setting.getKey()
             );
             return new DeprecationIssue(
-                DeprecationIssue.Level.WARNING,
+                DeprecationIssue.Level.CRITICAL,
                 message,
                 url,
                 details,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -751,7 +751,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             issues,
             containsInAnyOrder(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "Setting [index.search.slowlog.level] is deprecated",
                     expectedUrl,
                     "Remove the [index.search.slowlog.level] setting. Use the [index.*.slowlog.threshold] settings to set the log levels.",
@@ -761,7 +761,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                     )
                 ),
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "Setting [index.indexing.slowlog.level] is deprecated",
                     expectedUrl,
                     "Remove the [index.indexing.slowlog.level] setting. Use the [index.*.slowlog.threshold]"


### PR DESCRIPTION
index.indexing.slowlog.level or index.search.slowlog.level
settings have been removed in 8.0 and should be marked as CRITICAL
to prevent upgrade

relates #84992

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
